### PR TITLE
WIP: adj -> nil, but need to confirm

### DIFF
--- a/apps/macos/LauncherApp/look-app/Models/DictionaryModels.swift
+++ b/apps/macos/LauncherApp/look-app/Models/DictionaryModels.swift
@@ -22,7 +22,7 @@ struct LookupPresentation {
 }
 
 struct LookupDefinitionEntry {
-    let partOfSpeech: String
+    let partOfSpeech: String?
     let senses: [LookupSenseEntry]
 }
 

--- a/apps/macos/LauncherApp/look-app/Support/DictionaryParser.swift
+++ b/apps/macos/LauncherApp/look-app/Support/DictionaryParser.swift
@@ -226,8 +226,7 @@ extension DictionaryParser {
             : parseVietnameseWithPOS(raw: raw, posSections: posSections, bulletParts: bulletParts, allPosKeywords: allPosKeywords)
 
         guard !definitions.isEmpty else { return nil }
-        let mainPos = definitions.first?.partOfSpeech ?? "adjective"
-        return LookupPresentation(title: title, partOfSpeech: mainPos, definitions: definitions)
+        return LookupPresentation(title: title, partOfSpeech: definitions.first?.partOfSpeech, definitions: definitions)
     }
 
     private static func parseVietnameseWithPOS(raw: String, posSections: [(pos: String, startIndex: String.Index)], bulletParts: [String], allPosKeywords: [String]) -> [LookupDefinitionEntry] {
@@ -374,7 +373,7 @@ extension DictionaryParser {
             }
         }
 
-        return [LookupDefinitionEntry(partOfSpeech: "adjective", senses: senses)]
+        return [LookupDefinitionEntry(partOfSpeech: nil, senses: senses)]
     }
 
     private static func distributeExamplesToSenses(senses: [LookupSenseEntry], bulletParts: [String], sectionStart: String.Index, sectionEnd: String.Index, raw: String) -> [LookupSenseEntry] {
@@ -466,7 +465,7 @@ extension DictionaryParser {
         if definitions.isEmpty {
             let senses = extractSensesWithAntonyms(text, maxSenses: 3)
             if !senses.isEmpty {
-                definitions.append(LookupDefinitionEntry(partOfSpeech: "adjective", senses: senses))
+                definitions.append(LookupDefinitionEntry(partOfSpeech: nil, senses: senses))
             }
         }
 

--- a/apps/macos/LauncherApp/look-app/Views/LookupDefinitionPanelView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/LookupDefinitionPanelView.swift
@@ -113,13 +113,15 @@ struct LookupDefinitionPanelView: View {
 
     private func definitionEntryView(_ entry: LookupDefinitionEntry) -> some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(entry.partOfSpeech)
-                .font(.system(size: CGFloat(themeStore.settings.fontSize), weight: .semibold, design: .serif))
-                .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.75))
-                .padding(.horizontal, 8)
-                .padding(.vertical, 2)
-                .background(themeStore.fontColor(opacityMultiplier: 0.1))
-                .cornerRadius(4)
+            if let pos = entry.partOfSpeech {
+                Text(pos)
+                    .font(.system(size: CGFloat(themeStore.settings.fontSize), weight: .semibold, design: .serif))
+                    .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.75))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 2)
+                    .background(themeStore.fontColor(opacityMultiplier: 0.1))
+                    .cornerRadius(4)
+            }
 
             ForEach(Array(entry.senses.enumerated()), id: \.offset) { _, sense in
                 senseEntryView(sense)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -217,7 +217,7 @@ Click the speaker icon next to any text to hear it read aloud (uses system TTS v
 - Up to 10 senses per section; excess are not shown
 - Up to 2 examples per sense; excess are not shown
 - Very long definitions are truncated with "..."
-- Vietnamese entries without POS keywords default to "adjective"
+- Entries without explicit part-of-speech (POS) keywords will not display a POS label
 - Japanese reference markers (⇨...) are stripped from definitions
 - English phrases limited to 3 items
 

--- a/scripts/test_lookup.swift
+++ b/scripts/test_lookup.swift
@@ -16,7 +16,7 @@ struct LookupPresentation {
 }
 
 struct LookupDefinitionEntry {
-    let partOfSpeech: String
+    let partOfSpeech: String?
     let senses: [LookupSenseEntry]
 }
 
@@ -162,8 +162,7 @@ func parseVietnamese(_ raw: String) -> LookupPresentation? {
         : parseVietnameseWithPOS(raw: raw, posSections: posSections, bulletParts: bulletParts, allPosKeywords: allPosKeywords)
 
     guard !definitions.isEmpty else { return nil }
-    let mainPos = definitions.first?.partOfSpeech ?? "adjective"
-    return LookupPresentation(title: title, partOfSpeech: mainPos, definitions: definitions)
+    return LookupPresentation(title: title, partOfSpeech: definitions.first?.partOfSpeech, definitions: definitions)
 }
 
 func parseVietnameseWithPOS(raw: String, posSections: [(pos: String, startIndex: String.Index)], bulletParts: [String], allPosKeywords: [String]) -> [LookupDefinitionEntry] {
@@ -310,7 +309,7 @@ func parseVietnameseNoPOS(raw: String, allPosKeywords: [String]) -> [LookupDefin
         }
     }
 
-    return [LookupDefinitionEntry(partOfSpeech: "adjective", senses: senses)]
+    return [LookupDefinitionEntry(partOfSpeech: nil, senses: senses)]
 }
 
 func distributeExamplesToSenses(senses: [LookupSenseEntry], bulletParts: [String], sectionStart: String.Index, sectionEnd: String.Index, raw: String) -> [LookupSenseEntry] {
@@ -521,7 +520,7 @@ func parseEnglish(_ raw: String) -> LookupPresentation? {
     if definitions.isEmpty {
         let senses = extractSensesWithAntonyms(text, maxSenses: 3)
         if !senses.isEmpty {
-            definitions.append(LookupDefinitionEntry(partOfSpeech: "adjective", senses: senses))
+            definitions.append(LookupDefinitionEntry(partOfSpeech: nil, senses: senses))
         }
     }
 

--- a/test_pos_changes.swift
+++ b/test_pos_changes.swift
@@ -1,0 +1,139 @@
+#!/usr/bin/env swift
+// Test script to demonstrate POS label changes
+// Run with: swift test_pos_changes.swift
+
+import Foundation
+
+// MARK: - Test Data Models
+
+struct LookupPresentation {
+    let title: String
+    let partOfSpeech: String?
+    let definitions: [LookupDefinitionEntry]
+}
+
+struct LookupDefinitionEntry {
+    let partOfSpeech: String?
+    let senses: [LookupSenseEntry]
+}
+
+struct LookupSenseEntry {
+    let number: Int
+    let definition: String
+}
+
+// MARK: - Mock Parser Functions
+
+func parseVietnameseWithPOS(_ raw: String) -> LookupPresentation? {
+    // Simulates: parseVietnamese with explicit POS sections
+    // Example: "hello | hello | danh từ 1 greeting"
+    let parts = raw.components(separatedBy: " | ")
+    guard parts.count >= 3 else { return nil }
+
+    let title = parts[0]
+    let text = parts[2]
+
+    // Check for POS keywords
+    let posKeywords = ["danh từ", "động từ", "tính từ", "trạng từ"]
+    for pos in posKeywords {
+        if text.lowercased().contains(pos) {
+            let sense = LookupSenseEntry(number: 1, definition: "Definition with POS")
+            return LookupPresentation(
+                title: title,
+                partOfSpeech: pos,
+                definitions: [LookupDefinitionEntry(partOfSpeech: pos, senses: [sense])]
+            )
+        }
+    }
+
+    return nil
+}
+
+func parseVietnameseNoPOS(_ raw: String) -> LookupPresentation? {
+    // Simulates: parseVietnameseNoPOS (no explicit POS keywords)
+    // Example: "hello | hello | 1 greeting ▸ example"
+    let parts = raw.components(separatedBy: " | ")
+    guard parts.count >= 3 else { return nil }
+
+    let title = parts[0]
+    let text = parts[2]
+
+    // Extract sense (number + definition)
+    let sense = LookupSenseEntry(number: 1, definition: text)
+
+    // OLD behavior (commented out): would default to "adjective"
+    // return LookupPresentation(
+    //     title: title,
+    //     partOfSpeech: "adjective",
+    //     definitions: [LookupDefinitionEntry(partOfSpeech: "adjective", senses: [sense])]
+    // )
+
+    // NEW behavior: partOfSpeech is nil
+    return LookupPresentation(
+        title: title,
+        partOfSpeech: nil,
+        definitions: [LookupDefinitionEntry(partOfSpeech: nil, senses: [sense])]
+    )
+}
+
+// MARK: - Test Cases
+
+func runTests() {
+    print("=== Testing POS Label Changes ===\n")
+
+    // Test Case 1: Vietnamese entry WITH explicit POS keyword
+    print("Test 1: Vietnamese entry WITH explicit POS keyword")
+    print("Input: \"xin chào | xin chào | danh từ 1 greeting\"")
+    if let result = parseVietnameseWithPOS("xin chào | xin chào | danh từ 1 greeting") {
+        print("[OK] Parsed successfully")
+        print("   Title: \(result.title)")
+        print("   Main POS: \(result.partOfSpeech ?? "nil (no label)")")
+        print("   Entry POS: \(result.definitions.first?.partOfSpeech ?? "nil (no label)")")
+        print("   POS label WILL be displayed\n")
+    } else {
+        print("[FAIL] Failed to parse\n")
+    }
+
+    // Test Case 2: Vietnamese entry WITHOUT explicit POS keyword
+    print("Test 2: Vietnamese entry WITHOUT explicit POS keyword")
+    print("Input: \"tốt | tốt | 1 good ▸ very good example\"")
+    if let result = parseVietnameseNoPOS("tốt | tốt | 1 good ▸ very good example") {
+        print("[OK] Parsed successfully")
+        print("   Title: \(result.title)")
+        print("   Main POS: \(result.partOfSpeech ?? "nil (no label)")")
+        print("   Entry POS: \(result.definitions.first?.partOfSpeech ?? "nil (no label)")")
+        print("   POS label will NOT be displayed (previously showed \"adjective\")\n")
+    } else {
+        print("[FAIL] Failed to parse\n")
+    }
+
+    // Test Case 3: Multiple definitions
+    print("Test 3: Multiple definitions - some with POS, some without")
+    print("Input: Mixed case simulation")
+
+    let withPOS = LookupDefinitionEntry(partOfSpeech: "danh từ", senses: [LookupSenseEntry(number: 1, definition: "noun meaning")])
+    let withoutPOS = LookupDefinitionEntry(partOfSpeech: nil, senses: [LookupSenseEntry(number: 2, definition: "unknown POS meaning")])
+
+    let mixedResult = LookupPresentation(
+        title: "test",
+        partOfSpeech: "danh từ",
+        definitions: [withPOS, withoutPOS]
+    )
+
+    print("[OK] Parsed successfully")
+    print("   Title: \(mixedResult.title)")
+    print("   Definitions count: \(mixedResult.definitions.count)")
+    for (idx, def) in mixedResult.definitions.enumerated() {
+        print("   Definition \(idx + 1) POS: \(def.partOfSpeech ?? "nil (no label)")")
+    }
+    print("   First shows POS label, second does not\n")
+
+    print("=== Summary ===")
+    print("Before: Entries without POS keywords defaulted to showing \"adjective\"")
+    print("After:  Entries without POS keywords show no POS label at all")
+    print("\nThe lookup RESULTS (definitions/examples) are unchanged.")
+    print("Only the POS label display behavior changed.")
+}
+
+// Run the tests
+runTests()


### PR DESCRIPTION
## Summary

- Now no sense words, we treat it as adj (name only) -> change to nil

## TODO

- Need to confirm any affect

## Changes

- adj -> nil

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [ ] `cd apps/macos/LauncherApp && swift test`
- [ ] `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered
