### PR TITLE
Fix: Setting apps related issue

### DIFF
--- a/core/engine/src/lib.rs
+++ b/core/engine/src/lib.rs
@@ -411,4 +411,56 @@ mod tests {
         assert!(!results.is_empty());
         assert_eq!(results[0].0.id, "file.repo.readme");
     }
+
+    #[test]
+    fn ambiguous_query_ingo_prefers_relevant_file_over_settings_alias_noise() {
+        let mut settings = Candidate::new(
+            "setting:network",
+            CandidateKind::App,
+            "Network",
+            "x-apple.systempreferences:com.apple.preference.network",
+        );
+        settings.subtitle = Some(
+            "System Settings settings network ethernet dns proxy vpn notifications".to_string(),
+        );
+
+        let file = Candidate::new(
+            "file.concurrency",
+            CandidateKind::File,
+            "Concurrency in Go.pdf",
+            "/Users/test/Documents/books/Concurrency in Go.pdf",
+        );
+
+        let engine = QueryEngine::new(vec![settings, file]);
+        let results = engine.search_scored("ingo", 10);
+        assert_eq!(
+            results.first().map(|(candidate, _)| candidate.id.as_str()),
+            Some("file.concurrency")
+        );
+    }
+
+    #[test]
+    fn settings_prefix_query_sett_prioritizes_system_settings_entry() {
+        let mut settings_app = Candidate::new(
+            "setting:general",
+            CandidateKind::App,
+            "General",
+            "x-apple.systempreferences:com.apple.preference.general",
+        );
+        settings_app.subtitle = Some("System Settings settings general".to_string());
+
+        let settings_folder = Candidate::new(
+            "folder.settings",
+            CandidateKind::Folder,
+            "settings",
+            "/Users/test/Documents/settings",
+        );
+
+        let engine = QueryEngine::new(vec![settings_folder, settings_app]);
+        let results = engine.search_scored("sett", 10);
+        assert_eq!(
+            results.first().map(|(candidate, _)| candidate.id.as_str()),
+            Some("setting:general")
+        );
+    }
 }

--- a/core/engine/src/scoring.rs
+++ b/core/engine/src/scoring.rs
@@ -4,7 +4,15 @@ use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 
 const SETTINGS_SUBTITLE_PREFIX: &str = "System Settings";
-const USE_COUNT_WEIGHT: u64 = 35;
+const SETTINGS_PATH_PREFIX: &str = "x-apple.systempreferences:";
+const BROWSE_USAGE_LOG_SCALE: f64 = 60.0;
+
+const RECENT_LAST_HOUR_BOOST: i64 = 140;
+const RECENT_TODAY_BOOST: i64 = 90;
+const RECENT_THIS_WEEK_BOOST: i64 = 40;
+const RECENT_THIS_MONTH_BOOST: i64 = 12;
+
+const SETTINGS_ON_NON_SETTINGS_QUERY_PENALTY: i64 = -180;
 
 pub(crate) fn contains_match_score(
     query: &str,
@@ -80,9 +88,7 @@ pub(crate) fn kind_bias(candidate: &Candidate) -> i64 {
 }
 
 pub(crate) fn query_kind_penalty(query: &str, candidate: &Candidate) -> i64 {
-    let looks_like_settings_query = QUERY_SETTINGS_HINTS
-        .iter()
-        .any(|token| query.contains(token));
+    let looks_like_settings_query = looks_like_settings_query(query);
 
     if looks_like_settings_query {
         match candidate.kind {
@@ -100,9 +106,32 @@ pub(crate) fn query_kind_penalty(query: &str, candidate: &Candidate) -> i64 {
             }
             CandidateKind::Folder | CandidateKind::File => BIAS_NON_APP_ON_SETTINGS_QUERY,
         }
+    } else if is_system_settings_candidate(candidate) {
+        SETTINGS_ON_NON_SETTINGS_QUERY_PENALTY
     } else {
         0
     }
+}
+
+pub(crate) fn looks_like_settings_query(query: &str) -> bool {
+    query.split_whitespace().any(|term| {
+        if term.is_empty() {
+            return false;
+        }
+
+        QUERY_SETTINGS_HINTS
+            .iter()
+            .any(|hint| term.contains(hint) || (term.len() >= 3 && hint.starts_with(term)))
+    })
+}
+
+pub(crate) fn is_system_settings_candidate(candidate: &Candidate) -> bool {
+    candidate.path.starts_with(SETTINGS_PATH_PREFIX)
+        || candidate
+            .subtitle
+            .as_deref()
+            .unwrap_or("")
+            .contains(SETTINGS_SUBTITLE_PREFIX)
 }
 
 pub(crate) fn path_depth_penalty(candidate: &Candidate) -> i64 {
@@ -126,18 +155,27 @@ pub(crate) fn default_browse_score(candidate: &Candidate, now_unix_s: i64) -> i6
         CandidateKind::File => 0,
     };
 
-    let frequency_u64 = candidate.use_count.saturating_mul(USE_COUNT_WEIGHT);
-    let frequency = frequency_u64.min(i64::MAX as u64) as i64;
+    let frequency = ((candidate.use_count as f64 + 1.0).log2() * BROWSE_USAGE_LOG_SCALE) as i64;
     let recency = candidate
         .last_used_at_unix_s
         .map(|last| {
             let age_s = (now_unix_s - last).max(0);
             let age_hours = age_s / 3600;
-            (2000 - (age_hours * 8)).max(0)
+            browse_recency_boost(age_hours)
         })
         .unwrap_or(0);
 
     kind_boost + frequency + recency
+}
+
+fn browse_recency_boost(age_hours: i64) -> i64 {
+    match age_hours {
+        0 => RECENT_LAST_HOUR_BOOST,
+        1..=24 => RECENT_TODAY_BOOST - ((age_hours - 1) / 4),
+        25..=168 => RECENT_THIS_WEEK_BOOST - ((age_hours - 25) / 12),
+        169..=720 => RECENT_THIS_MONTH_BOOST - ((age_hours - 169) / 72),
+        _ => 0,
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -377,5 +415,50 @@ mod tests {
 
         assert!(settings_score > app_score);
         assert!(app_score > folder_score);
+    }
+
+    #[test]
+    fn query_kind_penalty_demotes_settings_for_non_settings_queries() {
+        let settings_app = Candidate {
+            id: "setting:network".to_string(),
+            kind: CandidateKind::App,
+            title: "Network".to_string(),
+            subtitle: Some("System Settings network".to_string()),
+            path: "x-apple.systempreferences:com.apple.preference.network".to_string(),
+            use_count: 0,
+            last_used_at_unix_s: None,
+        };
+
+        assert!(query_kind_penalty("ingo", &settings_app) < 0);
+    }
+
+    #[test]
+    fn looks_like_settings_query_accepts_short_prefixes() {
+        assert!(looks_like_settings_query("sett"));
+        assert!(looks_like_settings_query("priv"));
+        assert!(!looks_like_settings_query("ingo"));
+    }
+
+    #[test]
+    fn default_browse_score_recency_tiers_prefer_more_recent_candidates() {
+        let now = 1_775_462_400;
+        let mut candidate = app("Recent", "/Applications/Recent.app");
+        candidate.use_count = 1;
+
+        let mut last_hour = candidate.clone();
+        last_hour.last_used_at_unix_s = Some(now - 10 * 60);
+
+        let mut today = candidate.clone();
+        today.last_used_at_unix_s = Some(now - 6 * 3600);
+
+        let mut week = candidate.clone();
+        week.last_used_at_unix_s = Some(now - 3 * 24 * 3600);
+
+        let mut old = candidate;
+        old.last_used_at_unix_s = Some(now - 60 * 24 * 3600);
+
+        assert!(default_browse_score(&last_hour, now) > default_browse_score(&today, now));
+        assert!(default_browse_score(&today, now) > default_browse_score(&week, now));
+        assert!(default_browse_score(&week, now) > default_browse_score(&old, now));
     }
 }

--- a/core/engine/src/search.rs
+++ b/core/engine/src/search.rs
@@ -3,8 +3,8 @@ use crate::config::*;
 use crate::query::ParsedQuery;
 use crate::scoring::{
     ScoredMatch, contains_match_score, default_browse_score, finalize_top_k,
-    finalize_top_k_with_search, kind_bias, path_depth_penalty, path_match_score, push_top_k,
-    query_kind_penalty,
+    finalize_top_k_with_search, is_system_settings_candidate, kind_bias, looks_like_settings_query,
+    path_depth_penalty, path_match_score, push_top_k, query_kind_penalty,
 };
 use look_indexing::{Candidate, CandidateKind};
 use look_matching::{fuzzy_quality_bonus_prepared, fuzzy_score_prepared, prepare_query};
@@ -128,6 +128,7 @@ impl QueryEngine {
         let prepared_query = prepare_query(normalized_query);
         let mut top = BinaryHeap::new();
         let has_path_hint = normalized_query.contains('/');
+        let settings_query = looks_like_settings_query(normalized_query);
         let pool_limit = (limit.saturating_mul(RERANK_POOL_MULTIPLIER)).max(RERANK_TOP_N);
 
         for candidate in self
@@ -138,7 +139,12 @@ impl QueryEngine {
             // Use precomputed normalized strings from IndexedCandidate.
             // This avoids normalize_for_search allocations in the hot loop.
             let title_score = fuzzy_score_prepared(&prepared_query, &candidate.title_search);
-            let subtitle_search = candidate.subtitle_search.as_deref();
+            let subtitle_search =
+                if !settings_query && is_system_settings_candidate(&candidate.candidate) {
+                    None
+                } else {
+                    candidate.subtitle_search.as_deref()
+                };
             let subtitle_score = subtitle_search
                 .as_ref()
                 .and_then(|subtitle| fuzzy_score_prepared(&prepared_query, subtitle))


### PR DESCRIPTION
## Summary

Improve matching with settings unrelated queries
Update score system based on time boost

## Why

For instance: When I search "ingo", I don't want any settings related results, but the current search & match behaves in this way 

## Changes

Change scoring system, and add settings detection helper 

## Testing

- [x] `cargo check --workspace --manifest-path core/Cargo.toml`
- [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [x] `cd apps/macos/LauncherApp && swift test`
- [x] `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered
