### PR TITLE
Fix: Improve UI experience, fix small bugs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,15 +20,15 @@ repos:
   - repo: local
     hooks:
       - id: cargo-fmt-core
-        name: cargo fmt (core workspace)
-        entry: cargo fmt --manifest-path core/Cargo.toml --all -- --check
+        name: cargo fmt (core workspace, auto-fix)
+        entry: cargo fmt --manifest-path core/Cargo.toml --all
         language: system
         pass_filenames: false
         types: [rust]
 
       - id: cargo-fmt-ffi
-        name: cargo fmt (ffi workspace)
-        entry: cargo fmt --manifest-path bridge/ffi/Cargo.toml --all -- --check
+        name: cargo fmt (ffi workspace, auto-fix)
+        entry: cargo fmt --manifest-path bridge/ffi/Cargo.toml --all
         language: system
         pass_filenames: false
         types: [rust]

--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ Indexing config supports include roots plus exclude rules for both apps and file
 - `a"` / `f"` / `d"` / `r"`: apps/files/folders/regex scoped query prefix
 - `c"`: clipboard history scoped query prefix
 - `Cmd+Shift+,`: open/close settings panel
-- `Cmd+Shift+;`: reload `.look.config`
+- `Cmd+Shift+;`: reload `.look.config` after manual file edits
+- `Escape` (while settings open): close settings panel
 - `Cmd+-`, `Cmd+=`, `Cmd+0`: temporary UI zoom out/in/reset
 
 ## Installation

--- a/apps/macos/LauncherApp/LauncherLogicTests/BridgeErrorMappingTests.swift
+++ b/apps/macos/LauncherApp/LauncherLogicTests/BridgeErrorMappingTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import LauncherLogic
+
+final class BridgeErrorMappingTests: XCTestCase {
+    func testKnownUsageErrorCodeMapsToFriendlyMessage() {
+        let message = BridgeErrorMapping.userFacingMessage(
+            code: BridgeErrorCode.invalidUsageAction.rawValue,
+            fallback: "internal"
+        )
+        XCTAssertEqual(message, "This item could not be tracked.")
+    }
+
+    func testKnownTranslateInputErrorMapsToFriendlyMessage() {
+        let message = BridgeErrorMapping.userFacingMessage(
+            code: BridgeErrorCode.emptyText.rawValue,
+            fallback: "internal"
+        )
+        XCTAssertEqual(message, "Type some text to continue.")
+    }
+
+    func testUnknownCodeFallsBackToProvidedMessage() {
+        let message = BridgeErrorMapping.userFacingMessage(
+            code: "totally_unknown_code",
+            fallback: "Keep this fallback"
+        )
+        XCTAssertEqual(message, "Keep this fallback")
+    }
+}

--- a/apps/macos/LauncherApp/Package.swift
+++ b/apps/macos/LauncherApp/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
                 "Support/HintText.swift",
                 "Support/AppConstants.swift",
                 "Support/LauncherSearchLogic.swift",
+                "Support/BridgeErrorMapping.swift",
                 "Models/LauncherResult.swift",
             ]
         ),

--- a/apps/macos/LauncherApp/look-app.xcodeproj/project.pbxproj
+++ b/apps/macos/LauncherApp/look-app.xcodeproj/project.pbxproj
@@ -281,6 +281,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Look;
 				INFOPLIST_KEY_CFBundleIconFile = AppIcon;
+				INFOPLIST_KEY_LSMultipleInstancesProhibited = YES;
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				OTHER_LDFLAGS = (
@@ -319,6 +320,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Look;
 				INFOPLIST_KEY_CFBundleIconFile = AppIcon;
+				INFOPLIST_KEY_LSMultipleInstancesProhibited = YES;
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				OTHER_LDFLAGS = (

--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -95,7 +95,7 @@ enum AppConstants {
     }
 
     enum ThemeUI {
-        static let labelWidth: CGFloat = 110
+        static let labelWidth: CGFloat = 150
         static let pickerWidth: CGFloat = 140
     }
 }

--- a/apps/macos/LauncherApp/look-app/Support/AppDelegate.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppDelegate.swift
@@ -2,7 +2,35 @@ import AppKit
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
+        if shouldTerminateDuplicateInstance() {
+            NSApp.terminate(nil)
+            return
+        }
+
         NSApp.setActivationPolicy(.accessory)
+    }
+
+    private func shouldTerminateDuplicateInstance() -> Bool {
+        guard let bundleIdentifier = Bundle.main.bundleIdentifier else {
+            return false
+        }
+
+        let currentPID = ProcessInfo.processInfo.processIdentifier
+        let runningApps = NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier)
+        guard runningApps.count > 1 else {
+            return false
+        }
+
+        guard let primaryApp = runningApps.min(by: { $0.processIdentifier < $1.processIdentifier }) else {
+            return false
+        }
+
+        guard primaryApp.processIdentifier != currentPID else {
+            return false
+        }
+
+        primaryApp.activate(options: [.activateAllWindows])
+        return true
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {

--- a/apps/macos/LauncherApp/look-app/Support/BridgeErrorMapping.swift
+++ b/apps/macos/LauncherApp/look-app/Support/BridgeErrorMapping.swift
@@ -1,0 +1,44 @@
+enum BridgeErrorCode: String {
+    case emptyText = "empty_text"
+    case invalidInput = "invalid_input"
+    case invalidCandidateID = "invalid_candidate_id"
+    case invalidUsageAction = "invalid_usage_action"
+    case storageOpenFailed = "storage_open_failed"
+    case recordUsageFailed = "record_usage_failed"
+    case ffiNullResponse = "ffi_null_response"
+    case decodeFailed = "decode_failed"
+    case invalidTargetLang = "invalid_target_lang"
+    case translateRequestFailed = "translate_request_failed"
+    case translateExecFailed = "translate_exec_failed"
+    case translateParseFailed = "translate_parse_failed"
+    case translateDecodeFailed = "translate_decode_failed"
+    case translateEmptyResult = "translate_empty_result"
+    case serializeFailed = "serialize_failed"
+}
+
+enum BridgeErrorMapping {
+    static func userFacingMessage(code: String, fallback: String) -> String {
+        guard let code = BridgeErrorCode(rawValue: code) else {
+            return fallback
+        }
+
+        switch code {
+        case .emptyText:
+            return "Type some text to continue."
+        case .invalidInput, .invalidCandidateID, .invalidUsageAction:
+            return "This item could not be tracked."
+        case .storageOpenFailed, .recordUsageFailed:
+            return "Usage tracking is temporarily unavailable."
+        case .ffiNullResponse, .decodeFailed:
+            return "Backend response was invalid."
+        case .invalidTargetLang:
+            return "Language selection is not supported."
+        case .translateRequestFailed, .translateExecFailed:
+            return "Translation service is temporarily unavailable."
+        case .translateParseFailed, .translateDecodeFailed, .translateEmptyResult:
+            return "Could not read translation response."
+        case .serializeFailed:
+            return "Backend response was invalid."
+        }
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/EngineBridge.swift
+++ b/apps/macos/LauncherApp/look-app/Support/EngineBridge.swift
@@ -8,9 +8,9 @@ private func look_search_json(_ query: UnsafePointer<CChar>?, _ limit: UInt32) -
 nonisolated
 private func look_search_json_compact(_ query: UnsafePointer<CChar>?, _ limit: UInt32) -> UnsafeMutablePointer<CChar>?
 
-@_silgen_name("look_record_usage")
+@_silgen_name("look_record_usage_json")
 nonisolated
-private func look_record_usage(_ candidateID: UnsafePointer<CChar>?, _ action: UnsafePointer<CChar>?) -> Bool
+private func look_record_usage_json(_ candidateID: UnsafePointer<CChar>?, _ action: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
 
 @_silgen_name("look_free_cstring")
 nonisolated
@@ -48,6 +48,9 @@ final class EngineBridge {
         }
 
         if let compactPayload = try? JSONDecoder().decode(CompactSearchPayload.self, from: data) {
+            if compactPayload.error != nil {
+                return fallbackResults()
+            }
             return compactPayload.results.map { item in
                 LauncherResult(
                     id: item.id,
@@ -79,12 +82,29 @@ final class EngineBridge {
         }
     }
 
-    nonisolated func recordUsage(candidateID: String, action: String) {
-        _ = candidateID.withCString { idCstr in
+    nonisolated func recordUsage(candidateID: String, action: String) -> BridgeError? {
+        let ptr = candidateID.withCString { idCstr in
             action.withCString { actionCstr in
-                look_record_usage(idCstr, actionCstr)
+                look_record_usage_json(idCstr, actionCstr)
             }
         }
+
+        guard let ptr else {
+            return BridgeError(code: "ffi_null_response", message: "Usage tracking is temporarily unavailable")
+        }
+
+        defer {
+            look_free_cstring(ptr)
+        }
+
+        let raw = String(cString: ptr)
+        guard let data = raw.data(using: .utf8),
+            let payload = try? JSONDecoder().decode(UsageRecordPayload.self, from: data)
+        else {
+            return BridgeError(code: "decode_failed", message: "Usage tracking response could not be decoded")
+        }
+
+        return payload.error
     }
 
     nonisolated func reloadConfig() -> Bool {
@@ -135,11 +155,21 @@ private nonisolated struct SearchPayload: Decodable {
 private nonisolated struct CompactSearchPayload: Decodable {
     let count: Int
     let results: [SearchItem]
+    let error: BridgeError?
+}
+
+private nonisolated struct UsageRecordPayload: Decodable {
+    let ok: Bool
+    let error: BridgeError?
 }
 
 nonisolated struct BridgeError: Decodable {
     let code: String
     let message: String
+
+    var userFacingMessage: String {
+        BridgeErrorMapping.userFacingMessage(code: code, fallback: message)
+    }
 }
 
 private nonisolated struct SearchItem: Decodable {

--- a/apps/macos/LauncherApp/look-app/Support/HintText.swift
+++ b/apps/macos/LauncherApp/look-app/Support/HintText.swift
@@ -9,7 +9,7 @@ enum HintText {
     }
 
     enum Settings {
-        static let advancedApply = "Save Config, then press Cmd+Shift+; to apply backend indexing changes."
+        static let advancedApply = "Save Config applies changes immediately. Cmd+Shift+; is only needed after editing .look.config manually."
         static let shortcutsTips = "Tips: t\"word for web EN/VI/JA translation | tw\"word for dictionary lookup panel | /kill to force quit apps"
     }
 }

--- a/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
@@ -420,7 +420,23 @@ final class ThemeStore: ObservableObject {
         if trimmed.isEmpty {
             return ""
         }
-        return URL(fileURLWithPath: trimmed).standardizedFileURL.path
+        let expanded = expandConfigLikePath(trimmed)
+        return URL(fileURLWithPath: expanded).standardizedFileURL.path
+    }
+
+    private func expandConfigLikePath(_ value: String) -> String {
+        let home = NSHomeDirectory()
+        if value == "~" {
+            return home
+        }
+        if value.hasPrefix("~/") {
+            let relative = value.dropFirst(2)
+            return home + "/" + relative
+        }
+        if value.hasPrefix("/") {
+            return value
+        }
+        return home + "/" + value
     }
 
     private func resolveUsableFontName(_ input: String) -> String? {

--- a/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
@@ -20,6 +20,8 @@ final class ThemeStore: ObservableObject {
         }
     }
 
+    @Published private(set) var excludedFolderPaths: [String] = []
+
     private let defaultsKey = "look.theme.settings"
     private var scopedBackgroundURL: URL?
 
@@ -85,6 +87,7 @@ final class ThemeStore: ObservableObject {
         upsertConfigLine(&lines, key: "ui_border_opacity", value: String(format: "%.2f", settings.borderOpacity))
         upsertConfigLine(&lines, key: "file_scan_depth", value: String(settings.fileScanDepth))
         upsertConfigLine(&lines, key: "file_scan_limit", value: String(settings.fileScanLimit))
+        upsertConfigLine(&lines, key: "file_exclude_paths", value: excludedFolderPaths.joined(separator: ","))
         upsertConfigLine(&lines, key: "backend_log_level", value: settings.backendLogLevel.rawValue)
         upsertConfigLine(&lines, key: "launch_at_login", value: settings.launchAtLogin ? "true" : "false")
 
@@ -169,6 +172,23 @@ final class ThemeStore: ObservableObject {
         settings.backgroundImageBookmark = bookmark
     }
 
+    func addExcludedFolderPath(url: URL) {
+        let normalizedPath = normalizeExcludedFolderPath(url.path)
+        guard !normalizedPath.isEmpty else {
+            return
+        }
+        if excludedFolderPaths.contains(normalizedPath) {
+            return
+        }
+        excludedFolderPaths.append(normalizedPath)
+        excludedFolderPaths.sort { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+    }
+
+    func removeExcludedFolderPath(_ path: String) {
+        let normalizedPath = normalizeExcludedFolderPath(path)
+        excludedFolderPaths.removeAll { $0 == normalizedPath }
+    }
+
     deinit {
         scopedBackgroundURL?.stopAccessingSecurityScopedResource()
     }
@@ -182,6 +202,8 @@ final class ThemeStore: ObservableObject {
         guard let raw = try? String(contentsOf: Self.configPath(), encoding: .utf8) else {
             return
         }
+
+        excludedFolderPaths = []
 
         for line in raw.split(whereSeparator: \ .isNewline) {
             let stripped = stripComment(String(line)).trimmingCharacters(in: .whitespacesAndNewlines)
@@ -273,6 +295,8 @@ final class ThemeStore: ObservableObject {
                 if let parsed = parsePositiveInt(value) {
                     settings.fileScanLimit = parsed
                 }
+            case "file_exclude_paths":
+                excludedFolderPaths = parseExcludedFolderPaths(value)
             case "backend_log_level":
                 if let parsed = parseBackendLogLevel(value) {
                     settings.backendLogLevel = parsed
@@ -377,6 +401,28 @@ final class ThemeStore: ObservableObject {
         lines.append("\(key)=\(value)")
     }
 
+    private func parseExcludedFolderPaths(_ value: String) -> [String] {
+        var seen = Set<String>()
+        var paths: [String] = []
+        for token in value.split(separator: ",") {
+            let normalized = normalizeExcludedFolderPath(String(token))
+            if normalized.isEmpty || seen.contains(normalized) {
+                continue
+            }
+            seen.insert(normalized)
+            paths.append(normalized)
+        }
+        return paths.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+    }
+
+    private func normalizeExcludedFolderPath(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            return ""
+        }
+        return URL(fileURLWithPath: trimmed).standardizedFileURL.path
+    }
+
     private func resolveUsableFontName(_ input: String) -> String? {
         if let exact = NSFont(name: input, size: 12) {
             return exact.fontName
@@ -427,7 +473,7 @@ file_scan_limit=8000
 file_exclude_paths=
 backend_log_level=error
 launch_at_login=true
-skip_dir_names=node_modules,target,build,dist,library,applications,old firefox data
+skip_dir_names=node_modules,target,build,dist,library,applications,old firefox data,deriveddata,pods,vendor,out,coverage,tmp,cache,venv
 
 # UI theme
 ui_tint_red=0.08

--- a/apps/macos/LauncherApp/look-app/Views/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/LauncherView.swift
@@ -596,19 +596,28 @@ struct LauncherView: View {
 
         switch selected.kind {
         case .app:
-            openTarget(selected.path)
-            bridge.recordUsage(candidateID: selected.id, action: "open_app")
-            hideLauncherWindow()
-        case .file:
-            openTarget(selected.path)
-            bridge.recordUsage(candidateID: selected.id, action: "open_file")
-            hideLauncherWindow()
-        case .folder:
-            openTarget(selected.path)
-            if !selected.id.hasPrefix(AppConstants.Launcher.QuickFolder.idPrefix) {
-                bridge.recordUsage(candidateID: selected.id, action: "open_folder")
+            if openTarget(selected.path) {
+                if let error = bridge.recordUsage(candidateID: selected.id, action: "open_app") {
+                    showBanner(error.userFacingMessage, style: .info, duration: 1.4)
+                }
+                hideLauncherWindow()
             }
-            hideLauncherWindow()
+        case .file:
+            if openTarget(selected.path) {
+                if let error = bridge.recordUsage(candidateID: selected.id, action: "open_file") {
+                    showBanner(error.userFacingMessage, style: .info, duration: 1.4)
+                }
+                hideLauncherWindow()
+            }
+        case .folder:
+            if openTarget(selected.path) {
+                if !selected.id.hasPrefix(AppConstants.Launcher.QuickFolder.idPrefix),
+                    let error = bridge.recordUsage(candidateID: selected.id, action: "open_folder")
+                {
+                    showBanner(error.userFacingMessage, style: .info, duration: 1.4)
+                }
+                hideLauncherWindow()
+            }
         case .clipboard:
             guard let content = selected.clipboardContent, !content.isEmpty else { return }
             NSPasteboard.general.clearContents()
@@ -621,15 +630,26 @@ struct LauncherView: View {
         }
     }
 
-    private func openTarget(_ target: String) {
+    @discardableResult
+    private func openTarget(_ target: String) -> Bool {
         if target.contains(":") && !target.hasPrefix("/") {
             if let url = URL(string: target) {
-                NSWorkspace.shared.open(url)
-                return
+                if NSWorkspace.shared.open(url) {
+                    return true
+                }
+                showBanner("Could not open this item right now", style: .error, duration: 1.2)
+                return false
             }
+            showBanner("Invalid target URL", style: .error, duration: 1.2)
+            return false
         }
 
-        NSWorkspace.shared.open(URL(fileURLWithPath: target))
+        if NSWorkspace.shared.open(URL(fileURLWithPath: target)) {
+            return true
+        }
+
+        showBanner("Could not open this path", style: .error, duration: 1.2)
+        return false
     }
 
     private func revealSelectedInFinder() {
@@ -1081,7 +1101,7 @@ struct LauncherView: View {
                     "en",
                     NetworkTranslationResult(
                         translated: (translated?.isEmpty == false) ? translated : nil,
-                        errorMessage: result?.error?.message
+                        errorMessage: result?.error?.userFacingMessage
                     )
                 )
             }
@@ -1092,7 +1112,7 @@ struct LauncherView: View {
                     "vi",
                     NetworkTranslationResult(
                         translated: (translated?.isEmpty == false) ? translated : nil,
-                        errorMessage: result?.error?.message
+                        errorMessage: result?.error?.userFacingMessage
                     )
                 )
             }
@@ -1103,7 +1123,7 @@ struct LauncherView: View {
                     "ja",
                     NetworkTranslationResult(
                         translated: (translated?.isEmpty == false) ? translated : nil,
-                        errorMessage: result?.error?.message
+                        errorMessage: result?.error?.userFacingMessage
                     )
                 )
             }

--- a/apps/macos/LauncherApp/look-app/Views/ThemeSettingsView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/ThemeSettingsView.swift
@@ -15,6 +15,8 @@ struct ThemeSettingsView: View {
     @State private var fontSuggestions: [String] = []
     @State private var showsFontSuggestions = false
     @State private var isPickingFontSuggestion = false
+    @State private var fileScanDepthInput = ""
+    @State private var fileScanLimitInput = ""
     @FocusState private var focusedField: Field?
 
     var body: some View {
@@ -34,8 +36,13 @@ struct ThemeSettingsView: View {
                 }
 
                 Button("Save Config") {
+                    applyFileScanDepthInput()
+                    applyFileScanLimitInput()
                     let ok = themeStore.saveCurrentConfigToFile()
                     saveMessage = ok ? "Saved" : "Save failed"
+                    if ok {
+                        NotificationCenter.default.post(name: .lookReloadConfigRequested, object: nil)
+                    }
                     DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) {
                         saveMessage = nil
                     }
@@ -48,7 +55,7 @@ struct ThemeSettingsView: View {
                     NotificationCenter.default.post(name: .lookRefocusInputRequested, object: nil)
                 }
                 .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
-                Text("Cmd+Shift+, to close")
+                Text("Esc or Cmd+Shift+, to close")
                     .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
                     .foregroundStyle(.secondary)
             }
@@ -70,6 +77,10 @@ struct ThemeSettingsView: View {
             }
             .frame(maxHeight: .infinity, alignment: .top)
 
+        }
+        .onExitCommand {
+            appUIState.showsThemeSettings = false
+            NotificationCenter.default.post(name: .lookRefocusInputRequested, object: nil)
         }
     }
 
@@ -324,12 +335,13 @@ struct ThemeSettingsView: View {
                             .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
                             .foregroundStyle(.secondary)
 
-                        Stepper(value: $settings.fileScanDepth, in: 1...12) {
-                            Text("\(settings.fileScanDepth)")
-                                .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
-                                .frame(width: 50, alignment: .leading)
-                        }
-                        .frame(width: 190, alignment: .leading)
+                        TextField("4", text: $fileScanDepthInput)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 80, alignment: .leading)
+                            .onChange(of: fileScanDepthInput) { _, value in
+                                fileScanDepthInput = sanitizedNumericInput(value)
+                            }
+                            .onSubmit { applyFileScanDepthInput() }
 
                         Text("How many directory levels to index")
                             .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 2), weight: .regular))
@@ -344,18 +356,64 @@ struct ThemeSettingsView: View {
                             .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
                             .foregroundStyle(.secondary)
 
-                        Stepper(value: $settings.fileScanLimit, in: 500...50000, step: 500) {
-                            Text("\(settings.fileScanLimit)")
-                                .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
-                                .frame(width: 70, alignment: .leading)
-                        }
-                        .frame(width: 220, alignment: .leading)
+                        TextField("8000", text: $fileScanLimitInput)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 100, alignment: .leading)
+                            .onChange(of: fileScanLimitInput) { _, value in
+                                fileScanLimitInput = sanitizedNumericInput(value)
+                            }
+                            .onSubmit { applyFileScanLimitInput() }
 
                         Text("Max files indexed per refresh")
                             .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 2), weight: .regular))
                             .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.64))
                             .lineLimit(1)
                             .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+
+                    HStack(alignment: .top, spacing: 10) {
+                        Text("Skip Folders")
+                            .frame(width: AppConstants.ThemeUI.labelWidth, alignment: .leading)
+                            .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
+                            .foregroundStyle(.secondary)
+
+                        VStack(alignment: .leading, spacing: 8) {
+                            Button("Add Folder") {
+                                selectExcludedFolderPath()
+                            }
+
+                            if themeStore.excludedFolderPaths.isEmpty {
+                                Text("No excluded folder paths yet")
+                                    .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 2), weight: .regular))
+                                    .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.64))
+                            } else {
+                                ScrollView(.horizontal) {
+                                    HStack(spacing: 8) {
+                                        ForEach(themeStore.excludedFolderPaths, id: \.self) { path in
+                                            HStack(spacing: 6) {
+                                                Text(path)
+                                                    .lineLimit(1)
+                                                Button {
+                                                    themeStore.removeExcludedFolderPath(path)
+                                                } label: {
+                                                    Image(systemName: "xmark")
+                                                        .font(.system(size: 10, weight: .semibold))
+                                                }
+                                                .buttonStyle(.plain)
+                                            }
+                                            .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 2), weight: .regular))
+                                            .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.78))
+                                            .padding(.horizontal, 9)
+                                            .padding(.vertical, 5)
+                                            .background(.white.opacity(0.12), in: Capsule())
+                                        }
+                                    }
+                                }
+                                .scrollIndicators(.hidden)
+                            }
+
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
                     }
 
                     Divider()
@@ -408,6 +466,13 @@ struct ThemeSettingsView: View {
                 }
             }
             .scrollIndicators(.hidden)
+            .onAppear { syncIndexingInputsFromSettings() }
+            .onChange(of: settings.fileScanDepth) { _, _ in
+                fileScanDepthInput = String(settings.fileScanDepth)
+            }
+            .onChange(of: settings.fileScanLimit) { _, _ in
+                fileScanLimitInput = String(settings.fileScanLimit)
+            }
 
             Spacer(minLength: 0)
 
@@ -446,6 +511,43 @@ struct ThemeSettingsView: View {
         if panel.runModal() == .OK {
             themeStore.setBackgroundImage(url: panel.url)
         }
+    }
+
+    private func selectExcludedFolderPath() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        if panel.runModal() == .OK, let url = panel.url {
+            themeStore.addExcludedFolderPath(url: url)
+        }
+    }
+
+    private func syncIndexingInputsFromSettings() {
+        fileScanDepthInput = String(settings.fileScanDepth)
+        fileScanLimitInput = String(settings.fileScanLimit)
+    }
+
+    private func sanitizedNumericInput(_ value: String) -> String {
+        String(value.filter(\.isNumber))
+    }
+
+    private func applyFileScanDepthInput() {
+        guard let parsed = Int(fileScanDepthInput), parsed > 0 else {
+            fileScanDepthInput = String(settings.fileScanDepth)
+            return
+        }
+        settings.fileScanDepth = min(max(1, parsed), 12)
+        fileScanDepthInput = String(settings.fileScanDepth)
+    }
+
+    private func applyFileScanLimitInput() {
+        guard let parsed = Int(fileScanLimitInput), parsed > 0 else {
+            fileScanLimitInput = String(settings.fileScanLimit)
+            return
+        }
+        settings.fileScanLimit = min(max(500, parsed), 50_000)
+        fileScanLimitInput = String(settings.fileScanLimit)
     }
 }
 
@@ -558,6 +660,11 @@ private struct LabeledSlider: View {
     @Binding var value: Double
     let range: ClosedRange<Double>
 
+    private var valueColumnWidth: CGFloat {
+        let scaledFontSize = CGFloat(themeStore.settings.fontSize) * themeStore.uiScale
+        return max(42, scaledFontSize * 2.3 + 14)
+    }
+
     var body: some View {
         HStack(spacing: 10) {
             Text(title)
@@ -569,7 +676,9 @@ private struct LabeledSlider: View {
                 .tint(themeStore.fontColor(opacityMultiplier: 0.92))
             Text(value, format: .number.precision(.fractionLength(2)))
                 .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular))
-                .frame(width: 42, alignment: .trailing)
+                .monospacedDigit()
+                .lineLimit(1)
+                .frame(width: valueColumnWidth, alignment: .trailing)
                 .foregroundStyle(.secondary)
         }
     }

--- a/bridge/ffi/src/lib.rs
+++ b/bridge/ffi/src/lib.rs
@@ -31,6 +31,14 @@ pub extern "C" fn look_record_usage(candidate_id: *const c_char, action: *const 
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn look_record_usage_json(
+    candidate_id: *const c_char,
+    action: *const c_char,
+) -> *mut c_char {
+    usage_api::look_record_usage_json_impl(candidate_id, action)
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn look_reload_config() -> bool {
     runtime_config::reload_runtime_config();
     let path = state::default_db_path();
@@ -137,8 +145,57 @@ mod tests {
         let action = CString::new("open").expect("action cstring");
         assert!(look_record_usage(id.as_ptr(), action.as_ptr()));
 
+        let usage_ptr = look_record_usage_json(id.as_ptr(), action.as_ptr());
+        assert!(!usage_ptr.is_null());
+        let usage_raw = unsafe { CStr::from_ptr(usage_ptr) }
+            .to_string_lossy()
+            .into_owned();
+        look_free_cstring(usage_ptr);
+        let usage_payload: serde_json::Value =
+            serde_json::from_str(&usage_raw).expect("valid usage payload");
+        assert_eq!(
+            usage_payload.get("ok").and_then(|v| v.as_bool()),
+            Some(true)
+        );
+
         let empty = CString::new("").expect("empty cstring");
         assert!(!look_record_usage(empty.as_ptr(), action.as_ptr()));
+        let invalid_ptr = look_record_usage_json(empty.as_ptr(), action.as_ptr());
+        assert!(!invalid_ptr.is_null());
+        let invalid_raw = unsafe { CStr::from_ptr(invalid_ptr) }
+            .to_string_lossy()
+            .into_owned();
+        look_free_cstring(invalid_ptr);
+        let invalid_payload: serde_json::Value =
+            serde_json::from_str(&invalid_raw).expect("valid invalid-usage payload");
+        assert_eq!(
+            invalid_payload.get("ok").and_then(|v| v.as_bool()),
+            Some(false)
+        );
+        assert!(
+            invalid_payload
+                .get("error")
+                .and_then(|e| e.get("code"))
+                .and_then(|v| v.as_str())
+                .is_some()
+        );
+
+        let bad_action = CString::new("not_a_usage_action").expect("bad action");
+        let bad_action_ptr = look_record_usage_json(id.as_ptr(), bad_action.as_ptr());
+        assert!(!bad_action_ptr.is_null());
+        let bad_action_raw = unsafe { CStr::from_ptr(bad_action_ptr) }
+            .to_string_lossy()
+            .into_owned();
+        look_free_cstring(bad_action_ptr);
+        let bad_action_payload: serde_json::Value =
+            serde_json::from_str(&bad_action_raw).expect("valid bad-action payload");
+        assert_eq!(
+            bad_action_payload
+                .get("error")
+                .and_then(|e| e.get("code"))
+                .and_then(|v| v.as_str()),
+            Some("invalid_usage_action")
+        );
 
         let loaded = SqliteStore::open(&db_path)
             .expect("reopen sqlite")
@@ -148,7 +205,7 @@ mod tests {
             .iter()
             .find(|candidate| candidate.id.as_ref() == "app:smoke.test")
             .expect("smoke candidate exists");
-        assert_eq!(updated.use_count, 1);
+        assert_eq!(updated.use_count, 2);
         assert!(updated.last_used_at_unix_s.is_some());
 
         let _ = fs::remove_file(&db_path);

--- a/bridge/ffi/src/search_api.rs
+++ b/bridge/ffi/src/search_api.rs
@@ -28,6 +28,8 @@ struct FfiSearchPayload<'a> {
 struct FfiCompactSearchPayload<'a> {
     count: usize,
     results: Vec<FfiCompactLaunchResult<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<FfiErrorPayload>,
 }
 
 #[derive(Serialize)]
@@ -44,6 +46,25 @@ struct FfiCompactLaunchResult<'a> {
 struct FfiErrorPayload {
     code: &'static str,
     message: String,
+}
+
+#[derive(Clone, Copy)]
+enum SearchError {
+    SerializeFailed,
+}
+
+impl SearchError {
+    fn code(self) -> &'static str {
+        match self {
+            Self::SerializeFailed => "serialize_failed",
+        }
+    }
+
+    fn message(self) -> &'static str {
+        match self {
+            Self::SerializeFailed => "Failed to serialize search results",
+        }
+    }
 }
 
 pub(crate) fn look_search_count_impl(query_len: u32) -> FfiSearchResult {
@@ -85,12 +106,16 @@ pub(crate) fn look_search_json_compact_impl(query: *const c_char, limit: u32) ->
     let payload = FfiCompactSearchPayload {
         count: result_count,
         results: compact_results,
+        error: None,
     };
 
     let json = serde_json::to_string(&payload)
-        .unwrap_or_else(|_| "{\"count\":0,\"results\":[]}".to_string());
+        .unwrap_or_else(|_| search_error_json_compact(SearchError::SerializeFailed));
     let cstring = CString::new(json).unwrap_or_else(|_| {
-        CString::new("{\"count\":0,\"results\":[]}").expect("valid static json")
+        CString::new(
+            "{\"count\":0,\"results\":[],\"error\":{\"code\":\"serialize_failed\",\"message\":\"Failed to serialize search results\"}}",
+        )
+            .expect("valid static json")
     });
     log_debug(&format!(
         "search_compact query_len={} limit={} count={} elapsed_ms={}",
@@ -132,20 +157,35 @@ fn serialize_full_payload(query: &str, results: Vec<look_engine::LaunchResult>) 
         error: None,
     };
 
-    let json = serde_json::to_string(&payload).unwrap_or_else(|_| {
-        serde_json::json!({
-            "query": query,
-            "count": 0,
-            "results": [],
-            "error": {
-                "code": "serialize_failed",
-                "message": "Failed to serialize search results"
-            }
-        })
-        .to_string()
-    });
+    let json = serde_json::to_string(&payload)
+        .unwrap_or_else(|_| search_error_json_full(query, SearchError::SerializeFailed));
 
     CString::new(json).unwrap_or_else(|_| {
         CString::new("{\"query\":\"\",\"count\":0,\"results\":[]}").expect("valid static json")
     })
+}
+
+fn search_error_json_full(query: &str, err: SearchError) -> String {
+    serde_json::json!({
+        "query": query,
+        "count": 0,
+        "results": [],
+        "error": {
+            "code": err.code(),
+            "message": err.message()
+        }
+    })
+    .to_string()
+}
+
+fn search_error_json_compact(err: SearchError) -> String {
+    serde_json::json!({
+        "count": 0,
+        "results": [],
+        "error": {
+            "code": err.code(),
+            "message": err.message()
+        }
+    })
+    .to_string()
 }

--- a/bridge/ffi/src/translate_api.rs
+++ b/bridge/ffi/src/translate_api.rs
@@ -20,21 +20,46 @@ const CURL_ARGS_PREFIX: [&str; 9] = [
     "--compressed",
 ];
 
-const ERROR_EMPTY_TEXT: &str = "empty_text";
-const ERROR_REQUEST_FAILED: &str = "translate_request_failed";
-const ERROR_DECODE_FAILED: &str = "translate_decode_failed";
-const ERROR_EXEC_FAILED: &str = "translate_exec_failed";
-const ERROR_PARSE_FAILED: &str = "translate_parse_failed";
-const ERROR_EMPTY_RESULT: &str = "translate_empty_result";
+#[derive(Clone, Copy)]
+enum TranslateError {
+    EmptyText,
+    InvalidTargetLang,
+    RequestFailed,
+    DecodeFailed,
+    ExecFailed,
+    ParseFailed,
+    EmptyResult,
+    SerializeFailed,
+}
 
-const MESSAGE_EMPTY_TEXT: &str = "Type text after t\" to translate";
-const MESSAGE_REQUEST_FAILED: &str = "Translation request failed";
-const MESSAGE_DECODE_FAILED: &str = "Translation response decode failed";
-const MESSAGE_EXEC_FAILED: &str = "Translation command execution failed";
-const MESSAGE_PARSE_FAILED: &str = "Translation response parse failed";
-const MESSAGE_EMPTY_RESULT: &str = "Translation returned empty result";
+impl TranslateError {
+    fn code(self) -> &'static str {
+        match self {
+            Self::EmptyText => "empty_text",
+            Self::InvalidTargetLang => "invalid_target_lang",
+            Self::RequestFailed => "translate_request_failed",
+            Self::DecodeFailed => "translate_decode_failed",
+            Self::ExecFailed => "translate_exec_failed",
+            Self::ParseFailed => "translate_parse_failed",
+            Self::EmptyResult => "translate_empty_result",
+            Self::SerializeFailed => "serialize_failed",
+        }
+    }
 
-const JSON_ERROR_FALLBACK: &str = "{\"error\":\"json error\"}";
+    fn message(self) -> &'static str {
+        match self {
+            Self::EmptyText => "Type text after t\" to translate",
+            Self::InvalidTargetLang => "Invalid target language code",
+            Self::RequestFailed => "Translation request failed",
+            Self::DecodeFailed => "Translation response decode failed",
+            Self::ExecFailed => "Translation command execution failed",
+            Self::ParseFailed => "Translation response parse failed",
+            Self::EmptyResult => "Translation returned empty result",
+            Self::SerializeFailed => "Failed to serialize translation response",
+        }
+    }
+}
+
 const JSON_TRANSLATE_ERROR_FALLBACK: &str = "{\"original\":\"\",\"translated\":\"\",\"error\":{\"code\":\"unknown\",\"message\":\"Unknown translation error\"}}";
 
 #[derive(serde::Deserialize)]
@@ -48,11 +73,11 @@ pub(crate) fn look_translate_json_impl(
     let target_lang = cstr_to_string(target_lang);
 
     if text.trim().is_empty() {
-        return translate_error_json(&text, ERROR_EMPTY_TEXT, MESSAGE_EMPTY_TEXT);
+        return translate_error_json(&text, TranslateError::EmptyText);
     }
 
     if !is_valid_lang_code(&target_lang) {
-        return translate_error_json(&text, "invalid_target_lang", "Invalid target language code");
+        return translate_error_json(&text, TranslateError::InvalidTargetLang);
     }
 
     let encoded_text = percent_encode(&text);
@@ -75,30 +100,30 @@ pub(crate) fn look_translate_json_impl(
     let body = match output {
         Ok(out) => {
             if !out.status.success() {
-                return translate_error_json(&text, ERROR_REQUEST_FAILED, MESSAGE_REQUEST_FAILED);
+                return translate_error_json(&text, TranslateError::RequestFailed);
             }
             match String::from_utf8(out.stdout) {
                 Ok(s) => s,
                 Err(_) => {
-                    return translate_error_json(&text, ERROR_DECODE_FAILED, MESSAGE_DECODE_FAILED);
+                    return translate_error_json(&text, TranslateError::DecodeFailed);
                 }
             }
         }
         Err(_) => {
-            return translate_error_json(&text, ERROR_EXEC_FAILED, MESSAGE_EXEC_FAILED);
+            return translate_error_json(&text, TranslateError::ExecFailed);
         }
     };
 
     let parsed: TranslateResponse = match serde_json::from_str(&body) {
         Ok(p) => p,
         Err(_) => {
-            return translate_error_json(&text, ERROR_PARSE_FAILED, MESSAGE_PARSE_FAILED);
+            return translate_error_json(&text, TranslateError::ParseFailed);
         }
     };
 
     let translated = parse_translate_response(&parsed.0);
     if translated.trim().is_empty() {
-        return translate_error_json(&text, ERROR_EMPTY_RESULT, MESSAGE_EMPTY_RESULT);
+        return translate_error_json(&text, TranslateError::EmptyResult);
     }
 
     let result = serde_json::json!({
@@ -107,24 +132,28 @@ pub(crate) fn look_translate_json_impl(
         "error": null
     });
 
-    let json = serde_json::to_string(&result).unwrap_or_else(|_| JSON_ERROR_FALLBACK.to_string());
+    let json = serde_json::to_string(&result)
+        .unwrap_or_else(|_| translate_error_string("", TranslateError::SerializeFailed));
     let cstring = CString::new(json).expect("valid json");
     store_json_allocation(cstring)
 }
 
-fn translate_error_json(text: &str, code: &'static str, message: &str) -> *mut c_char {
+fn translate_error_json(text: &str, err: TranslateError) -> *mut c_char {
+    let json = translate_error_string(text, err);
+    let cstring = CString::new(json).expect("valid json");
+    store_json_allocation(cstring)
+}
+
+fn translate_error_string(text: &str, err: TranslateError) -> String {
     let payload = serde_json::json!({
         "original": text,
         "translated": "",
         "error": {
-            "code": code,
-            "message": message,
+            "code": err.code(),
+            "message": err.message(),
         }
     });
-    let json = serde_json::to_string(&payload)
-        .unwrap_or_else(|_| JSON_TRANSLATE_ERROR_FALLBACK.to_string());
-    let cstring = CString::new(json).expect("valid json");
-    store_json_allocation(cstring)
+    serde_json::to_string(&payload).unwrap_or_else(|_| JSON_TRANSLATE_ERROR_FALLBACK.to_string())
 }
 
 fn parse_translate_response(value: &serde_json::Value) -> String {

--- a/bridge/ffi/src/usage_api.rs
+++ b/bridge/ffi/src/usage_api.rs
@@ -1,33 +1,113 @@
 use crate::runtime_config::{log_debug, log_error};
-use crate::state::{cstr_to_string, default_db_path, with_engine_mut};
+use crate::state::{cstr_to_string, default_db_path, store_json_allocation, with_engine_mut};
 use look_indexing::{CandidateIdKind, UsageAction};
 use look_storage::SqliteStore;
+use std::ffi::CString;
 use std::os::raw::c_char;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+#[derive(serde::Serialize)]
+struct UsageRecordPayload {
+    ok: bool,
+    error: Option<FfiErrorPayload>,
+}
+
+#[derive(serde::Serialize)]
+struct FfiErrorPayload {
+    code: &'static str,
+    message: String,
+}
+
+#[derive(Clone, Copy)]
+enum UsageRecordError {
+    InvalidInput,
+    InvalidCandidateId,
+    InvalidUsageAction,
+    StorageOpenFailed,
+    RecordUsageFailed,
+}
+
+impl UsageRecordError {
+    fn code(self) -> &'static str {
+        match self {
+            Self::InvalidInput => "invalid_input",
+            Self::InvalidCandidateId => "invalid_candidate_id",
+            Self::InvalidUsageAction => "invalid_usage_action",
+            Self::StorageOpenFailed => "storage_open_failed",
+            Self::RecordUsageFailed => "record_usage_failed",
+        }
+    }
+
+    fn message(self) -> &'static str {
+        match self {
+            Self::InvalidInput => "Candidate ID and usage action must be non-empty",
+            Self::InvalidCandidateId => "Candidate ID format is invalid for usage recording",
+            Self::InvalidUsageAction => "Usage action is invalid for usage recording",
+            Self::StorageOpenFailed => "Failed to open backend storage for usage recording",
+            Self::RecordUsageFailed => "Failed to persist usage event to backend storage",
+        }
+    }
+}
+
 pub(crate) fn look_record_usage_impl(candidate_id: *const c_char, action: *const c_char) -> bool {
+    validate_and_record_usage(candidate_id, action).is_ok()
+}
+
+pub(crate) fn look_record_usage_json_impl(
+    candidate_id: *const c_char,
+    action: *const c_char,
+) -> *mut c_char {
+    let payload = match validate_and_record_usage(candidate_id, action) {
+        Ok(()) => UsageRecordPayload {
+            ok: true,
+            error: None,
+        },
+        Err(err) => UsageRecordPayload {
+            ok: false,
+            error: Some(FfiErrorPayload {
+                code: err.code(),
+                message: err.message().to_string(),
+            }),
+        },
+    };
+
+    let json = serde_json::to_string(&payload)
+        .unwrap_or_else(|_| "{\"ok\":false,\"error\":{\"code\":\"serialize_failed\",\"message\":\"Failed to serialize usage response\"}}".to_string());
+    let cstring = CString::new(json).unwrap_or_else(|_| {
+        CString::new("{\"ok\":false,\"error\":{\"code\":\"serialize_failed\",\"message\":\"Failed to serialize usage response\"}}")
+            .expect("valid static json")
+    });
+    store_json_allocation(cstring)
+}
+
+fn validate_and_record_usage(
+    candidate_id: *const c_char,
+    action: *const c_char,
+) -> Result<(), UsageRecordError> {
     let candidate_id = cstr_to_string(candidate_id);
     let action = cstr_to_string(action);
 
     if candidate_id.trim().is_empty() || action.trim().is_empty() {
-        return false;
+        return Err(UsageRecordError::InvalidInput);
     }
 
     let trimmed_id = candidate_id.trim();
     let trimmed_action = action.trim();
 
-    if CandidateIdKind::from_candidate_id(trimmed_id).is_none()
-        || trimmed_action.parse::<UsageAction>().is_err()
-    {
+    if CandidateIdKind::from_candidate_id(trimmed_id).is_none() {
         log_error(&format!(
             "invalid usage record attempt: id={}, action={}",
             trimmed_id, trimmed_action
         ));
-        return false;
+        return Err(UsageRecordError::InvalidCandidateId);
+    }
+
+    if trimmed_action.parse::<UsageAction>().is_err() {
+        return Err(UsageRecordError::InvalidUsageAction);
     }
 
     let Ok(store) = SqliteStore::open(default_db_path()) else {
-        return false;
+        return Err(UsageRecordError::StorageOpenFailed);
     };
 
     let ok = store.record_usage_event(trimmed_id, trimmed_action).is_ok();
@@ -46,7 +126,8 @@ pub(crate) fn look_record_usage_impl(candidate_id: *const c_char, action: *const
         log_debug("record_usage success");
     } else {
         log_error("record_usage failed");
+        return Err(UsageRecordError::RecordUsageFailed);
     }
 
-    ok
+    Ok(())
 }

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -42,7 +42,7 @@ pub const QUERY_SETTINGS_HINTS: [&str; 6] = [
     "sound",
 ];
 
-pub const SKIP_DIR_NAMES: [&str; 7] = [
+pub const SKIP_DIR_NAMES: [&str; 15] = [
     "node_modules",
     "target",
     "build",
@@ -50,6 +50,14 @@ pub const SKIP_DIR_NAMES: [&str; 7] = [
     "library",
     "applications",
     "old firefox data",
+    "deriveddata",
+    "pods",
+    "vendor",
+    "out",
+    "coverage",
+    "tmp",
+    "cache",
+    "venv",
 ];
 
 #[derive(Clone, Debug)]
@@ -179,7 +187,15 @@ impl RuntimeConfig {
                         .map(|entry| entry.to_lowercase())
                         .collect::<Vec<_>>();
                     if !parsed.is_empty() {
-                        self.skip_dir_names = parsed;
+                        for entry in parsed {
+                            if !self
+                                .skip_dir_names
+                                .iter()
+                                .any(|existing| existing == &entry)
+                            {
+                                self.skip_dir_names.push(entry);
+                            }
+                        }
                     }
                 }
                 _ => {}
@@ -222,7 +238,7 @@ file_scan_roots=Desktop,Documents,Downloads\n\
 file_scan_depth=4\n\
 file_scan_limit=8000\n\
 file_exclude_paths=\n\
-skip_dir_names=node_modules,target,build,dist,library,applications,old firefox data\n\
+skip_dir_names=node_modules,target,build,dist,library,applications,old firefox data,deriveddata,pods,vendor,out,coverage,tmp,cache,venv\n\
 \n\
 # UI theme\n\
 ui_tint_red=0.08\n\
@@ -336,5 +352,32 @@ mod tests {
                 |root| root == &"/System/Library/CoreServices/Finder.app/Contents/Applications"
             )
         );
+    }
+
+    #[test]
+    fn skip_dir_names_from_config_are_appended_not_replaced() {
+        let tmp = std::env::temp_dir().join(format!(
+            "look-config-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time should be after epoch")
+                .as_nanos()
+        ));
+
+        std::fs::write(&tmp, "skip_dir_names=vendor\n").expect("should write temporary config");
+
+        let mut config = RuntimeConfig::default();
+        config.apply_from_file(&tmp);
+
+        assert!(
+            config
+                .skip_dir_names
+                .iter()
+                .any(|name| name == "node_modules")
+        );
+        assert!(config.skip_dir_names.iter().any(|name| name == "vendor"));
+
+        let _ = std::fs::remove_file(&tmp);
     }
 }

--- a/core/engine/src/index/files.rs
+++ b/core/engine/src/index/files.rs
@@ -27,13 +27,45 @@ fn walk_files(
     }
 
     let mut walker = WalkBuilder::new(path);
+    let root_path = path.to_string();
+    let exclude_paths = config.file_exclude_paths.clone();
+    let skip_dir_names = config.skip_dir_names.clone();
     walker
         .hidden(false)
         .git_ignore(false)
         .git_global(false)
         .git_exclude(false)
         .parents(false)
-        .max_depth(Some(config.file_scan_depth));
+        .max_depth(Some(config.file_scan_depth))
+        .filter_entry(move |entry| {
+            let path_buf = entry.path();
+            let Some(path_str) = path_buf.to_str() else {
+                return false;
+            };
+
+            if path_str != root_path && should_exclude_path(path_str, &exclude_paths) {
+                return false;
+            }
+
+            let Some(name) = path_buf.file_name().and_then(|value| value.to_str()) else {
+                return false;
+            };
+
+            if name.starts_with('.') {
+                return false;
+            }
+
+            if entry
+                .file_type()
+                .map(|file_type| file_type.is_dir())
+                .unwrap_or(false)
+                && (name.ends_with(".app") || should_skip_dir(name, &skip_dir_names))
+            {
+                return false;
+            }
+
+            true
+        });
 
     for entry in walker.build().flatten() {
         if *file_count >= config.file_scan_limit {
@@ -44,21 +76,14 @@ fn walk_files(
         let Some(path_str) = path_buf.to_str() else {
             continue;
         };
-        if path_str == path || should_exclude_path(path_str, &config.file_exclude_paths) {
+        if path_str == path {
             continue;
         }
 
         let Some(name) = path_buf.file_name().and_then(|s| s.to_str()) else {
             continue;
         };
-        if name.starts_with('.') {
-            continue;
-        }
-
         if path_buf.is_dir() {
-            if name.ends_with(".app") || should_skip_dir(name, &config.skip_dir_names) {
-                continue;
-            }
             let key = format!("{FOLDER_CANDIDATE_ID_PREFIX}{}", path_str.to_lowercase());
             let mut candidate = Candidate::new(&key, CandidateKind::Folder, name, path_str);
             candidate.subtitle = Some(CandidateKind::Folder.as_str().into());

--- a/core/engine/src/index/files.rs
+++ b/core/engine/src/index/files.rs
@@ -43,7 +43,11 @@ fn walk_files(
                 return false;
             };
 
-            if path_str != root_path && should_exclude_path(path_str, &exclude_paths) {
+            if path_str == root_path {
+                return true;
+            }
+
+            if should_exclude_path(path_str, &exclude_paths) {
                 return false;
             }
 

--- a/core/engine/src/index/settings.rs
+++ b/core/engine/src/index/settings.rs
@@ -110,3 +110,79 @@ pub fn discover_system_settings_entries(tx: mpsc::SyncSender<Candidate>) {
         let _ = tx.send(candidate);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use look_indexing::CandidateIdKind;
+    use std::collections::HashSet;
+
+    #[test]
+    fn curated_settings_catalog_has_valid_fields() {
+        let mut seen_bundle_ids = HashSet::new();
+        let mut seen_titles = HashSet::new();
+
+        for entry in SETTINGS_CATALOG {
+            assert!(!entry.title.trim().is_empty(), "title must be non-empty");
+            assert!(
+                seen_titles.insert(entry.title.to_ascii_lowercase()),
+                "duplicate title: {}",
+                entry.title
+            );
+
+            assert!(
+                !entry.bundle_id.trim().is_empty(),
+                "bundle_id must be non-empty"
+            );
+            assert!(
+                entry.bundle_id.starts_with("com.apple."),
+                "bundle_id should use com.apple.* namespace: {}",
+                entry.bundle_id
+            );
+            assert!(
+                entry
+                    .bundle_id
+                    .chars()
+                    .all(|ch| ch.is_ascii_alphanumeric() || ch == '.' || ch == '-' || ch == '_'),
+                "bundle_id has invalid chars: {}",
+                entry.bundle_id
+            );
+            assert!(
+                seen_bundle_ids.insert(entry.bundle_id.to_ascii_lowercase()),
+                "duplicate bundle_id: {}",
+                entry.bundle_id
+            );
+
+            assert!(
+                !entry.aliases.trim().is_empty(),
+                "aliases must be non-empty"
+            );
+            assert!(
+                entry.aliases.contains("settings"),
+                "aliases should include settings hint: {}",
+                entry.aliases
+            );
+        }
+    }
+
+    #[test]
+    fn discovery_outputs_valid_settings_candidates() {
+        let (tx, rx) = mpsc::sync_channel(64);
+        discover_system_settings_entries(tx);
+        let discovered: Vec<Candidate> = rx.into_iter().collect();
+
+        assert_eq!(discovered.len(), SETTINGS_CATALOG.len());
+
+        for candidate in discovered {
+            assert_eq!(candidate.kind, CandidateKind::App);
+            assert!(candidate.id.starts_with(CandidateIdKind::PREFIX_SETTING));
+            assert!(candidate.path.starts_with(SETTINGS_URL_SCHEME_PREFIX));
+            assert!(
+                candidate
+                    .subtitle
+                    .as_deref()
+                    .is_some_and(|s| s.starts_with(SETTINGS_SUBTITLE_PREFIX))
+            );
+        }
+    }
+}

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -12,15 +12,19 @@ Now:
 
 Next:
 
-- [x] add ffi-level smoke tests for `look_search_json` and `look_record_usage`
-- [x] add structured error mapping for UI feedback
-- [ ] route settings updates to backend persistence
+- [x] keep `.look.config` as canonical user settings source (no backend table migration for user-editable settings)
+- [x] finish open Milestone G reliability tasks (error model + user fallback messaging)
 
-Later:
+Recently completed (current optimization cycle):
 
-- [ ] add in-memory cache for top-N results
-- [ ] add result pagination/streaming for large result sets (optional)
-- [ ] Homebrew release packaging
+- [x] move hot-path candidate normalization to load-time precompute
+- [x] replace greedy fuzzy base matching with bounded DP scorer
+- [x] switch usage boost to logarithmic scaling
+- [x] tune settings/query disambiguation (`ingo` noise fix + `sett` prefix intent)
+- [x] add compact FFI search payload and switch UI bridge default to compact path
+- [x] stream indexing with bounded channels and chunked bootstrap upsert
+- [x] add stale candidate cleanup and usage-event retention policy
+- [x] migrate `Candidate` read-mostly text fields to `Box<str>`
 
 ## Milestone A: Storage foundation (SQLite)
 
@@ -45,6 +49,10 @@ Later:
 - [x] support exclude paths and hidden file policy (`app_exclude_paths`, `app_exclude_names`, `file_exclude_paths`)
 - [x] add startup full scan + snapshot upsert
 - [x] persist index snapshots to SQLite
+- [x] move indexing to streaming source pipeline with bounded channel backpressure
+- [x] add worker panic diagnostics for indexing threads
+- [x] switch file traversal to `ignore::WalkBuilder`
+- [x] add chunked bootstrap upsert path (no full discovery vector required)
 
 ## Milestone D: Bridge and app integration
 
@@ -54,7 +62,7 @@ Later:
 - [x] translate text via FFI (network-gated)
 - [x] command mode with `calc`, `shell`, `kill` commands
 - [x] command keyboard shortcuts (Cmd+/, Cmd+1/2/3, Tab, Esc hide, Cmd+Esc)
-- [ ] route settings updates to backend persistence
+- [x] keep settings persistence file-based via `.look.config` (user-portable, copyable config)
 - [x] add structured error mapping for UI feedback
 
 ## Milestone E: Ranking and safety
@@ -71,12 +79,23 @@ Later:
 - [ ] add in-memory cache for top-N results
 - [x] optimize startup path and background index scheduling
 - [x] add diagnostics/debug toggles for development
-- [ ] update docs and user guide for finalized behavior
+- [x] update docs and user guide for finalized behavior
+- [x] remove hot-loop normalization allocations via indexed candidate precompute
+- [x] reduce ranking-heap extra string allocations in rerank flow
+- [x] optimize FFI search payload size with compact endpoint
+
+## Milestone H: Data lifecycle and retention
+
+- [x] add candidate `indexed_at_unix_s` watermarking in SQLite
+- [x] delete stale candidates not refreshed in current index run
+- [x] clean legacy `NULL` indexed candidates during stale cleanup
+- [x] prune `usage_events` by age window (90 days)
+- [x] enforce max `usage_events` cap (50,000 rows)
 
 ## Milestone G: Reliability (errors, tests, logs)
 
-- [ ] add structured error model across engine/storage/ffi boundaries
-- [ ] add safe user-facing fallback messages for action failures
+- [x] complete phase-2 structured error model across engine/storage/ffi boundaries
+- [x] add safe user-facing fallback messages for action failures
 - [x] add unit tests for search scoring and empty-query top-picks behavior
 - [ ] add unit tests for curated settings catalog integrity (id/title/target validity)
 - [x] add storage tests for usage-event writes and candidate upsert semantics

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -151,7 +151,7 @@ This includes:
 
 If results look stale or missing after config/indexing changes:
 
-- press `Cmd+Shift+;` to reload config and refresh backend index
+- if you edited `~/.look.config` directly, press `Cmd+Shift+;` to reload config and refresh backend index
 - check `file_scan_roots`, `file_scan_depth`, and `file_scan_limit` in `~/.look.config`
 
 Path-style query is supported directly in normal search:
@@ -306,8 +306,11 @@ Troubleshooting first-run launch block (Gatekeeper):
 
 Other settings UX:
 
-- **Save Config** writes current UI values back into `~/.look.config`
+- **Save Config** writes current UI values back into `~/.look.config` and applies backend changes immediately
 - font name field supports installed-font suggestions in a dropdown
+- indexing depth/limit fields accept direct numeric typing (validated on submit/save)
+- Advanced -> Skip Folders uses exact folder paths with removable tags (x)
+- press `Escape` to close settings quickly
 
 Background image modes:
 
@@ -321,7 +324,7 @@ You can also configure backend indexing behavior with a user config file:
 - path: `~/.look.config`
 - optional override path: `LOOK_CONFIG_PATH=/path/to/custom.config`
 - first launch creates this file automatically with defaults if it does not exist
-- live reload: press `Cmd+Shift+;` after editing the file
+- live reload: press `Cmd+Shift+;` after editing the file directly
 
 Local dev run note (repository `make app-run`):
 
@@ -344,7 +347,7 @@ Backend indexing keys:
 - `translate_allow_network`: allow network translation requests (`true`/`false`); default: `false`
 - `backend_log_level`: backend log verbosity (`error`/`info`/`debug`); default: `error`
 - `launch_at_login`: auto-start look after user sign-in (`true`/`false`); default: `true`
-- `skip_dir_names`: comma-separated directory names to ignore during file scan (case-insensitive); default: `node_modules,target,build,dist,library,applications,old firefox data`
+- `skip_dir_names`: comma-separated directory names to ignore during file scan (case-insensitive); default: `node_modules,target,build,dist,library,applications,old firefox data,deriveddata,pods,vendor,out,coverage,tmp,cache,venv`
 
 UI keys:
 
@@ -394,7 +397,7 @@ file_exclude_paths=
 translate_allow_network=false
 backend_log_level=error
 launch_at_login=true
-skip_dir_names=node_modules,target,build,dist,library,applications,old firefox data
+skip_dir_names=node_modules,target,build,dist,library,applications,old firefox data,deriveddata,pods,vendor,out,coverage,tmp,cache,venv
 
 # UI theme
 ui_tint_red=0.08
@@ -438,6 +441,7 @@ ui_border_opacity=0.12
 - `Cmd+Option+Q`: quit app
 - `Cmd+Shift+,`: open/close settings panel
 - `Cmd+Shift+;`: reload `.look.config`
+- `Escape` (while settings open): close settings and return focus to launcher input
 - `Cmd+-`: zoom out (temporary UI scale)
 - `Cmd+=` (`Cmd++`): zoom in (temporary UI scale)
 - `Cmd+0`: reset temporary UI scale


### PR DESCRIPTION
## Summary
- Improve Advanced Settings UX and indexing safety by making config changes apply immediately, adding path-based skip folder management, expanding default skip directories, and fixing directory traversal pruning in backend indexing.
## Why
- Users should not need a separate reload step after using Save Config.
- Skip-folder behavior was confusing and error-prone (name-only, overwrite semantics, traversal not fully pruned).
- Advanced settings controls had usability issues (numeric input friction, crowded labels, slider value wrapping).
- Pre-commit formatting failures were frequent friction and should be auto-fixed.
## Changes
- Backend indexing/config:
  - Fix file walker to prune excluded/skipped directories during traversal (file_exclude_paths, skip_dir_names), not only skip result emission.
  - Change skip_dir_names parsing to append user entries to defaults (instead of replacing defaults).
  - Expand default skipped directory names with high-impact entries: deriveddata, pods, vendor, out, coverage, tmp, cache, venv.
  - Add regression coverage for skip-dir config behavior.
- macOS Settings UI (Advanced):
  - Save Config now triggers immediate backend reload; manual Cmd+Shift+; remains for direct file edits.
  - Replace skip-dir name UX with exact path excludes via folder picker (file_exclude_paths), shown as removable tags with x.
  - Increase left label width to reduce title wrapping.
  - Replace stepper-only depth/limit controls with typed numeric input + validation/clamping.
  - Add Esc to close settings and refocus launcher input.
  - Improve slider value layout so right-side numeric value stays single-line at larger font sizes.
- Docs and hints:
  - Update user guide and README to reflect immediate apply behavior, manual reload semantics, skip path tags, typed indexing inputs, and settings Esc close behavior.
  - Update settings hint text accordingly.
- Tooling:
  - Update pre-commit rustfmt hooks for both core and bridge/ffi to auto-format (not check-only).
## Testing
- [x] cargo check --workspace --manifest-path core/Cargo.toml
- [x] cargo check --manifest-path bridge/ffi/Cargo.toml
- [x] cd apps/macos/LauncherApp && swift test
- [x] xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build
- [x] Manual verification completed (if UI/behavior changed)
## Additional executed verification:
- cargo test -p look-engine (core)
- pre-commit run cargo-fmt-core --all-files
- pre-commit run cargo-fmt-ffi --all-files
- cargo fmt --all for core and bridge/ffi
Screenshots / Recordings (if UI changed)
## Before
- Advanced tab had stepper-only depth/limit controls, remove buttons for skip folders, no Esc close hint, and slider values could wrap at larger font sizes.
## After
- Advanced tab supports typed depth/limit with validation, path-tag skip folders with x, immediate config apply on save, Esc close support, and stable single-line slider values.
## Risks / Notes
- Existing users with custom skip_dir_names may observe broader skipping because defaults are now preserved and user entries are appended.
- Path-based excludes in Settings write to file_exclude_paths; behavior is more precise but differs from prior name-based-only customization UX.
- Immediate reload on save increases side effects of save action (intended behavior).
## Checklist
- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered