### PR TITLE
Chore: improve setting appearance

### DIFF
--- a/apps/macos/LauncherApp/look-app/Support/AppUIState.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppUIState.swift
@@ -3,6 +3,23 @@ import Combine
 
 final class AppUIState: ObservableObject {
     @Published var showsThemeSettings = false
+    @Published var settingsBlurMultiplier: Double {
+        didSet {
+            UserDefaults.standard.set(settingsBlurMultiplier, forKey: Self.settingsBlurMultiplierKey)
+        }
+    }
+
+    private static let settingsBlurMultiplierKey = "look.ui.settingsBlurMultiplier"
+
+    init() {
+        if let stored = UserDefaults.standard.object(forKey: Self.settingsBlurMultiplierKey) as? Double,
+            stored > 0
+        {
+            settingsBlurMultiplier = min(max(stored, 0.4), 1.0)
+        } else {
+            settingsBlurMultiplier = 0.5
+        }
+    }
 }
 
 extension Notification.Name {

--- a/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
@@ -23,6 +23,9 @@ final class ThemeStore: ObservableObject {
     @Published private(set) var excludedFolderPaths: [String] = []
 
     private let defaultsKey = "look.theme.settings"
+    private let cachedFontFamilies: [String] = NSFontManager.shared.availableFontFamilies.sorted {
+        $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
+    }
     private var scopedBackgroundURL: URL?
 
     init() {
@@ -133,6 +136,14 @@ final class ThemeStore: ObservableObject {
         return Color(red: settings.fontRed, green: settings.fontGreen, blue: settings.fontBlue, opacity: alpha)
     }
 
+    func secondaryTextColor() -> Color {
+        fontColor(opacityMultiplier: 1.0)
+    }
+
+    func mutedTextColor() -> Color {
+        fontColor(opacityMultiplier: 0.8)
+    }
+
     func borderColor() -> Color {
         Color(
             red: settings.borderRed,
@@ -147,7 +158,7 @@ final class ThemeStore: ObservableObject {
     }
 
     func fontNameSuggestions(for input: String, limit: Int = 8) -> [String] {
-        let allFonts = NSFontManager.shared.availableFontFamilies.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+        let allFonts = cachedFontFamilies
         let query = input.trimmingCharacters(in: .whitespacesAndNewlines)
         if query.isEmpty {
             return Array(allFonts.prefix(limit))

--- a/apps/macos/LauncherApp/look-app/Views/LauncherRowView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/LauncherRowView.swift
@@ -78,7 +78,7 @@ struct LauncherRowView: View {
                         .foregroundStyle(themeStore.fontColor())
                     Text(metaLabel)
                         .font(themeStore.uiFont(size: CGFloat(max(10, themeStore.settings.fontSize - 3)), weight: .regular))
-                        .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.65))
+                        .foregroundStyle(themeStore.mutedTextColor())
                         .lineLimit(1)
                 }
                 Spacer(minLength: 0)

--- a/apps/macos/LauncherApp/look-app/Views/LauncherSubviews.swift
+++ b/apps/macos/LauncherApp/look-app/Views/LauncherSubviews.swift
@@ -41,7 +41,7 @@ struct SearchInputBar: View {
                     .keyboardShortcut(.escape, modifiers: [.shift])
                     .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular))
                     .buttonStyle(.plain)
-                    .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.72))
+                    .foregroundStyle(themeStore.secondaryTextColor())
             }
         }
         .padding(.horizontal, 12)
@@ -86,7 +86,7 @@ struct CommandListView: View {
                                 .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .semibold))
                             Text(command.detail)
                                 .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular))
-                                .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.72))
+                                .foregroundStyle(themeStore.secondaryTextColor())
                                 .lineLimit(1)
                         }
                         Spacer(minLength: 0)
@@ -149,7 +149,7 @@ struct HintBar: View {
     var body: some View {
         Text(hint)
             .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular))
-            .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.72))
+            .foregroundStyle(themeStore.secondaryTextColor())
     }
 }
 
@@ -172,7 +172,7 @@ struct ClipboardEmptyStateView: View {
 
                 Text("Copy any text, then search with c\"word to find it here.")
                     .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular))
-                    .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.72))
+                    .foregroundStyle(themeStore.secondaryTextColor())
                     .lineLimit(2)
 
                 Spacer(minLength: 0)
@@ -191,7 +191,7 @@ struct ClipboardEmptyStateView: View {
                     .foregroundStyle(themeStore.fontColor())
                 Text("• Type c\" to list latest 10 clips\n• Type c\"mail to filter\n• Press Enter to copy selected item")
                     .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular))
-                    .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.72))
+                    .foregroundStyle(themeStore.secondaryTextColor())
                     .lineSpacing(4)
                 Spacer(minLength: 0)
             }
@@ -284,7 +284,7 @@ private struct ShortcutHelpSection: View {
                         .background(.white.opacity(0.14), in: Capsule())
                     Text(item.1)
                         .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular))
-                        .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.82))
+                        .foregroundStyle(themeStore.mutedTextColor())
                     Spacer(minLength: 0)
                 }
             }

--- a/apps/macos/LauncherApp/look-app/Views/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/LauncherView.swift
@@ -1442,7 +1442,9 @@ struct LauncherView: View {
                     1,
                     max(
                         0,
-                        themeStore.settings.blurOpacity * themeStore.settings.blurMaterial.blurOpacityScale
+                        themeStore.settings.blurOpacity
+                            * themeStore.settings.blurMaterial.blurOpacityScale
+                            * (appUIState.showsThemeSettings ? appUIState.settingsBlurMultiplier : 1.0)
                     )
                 )
             )

--- a/apps/macos/LauncherApp/look-app/Views/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/ResultPreviewView.swift
@@ -180,7 +180,7 @@ struct ResultPreviewView: View {
                         .foregroundStyle(themeStore.fontColor())
                     Text("Captured \(capturedAt)")
                         .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular))
-                        .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.66))
+                        .foregroundStyle(themeStore.mutedTextColor())
                 }
                 Spacer()
 
@@ -203,15 +203,15 @@ struct ResultPreviewView: View {
                 KindBadge(kind: "clipboard")
                 Text("\(characterCount) chars")
                     .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular))
-                    .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.72))
+                    .foregroundStyle(themeStore.secondaryTextColor())
                 Text("\(lineCount) lines")
                     .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular))
-                    .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.72))
+                    .foregroundStyle(themeStore.secondaryTextColor())
             }
 
             Text("Preview")
                 .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .medium))
-                .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.62))
+                .foregroundStyle(themeStore.mutedTextColor())
 
             ScrollView {
                 Text(content)

--- a/apps/macos/LauncherApp/look-app/Views/SystemInfoCommand.swift
+++ b/apps/macos/LauncherApp/look-app/Views/SystemInfoCommand.swift
@@ -26,16 +26,16 @@ struct SystemInfoView: View {
                     } else if item.label.isEmpty {
                         Text(item.value)
                             .font(.system(size: CGFloat(themeStore.settings.fontSize - 1), design: .monospaced))
-                            .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.85))
+                            .foregroundStyle(themeStore.secondaryTextColor())
                     } else {
                         HStack(alignment: .top, spacing: 4) {
                             Text(item.label)
                                 .font(.system(size: CGFloat(themeStore.settings.fontSize - 1), design: .monospaced))
-                                .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.6))
+                                .foregroundStyle(themeStore.mutedTextColor())
                                 .frame(minWidth: 70, alignment: .leading)
                             Text(item.value)
                                 .font(.system(size: CGFloat(themeStore.settings.fontSize - 1), design: .monospaced))
-                                .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.9))
+                                .foregroundStyle(themeStore.secondaryTextColor())
                         }
                     }
                 }

--- a/apps/macos/LauncherApp/look-app/Views/ThemeSettingsView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/ThemeSettingsView.swift
@@ -57,7 +57,7 @@ struct ThemeSettingsView: View {
                 .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
                 Text("Esc or Cmd+Shift+, to close")
                     .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(themeStore.mutedTextColor())
             }
 
             HStack(spacing: 8) {
@@ -89,7 +89,7 @@ struct ThemeSettingsView: View {
             VStack(alignment: .leading, spacing: 10) {
                 Text("Tint Color")
                     .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .semibold))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(themeStore.secondaryTextColor())
 
                 LabeledSlider(title: "Red", value: $settings.tintRed, range: 0...1)
                 LabeledSlider(title: "Green", value: $settings.tintGreen, range: 0...1)
@@ -97,25 +97,27 @@ struct ThemeSettingsView: View {
                 LabeledSlider(title: "Tint Opacity", value: $settings.tintOpacity, range: 0...1)
 
                 LabeledSlider(title: "Blur Opacity", value: $settings.blurOpacity, range: 0...1)
+                LabeledSlider(title: "Settings Blur", value: $appUIState.settingsBlurMultiplier, range: 0.4...1)
 
                 HStack(spacing: 10) {
                     Text("Font Name")
                         .frame(width: AppConstants.ThemeUI.labelWidth, alignment: .leading)
                         .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
-                        .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.72))
+                        .foregroundStyle(themeStore.secondaryTextColor())
 
                     TextField("SF Pro Text", text: $settings.fontName)
                         .textFieldStyle(.roundedBorder)
                         .focused($focusedField, equals: .fontName)
                         .onTapGesture {
                             focusedField = .fontName
+                            fontSuggestions = themeStore.fontNameSuggestions(for: settings.fontName, limit: 24)
                             showsFontSuggestions = true
                         }
                         .onChange(of: settings.fontName) { _, newValue in
                             if isPickingFontSuggestion {
                                 return
                             }
-                            fontSuggestions = themeStore.fontNameSuggestions(for: newValue, limit: 120)
+                            fontSuggestions = themeStore.fontNameSuggestions(for: newValue, limit: 24)
                             showsFontSuggestions = focusedField == .fontName
                         }
                         .onSubmit {
@@ -133,7 +135,7 @@ struct ThemeSettingsView: View {
 
                     Text("Installed font name")
                         .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 2), weight: .regular))
-                        .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.64))
+                        .foregroundStyle(themeStore.mutedTextColor())
                         .lineLimit(1)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -149,7 +151,7 @@ struct ThemeSettingsView: View {
 
                 Text("Font Color")
                     .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .semibold))
-                    .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.72))
+                    .foregroundStyle(themeStore.secondaryTextColor())
 
                 LabeledSlider(title: "Text Red", value: $settings.fontRed, range: 0...1)
                 LabeledSlider(title: "Text Green", value: $settings.fontGreen, range: 0...1)
@@ -158,7 +160,7 @@ struct ThemeSettingsView: View {
 
                 Text("Border")
                     .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .semibold))
-                    .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.72))
+                    .foregroundStyle(themeStore.secondaryTextColor())
 
                 LabeledSlider(title: "Border Thick", value: $settings.borderThickness, range: 0...6)
                 LabeledSlider(title: "Border Red", value: $settings.borderRed, range: 0...1)
@@ -170,7 +172,7 @@ struct ThemeSettingsView: View {
                     Text("Blur Style")
                         .frame(width: AppConstants.ThemeUI.labelWidth, alignment: .leading)
                         .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(themeStore.secondaryTextColor())
 
                     Picker("Blur Style", selection: $settings.blurMaterial) {
                         ForEach(LauncherBlurMaterial.allCases) { item in
@@ -183,16 +185,13 @@ struct ThemeSettingsView: View {
 
                     Text(settings.blurMaterial.detail)
                         .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 2), weight: .regular))
-                        .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.64))
+                        .foregroundStyle(themeStore.mutedTextColor())
                         .lineLimit(1)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
             .onAppear {
-                fontSuggestions = themeStore.fontNameSuggestions(for: settings.fontName, limit: 120)
-                DispatchQueue.main.async {
-                    focusedField = .fontName
-                }
+                focusedField = nil
             }
             .onChange(of: focusedField) { _, focused in
                 if focused != .fontName {
@@ -217,7 +216,7 @@ struct ThemeSettingsView: View {
         } label: {
             Text(title)
                 .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .medium))
-                .foregroundStyle(isActive ? themeStore.fontColor() : themeStore.fontColor(opacityMultiplier: 0.72))
+                .foregroundStyle(isActive ? themeStore.fontColor() : themeStore.secondaryTextColor())
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 7)
                 .background(
@@ -243,7 +242,7 @@ struct ThemeSettingsView: View {
                     Button {
                         isPickingFontSuggestion = true
                         settings.fontName = suggestion
-                        fontSuggestions = themeStore.fontNameSuggestions(for: suggestion, limit: 120)
+                        fontSuggestions = themeStore.fontNameSuggestions(for: suggestion, limit: 24)
                         showsFontSuggestions = false
                         DispatchQueue.main.async {
                             focusedField = .fontName
@@ -278,7 +277,7 @@ struct ThemeSettingsView: View {
                 VStack(alignment: .leading, spacing: 10) {
                     Text("Background")
                         .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .semibold))
-                        .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.72))
+                        .foregroundStyle(themeStore.secondaryTextColor())
 
                     HStack {
                         Button("Choose Background Image") {
@@ -293,14 +292,14 @@ struct ThemeSettingsView: View {
 
                     Text(settings.backgroundImagePath ?? "No image selected")
                         .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
-                        .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.72))
+                        .foregroundStyle(themeStore.secondaryTextColor())
                         .lineLimit(1)
 
                     HStack(spacing: 10) {
                         Text("Image Layout")
                             .frame(width: AppConstants.ThemeUI.labelWidth, alignment: .leading)
                             .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(themeStore.secondaryTextColor())
 
                         Picker("Image Layout", selection: $settings.backgroundImageMode) {
                             ForEach(BackgroundImageMode.allCases) { mode in
@@ -313,7 +312,7 @@ struct ThemeSettingsView: View {
 
                         Text(settings.backgroundImageMode.detail)
                             .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 2), weight: .regular))
-                            .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.64))
+                            .foregroundStyle(themeStore.mutedTextColor())
                             .lineLimit(1)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
@@ -327,13 +326,13 @@ struct ThemeSettingsView: View {
 
                     Text("Indexing")
                         .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .semibold))
-                        .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.72))
+                        .foregroundStyle(themeStore.secondaryTextColor())
 
                     HStack(spacing: 10) {
                         Text("File Scan Depth")
                             .frame(width: AppConstants.ThemeUI.labelWidth, alignment: .leading)
                             .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(themeStore.secondaryTextColor())
 
                         TextField("4", text: $fileScanDepthInput)
                             .textFieldStyle(.roundedBorder)
@@ -345,7 +344,7 @@ struct ThemeSettingsView: View {
 
                         Text("How many directory levels to index")
                             .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 2), weight: .regular))
-                            .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.64))
+                            .foregroundStyle(themeStore.mutedTextColor())
                             .lineLimit(1)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
@@ -354,7 +353,7 @@ struct ThemeSettingsView: View {
                         Text("File Scan Limit")
                             .frame(width: AppConstants.ThemeUI.labelWidth, alignment: .leading)
                             .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(themeStore.secondaryTextColor())
 
                         TextField("8000", text: $fileScanLimitInput)
                             .textFieldStyle(.roundedBorder)
@@ -366,7 +365,7 @@ struct ThemeSettingsView: View {
 
                         Text("Max files indexed per refresh")
                             .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 2), weight: .regular))
-                            .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.64))
+                            .foregroundStyle(themeStore.mutedTextColor())
                             .lineLimit(1)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
@@ -375,7 +374,7 @@ struct ThemeSettingsView: View {
                         Text("Skip Folders")
                             .frame(width: AppConstants.ThemeUI.labelWidth, alignment: .leading)
                             .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(themeStore.secondaryTextColor())
 
                         VStack(alignment: .leading, spacing: 8) {
                             Button("Add Folder") {
@@ -385,7 +384,7 @@ struct ThemeSettingsView: View {
                             if themeStore.excludedFolderPaths.isEmpty {
                                 Text("No excluded folder paths yet")
                                     .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 2), weight: .regular))
-                                    .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.64))
+                                    .foregroundStyle(themeStore.mutedTextColor())
                             } else {
                                 ScrollView(.horizontal) {
                                     HStack(spacing: 8) {
@@ -402,7 +401,7 @@ struct ThemeSettingsView: View {
                                                 .buttonStyle(.plain)
                                             }
                                             .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 2), weight: .regular))
-                                            .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.78))
+                                            .foregroundStyle(themeStore.secondaryTextColor())
                                             .padding(.horizontal, 9)
                                             .padding(.vertical, 5)
                                             .background(.white.opacity(0.12), in: Capsule())
@@ -422,13 +421,13 @@ struct ThemeSettingsView: View {
 
                     Text("Privacy & Logs")
                         .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .semibold))
-                        .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.72))
+                        .foregroundStyle(themeStore.secondaryTextColor())
 
                     HStack(spacing: 10) {
                         Text("Backend Log Level")
                             .frame(width: AppConstants.ThemeUI.labelWidth, alignment: .leading)
                             .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(themeStore.secondaryTextColor())
 
                         Picker("Backend Log Level", selection: $settings.backendLogLevel) {
                             ForEach(BackendLogLevel.allCases) { level in
@@ -441,7 +440,7 @@ struct ThemeSettingsView: View {
 
                         Text("Error only by default; use Info/Debug for troubleshooting")
                             .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 2), weight: .regular))
-                            .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.64))
+                            .foregroundStyle(themeStore.mutedTextColor())
                             .lineLimit(1)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
@@ -452,7 +451,7 @@ struct ThemeSettingsView: View {
 
                     Text("Startup")
                         .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .semibold))
-                        .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.72))
+                        .foregroundStyle(themeStore.secondaryTextColor())
 
                     Toggle(isOn: $settings.launchAtLogin) {
                         VStack(alignment: .leading, spacing: 2) {
@@ -460,7 +459,7 @@ struct ThemeSettingsView: View {
                                 .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
                             Text("Start look automatically when you sign in")
                                 .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 2), weight: .regular))
-                                .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.64))
+                                .foregroundStyle(themeStore.mutedTextColor())
                         }
                     }
                 }
@@ -478,7 +477,7 @@ struct ThemeSettingsView: View {
 
             Text(HintText.Settings.advancedApply)
                 .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 2), weight: .regular))
-                .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.64))
+                .foregroundStyle(themeStore.mutedTextColor())
         }
     }
 
@@ -491,11 +490,11 @@ struct ThemeSettingsView: View {
 
                 Text("This panel is intended as living documentation. We can add command and workflow docs here as features grow.")
                     .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
-                    .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.72))
+                    .foregroundStyle(themeStore.secondaryTextColor())
 
                 Text(HintText.Settings.shortcutsTips)
                     .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
-                    .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.72))
+                    .foregroundStyle(themeStore.secondaryTextColor())
             }
             .padding(.top, 4)
         }
@@ -634,7 +633,7 @@ private struct ShortcutSection: View {
         VStack(alignment: .leading, spacing: 8) {
             Text(title)
                 .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize), weight: .medium))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(themeStore.secondaryTextColor())
 
             ForEach(items) { item in
                 HStack(alignment: .firstTextBaseline, spacing: 10) {
@@ -645,7 +644,7 @@ private struct ShortcutSection: View {
                         .background(.white.opacity(0.14), in: Capsule())
                     Text(item.action)
                         .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular))
-                        .foregroundStyle(.primary)
+                        .foregroundStyle(themeStore.secondaryTextColor())
                     Spacer(minLength: 0)
                 }
             }
@@ -670,7 +669,7 @@ private struct LabeledSlider: View {
             Text(title)
                 .frame(width: AppConstants.ThemeUI.labelWidth, alignment: .leading)
                 .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(themeStore.secondaryTextColor())
             Slider(value: $value, in: range)
                 .controlSize(.mini)
                 .tint(themeStore.fontColor(opacityMultiplier: 0.92))
@@ -679,7 +678,7 @@ private struct LabeledSlider: View {
                 .monospacedDigit()
                 .lineLimit(1)
                 .frame(width: valueColumnWidth, alignment: .trailing)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(themeStore.mutedTextColor())
         }
     }
 }

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -89,6 +89,7 @@ Open settings with `Cmd+Shift+,`.
 Main controls include:
 
 - appearance (tint, blur, font, border, background)
+- settings-only blur multiplier (`Settings Blur`) for readability when settings is open
 - indexing scope/depth/limits
 - translation privacy and backend log level
 - launch at login
@@ -107,6 +108,8 @@ Backend-related keys:
 - `translate_allow_network`, `backend_log_level`, `launch_at_login`
 
 UI-related keys include the `ui_*` group (tint/blur/font/border values).
+
+Note: `Settings Blur` is stored as local app UI state (UserDefaults) and is not written to `~/.look.config`.
 
 ## 7) Keyboard shortcuts (quick reference)
 


### PR DESCRIPTION
## Summary

- Improve appearances

## Why

Setting screen's texts ,... are quite blurry -> fix, reduce blur value, increase text opacity, ...

## Changes

in the pr

## Testing

- [x] `cargo check --workspace --manifest-path core/Cargo.toml`
- [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [x] `cd apps/macos/LauncherApp && swift test`
- [x] `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered
