### PR TITLE
lazy indexing with a dirty flag

### DIFF
--- a/apps/macos/LauncherApp/look-app/Models/ThemeSettings.swift
+++ b/apps/macos/LauncherApp/look-app/Models/ThemeSettings.swift
@@ -132,6 +132,7 @@ struct ThemeSettings: Codable, Equatable {
 
     var fileScanDepth: Int = 4
     var fileScanLimit: Int = 4000
+    var lazyIndexingEnabled: Bool = true
     var backendLogLevel: BackendLogLevel = .error
     var launchAtLogin: Bool = true
 

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
@@ -20,6 +20,10 @@ private func look_free_cstring(_ ptr: UnsafeMutablePointer<CChar>?)
 nonisolated
 private func look_reload_config() -> Bool
 
+@_silgen_name("look_request_index_refresh")
+nonisolated
+private func look_request_index_refresh() -> Bool
+
 @_silgen_name("look_translate_json")
 nonisolated
 private func look_translate_json(_ text: UnsafePointer<CChar>?, _ targetLang: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
@@ -109,6 +113,11 @@ final class EngineBridge {
 
     nonisolated func reloadConfig() -> Bool {
         look_reload_config()
+    }
+
+    @discardableResult
+    nonisolated func requestIndexRefresh() -> Bool {
+        look_request_index_refresh()
     }
 
     nonisolated func translate(text: String, targetLang: String = "en") -> TranslationResult? {

--- a/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
@@ -186,6 +186,11 @@ final class ThemeStore: ObservableObject {
         upsertConfigLine(&lines, key: "file_scan_limit", value: String(settings.fileScanLimit))
         upsertConfigLine(
             &lines,
+            key: "lazy_indexing_enabled",
+            value: settings.lazyIndexingEnabled ? "true" : "false"
+        )
+        upsertConfigLine(
+            &lines,
             key: "file_exclude_paths",
             value: excludedFolderPaths.map(escapeCSVToken).joined(separator: ",")
         )
@@ -400,6 +405,10 @@ final class ThemeStore: ObservableObject {
             case "file_scan_limit":
                 if let parsed = parsePositiveInt(value) {
                     settings.fileScanLimit = parsed
+                }
+            case "lazy_indexing_enabled":
+                if let parsed = parseBool(value) {
+                    settings.lazyIndexingEnabled = parsed
                 }
             case "file_exclude_paths":
                 excludedFolderPaths = parseExcludedFolderPaths(value)
@@ -664,6 +673,7 @@ app_exclude_names=
 file_scan_roots=Desktop,Documents,Downloads
 file_scan_depth=4
 file_scan_limit=8000
+lazy_indexing_enabled=true
 file_exclude_paths=
 backend_log_level=error
 launch_at_login=true

--- a/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
@@ -31,13 +31,7 @@ final class ThemeStore: ObservableObject {
     init() {
         Self.ensureDefaultConfigFileExists(at: Self.configPath())
 
-        if let data = UserDefaults.standard.data(forKey: defaultsKey),
-            let decoded = try? JSONDecoder().decode(ThemeSettings.self, from: data)
-        {
-            settings = decoded
-        } else {
-            settings = .default
-        }
+        settings = Self.loadThemeSettings(from: UserDefaults.standard.data(forKey: defaultsKey))
 
         applyThemeOverridesFromConfigFile()
         _ = applyLaunchAtLoginSetting()
@@ -698,6 +692,33 @@ ui_border_green=1.0
 ui_border_blue=1.0
 ui_border_opacity=0.12
 """
+
+    private static func loadThemeSettings(from data: Data?) -> ThemeSettings {
+        guard let data else {
+            return .default
+        }
+
+        let decoder = JSONDecoder()
+        if let decoded = try? decoder.decode(ThemeSettings.self, from: data) {
+            return decoded
+        }
+
+        guard
+            var object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+            object["lazyIndexingEnabled"] == nil
+        else {
+            return .default
+        }
+
+        object["lazyIndexingEnabled"] = true
+        guard
+            let migratedData = try? JSONSerialization.data(withJSONObject: object),
+            let migrated = try? decoder.decode(ThemeSettings.self, from: migratedData)
+        else {
+            return .default
+        }
+        return migrated
+    }
 
     private func refreshBackgroundImageURL() {
         scopedBackgroundURL?.stopAccessingSecurityScopedResource()

--- a/apps/macos/LauncherApp/look-app/Views/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/LauncherView.swift
@@ -929,6 +929,7 @@ struct LauncherView: View {
             return
         }
 
+        _ = bridge.requestIndexRefresh()
         NSApplication.shared.activate(ignoringOtherApps: true)
         window.makeKeyAndOrderFront(nil)
         activateLauncherModeAndFocus()

--- a/apps/macos/LauncherApp/look-app/Views/ThemeSettingsView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/ThemeSettingsView.swift
@@ -447,6 +447,16 @@ struct ThemeSettingsView: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
 
+                    Toggle(isOn: $settings.lazyIndexingEnabled) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Lazy indexing")
+                                .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
+                            Text("Refresh index automatically when launcher opens after file/app changes")
+                                .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 2), weight: .regular))
+                                .foregroundStyle(themeStore.mutedTextColor())
+                        }
+                    }
+
                     HStack(alignment: .top, spacing: 10) {
                         Text("Skip Folders")
                             .frame(width: AppConstants.ThemeUI.labelWidth, alignment: .leading)

--- a/apps/macos/LauncherApp/look-app/Views/ThemeSettingsView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/ThemeSettingsView.swift
@@ -19,6 +19,7 @@ struct ThemeSettingsView: View {
     @State private var fileScanLimitInput = ""
     @State private var fileScanDepthError: String?
     @State private var fileScanLimitError: String?
+    @State private var localKeyMonitor: Any?
     @FocusState private var focusedField: Field?
 
     var body: some View {
@@ -55,8 +56,7 @@ struct ThemeSettingsView: View {
                 .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
 
                 Button("Back to Launcher") {
-                    appUIState.showsThemeSettings = false
-                    NotificationCenter.default.post(name: .lookRefocusInputRequested, object: nil)
+                    closeSettingsPanel()
                 }
                 .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
                 Text("Esc or Cmd+Shift+, to close")
@@ -83,8 +83,13 @@ struct ThemeSettingsView: View {
 
         }
         .onExitCommand {
-            appUIState.showsThemeSettings = false
-            NotificationCenter.default.post(name: .lookRefocusInputRequested, object: nil)
+            closeSettingsPanel()
+        }
+        .onAppear {
+            installLocalKeyMonitorIfNeeded()
+        }
+        .onDisappear {
+            removeLocalKeyMonitor()
         }
     }
 
@@ -632,6 +637,39 @@ struct ThemeSettingsView: View {
         }
         settings.fileScanLimit = min(max(500, parsed), 50_000)
         fileScanLimitInput = String(settings.fileScanLimit)
+    }
+
+    private func closeSettingsPanel() {
+        appUIState.showsThemeSettings = false
+        NotificationCenter.default.post(name: .lookRefocusInputRequested, object: nil)
+    }
+
+    private func installLocalKeyMonitorIfNeeded() {
+        guard localKeyMonitor == nil else { return }
+
+        localKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+
+            if event.keyCode == 53 && flags.isEmpty {
+                closeSettingsPanel()
+                return nil
+            }
+
+            if flags == [.command, .shift]
+                && (event.charactersIgnoringModifiers == "," || event.keyCode == 43)
+            {
+                closeSettingsPanel()
+                return nil
+            }
+
+            return event
+        }
+    }
+
+    private func removeLocalKeyMonitor() {
+        guard let localKeyMonitor else { return }
+        NSEvent.removeMonitor(localKeyMonitor)
+        self.localKeyMonitor = nil
     }
 
     private var hasIndexingError: Bool {

--- a/bridge/ffi/Cargo.lock
+++ b/bridge/ffi/Cargo.lock
@@ -19,6 +19,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -54,6 +60,15 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -108,6 +123,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +144,15 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "globset"
@@ -177,6 +212,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +245,44 @@ checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.184"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "plain",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -232,6 +325,7 @@ dependencies = [
  "look-engine",
  "look-indexing",
  "look-storage",
+ "notify",
  "serde",
  "serde_json",
 ]
@@ -269,6 +363,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +410,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -333,6 +464,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,7 +517,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -577,6 +717,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,7 +773,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -638,12 +784,78 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "zmij"

--- a/bridge/ffi/Cargo.toml
+++ b/bridge/ffi/Cargo.toml
@@ -13,3 +13,4 @@ look-indexing = { path = "../../core/indexing" }
 look-storage = { path = "../../core/storage" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+notify = "6"

--- a/bridge/ffi/src/lib.rs
+++ b/bridge/ffi/src/lib.rs
@@ -41,12 +41,20 @@ pub extern "C" fn look_record_usage_json(
 #[unsafe(no_mangle)]
 pub extern "C" fn look_reload_config() -> bool {
     runtime_config::reload_runtime_config();
+    state::restart_index_watchers();
     let path = state::default_db_path();
     if QueryEngine::bootstrap_sqlite(&path).is_err() {
+        state::mark_index_dirty();
         return false;
     }
     state::refresh_engine_cache();
+    state::clear_index_dirty();
     true
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn look_request_index_refresh() -> bool {
+    state::request_background_index_refresh()
 }
 
 #[unsafe(no_mangle)]

--- a/bridge/ffi/src/state.rs
+++ b/bridge/ffi/src/state.rs
@@ -1,17 +1,29 @@
 use crate::runtime_config::{log_error, log_info};
 use look_engine::QueryEngine;
+use look_engine::config::RuntimeConfig;
+use notify::event::{ModifyKind, RenameMode};
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use std::collections::HashMap;
 use std::env;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
+use std::panic::{self, AssertUnwindSafe};
+use std::path::Path;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::mpsc;
 use std::sync::{Mutex, OnceLock, RwLock};
 use std::thread;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 static ENGINE_CACHE: OnceLock<RwLock<QueryEngine>> = OnceLock::new();
 static JSON_ALLOCS: OnceLock<Mutex<HashMap<usize, CString>>> = OnceLock::new();
 static BOOTSTRAP_REFRESH_STARTED: OnceLock<()> = OnceLock::new();
+static INDEX_WATCHER_BOOTSTRAP_STARTED: OnceLock<()> = OnceLock::new();
+static INDEX_REFRESH_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
+static INDEX_DIRTY: AtomicBool = AtomicBool::new(false);
+static INDEX_CHANGE_VERSION: AtomicU64 = AtomicU64::new(0);
+static INDEX_WATCHER_CONTROL: OnceLock<Mutex<Option<mpsc::Sender<()>>>> = OnceLock::new();
 
 pub(crate) fn default_db_path() -> PathBuf {
     if let Ok(custom) = env::var("LOOK_DB_PATH")
@@ -50,6 +62,191 @@ pub(crate) fn refresh_engine_cache() {
         {
             *guard = engine;
         }
+    }
+}
+
+pub(crate) fn request_background_index_refresh() -> bool {
+    request_background_index_refresh_internal()
+}
+
+pub(crate) fn mark_index_dirty() {
+    INDEX_CHANGE_VERSION.fetch_add(1, Ordering::AcqRel);
+    INDEX_DIRTY.store(true, Ordering::Release);
+}
+
+pub(crate) fn clear_index_dirty_if_unchanged(snapshot_version: u64) {
+    if INDEX_CHANGE_VERSION.load(Ordering::Acquire) == snapshot_version {
+        INDEX_DIRTY.store(false, Ordering::Release);
+    }
+}
+
+pub(crate) fn clear_index_dirty() {
+    INDEX_DIRTY.store(false, Ordering::Release);
+}
+
+pub(crate) fn restart_index_watchers() {
+    stop_index_watchers();
+
+    let config = RuntimeConfig::load();
+    if !config.lazy_indexing_enabled {
+        log_info("index watcher: disabled by lazy_indexing_enabled=false");
+        return;
+    }
+
+    let mut roots = config.app_scan_roots;
+    roots.extend(config.file_scan_roots);
+    roots.sort();
+    roots.dedup();
+
+    let active_roots: Vec<String> = roots
+        .into_iter()
+        .filter(|root| !root.trim().is_empty() && Path::new(root).exists())
+        .collect();
+
+    if active_roots.is_empty() {
+        log_info("index watcher: no valid roots to monitor");
+        return;
+    }
+
+    let (stop_tx, stop_rx) = mpsc::channel::<()>();
+    let control = INDEX_WATCHER_CONTROL.get_or_init(|| Mutex::new(None));
+    if let Ok(mut guard) = control.lock() {
+        *guard = Some(stop_tx);
+    }
+
+    thread::spawn(move || {
+        let (event_tx, event_rx) = mpsc::channel::<notify::Result<Event>>();
+        let mut watcher = match RecommendedWatcher::new(
+            move |result| {
+                let _ = event_tx.send(result);
+            },
+            notify::Config::default(),
+        ) {
+            Ok(watcher) => watcher,
+            Err(err) => {
+                log_error(&format!("index watcher init failed error={err}"));
+                return;
+            }
+        };
+
+        let mut watched_count = 0usize;
+        for root in &active_roots {
+            if watcher
+                .watch(Path::new(root), RecursiveMode::Recursive)
+                .is_ok()
+            {
+                watched_count += 1;
+            } else {
+                log_error(&format!("index watcher failed root={root}"));
+            }
+        }
+
+        if watched_count == 0 {
+            log_error("index watcher failed: no roots watched");
+            return;
+        }
+
+        log_info(&format!("index watcher active roots={watched_count}"));
+
+        loop {
+            if stop_rx.try_recv().is_ok() {
+                break;
+            }
+
+            match event_rx.recv_timeout(Duration::from_secs(1)) {
+                Ok(Ok(event)) => {
+                    if should_mark_dirty_from_event(&event) {
+                        mark_index_dirty();
+                    }
+                }
+                Ok(Err(err)) => {
+                    log_error(&format!("index watcher event error={err}"));
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => {}
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    log_error("index watcher channel disconnected");
+                    break;
+                }
+            }
+        }
+    });
+}
+
+fn request_background_index_refresh_internal() -> bool {
+    let _ = engine_cache();
+
+    let lazy_indexing_enabled = RuntimeConfig::load().lazy_indexing_enabled;
+    // Lazy indexing ON: refresh only when watcher marked index as dirty.
+    // Lazy indexing OFF: refresh on every Cmd+Space request.
+    if !refresh_allowed_by_dirty_mode(lazy_indexing_enabled, INDEX_DIRTY.load(Ordering::Acquire)) {
+        return false;
+    }
+    if !try_acquire_index_refresh_slot() {
+        return false;
+    }
+
+    let dirty_version_snapshot = INDEX_CHANGE_VERSION.load(Ordering::Acquire);
+    thread::spawn(move || {
+        // Keep refresh slot release tied to scope exit so the in-progress flag
+        // is reset for success, error, and panic-unwind paths.
+        let _refresh_slot = IndexRefreshGuard;
+        let started_at = Instant::now();
+        let run_result = panic::catch_unwind(AssertUnwindSafe(|| {
+            let path = default_db_path();
+            match QueryEngine::bootstrap_sqlite(&path) {
+                Ok(()) => {
+                    refresh_engine_cache();
+                    clear_index_dirty_if_unchanged(dirty_version_snapshot);
+                    let candidate_count = with_engine(|engine| engine.search("", 2000).len());
+                    log_info(&format!(
+                        "background index refresh ok candidates={} elapsed_ms={}",
+                        candidate_count,
+                        started_at.elapsed().as_millis()
+                    ));
+                }
+                Err(err) => {
+                    mark_index_dirty();
+                    log_error(&format!(
+                        "background index refresh failed error={} elapsed_ms={}",
+                        err,
+                        started_at.elapsed().as_millis()
+                    ));
+                }
+            }
+        }));
+
+        if run_result.is_err() {
+            mark_index_dirty();
+            log_error(&format!(
+                "background index refresh panicked elapsed_ms={}",
+                started_at.elapsed().as_millis()
+            ));
+        }
+    });
+
+    true
+}
+
+fn refresh_allowed_by_dirty_mode(lazy_indexing_enabled: bool, index_dirty: bool) -> bool {
+    if lazy_indexing_enabled {
+        return index_dirty;
+    }
+    true
+}
+
+fn try_acquire_index_refresh_slot() -> bool {
+    INDEX_REFRESH_IN_PROGRESS
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_ok()
+}
+
+// Ensures INDEX_REFRESH_IN_PROGRESS is always cleared when the refresh worker
+// exits, preventing a stuck "refresh in progress" state.
+struct IndexRefreshGuard;
+
+impl Drop for IndexRefreshGuard {
+    fn drop(&mut self) {
+        INDEX_REFRESH_IN_PROGRESS.store(false, Ordering::Release);
     }
 }
 
@@ -96,6 +293,7 @@ fn engine_cache() -> &'static RwLock<QueryEngine> {
         RwLock::new(engine)
     });
     start_background_bootstrap_refresh();
+    start_index_watcher_bootstrap();
     cache
 }
 
@@ -107,6 +305,7 @@ fn start_background_bootstrap_refresh() {
             match QueryEngine::bootstrap_sqlite(&path) {
                 Ok(()) => {
                     refresh_engine_cache();
+                    clear_index_dirty();
                     let candidate_count = with_engine(|engine| engine.search("", 2000).len());
                     log_info(&format!(
                         "bootstrap refresh ok candidates={} elapsed_ms={}",
@@ -115,6 +314,7 @@ fn start_background_bootstrap_refresh() {
                     ));
                 }
                 Err(err) => {
+                    mark_index_dirty();
                     log_error(&format!(
                         "bootstrap refresh failed error={} elapsed_ms={}",
                         err,
@@ -124,4 +324,151 @@ fn start_background_bootstrap_refresh() {
             }
         });
     });
+}
+
+fn start_index_watcher_bootstrap() {
+    let _ = INDEX_WATCHER_BOOTSTRAP_STARTED.get_or_init(restart_index_watchers);
+}
+
+fn stop_index_watchers() {
+    if let Some(control) = INDEX_WATCHER_CONTROL.get()
+        && let Ok(mut guard) = control.lock()
+        && let Some(tx) = guard.take()
+    {
+        let _ = tx.send(());
+    }
+}
+
+fn should_mark_dirty_from_event(event: &Event) -> bool {
+    if event.paths.is_empty() {
+        return false;
+    }
+
+    match event.kind {
+        EventKind::Create(_) | EventKind::Remove(_) | EventKind::Any => true,
+        EventKind::Modify(ModifyKind::Name(RenameMode::Any))
+        | EventKind::Modify(ModifyKind::Name(RenameMode::Both))
+        | EventKind::Modify(ModifyKind::Name(RenameMode::From))
+        | EventKind::Modify(ModifyKind::Name(RenameMode::To))
+        | EventKind::Modify(ModifyKind::Name(RenameMode::Other)) => true,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_mark_dirty_from_event;
+    use super::{
+        INDEX_CHANGE_VERSION, INDEX_DIRTY, INDEX_REFRESH_IN_PROGRESS, IndexRefreshGuard,
+        clear_index_dirty, clear_index_dirty_if_unchanged, mark_index_dirty,
+        refresh_allowed_by_dirty_mode, try_acquire_index_refresh_slot,
+    };
+    use notify::event::{CreateKind, DataChange, ModifyKind, RemoveKind, RenameMode};
+    use notify::{Event, EventKind};
+    use std::path::PathBuf;
+    use std::sync::{Mutex, OnceLock};
+
+    fn test_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("test lock should not be poisoned")
+    }
+
+    fn event(kind: EventKind, path: &str) -> Event {
+        Event {
+            kind,
+            paths: vec![PathBuf::from(path)],
+            attrs: Default::default(),
+        }
+    }
+
+    #[test]
+    fn dirty_marking_accepts_create_remove_and_rename() {
+        let _guard = test_lock();
+        let created = event(EventKind::Create(CreateKind::File), "/tmp/foo.txt");
+        assert!(should_mark_dirty_from_event(&created));
+
+        let removed = event(EventKind::Remove(RemoveKind::File), "/tmp/foo.txt");
+        assert!(should_mark_dirty_from_event(&removed));
+
+        let renamed = event(
+            EventKind::Modify(ModifyKind::Name(RenameMode::To)),
+            "/tmp/foo-renamed.txt",
+        );
+        assert!(should_mark_dirty_from_event(&renamed));
+    }
+
+    #[test]
+    fn dirty_marking_ignores_non_rename_modify_and_empty_paths() {
+        let _guard = test_lock();
+        let content_write = event(
+            EventKind::Modify(ModifyKind::Data(DataChange::Content)),
+            "/tmp/foo.txt",
+        );
+        assert!(!should_mark_dirty_from_event(&content_write));
+
+        let empty_paths = Event {
+            kind: EventKind::Create(CreateKind::File),
+            paths: vec![],
+            attrs: Default::default(),
+        };
+        assert!(!should_mark_dirty_from_event(&empty_paths));
+    }
+
+    #[test]
+    fn clear_index_dirty_if_unchanged_clears_when_version_matches() {
+        let _guard = test_lock();
+
+        clear_index_dirty();
+        mark_index_dirty();
+        let snapshot = INDEX_CHANGE_VERSION.load(std::sync::atomic::Ordering::Acquire);
+
+        clear_index_dirty_if_unchanged(snapshot);
+        assert!(!INDEX_DIRTY.load(std::sync::atomic::Ordering::Acquire));
+    }
+
+    #[test]
+    fn clear_index_dirty_if_unchanged_keeps_dirty_when_version_moves() {
+        let _guard = test_lock();
+
+        clear_index_dirty();
+        mark_index_dirty();
+        let snapshot = INDEX_CHANGE_VERSION.load(std::sync::atomic::Ordering::Acquire);
+        mark_index_dirty();
+
+        clear_index_dirty_if_unchanged(snapshot);
+        assert!(INDEX_DIRTY.load(std::sync::atomic::Ordering::Acquire));
+    }
+
+    #[test]
+    fn refresh_mode_logic_matches_lazy_toggle_expectations() {
+        let _guard = test_lock();
+
+        assert!(!refresh_allowed_by_dirty_mode(true, false));
+        assert!(refresh_allowed_by_dirty_mode(true, true));
+        assert!(refresh_allowed_by_dirty_mode(false, false));
+        assert!(refresh_allowed_by_dirty_mode(false, true));
+    }
+
+    #[test]
+    fn refresh_slot_acquire_and_guard_release_are_consistent() {
+        let _guard = test_lock();
+
+        INDEX_REFRESH_IN_PROGRESS.store(false, std::sync::atomic::Ordering::Release);
+        assert!(try_acquire_index_refresh_slot());
+        assert!(!try_acquire_index_refresh_slot());
+
+        {
+            let _slot_guard = IndexRefreshGuard;
+        }
+
+        assert!(try_acquire_index_refresh_slot());
+
+        {
+            let _slot_guard = IndexRefreshGuard;
+        }
+
+        INDEX_REFRESH_IN_PROGRESS.store(false, std::sync::atomic::Ordering::Release);
+    }
 }

--- a/bridge/ffi/src/state.rs
+++ b/bridge/ffi/src/state.rs
@@ -344,15 +344,17 @@ fn should_mark_dirty_from_event(event: &Event) -> bool {
         return false;
     }
 
-    match event.kind {
-        EventKind::Create(_) | EventKind::Remove(_) | EventKind::Any => true,
-        EventKind::Modify(ModifyKind::Name(RenameMode::Any))
-        | EventKind::Modify(ModifyKind::Name(RenameMode::Both))
-        | EventKind::Modify(ModifyKind::Name(RenameMode::From))
-        | EventKind::Modify(ModifyKind::Name(RenameMode::To))
-        | EventKind::Modify(ModifyKind::Name(RenameMode::Other)) => true,
-        _ => false,
-    }
+    matches!(
+        event.kind,
+        EventKind::Create(_)
+            | EventKind::Remove(_)
+            | EventKind::Any
+            | EventKind::Modify(ModifyKind::Name(RenameMode::Any))
+            | EventKind::Modify(ModifyKind::Name(RenameMode::Both))
+            | EventKind::Modify(ModifyKind::Name(RenameMode::From))
+            | EventKind::Modify(ModifyKind::Name(RenameMode::To))
+            | EventKind::Modify(ModifyKind::Name(RenameMode::Other))
+    )
 }
 
 #[cfg(test)]

--- a/bridge/ffi/src/state.rs
+++ b/bridge/ffi/src/state.rs
@@ -301,11 +301,12 @@ fn start_background_bootstrap_refresh() {
     let _ = BOOTSTRAP_REFRESH_STARTED.get_or_init(|| {
         thread::spawn(|| {
             let started_at = Instant::now();
+            let dirty_version_snapshot = INDEX_CHANGE_VERSION.load(Ordering::Acquire);
             let path = default_db_path();
             match QueryEngine::bootstrap_sqlite(&path) {
                 Ok(()) => {
                     refresh_engine_cache();
-                    clear_index_dirty();
+                    clear_index_dirty_if_unchanged(dirty_version_snapshot);
                     let candidate_count = with_engine(|engine| engine.search("", 2000).len());
                     log_info(&format!(
                         "bootstrap refresh ok candidates={} elapsed_ms={}",

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -20,6 +20,7 @@ pub const FILE_SCAN_LIMIT: usize = 8000;
 pub const FILE_SCAN_LIMIT_MIN: usize = 500;
 pub const FILE_SCAN_LIMIT_MAX: usize = 50_000;
 pub const FILE_EXCLUDE_PATHS: [&str; 0] = [];
+pub const LAZY_INDEXING_ENABLED: bool = true;
 
 pub const SCORE_TITLE_CONTAINS: i64 = 1200;
 pub const SCORE_SUBTITLE_CONTAINS: i64 = 900;
@@ -75,6 +76,7 @@ pub struct RuntimeConfig {
     pub file_scan_limit: usize,
     pub file_exclude_paths: Vec<String>,
     pub skip_dir_names: Vec<String>,
+    pub lazy_indexing_enabled: bool,
 }
 
 impl Default for RuntimeConfig {
@@ -104,6 +106,7 @@ impl Default for RuntimeConfig {
                 .iter()
                 .map(|value| value.to_string())
                 .collect(),
+            lazy_indexing_enabled: LAZY_INDEXING_ENABLED,
         }
     }
 }
@@ -204,6 +207,11 @@ impl RuntimeConfig {
                         }
                     }
                 }
+                "lazy_indexing_enabled" => {
+                    if let Some(parsed) = parse_bool(value) {
+                        self.lazy_indexing_enabled = parsed;
+                    }
+                }
                 _ => {}
             }
         }
@@ -244,6 +252,7 @@ file_scan_roots=Desktop,Documents,Downloads\n\
 file_scan_depth=4\n\
 file_scan_limit=8000\n\
 file_exclude_paths=\n\
+lazy_indexing_enabled=true\n\
 skip_dir_names=node_modules,target,build,dist,library,applications,old firefox data,deriveddata,pods,vendor,out,coverage,tmp,cache,venv\n\
 \n\
 # UI theme\n\
@@ -328,6 +337,14 @@ fn parse_positive_usize(value: &str) -> Option<usize> {
         .parse::<usize>()
         .ok()
         .filter(|parsed| *parsed > 0)
+}
+
+fn parse_bool(value: &str) -> Option<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    }
 }
 
 fn expand_path(value: &str, home: Option<&str>) -> String {
@@ -423,5 +440,33 @@ mod tests {
         assert!(config.skip_dir_names.iter().any(|name| name == "vendor"));
 
         let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn lazy_indexing_enabled_is_loaded_from_config() {
+        let tmp = std::env::temp_dir().join(format!(
+            "look-config-test-lazy-indexing-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time should be after epoch")
+                .as_nanos()
+        ));
+
+        std::fs::write(&tmp, "lazy_indexing_enabled=false\n")
+            .expect("should write temporary config");
+
+        let mut config = RuntimeConfig::default();
+        assert!(config.lazy_indexing_enabled);
+
+        config.apply_from_file(&tmp);
+        assert!(!config.lazy_indexing_enabled);
+
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn default_config_contents_include_lazy_indexing_enabled() {
+        assert!(default_config_contents().contains("lazy_indexing_enabled=true"));
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -140,6 +140,14 @@ The indexing flow is designed as a bounded pipeline:
 - prune usage history,
 - refresh in-memory cache for fast queries.
 
+Runtime refresh triggers:
+
+- file-system watcher monitors configured app/file roots and marks in-memory `index_dirty` on create/remove/rename events,
+- launcher open (`Cmd+Space`) requests background refresh through FFI,
+- refresh execution mode depends on `lazy_indexing_enabled`:
+  - `true`: run only when dirty,
+  - `false`: run on every launcher open request.
+
 ```mermaid
 flowchart TD
     Start[Engine cache init or config reload] --> Bootstrap[QueryEngine bootstrap_sqlite]

--- a/docs/backend-guide.md
+++ b/docs/backend-guide.md
@@ -115,7 +115,10 @@ After launch, validate:
 
 - search returns expected results,
 - usage events update ranking after opening items,
-- config reload (`Cmd+Shift+;`) applies expected runtime changes.
+- config reload (`Cmd+Shift+;`) applies expected runtime changes,
+- lazy indexing mode behavior:
+  - `lazy_indexing_enabled=true`: `Cmd+Space` refreshes only when dirty,
+  - `lazy_indexing_enabled=false`: `Cmd+Space` always requests background refresh.
 
 ## Reliability rules
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -49,6 +49,7 @@ This document tracks what `look` supports today and what is planned next.
 
 - SQLite-backed candidate + usage storage
 - startup/index refresh pipeline for apps/files/settings
+- dirty-aware incremental indexing via file-system events (`Cmd+Space` refresh-on-dirty)
 - usage-event feedback loop for ranking updates
 - Rust core + FFI bridge to Swift app shell
 
@@ -61,7 +62,6 @@ This document tracks what `look` supports today and what is planned next.
 
 ## Planned direction
 
-- incremental indexing via file-system events
 - optional extension/plugin injection model (without bloating base UX)
 - broader platform support after macOS quality stabilizes (Windows first)
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -116,8 +116,15 @@ Default values:
 
 - **File Scan Depth**: 4 (range: 1-12)
 - **File Scan Limit**: 4000 (range: 500-50000)
+- **Lazy indexing**: On
 
 These control how deeply and how many files are indexed for search.
+
+Lazy indexing behavior:
+
+- when **On**, Look listens for file/app create/remove/rename events and marks the index dirty,
+- pressing `Cmd+Space` triggers background reindex only when dirty,
+- when **Off**, pressing `Cmd+Space` always triggers background reindex.
 
 ### Other Settings
 
@@ -135,6 +142,7 @@ Backend-related keys:
 
 - `app_scan_roots`, `app_scan_depth`, `app_exclude_paths`, `app_exclude_names`
 - `file_scan_roots`, `file_scan_depth`, `file_scan_limit`, `file_exclude_paths`
+- `lazy_indexing_enabled`
 - `skip_dir_names`
 - `translate_allow_network`, `backend_log_level`, `launch_at_login`
 


### PR DESCRIPTION
## Summary

#62 

## Why

#62 

## Changes

- Added Lazy indexing setting in Advanced UI and persisted it to ~/.look.config as lazy_indexing_enabled.
- Added runtime config parsing for lazy_indexing_enabled in Rust core.
- Added FFI look_request_index_refresh and hooked launcher open (Cmd+Space) to call it.
- Added FS watcher (notify) to mark in-memory index_dirty on create/remove/rename.
- Removed scheduled reindex; now it’s watcher dirty flag + Cmd+Space.
- Refresh behavior:
  - lazy ON -> reindex only if dirty
  - lazy OFF -> reindex on every Cmd+Space
- Hardened INDEX_REFRESH_IN_PROGRESS with guard + panic-safe release.
- Added tests for config parsing, dirty-event filtering, dirty-clear race handling, and refresh slot logic.


## Testing

- [x] `cargo check --workspace --manifest-path core/Cargo.toml`
- [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [x] `cd apps/macos/LauncherApp && swift test`
- [x] `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

- User's Cpu usage might be increased by enabling the flag but this is so tiny (like you calc 1+1 = 2)

## Checklist

- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered
