### PR TITLE
Feat/aliases result

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Highlights:
 - very fast local app and file search
 - clipboard history lookup with preview
 - built-in quick commands (calculator, shell, force quit, system info)
+- query aliases for apps + System Settings via `~/.look.config` (for example `alias_note`, `alias_code`)
 - lightweight native app with local-first behavior
 
 ## Quick navigation
@@ -50,6 +51,13 @@ If you want a minimal launcher that stays fast and predictable, `look` is built 
 
 User-level behavior can be configured with `~/.look.config` (indexing + UI theme/font; see [User Guide](docs/user-guide.md) for supported keys).
 
+Theme and alias notes:
+
+- current built-in themes: Catppuccin, Tokyo Night, Rose Pine, Gruvbox, Dracula, Kanagawa, Custom
+- built-in themes are available in `Settings > Appearance` and persisted in `~/.look.config`
+- search aliases are configured with `alias_<keyword>=Term1|Term2|...` in `~/.look.config` and apply to app + System Settings search
+- fresh config presets include `alias_note`, `alias_code`, `alias_term`, `alias_chat`, `alias_music`, and `alias_brow`
+
 Indexing config supports include roots plus exclude rules for both apps and files.
 
 ## Repository layout
@@ -74,7 +82,7 @@ Indexing config supports include roots plus exclude rules for both apps and file
 
 ## UI
 
-Customizable themes available (Settings > Appearance):
+Current built-in themes (Settings > Appearance):
 - Catppuccin, Tokyo Night, Rose Pine, Gruvbox, Dracula, Kanagawa, Custom
 
 ![Look UI 1](assets/look-ui/1.png)

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -284,7 +284,7 @@ ui_border_blue=1.0\n\
 ui_border_opacity=0.12\n\
 \n\
 # Search aliases (apps + System Settings). Format: alias_<keyword>=Term1|Term2|Term3\n\
-alias_note=Notion|Obsidian|Notes\n\
+alias_note=Notion|Obsidian|Notes|Apple Notes|Bear|Logseq\n\
 alias_code=Visual Studio Code|VSCode|Cursor|Windsurf|IntelliJ IDEA|PyCharm|WebStorm|Neovim|Xcode|Zed\n\
 alias_term=Terminal|iTerm|iTerm2|Ghostty|WezTerm|Alacritty|Kitty|Warp\n\
 alias_chat=Slack|Discord|Telegram|Messages\n\
@@ -655,7 +655,7 @@ mod tests {
     #[test]
     fn default_config_contents_include_alias_entries() {
         let contents = default_config_contents();
-        assert!(contents.contains("alias_note=Notion|Obsidian|Notes"));
+        assert!(contents.contains("alias_note=Notion|Obsidian|Notes|Apple Notes|Bear|Logseq"));
         assert!(contents
             .contains("alias_code=Visual Studio Code|VSCode|Cursor|Windsurf|IntelliJ IDEA|PyCharm|WebStorm|Neovim|Xcode|Zed"));
         assert!(

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -1,3 +1,5 @@
+use crate::normalize::normalize_for_search;
+use std::collections::HashMap;
 use std::env;
 use std::path::{Path, PathBuf};
 
@@ -77,6 +79,7 @@ pub struct RuntimeConfig {
     pub file_exclude_paths: Vec<String>,
     pub skip_dir_names: Vec<String>,
     pub lazy_indexing_enabled: bool,
+    pub search_aliases: HashMap<String, Vec<String>>,
 }
 
 impl Default for RuntimeConfig {
@@ -107,6 +110,7 @@ impl Default for RuntimeConfig {
                 .map(|value| value.to_string())
                 .collect(),
             lazy_indexing_enabled: LAZY_INDEXING_ENABLED,
+            search_aliases: default_search_aliases(),
         }
     }
 }
@@ -212,6 +216,11 @@ impl RuntimeConfig {
                         self.lazy_indexing_enabled = parsed;
                     }
                 }
+                _ if key.strip_prefix("alias_").is_some() => {
+                    if let Some(alias_key) = key.strip_prefix("alias_") {
+                        apply_alias_override(alias_key, value, &mut self.search_aliases);
+                    }
+                }
                 _ => {}
             }
         }
@@ -272,7 +281,96 @@ ui_border_thickness=1.0\n\
 ui_border_red=1.0\n\
 ui_border_green=1.0\n\
 ui_border_blue=1.0\n\
-ui_border_opacity=0.12\n"
+ui_border_opacity=0.12\n\
+\n\
+# Search aliases (apps + System Settings). Format: alias_<keyword>=Term1|Term2|Term3\n\
+alias_note=Notion|Obsidian|Notes\n\
+alias_code=Visual Studio Code|VSCode|Cursor|Windsurf|IntelliJ IDEA|PyCharm|WebStorm|Neovim|Xcode|Zed\n\
+alias_term=Terminal|iTerm|iTerm2|Ghostty|WezTerm|Alacritty|Kitty|Warp\n\
+alias_chat=Slack|Discord|Telegram|Messages\n\
+alias_music=Spotify|Apple Music|Music\n\
+alias_brow=Safari|Arc|Google Chrome|Chrome|Firefox|Brave\n"
+}
+
+fn default_search_aliases() -> HashMap<String, Vec<String>> {
+    let mut aliases = HashMap::new();
+    aliases.insert(
+        "note".to_string(),
+        vec![
+            "notion",
+            "obsidian",
+            "notes",
+            "apple notes",
+            "bear",
+            "logseq",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect(),
+    );
+    aliases.insert(
+        "code".to_string(),
+        vec![
+            "visual studio code",
+            "vscode",
+            "cursor",
+            "windsurf",
+            "intellij idea",
+            "pycharm",
+            "webstorm",
+            "neovim",
+            "xcode",
+            "zed",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect(),
+    );
+    aliases.insert(
+        "term".to_string(),
+        vec![
+            "terminal",
+            "iterm",
+            "iterm2",
+            "ghostty",
+            "wezterm",
+            "alacritty",
+            "kitty",
+            "warp",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect(),
+    );
+    aliases.insert(
+        "chat".to_string(),
+        vec!["slack", "discord", "telegram", "messages"]
+            .into_iter()
+            .map(String::from)
+            .collect(),
+    );
+    aliases.insert(
+        "music".to_string(),
+        vec!["spotify", "apple music", "music"]
+            .into_iter()
+            .map(String::from)
+            .collect(),
+    );
+    aliases.insert(
+        "brow".to_string(),
+        vec![
+            "safari",
+            "arc",
+            "google chrome",
+            "chrome",
+            "firefox",
+            "brave",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect(),
+    );
+    aliases
 }
 
 fn default_file_scan_roots() -> Vec<String> {
@@ -345,6 +443,32 @@ fn parse_bool(value: &str) -> Option<bool> {
         "0" | "false" | "no" | "off" => Some(false),
         _ => None,
     }
+}
+
+fn parse_alias_values(value: &str) -> Vec<String> {
+    let mut values = Vec::new();
+    for raw in value.split('|') {
+        let normalized = normalize_for_search(raw.trim());
+        if !normalized.is_empty() && !values.iter().any(|entry| entry == &normalized) {
+            values.push(normalized);
+        }
+    }
+    values
+}
+
+fn apply_alias_override(alias_key: &str, value: &str, aliases: &mut HashMap<String, Vec<String>>) {
+    let normalized_key = normalize_for_search(alias_key.trim());
+    if normalized_key.is_empty() {
+        return;
+    }
+
+    let parsed = parse_alias_values(value);
+    if parsed.is_empty() {
+        aliases.remove(&normalized_key);
+        return;
+    }
+
+    aliases.insert(normalized_key, parsed);
 }
 
 fn expand_path(value: &str, home: Option<&str>) -> String {
@@ -468,5 +592,78 @@ mod tests {
     #[test]
     fn default_config_contents_include_lazy_indexing_enabled() {
         assert!(default_config_contents().contains("lazy_indexing_enabled=true"));
+    }
+
+    #[test]
+    fn alias_entries_are_loaded_from_config() {
+        let tmp = std::env::temp_dir().join(format!(
+            "look-config-test-aliases-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time should be after epoch")
+                .as_nanos()
+        ));
+
+        std::fs::write(
+            &tmp,
+            "alias_note=Notion| Obsidian | Notes\nalias_code=VSCode|IntelliJ IDEA\n",
+        )
+        .expect("should write temporary config");
+
+        let mut config = RuntimeConfig::default();
+        config.apply_from_file(&tmp);
+
+        assert_eq!(
+            config.search_aliases.get("note"),
+            Some(&vec![
+                "notion".to_string(),
+                "obsidian".to_string(),
+                "notes".to_string()
+            ])
+        );
+        assert_eq!(
+            config.search_aliases.get("code"),
+            Some(&vec!["vscode".to_string(), "intellij idea".to_string()])
+        );
+
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn alias_entry_can_remove_default_alias() {
+        let tmp = std::env::temp_dir().join(format!(
+            "look-config-test-alias-remove-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time should be after epoch")
+                .as_nanos()
+        ));
+
+        std::fs::write(&tmp, "alias_note=\n").expect("should write temporary config");
+
+        let mut config = RuntimeConfig::default();
+        assert!(config.search_aliases.contains_key("note"));
+
+        config.apply_from_file(&tmp);
+        assert!(!config.search_aliases.contains_key("note"));
+
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn default_config_contents_include_alias_entries() {
+        let contents = default_config_contents();
+        assert!(contents.contains("alias_note=Notion|Obsidian|Notes"));
+        assert!(contents
+            .contains("alias_code=Visual Studio Code|VSCode|Cursor|Windsurf|IntelliJ IDEA|PyCharm|WebStorm|Neovim|Xcode|Zed"));
+        assert!(
+            contents
+                .contains("alias_term=Terminal|iTerm|iTerm2|Ghostty|WezTerm|Alacritty|Kitty|Warp")
+        );
+        assert!(contents.contains("alias_chat=Slack|Discord|Telegram|Messages"));
+        assert!(contents.contains("alias_music=Spotify|Apple Music|Music"));
+        assert!(contents.contains("alias_brow=Safari|Arc|Google Chrome|Chrome|Firefox|Brave"));
     }
 }

--- a/core/engine/src/lib.rs
+++ b/core/engine/src/lib.rs
@@ -574,4 +574,34 @@ mod tests {
             Some("file.note")
         );
     }
+
+    #[test]
+    fn alias_brow_does_not_promote_archive_for_arc_term() {
+        let mut config = RuntimeConfig::default();
+        config
+            .search_aliases
+            .insert("brow".to_string(), vec!["arc".to_string()]);
+
+        let mut archive = Candidate::new(
+            "app.archive",
+            CandidateKind::App,
+            "Archive Utility",
+            "/System/Library/CoreServices/Applications/Archive Utility.app",
+        );
+        archive.use_count = 2_000;
+
+        let arc = Candidate::new(
+            "app.arc",
+            CandidateKind::App,
+            "Arc",
+            "/Applications/Arc.app",
+        );
+
+        let engine = QueryEngine::new_with_config(vec![archive, arc], &config);
+        let results = engine.search_scored("brow", 10);
+        assert_eq!(
+            results.first().map(|(candidate, _)| candidate.id.as_ref()),
+            Some("app.arc")
+        );
+    }
 }

--- a/core/engine/src/lib.rs
+++ b/core/engine/src/lib.rs
@@ -13,6 +13,7 @@ use look_indexing::{Candidate, CandidateKind};
 use look_storage::{SearchSettings, SqliteStore, StorageError};
 use normalize::normalize_for_search;
 pub use result::{LaunchResult, LaunchResultAction};
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -33,13 +34,22 @@ struct IndexedCandidate {
 #[derive(Default)]
 pub struct QueryEngine {
     candidates: Vec<IndexedCandidate>,
+    search_aliases: HashMap<String, Vec<String>>,
 }
 
 impl QueryEngine {
     pub fn new(candidates: Vec<Candidate>) -> Self {
+        let runtime_config = RuntimeConfig::default();
+        Self::new_with_config(candidates, &runtime_config)
+    }
+
+    pub fn new_with_config(candidates: Vec<Candidate>, config: &RuntimeConfig) -> Self {
         // Build an in-memory search index up front (hot path reads only).
         let candidates = candidates.into_iter().map(IndexedCandidate::new).collect();
-        Self { candidates }
+        Self {
+            candidates,
+            search_aliases: config.search_aliases.clone(),
+        }
     }
 
     pub fn search(&self, query: &str, limit: usize) -> Vec<LaunchResult> {
@@ -97,13 +107,17 @@ impl QueryEngine {
     }
 
     pub fn from_sqlite(path: impl AsRef<Path>) -> Result<Self, StorageError> {
+        let runtime_config = RuntimeConfig::load();
         let store = SqliteStore::open(path)?;
         let candidates = store.load_candidates(None)?;
         if candidates.is_empty() {
-            return Ok(Self::new(Self::demo_candidates()));
+            return Ok(Self::new_with_config(
+                Self::demo_candidates(),
+                &runtime_config,
+            ));
         }
 
-        Ok(Self::new(candidates))
+        Ok(Self::new_with_config(candidates, &runtime_config))
     }
 
     pub fn bootstrap_sqlite(path: impl AsRef<Path>) -> Result<(), StorageError> {
@@ -497,6 +511,67 @@ mod tests {
         assert_eq!(
             results.first().map(|(candidate, _)| candidate.id.as_ref()),
             Some("setting:general")
+        );
+    }
+
+    #[test]
+    fn alias_note_promotes_matching_app_results() {
+        let mut config = RuntimeConfig::default();
+        config
+            .search_aliases
+            .insert("note".to_string(), vec!["notion".to_string()]);
+
+        let app = Candidate::new(
+            "app.notion",
+            CandidateKind::App,
+            "Notion",
+            "/Applications/Notion.app",
+        );
+        let file = Candidate::new(
+            "file.note",
+            CandidateKind::File,
+            "notes.txt",
+            "/Users/test/Documents/notes.txt",
+        );
+
+        let engine = QueryEngine::new_with_config(vec![app, file], &config);
+        let results = engine.search_scored("note", 10);
+        assert_eq!(
+            results.first().map(|(candidate, _)| candidate.id.as_ref()),
+            Some("app.notion")
+        );
+    }
+
+    #[test]
+    fn alias_is_not_applied_for_file_scope_queries() {
+        let mut config = RuntimeConfig::default();
+        config
+            .search_aliases
+            .insert("note".to_string(), vec!["notion".to_string()]);
+
+        let app = Candidate::new(
+            "app.notion",
+            CandidateKind::App,
+            "Notion",
+            "/Applications/Notion.app",
+        );
+        let file = Candidate::new(
+            "file.note",
+            CandidateKind::File,
+            "notes.txt",
+            "/Users/test/Documents/notes.txt",
+        );
+
+        let engine = QueryEngine::new_with_config(vec![app, file], &config);
+        let results = engine.search_scored("f\"note", 10);
+        assert!(
+            results
+                .iter()
+                .all(|(candidate, _)| candidate.kind == CandidateKind::File)
+        );
+        assert_eq!(
+            results.first().map(|(candidate, _)| candidate.id.as_ref()),
+            Some("file.note")
         );
     }
 }

--- a/core/engine/src/search.rs
+++ b/core/engine/src/search.rs
@@ -18,6 +18,8 @@ const RERANK_POOL_MULTIPLIER: usize = 4;
 const RERANK_TOP_N: usize = 80;
 const RERANK_MIN_QUERY_CHARS: usize = 3;
 const REGEX_SIZE_LIMIT_BYTES: usize = 1024 * 1024;
+const SCORE_ALIAS_TITLE_MATCH: i64 = 1_520;
+const SCORE_ALIAS_SUBTITLE_MATCH: i64 = 1_260;
 
 fn top_limit(mut ranked: Vec<(Candidate, i64)>, limit: usize) -> Vec<(Candidate, i64)> {
     ranked.truncate(limit);
@@ -25,6 +27,42 @@ fn top_limit(mut ranked: Vec<(Candidate, i64)>, limit: usize) -> Vec<(Candidate,
 }
 
 impl QueryEngine {
+    fn alias_terms_for_query<'a>(
+        &'a self,
+        normalized_query: &str,
+        kind_filter: Option<&CandidateKind>,
+    ) -> Option<&'a Vec<String>> {
+        if normalized_query.is_empty() {
+            return None;
+        }
+
+        if let Some(kind) = kind_filter
+            && *kind != CandidateKind::App
+        {
+            return None;
+        }
+
+        self.search_aliases.get(normalized_query)
+    }
+
+    fn alias_match_score(
+        alias_terms: &[String],
+        title_search: &str,
+        subtitle_search: Option<&str>,
+    ) -> Option<i64> {
+        let mut best = None;
+        for term in alias_terms {
+            if title_search.contains(term) {
+                best = Some(best.unwrap_or(0).max(SCORE_ALIAS_TITLE_MATCH));
+            }
+
+            if subtitle_search.is_some_and(|subtitle| subtitle.contains(term)) {
+                best = Some(best.unwrap_or(0).max(SCORE_ALIAS_SUBTITLE_MATCH));
+            }
+        }
+        best
+    }
+
     fn kind_matches(
         candidate: &crate::IndexedCandidate,
         kind_filter: Option<&CandidateKind>,
@@ -125,6 +163,7 @@ impl QueryEngine {
         let has_path_hint = normalized_query.contains('/');
         let settings_query = looks_like_settings_query(normalized_query);
         let pool_limit = (limit.saturating_mul(RERANK_POOL_MULTIPLIER)).max(RERANK_TOP_N);
+        let alias_terms = self.alias_terms_for_query(normalized_query, kind_filter);
 
         for candidate in self
             .candidates
@@ -151,11 +190,23 @@ impl QueryEngine {
             } else {
                 None
             };
+            let alias_score = alias_terms.and_then(|terms| {
+                if candidate.candidate.kind != CandidateKind::App {
+                    return None;
+                }
+                Self::alias_match_score(terms, &candidate.title_search, subtitle_search)
+            });
 
-            let base = [title_score, subtitle_score, contains_score, path_score]
-                .into_iter()
-                .flatten()
-                .max();
+            let base = [
+                title_score,
+                subtitle_score,
+                contains_score,
+                path_score,
+                alias_score,
+            ]
+            .into_iter()
+            .flatten()
+            .max();
 
             let Some(base) = base else {
                 continue;

--- a/core/engine/src/search.rs
+++ b/core/engine/src/search.rs
@@ -27,6 +27,29 @@ fn top_limit(mut ranked: Vec<(Candidate, i64)>, limit: usize) -> Vec<(Candidate,
 }
 
 impl QueryEngine {
+    fn has_term_boundary_match(haystack: &str, term: &str) -> bool {
+        if term.is_empty() {
+            return false;
+        }
+
+        for (start, _) in haystack.match_indices(term) {
+            let end = start + term.len();
+            let left_ok = haystack[..start]
+                .chars()
+                .next_back()
+                .is_none_or(|ch| !ch.is_alphanumeric());
+            let right_ok = haystack[end..]
+                .chars()
+                .next()
+                .is_none_or(|ch| !ch.is_alphanumeric());
+            if left_ok && right_ok {
+                return true;
+            }
+        }
+
+        false
+    }
+
     fn alias_terms_for_query<'a>(
         &'a self,
         normalized_query: &str,
@@ -52,11 +75,12 @@ impl QueryEngine {
     ) -> Option<i64> {
         let mut best = None;
         for term in alias_terms {
-            if title_search.contains(term) {
+            if Self::has_term_boundary_match(title_search, term) {
                 best = Some(best.unwrap_or(0).max(SCORE_ALIAS_TITLE_MATCH));
             }
 
-            if subtitle_search.is_some_and(|subtitle| subtitle.contains(term)) {
+            if subtitle_search.is_some_and(|subtitle| Self::has_term_boundary_match(subtitle, term))
+            {
                 best = Some(best.unwrap_or(0).max(SCORE_ALIAS_SUBTITLE_MATCH));
             }
         }
@@ -262,5 +286,24 @@ impl QueryEngine {
         }
 
         self.search_text_query(&parsed_query.normalized_query, kind_filter, limit)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::QueryEngine;
+
+    #[test]
+    fn term_boundary_match_rejects_inner_substring() {
+        assert!(!QueryEngine::has_term_boundary_match(
+            "archive utility",
+            "arc"
+        ));
+    }
+
+    #[test]
+    fn term_boundary_match_accepts_full_token() {
+        assert!(QueryEngine::has_term_boundary_match("arc browser", "arc"));
+        assert!(QueryEngine::has_term_boundary_match("arc-browser", "arc"));
     }
 }

--- a/docs/features.md
+++ b/docs/features.md
@@ -41,6 +41,7 @@ This document tracks what `look` supports today and what is planned next.
 - local config file `~/.look.config`
 - runtime reload (`Cmd+Shift+;`)
 - 7 built-in theme presets (Catppuccin, Tokyo Night, Rose Pine, Gruvbox, Dracula, Kanagawa, Custom)
+- query alias presets in `~/.look.config` for app + System Settings intent expansion (`alias_note`, `alias_code`, `alias_term`, `alias_chat`, `alias_music`, `alias_brow`)
 - semantic color system with auto-derived text colors in Custom mode
 - indexing, UI, privacy/logging, launch-at-login controls
 - immediate validation feedback for invalid settings input

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -144,7 +144,7 @@ Backend-related keys:
 - `file_scan_roots`, `file_scan_depth`, `file_scan_limit`, `file_exclude_paths`
 - `lazy_indexing_enabled`
 - `skip_dir_names`
-- `alias_<keyword>` (for app + System Settings query aliases, for example `alias_note=Notion|Obsidian|Notes`)
+- `alias_<keyword>` (for app + System Settings query aliases, for example `alias_note=Notion|Obsidian|Notes|Apple Notes|Bear|Logseq`)
 - `translate_allow_network`, `backend_log_level`, `launch_at_login`
 
 Alias note:
@@ -152,6 +152,20 @@ Alias note:
 - aliases do not create synthetic results; they only boost existing indexed app/System Settings entries
 - if an aliased app is not installed, there is no error and no result is added
 - keep alias lists short (around 5-10 targets per keyword) to avoid noisy ranking
+
+Default alias presets (fresh config files):
+
+- `alias_note=Notion|Obsidian|Notes|Apple Notes|Bear|Logseq`
+- `alias_code=Visual Studio Code|VSCode|Cursor|Windsurf|IntelliJ IDEA|PyCharm|WebStorm|Neovim|Xcode|Zed`
+- `alias_term=Terminal|iTerm|iTerm2|Ghostty|WezTerm|Alacritty|Kitty|Warp`
+- `alias_chat=Slack|Discord|Telegram|Messages`
+- `alias_music=Spotify|Apple Music|Music`
+- `alias_brow=Safari|Arc|Google Chrome|Chrome|Firefox|Brave`
+
+Preset update behavior:
+
+- presets are written automatically only when `~/.look.config` is created for the first time
+- app updates do not rewrite an existing config file, so existing users should add new `alias_*` keys manually
 
 UI-related keys include the `ui_*` group (tint/blur/font/border values).
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -144,7 +144,14 @@ Backend-related keys:
 - `file_scan_roots`, `file_scan_depth`, `file_scan_limit`, `file_exclude_paths`
 - `lazy_indexing_enabled`
 - `skip_dir_names`
+- `alias_<keyword>` (for app + System Settings query aliases, for example `alias_note=Notion|Obsidian|Notes`)
 - `translate_allow_network`, `backend_log_level`, `launch_at_login`
+
+Alias note:
+
+- aliases do not create synthetic results; they only boost existing indexed app/System Settings entries
+- if an aliased app is not installed, there is no error and no result is added
+- keep alias lists short (around 5-10 targets per keyword) to avoid noisy ranking
 
 UI-related keys include the `ui_*` group (tint/blur/font/border values).
 


### PR DESCRIPTION
## Summary

#66 

## Why

#66 

## Changes

Add aliases feature, user can use this for fast matching app, settings by their declared category

## Testing

- [x] `cargo check --workspace --manifest-path core/Cargo.toml`
- [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [x] `cd apps/macos/LauncherApp && swift test`
- [x] `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered
