### PR TITLE
feat: Reset config to default, CI update

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,42 @@
+# GitHub Automation Notes
+
+This folder contains workflow and repo automation config.
+
+## Workflows
+
+- `workflows/ci.yml`
+  - regular CI checks for pushes/PRs
+  - does not run Apple signing/notarization
+
+- `workflows/release-macos.yml`
+  - lightweight release entrypoint
+  - triggers on:
+    - manual dispatch (`workflow_dispatch`)
+    - tag push (`v*`)
+  - delegates to reusable release workflow
+
+- `workflows/reusable-release-macos.yml`
+  - full macOS release pipeline:
+    - build artifact
+    - optional Developer ID signing
+    - optional notarization + stapling
+    - artifact upload and optional GitHub Release attach
+
+## Strict mode
+
+- strict mode is enabled when release ref/version text includes `strict`
+  - examples: `1.2.3-strict`, `v1.2.3-strict`
+- in strict mode, missing secrets fail fast and notarization timeout/failure fails the run
+- in non-strict mode, notarization queue timeout can continue with signed (unstapled) artifact for testing
+
+## Required secrets for signed + notarized releases
+
+- `APPLE_DEVELOPER_ID_CERT_BASE64`
+- `APPLE_DEVELOPER_ID_CERT_PASSWORD`
+- `APPLE_KEYCHAIN_PASSWORD`
+- `APPLE_DEVELOPER_ID_APPLICATION`
+- `APPLE_NOTARY_APPLE_ID`
+- `APPLE_NOTARY_APP_PASSWORD`
+- `APPLE_NOTARY_TEAM_ID`
+
+See `docs/apple-developer-release-guide.md` for full setup and troubleshooting.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
               - '.github/workflows/ci.yml'
 
   lint:
-    name: Lint
+    name: lint
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.rust == 'true'
@@ -63,7 +63,7 @@ jobs:
         run: cargo clippy --manifest-path bridge/ffi/Cargo.toml -- -D warnings
 
   security:
-    name: Rust Security
+    name: security
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.rust == 'true'
@@ -86,7 +86,7 @@ jobs:
         run: cargo audit --file bridge/ffi/Cargo.lock
 
   secrets-scan:
-    name: Secrets Scan
+    name: secrets-scan
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -99,7 +99,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test:
-    name: Test
+    name: test
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.rust == 'true'
@@ -119,10 +119,14 @@ jobs:
         run: cargo test --manifest-path bridge/ffi/Cargo.toml
 
   build:
-    name: Build
+    name: build
     runs-on: ubuntu-latest
     needs: changes
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.rust == 'true'
+    if: |
+      needs.changes.outputs.rust == 'true' && (
+        (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')) ||
+        (github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'dev'))
+      )
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -5,6 +5,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   workflow_dispatch:
     inputs:
@@ -18,158 +19,10 @@ on:
 
 jobs:
   build-release:
-    name: Build macOS release artifact
-    runs-on: macos-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Resolve release version
-        id: version
-        run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            VERSION="${{ inputs.version }}"
-          else
-            VERSION="${GITHUB_REF_NAME#v}"
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Build release zip + manifest
-        run: ./scripts/build-release.sh "${{ steps.version.outputs.version }}"
-
-      - name: Configure macOS signing keychain (optional)
-        env:
-          APPLE_DEVELOPER_ID_CERT_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERT_BASE64 }}
-          APPLE_DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERT_PASSWORD }}
-          APPLE_KEYCHAIN_PASSWORD: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
-        run: |
-          if [[ -z "${APPLE_DEVELOPER_ID_CERT_BASE64}" ]]; then
-            echo "No Developer ID certificate secret configured; skipping signing setup."
-            exit 0
-          fi
-
-          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
-          CERT_PATH="$RUNNER_TEMP/developer-id.p12"
-
-          echo -n "$APPLE_DEVELOPER_ID_CERT_BASE64" | base64 --decode > "$CERT_PATH"
-          security create-keychain -p "$APPLE_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$APPLE_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security import "$CERT_PATH" -P "$APPLE_DEVELOPER_ID_CERT_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-          security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain-db
-          security set-key-partition-list -S apple-tool:,apple: -s -k "$APPLE_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-      - name: Codesign app bundle (optional)
-        env:
-          APPLE_DEVELOPER_ID_APPLICATION: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION }}
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          APP_PATH=".build/release-macos/DerivedData/Build/Products/Release/Look.app"
-          ZIP_PATH="dist/Look-${VERSION}-macOS.zip"
-          MANIFEST_PATH="dist/Look-${VERSION}-manifest.txt"
-
-          if [[ -z "${APPLE_DEVELOPER_ID_APPLICATION}" ]]; then
-            echo "No Developer ID identity configured; skipping codesign."
-            exit 0
-          fi
-
-          if [[ ! -d "$APP_PATH" ]]; then
-            echo "App bundle missing at $APP_PATH" >&2
-            exit 1
-          fi
-
-          codesign --force --deep --options runtime --timestamp \
-            --sign "$APPLE_DEVELOPER_ID_APPLICATION" "$APP_PATH"
-          codesign --verify --deep --strict --verbose=2 "$APP_PATH"
-
-          rm -f "$ZIP_PATH"
-          ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" "$ZIP_PATH"
-          SHA256="$(shasum -a 256 "$ZIP_PATH" | awk '{print $1}')"
-          cat > "$MANIFEST_PATH" <<EOF
-          version=${VERSION}
-          artifact=$(basename "$ZIP_PATH")
-          sha256=${SHA256}
-          EOF
-
-      - name: Notarize release zip (optional)
-        env:
-          APPLE_NOTARY_APPLE_ID: ${{ secrets.APPLE_NOTARY_APPLE_ID }}
-          APPLE_NOTARY_APP_PASSWORD: ${{ secrets.APPLE_NOTARY_APP_PASSWORD }}
-          APPLE_NOTARY_TEAM_ID: ${{ secrets.APPLE_NOTARY_TEAM_ID }}
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          ZIP_PATH="dist/Look-${VERSION}-macOS.zip"
-          MANIFEST_PATH="dist/Look-${VERSION}-manifest.txt"
-
-          if [[ -z "${APPLE_NOTARY_APPLE_ID}" || -z "${APPLE_NOTARY_APP_PASSWORD}" || -z "${APPLE_NOTARY_TEAM_ID}" ]]; then
-            echo "Notary credentials not configured; skipping notarization."
-            exit 0
-          fi
-
-          xcrun notarytool submit "$ZIP_PATH" \
-            --apple-id "$APPLE_NOTARY_APPLE_ID" \
-            --password "$APPLE_NOTARY_APP_PASSWORD" \
-            --team-id "$APPLE_NOTARY_TEAM_ID" \
-            --wait
-
-          WORK_DIR="$RUNNER_TEMP/notary"
-          rm -rf "$WORK_DIR"
-          mkdir -p "$WORK_DIR"
-          ditto -x -k "$ZIP_PATH" "$WORK_DIR"
-          xcrun stapler staple "$WORK_DIR/Look.app"
-
-          rm -f "$ZIP_PATH"
-          ditto -c -k --sequesterRsrc --keepParent "$WORK_DIR/Look.app" "$ZIP_PATH"
-          SHA256="$(shasum -a 256 "$ZIP_PATH" | awk '{print $1}')"
-          cat > "$MANIFEST_PATH" <<EOF
-          version=${VERSION}
-          artifact=$(basename "$ZIP_PATH")
-          sha256=${SHA256}
-          EOF
-
-      - name: Upload release artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: look-macos-${{ steps.version.outputs.version }}
-          path: |
-            dist/Look-${{ steps.version.outputs.version }}-macOS.zip
-            dist/Look-${{ steps.version.outputs.version }}-manifest.txt
-          retention-days: 14
-
-      - name: Attach assets to GitHub release (tag pushes only)
-        if: github.event_name == 'push'
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            dist/Look-${{ steps.version.outputs.version }}-macOS.zip
-            dist/Look-${{ steps.version.outputs.version }}-manifest.txt
-
-      - name: Release security summary
-        if: always()
-        env:
-          APPLE_DEVELOPER_ID_CERT_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERT_BASE64 }}
-          APPLE_DEVELOPER_ID_APPLICATION: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION }}
-          APPLE_NOTARY_APPLE_ID: ${{ secrets.APPLE_NOTARY_APPLE_ID }}
-          APPLE_NOTARY_APP_PASSWORD: ${{ secrets.APPLE_NOTARY_APP_PASSWORD }}
-          APPLE_NOTARY_TEAM_ID: ${{ secrets.APPLE_NOTARY_TEAM_ID }}
-        run: |
-          SIGNING_READY="false"
-          NOTARY_READY="false"
-
-          if [[ -n "${APPLE_DEVELOPER_ID_CERT_BASE64}" && -n "${APPLE_DEVELOPER_ID_APPLICATION}" ]]; then
-            SIGNING_READY="true"
-          fi
-
-          if [[ -n "${APPLE_NOTARY_APPLE_ID}" && -n "${APPLE_NOTARY_APP_PASSWORD}" && -n "${APPLE_NOTARY_TEAM_ID}" ]]; then
-            NOTARY_READY="true"
-          fi
-
-          {
-            echo "## Release Security Summary"
-            echo "- Codesign configured: ${SIGNING_READY}"
-            echo "- Notarization configured: ${NOTARY_READY}"
-            if [[ "${SIGNING_READY}" != "true" || "${NOTARY_READY}" != "true" ]]; then
-              echo "- This release is likely unsigned and/or not notarized."
-              echo "- Users may need first-run Gatekeeper bypass (Open Anyway / right-click Open)."
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
+    uses: ./.github/workflows/reusable-release-macos.yml
+    with:
+      release_ref: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
+      trigger_event: ${{ github.event_name }}
+      attach_release: ${{ github.event_name == 'push' }}
+      concurrency_ref: ${{ github.ref }}
+    secrets: inherit

--- a/.github/workflows/reusable-release-macos.yml
+++ b/.github/workflows/reusable-release-macos.yml
@@ -239,7 +239,8 @@ jobs:
               fi
 
               echo "Notarization status '$NOTARY_STATUS' in non-strict mode; keeping signed artifact without stapling." >&2
-              echo "result=${NOTARY_STATUS,,}" >> "$GITHUB_OUTPUT"
+              NOTARY_STATUS_LOWER="$(printf '%s' "$NOTARY_STATUS" | tr '[:upper:]' '[:lower:]')"
+              echo "result=${NOTARY_STATUS_LOWER}" >> "$GITHUB_OUTPUT"
               exit 0
             fi
 

--- a/.github/workflows/reusable-release-macos.yml
+++ b/.github/workflows/reusable-release-macos.yml
@@ -1,0 +1,335 @@
+name: Reusable macOS Release
+
+permissions:
+  contents: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+on:
+  workflow_call:
+    inputs:
+      release_ref:
+        description: "Raw version input or ref name"
+        required: true
+        type: string
+      trigger_event:
+        description: "Original triggering event name"
+        required: true
+        type: string
+      attach_release:
+        description: "Attach assets to GitHub release"
+        required: true
+        type: boolean
+      concurrency_ref:
+        description: "Ref key used for concurrency grouping"
+        required: true
+        type: string
+    secrets:
+      APPLE_DEVELOPER_ID_CERT_BASE64:
+        required: false
+      APPLE_DEVELOPER_ID_CERT_PASSWORD:
+        required: false
+      APPLE_KEYCHAIN_PASSWORD:
+        required: false
+      APPLE_DEVELOPER_ID_APPLICATION:
+        required: false
+      APPLE_NOTARY_APPLE_ID:
+        required: false
+      APPLE_NOTARY_APP_PASSWORD:
+        required: false
+      APPLE_NOTARY_TEAM_ID:
+        required: false
+
+jobs:
+  build-release:
+    name: Build macOS release artifact
+    runs-on: macos-latest
+    concurrency:
+      group: release-macos-${{ inputs.concurrency_ref }}
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve release version
+        id: version
+        run: |
+          if [[ "${{ inputs.trigger_event }}" == "workflow_dispatch" ]]; then
+            VERSION="${{ inputs.release_ref }}"
+          else
+            VERSION="${{ inputs.release_ref }}"
+            VERSION="${VERSION#v}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve strict mode
+        id: strict
+        run: |
+          SOURCE="${{ inputs.release_ref }}"
+          SOURCE_LOWER="$(printf '%s' "$SOURCE" | tr '[:upper:]' '[:lower:]')"
+          STRICT_MODE="false"
+          if [[ "$SOURCE_LOWER" == *"strict"* ]]; then
+            STRICT_MODE="true"
+          fi
+
+          echo "strict_mode=$STRICT_MODE" >> "$GITHUB_OUTPUT"
+          echo "strict_source=$SOURCE" >> "$GITHUB_OUTPUT"
+
+      - name: Validate release security prerequisites (strict mode)
+        if: steps.strict.outputs.strict_mode == 'true'
+        env:
+          APPLE_DEVELOPER_ID_CERT_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERT_BASE64 }}
+          APPLE_DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERT_PASSWORD }}
+          APPLE_KEYCHAIN_PASSWORD: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
+          APPLE_DEVELOPER_ID_APPLICATION: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION }}
+          APPLE_NOTARY_APPLE_ID: ${{ secrets.APPLE_NOTARY_APPLE_ID }}
+          APPLE_NOTARY_APP_PASSWORD: ${{ secrets.APPLE_NOTARY_APP_PASSWORD }}
+          APPLE_NOTARY_TEAM_ID: ${{ secrets.APPLE_NOTARY_TEAM_ID }}
+        run: |
+          missing=0
+
+          for name in \
+            APPLE_DEVELOPER_ID_CERT_BASE64 \
+            APPLE_DEVELOPER_ID_CERT_PASSWORD \
+            APPLE_KEYCHAIN_PASSWORD \
+            APPLE_DEVELOPER_ID_APPLICATION \
+            APPLE_NOTARY_APPLE_ID \
+            APPLE_NOTARY_APP_PASSWORD \
+            APPLE_NOTARY_TEAM_ID; do
+            if [[ -z "${!name}" ]]; then
+              echo "Missing required secret in strict mode: $name" >&2
+              missing=1
+            fi
+          done
+
+          if [[ "$missing" -ne 0 ]]; then
+            echo "Strict mode enabled by ref/input '${{ steps.strict.outputs.strict_source }}'; aborting unsigned release." >&2
+            exit 1
+          fi
+
+      - name: Build release zip + manifest
+        run: ./scripts/build-release.sh "${{ steps.version.outputs.version }}"
+
+      - name: Configure macOS signing keychain (optional)
+        env:
+          APPLE_DEVELOPER_ID_CERT_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERT_BASE64 }}
+          APPLE_DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERT_PASSWORD }}
+          APPLE_KEYCHAIN_PASSWORD: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
+        run: |
+          if [[ -z "${APPLE_DEVELOPER_ID_CERT_BASE64}" ]]; then
+            if [[ "${{ steps.strict.outputs.strict_mode }}" == "true" ]]; then
+              echo "Strict mode requires APPLE_DEVELOPER_ID_CERT_BASE64." >&2
+              exit 1
+            fi
+            echo "No Developer ID certificate secret configured; skipping signing setup."
+            exit 0
+          fi
+
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+          CERT_PATH="$RUNNER_TEMP/developer-id.p12"
+
+          echo -n "$APPLE_DEVELOPER_ID_CERT_BASE64" | base64 --decode > "$CERT_PATH"
+          security create-keychain -p "$APPLE_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$APPLE_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -P "$APPLE_DEVELOPER_ID_CERT_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain-db
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$APPLE_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+      - name: Codesign app bundle (optional)
+        env:
+          APPLE_DEVELOPER_ID_APPLICATION: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          APP_PATH=".build/release-macos/DerivedData/Build/Products/Release/Look.app"
+          ZIP_PATH="dist/Look-${VERSION}-macOS.zip"
+          MANIFEST_PATH="dist/Look-${VERSION}-manifest.txt"
+
+          if [[ -z "${APPLE_DEVELOPER_ID_APPLICATION}" ]]; then
+            if [[ "${{ steps.strict.outputs.strict_mode }}" == "true" ]]; then
+              echo "Strict mode requires APPLE_DEVELOPER_ID_APPLICATION." >&2
+              exit 1
+            fi
+            echo "No Developer ID identity configured; skipping codesign."
+            exit 0
+          fi
+
+          if [[ ! -d "$APP_PATH" ]]; then
+            echo "App bundle missing at $APP_PATH" >&2
+            exit 1
+          fi
+
+          codesign --force --deep --options runtime --timestamp \
+            --sign "$APPLE_DEVELOPER_ID_APPLICATION" "$APP_PATH"
+          codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+
+          rm -f "$ZIP_PATH"
+          ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" "$ZIP_PATH"
+          SHA256="$(shasum -a 256 "$ZIP_PATH" | awk '{print $1}')"
+          cat > "$MANIFEST_PATH" <<EOF
+          version=${VERSION}
+          artifact=$(basename "$ZIP_PATH")
+          sha256=${SHA256}
+          EOF
+
+      - name: Notarize release zip (optional)
+        id: notarize
+        timeout-minutes: 35
+        env:
+          APPLE_NOTARY_APPLE_ID: ${{ secrets.APPLE_NOTARY_APPLE_ID }}
+          APPLE_NOTARY_APP_PASSWORD: ${{ secrets.APPLE_NOTARY_APP_PASSWORD }}
+          APPLE_NOTARY_TEAM_ID: ${{ secrets.APPLE_NOTARY_TEAM_ID }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          ZIP_PATH="dist/Look-${VERSION}-macOS.zip"
+          MANIFEST_PATH="dist/Look-${VERSION}-manifest.txt"
+
+          if [[ -z "${APPLE_NOTARY_APPLE_ID}" || -z "${APPLE_NOTARY_APP_PASSWORD}" || -z "${APPLE_NOTARY_TEAM_ID}" ]]; then
+            if [[ "${{ steps.strict.outputs.strict_mode }}" == "true" ]]; then
+              echo "Strict mode requires notary credentials." >&2
+              exit 1
+            fi
+            echo "Notary credentials not configured; skipping notarization."
+            echo "result=skipped_missing_credentials" >> "$GITHUB_OUTPUT"
+            echo "submission_id=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          SUBMIT_JSON="$(xcrun notarytool submit "$ZIP_PATH" \
+            --apple-id "$APPLE_NOTARY_APPLE_ID" \
+            --password "$APPLE_NOTARY_APP_PASSWORD" \
+            --team-id "$APPLE_NOTARY_TEAM_ID" \
+            --output-format json)"
+
+          SUBMISSION_ID="$(printf '%s' "$SUBMIT_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("id",""))')"
+
+          if [[ -z "$SUBMISSION_ID" ]]; then
+            echo "Failed to parse notarization submission id." >&2
+            echo "$SUBMIT_JSON"
+            exit 1
+          fi
+
+          echo "Notarization submission id: $SUBMISSION_ID"
+          echo "submission_id=$SUBMISSION_ID" >> "$GITHUB_OUTPUT"
+
+          NOTARY_STATUS="In Progress"
+          for _ in {1..90}; do
+            INFO_JSON="$(xcrun notarytool info "$SUBMISSION_ID" \
+              --apple-id "$APPLE_NOTARY_APPLE_ID" \
+              --password "$APPLE_NOTARY_APP_PASSWORD" \
+              --team-id "$APPLE_NOTARY_TEAM_ID" \
+              --output-format json)"
+
+            NOTARY_STATUS="$(printf '%s' "$INFO_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("status",""))')"
+
+            echo "Current notary status: $NOTARY_STATUS"
+
+            if [[ "$NOTARY_STATUS" == "Accepted" ]]; then
+              break
+            fi
+
+            if [[ "$NOTARY_STATUS" == "Invalid" || "$NOTARY_STATUS" == "Rejected" ]]; then
+              xcrun notarytool log "$SUBMISSION_ID" \
+                --apple-id "$APPLE_NOTARY_APPLE_ID" \
+                --password "$APPLE_NOTARY_APP_PASSWORD" \
+                --team-id "$APPLE_NOTARY_TEAM_ID"
+              if [[ "${{ steps.strict.outputs.strict_mode }}" == "true" ]]; then
+                exit 1
+              fi
+
+              echo "Notarization status '$NOTARY_STATUS' in non-strict mode; keeping signed artifact without stapling." >&2
+              echo "result=${NOTARY_STATUS,,}" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            sleep 20
+          done
+
+          if [[ "$NOTARY_STATUS" != "Accepted" ]]; then
+            echo "Timed out waiting for notarization result (last status: $NOTARY_STATUS)." >&2
+            xcrun notarytool log "$SUBMISSION_ID" \
+              --apple-id "$APPLE_NOTARY_APPLE_ID" \
+              --password "$APPLE_NOTARY_APP_PASSWORD" \
+              --team-id "$APPLE_NOTARY_TEAM_ID" || true
+            if [[ "${{ steps.strict.outputs.strict_mode }}" == "true" ]]; then
+              exit 1
+            fi
+
+            echo "Notarization timed out in non-strict mode; keeping signed artifact without stapling." >&2
+            echo "result=timeout" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          WORK_DIR="$RUNNER_TEMP/notary"
+          rm -rf "$WORK_DIR"
+          mkdir -p "$WORK_DIR"
+          ditto -x -k "$ZIP_PATH" "$WORK_DIR"
+          xcrun stapler staple "$WORK_DIR/Look.app"
+          xcrun stapler validate "$WORK_DIR/Look.app"
+          spctl -a -vv "$WORK_DIR/Look.app"
+
+          rm -f "$ZIP_PATH"
+          ditto -c -k --sequesterRsrc --keepParent "$WORK_DIR/Look.app" "$ZIP_PATH"
+          SHA256="$(shasum -a 256 "$ZIP_PATH" | awk '{print $1}')"
+          cat > "$MANIFEST_PATH" <<EOF
+          version=${VERSION}
+          artifact=$(basename "$ZIP_PATH")
+          sha256=${SHA256}
+          EOF
+          echo "result=accepted" >> "$GITHUB_OUTPUT"
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: look-macos-${{ steps.version.outputs.version }}
+          path: |
+            dist/Look-${{ steps.version.outputs.version }}-macOS.zip
+            dist/Look-${{ steps.version.outputs.version }}-manifest.txt
+          retention-days: 14
+
+      - name: Attach assets to GitHub release (tag pushes only)
+        if: inputs.attach_release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/Look-${{ steps.version.outputs.version }}-macOS.zip
+            dist/Look-${{ steps.version.outputs.version }}-manifest.txt
+
+      - name: Release security summary
+        if: always()
+        env:
+          APPLE_DEVELOPER_ID_CERT_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERT_BASE64 }}
+          APPLE_DEVELOPER_ID_APPLICATION: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION }}
+          APPLE_NOTARY_APPLE_ID: ${{ secrets.APPLE_NOTARY_APPLE_ID }}
+          APPLE_NOTARY_APP_PASSWORD: ${{ secrets.APPLE_NOTARY_APP_PASSWORD }}
+          APPLE_NOTARY_TEAM_ID: ${{ secrets.APPLE_NOTARY_TEAM_ID }}
+        run: |
+          SIGNING_READY="false"
+          NOTARY_READY="false"
+
+          if [[ -n "${APPLE_DEVELOPER_ID_CERT_BASE64}" && -n "${APPLE_DEVELOPER_ID_APPLICATION}" ]]; then
+            SIGNING_READY="true"
+          fi
+
+          if [[ -n "${APPLE_NOTARY_APPLE_ID}" && -n "${APPLE_NOTARY_APP_PASSWORD}" && -n "${APPLE_NOTARY_TEAM_ID}" ]]; then
+            NOTARY_READY="true"
+          fi
+
+          {
+            echo "## Release Security Summary"
+            echo "- Strict mode: ${{ steps.strict.outputs.strict_mode }} (source: ${{ steps.strict.outputs.strict_source }})"
+            echo "- Codesign configured: ${SIGNING_READY}"
+            echo "- Notarization configured: ${NOTARY_READY}"
+            echo "- Notarization result: ${{ steps.notarize.outputs.result || 'not_run' }}"
+            if [[ -n "${{ steps.notarize.outputs.submission_id }}" ]]; then
+              echo "- Notary submission id: ${{ steps.notarize.outputs.submission_id }}"
+            fi
+            if [[ "${SIGNING_READY}" != "true" || "${NOTARY_READY}" != "true" ]]; then
+              echo "- This release is likely unsigned and/or not notarized."
+              echo "- Users may need first-run Gatekeeper bypass (Open Anyway / right-click Open)."
+            fi
+            if [[ "${{ steps.strict.outputs.strict_mode }}" != "true" && "${{ steps.notarize.outputs.result || '' }}" == "timeout" ]]; then
+              echo "- Non-strict run timed out in notarization queue; rerun later for stapled notarized artifact."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Theme and alias notes:
 - built-in themes are available in `Settings > Appearance` and persisted in `~/.look.config`
 - search aliases are configured with `alias_<keyword>=Term1|Term2|...` in `~/.look.config` and apply to app + System Settings search
 - fresh config presets include `alias_note`, `alias_code`, `alias_term`, `alias_chat`, `alias_music`, and `alias_brow`
+- `Settings > Advanced > Create Fresh Config` recreates the current config file from latest defaults (with confirmation popup)
 
 Indexing config supports include roots plus exclude rules for both apps and files.
 
@@ -108,6 +109,7 @@ Current built-in themes (Settings > Appearance):
 
 - Backend currently includes: SQLite-backed candidate storage, dynamic app/settings/file indexing, and usage event logging.
 - User guide: [docs/user-guide.md](docs/user-guide.md).
+- Apple release signing/notarization guide: [docs/apple-developer-release-guide.md](docs/apple-developer-release-guide.md).
 - Backend contributor guide (edit targets + verification): [docs/backend-guide.md](docs/backend-guide.md).
 - Feature status: [docs/features.md](docs/features.md).
 - Task breakdown: [docs/tasks.md](docs/tasks.md).
@@ -126,6 +128,7 @@ Current built-in themes (Settings > Appearance):
 - `Cmd+Option+Q`: quit app
 - `Enter`: launch selected app, execute active command, run web translation (if `t"...`), refresh lookup translation (if `tw"...`), or confirm kill
 - `Y` / `N`: confirm/cancel in kill command confirmation
+- `Y`: confirm the Create Fresh Config popup action
 - `Cmd+Enter`: web search current query using Google
 - `Cmd+C`: copy selected file/folder to pasteboard
 - `Cmd+F`: reveal selected app/file/folder in Finder

--- a/README.md
+++ b/README.md
@@ -128,7 +128,6 @@ Current built-in themes (Settings > Appearance):
 - `Cmd+Option+Q`: quit app
 - `Enter`: launch selected app, execute active command, run web translation (if `t"...`), refresh lookup translation (if `tw"...`), or confirm kill
 - `Y` / `N`: confirm/cancel in kill command confirmation
-- `Y`: confirm the Create Fresh Config popup action
 - `Cmd+Enter`: web search current query using Google
 - `Cmd+C`: copy selected file/folder to pasteboard
 - `Cmd+F`: reveal selected app/file/folder in Finder
@@ -271,7 +270,6 @@ In scope for first milestone:
 - translate text with `t"...` (network, returns VI/EN/JA)
 - dictionary lookup panel with `tw"...` (definitions/examples from installed dictionaries)
 - command mode with `calc`, `shell`, `kill`, and `sys`
-- optional translation exists behind network opt-in (`translate_allow_network=true`)
 - predictable, local-first behavior
 
 Out of scope for v1:

--- a/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
@@ -217,6 +217,27 @@ final class ThemeStore: ObservableObject {
         }
     }
 
+    func regenerateFreshConfigFile() -> Bool {
+        let path = Self.configPath()
+        if FileManager.default.fileExists(atPath: path.path) {
+            do {
+                try FileManager.default.removeItem(at: path)
+            } catch {
+                return false
+            }
+        }
+
+        Self.ensureDefaultConfigFileExists(at: path)
+        guard FileManager.default.fileExists(atPath: path.path) else {
+            return false
+        }
+
+        settings = .default
+        applyThemeOverridesFromConfigFile()
+        _ = applyLaunchAtLoginSetting()
+        return true
+    }
+
     func zoomIn() {
         uiScale = min(1.8, uiScale + 0.1)
     }
@@ -660,7 +681,7 @@ final class ThemeStore: ObservableObject {
 # Generated on first launch. Edit values and press Cmd+Shift+; to reload.
 
 # Backend indexing
-app_scan_roots=/Applications,/System/Applications,/System/Applications/Utilities
+app_scan_roots=/Applications,/System/Applications,/System/Applications/Utilities,/System/Library/CoreServices/Applications,/System/Library/CoreServices/Finder.app/Contents/Applications
 app_scan_depth=3
 app_exclude_paths=
 app_exclude_names=
@@ -691,6 +712,14 @@ ui_border_red=1.0
 ui_border_green=1.0
 ui_border_blue=1.0
 ui_border_opacity=0.12
+
+# Search aliases (apps + System Settings). Format: alias_<keyword>=Term1|Term2|Term3
+alias_note=Notion|Obsidian|Notes|Apple Notes|Bear|Logseq
+alias_code=Visual Studio Code|VSCode|Cursor|Windsurf|IntelliJ IDEA|PyCharm|WebStorm|Neovim|Xcode|Zed
+alias_term=Terminal|iTerm|iTerm2|Ghostty|WezTerm|Alacritty|Kitty|Warp
+alias_chat=Slack|Discord|Telegram|Messages
+alias_music=Spotify|Apple Music|Music
+alias_brow=Safari|Arc|Google Chrome|Chrome|Firefox|Brave
 """
 
     private static func loadThemeSettings(from data: Data?) -> ThemeSettings {

--- a/apps/macos/LauncherApp/look-app/Views/ThemeSettingsView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/ThemeSettingsView.swift
@@ -19,6 +19,8 @@ struct ThemeSettingsView: View {
     @State private var fileScanLimitInput = ""
     @State private var fileScanDepthError: String?
     @State private var fileScanLimitError: String?
+    @State private var showFreshConfigConfirm = false
+    @State private var freshConfigMessage: String?
     @State private var localKeyMonitor: Any?
     @FocusState private var focusedField: Field?
 
@@ -90,6 +92,14 @@ struct ThemeSettingsView: View {
         }
         .onDisappear {
             removeLocalKeyMonitor()
+        }
+        .alert("Create fresh config file?", isPresented: $showFreshConfigConfirm) {
+            Button("Cancel", role: .cancel) {}
+            Button("Create Fresh Config", role: .destructive) {
+                runFreshConfigReset()
+            }
+        } message: {
+            Text("This will replace your current config file with default values.")
         }
     }
 
@@ -453,12 +463,15 @@ struct ThemeSettingsView: View {
                     }
 
                     Toggle(isOn: $settings.lazyIndexingEnabled) {
-                        VStack(alignment: .leading, spacing: 2) {
+                        HStack(spacing: 10) {
                             Text("Lazy indexing")
+                                .frame(width: AppConstants.ThemeUI.labelWidth, alignment: .leading)
                                 .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
                             Text("Refresh index automatically when launcher opens after file/app changes")
                                 .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 2), weight: .regular))
                                 .foregroundStyle(themeStore.mutedTextColor())
+                                .lineLimit(1)
+                                .frame(maxWidth: .infinity, alignment: .leading)
                         }
                     }
 
@@ -546,14 +559,45 @@ struct ThemeSettingsView: View {
                         .foregroundStyle(themeStore.secondaryTextColor())
 
                     Toggle(isOn: $settings.launchAtLogin) {
-                        VStack(alignment: .leading, spacing: 2) {
+                        HStack(spacing: 10) {
                             Text("Launch at login")
+                                .frame(width: AppConstants.ThemeUI.labelWidth, alignment: .leading)
                                 .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
                             Text("Start look automatically when you sign in")
                                 .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 2), weight: .regular))
                                 .foregroundStyle(themeStore.mutedTextColor())
+                                .lineLimit(1)
+                                .frame(maxWidth: .infinity, alignment: .leading)
                         }
                     }
+
+                    Divider()
+                        .overlay(.white.opacity(0.1))
+                        .padding(.vertical, 4)
+
+                    Text("Config file")
+                        .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .semibold))
+                        .foregroundStyle(themeStore.secondaryTextColor())
+
+                    HStack(spacing: 10) {
+                        Button("Create Fresh Config") {
+                            showFreshConfigConfirm = true
+                            freshConfigMessage = nil
+                        }
+
+                        Text("Regenerate a fresh default config file. Your current file will be replaced.")
+                            .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 2), weight: .regular))
+                            .foregroundStyle(themeStore.mutedTextColor())
+                            .lineLimit(1)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+
+                        if let freshConfigMessage {
+                            Text(freshConfigMessage)
+                                .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 2), weight: .regular))
+                                .foregroundStyle(themeStore.mutedTextColor())
+                        }
+                    }
+
                 }
             }
             .onAppear { syncIndexingInputsFromSettings() }
@@ -655,6 +699,14 @@ struct ThemeSettingsView: View {
                 return nil
             }
 
+            if showFreshConfigConfirm,
+               flags.isEmpty,
+               event.charactersIgnoringModifiers?.lowercased() == "y" {
+                showFreshConfigConfirm = false
+                runFreshConfigReset()
+                return nil
+            }
+
             if flags == [.command, .shift]
                 && (event.charactersIgnoringModifiers == "," || event.keyCode == 43)
             {
@@ -674,6 +726,19 @@ struct ThemeSettingsView: View {
 
     private var hasIndexingError: Bool {
         fileScanDepthError != nil || fileScanLimitError != nil
+    }
+
+    private func runFreshConfigReset() {
+        let ok = themeStore.regenerateFreshConfigFile()
+        syncIndexingInputsFromSettings()
+        freshConfigMessage = ok ? "Fresh config created" : "Failed to recreate config"
+        if ok {
+            NotificationCenter.default.post(name: .lookReloadConfigRequested, object: nil)
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            freshConfigMessage = nil
+        }
+        NotificationCenter.default.post(name: .lookFocusSettingsInputRequested, object: nil)
     }
 }
 

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -601,12 +601,16 @@ mod tests {
 
     #[test]
     fn app_scan_roots_include_finder_embedded_apps() {
-        assert!(APP_SCAN_ROOTS
-            .iter()
-            .any(|root| root == &"/System/Library/CoreServices/Finder.app/Contents/Applications"));
-        assert!(APP_SCAN_ROOTS
-            .iter()
-            .any(|root| root == &"/System/Library/CoreServices/Applications"));
+        assert!(
+            APP_SCAN_ROOTS.iter().any(
+                |root| root == &"/System/Library/CoreServices/Finder.app/Contents/Applications"
+            )
+        );
+        assert!(
+            APP_SCAN_ROOTS
+                .iter()
+                .any(|root| root == &"/System/Library/CoreServices/Applications")
+        );
     }
 
     #[test]
@@ -625,10 +629,12 @@ mod tests {
         let mut config = RuntimeConfig::default();
         config.apply_from_file(&tmp);
 
-        assert!(config
-            .skip_dir_names
-            .iter()
-            .any(|name| name == "node_modules"));
+        assert!(
+            config
+                .skip_dir_names
+                .iter()
+                .any(|name| name == "node_modules")
+        );
         assert!(config.skip_dir_names.iter().any(|name| name == "vendor"));
 
         let _ = std::fs::remove_file(&tmp);
@@ -731,8 +737,10 @@ mod tests {
         assert!(contents.contains("alias_note=Notion|Obsidian|Notes|Apple Notes|Bear|Logseq"));
         assert!(contents
             .contains("alias_code=Visual Studio Code|VSCode|Cursor|Windsurf|IntelliJ IDEA|PyCharm|WebStorm|Neovim|Xcode|Zed"));
-        assert!(contents
-            .contains("alias_term=Terminal|iTerm|iTerm2|Ghostty|WezTerm|Alacritty|Kitty|Warp"));
+        assert!(
+            contents
+                .contains("alias_term=Terminal|iTerm|iTerm2|Ghostty|WezTerm|Alacritty|Kitty|Warp")
+        );
         assert!(contents.contains("alias_chat=Slack|Discord|Telegram|Messages"));
         assert!(contents.contains("alias_music=Spotify|Apple Music|Music"));
         assert!(contents.contains("alias_brow=Safari|Arc|Google Chrome|Chrome|Firefox|Brave"));

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -532,11 +532,9 @@ mod tests {
 
     #[test]
     fn app_scan_roots_include_finder_embedded_apps() {
-        assert!(
-            APP_SCAN_ROOTS.iter().any(
-                |root| root == &"/System/Library/CoreServices/Finder.app/Contents/Applications"
-            )
-        );
+        assert!(APP_SCAN_ROOTS
+            .iter()
+            .any(|root| root == &"/System/Library/CoreServices/Finder.app/Contents/Applications"));
     }
 
     #[test]
@@ -555,12 +553,10 @@ mod tests {
         let mut config = RuntimeConfig::default();
         config.apply_from_file(&tmp);
 
-        assert!(
-            config
-                .skip_dir_names
-                .iter()
-                .any(|name| name == "node_modules")
-        );
+        assert!(config
+            .skip_dir_names
+            .iter()
+            .any(|name| name == "node_modules"));
         assert!(config.skip_dir_names.iter().any(|name| name == "vendor"));
 
         let _ = std::fs::remove_file(&tmp);
@@ -658,10 +654,8 @@ mod tests {
         assert!(contents.contains("alias_note=Notion|Obsidian|Notes|Apple Notes|Bear|Logseq"));
         assert!(contents
             .contains("alias_code=Visual Studio Code|VSCode|Cursor|Windsurf|IntelliJ IDEA|PyCharm|WebStorm|Neovim|Xcode|Zed"));
-        assert!(
-            contents
-                .contains("alias_term=Terminal|iTerm|iTerm2|Ghostty|WezTerm|Alacritty|Kitty|Warp")
-        );
+        assert!(contents
+            .contains("alias_term=Terminal|iTerm|iTerm2|Ghostty|WezTerm|Alacritty|Kitty|Warp"));
         assert!(contents.contains("alias_chat=Slack|Discord|Telegram|Messages"));
         assert!(contents.contains("alias_music=Spotify|Apple Music|Music"));
         assert!(contents.contains("alias_brow=Safari|Arc|Google Chrome|Chrome|Firefox|Brave"));

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -1,12 +1,13 @@
 use crate::normalize::normalize_for_search;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::path::{Path, PathBuf};
 
-pub const APP_SCAN_ROOTS: [&str; 4] = [
+pub const APP_SCAN_ROOTS: [&str; 5] = [
     "/Applications",
     "/System/Applications",
     "/System/Applications/Utilities",
+    "/System/Library/CoreServices/Applications",
     "/System/Library/CoreServices/Finder.app/Contents/Applications",
 ];
 
@@ -242,10 +243,58 @@ fn config_path() -> Option<PathBuf> {
 
 fn ensure_default_config_file(path: &Path) {
     if path.exists() {
+        append_missing_default_config_entries(path);
         return;
     }
 
     let _ = std::fs::write(path, default_config_contents());
+}
+
+fn append_missing_default_config_entries(path: &Path) {
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return;
+    };
+
+    let existing_keys = parse_config_keys(&contents);
+    let mut missing_entries = Vec::new();
+
+    for default_line in default_config_contents().lines() {
+        let line = strip_comments(default_line).trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let Some((key, _)) = line.split_once('=') else {
+            continue;
+        };
+
+        let key = key.trim();
+        if key.is_empty() || existing_keys.contains(key) {
+            continue;
+        }
+
+        missing_entries.push(line.to_string());
+    }
+
+    if missing_entries.is_empty() {
+        return;
+    }
+
+    let mut appended = String::new();
+    if !contents.ends_with('\n') {
+        appended.push('\n');
+    }
+    appended.push('\n');
+    appended.push_str("# Added by look update\n");
+    for entry in missing_entries {
+        appended.push_str(&entry);
+        appended.push('\n');
+    }
+
+    let _ = std::fs::OpenOptions::new()
+        .append(true)
+        .open(path)
+        .and_then(|mut file| std::io::Write::write_all(&mut file, appended.as_bytes()));
 }
 
 fn default_config_contents() -> &'static str {
@@ -253,7 +302,7 @@ fn default_config_contents() -> &'static str {
 # Generated on first launch. Edit values and press Cmd+Shift+; to reload.\n\
 \n\
 # Backend indexing (file_scan_depth: 1-12, file_scan_limit: 500-50000)\n\
-app_scan_roots=/Applications,/System/Applications,/System/Applications/Utilities,/System/Library/CoreServices/Finder.app/Contents/Applications\n\
+app_scan_roots=/Applications,/System/Applications,/System/Applications/Utilities,/System/Library/CoreServices/Applications,/System/Library/CoreServices/Finder.app/Contents/Applications\n\
 app_scan_depth=3\n\
 app_exclude_paths=\n\
 app_exclude_names=\n\
@@ -386,6 +435,26 @@ fn strip_comments(value: &str) -> &str {
         .split_once('#')
         .map(|(prefix, _)| prefix)
         .unwrap_or(value)
+}
+
+fn parse_config_keys(contents: &str) -> HashSet<String> {
+    let mut keys = HashSet::new();
+    for raw_line in contents.lines() {
+        let line = strip_comments(raw_line).trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let Some((key, _)) = line.split_once('=') else {
+            continue;
+        };
+
+        let key = key.trim();
+        if !key.is_empty() {
+            keys.insert(key.to_string());
+        }
+    }
+    keys
 }
 
 fn parse_csv(value: &str) -> Vec<String> {
@@ -535,6 +604,9 @@ mod tests {
         assert!(APP_SCAN_ROOTS
             .iter()
             .any(|root| root == &"/System/Library/CoreServices/Finder.app/Contents/Applications"));
+        assert!(APP_SCAN_ROOTS
+            .iter()
+            .any(|root| root == &"/System/Library/CoreServices/Applications"));
     }
 
     #[test]
@@ -588,6 +660,11 @@ mod tests {
     #[test]
     fn default_config_contents_include_lazy_indexing_enabled() {
         assert!(default_config_contents().contains("lazy_indexing_enabled=true"));
+    }
+
+    #[test]
+    fn default_config_contents_include_coreservices_applications_root() {
+        assert!(default_config_contents().contains("/System/Library/CoreServices/Applications"));
     }
 
     #[test]
@@ -659,5 +736,37 @@ mod tests {
         assert!(contents.contains("alias_chat=Slack|Discord|Telegram|Messages"));
         assert!(contents.contains("alias_music=Spotify|Apple Music|Music"));
         assert!(contents.contains("alias_brow=Safari|Arc|Google Chrome|Chrome|Firefox|Brave"));
+    }
+
+    #[test]
+    fn ensure_default_config_file_appends_missing_keys_without_overwriting_existing() {
+        let tmp = std::env::temp_dir().join(format!(
+            "look-config-test-migrate-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time should be after epoch")
+                .as_nanos()
+        ));
+
+        std::fs::write(
+            &tmp,
+            "# existing user settings\napp_scan_depth=9\napp_scan_roots=/Applications\n",
+        )
+        .expect("should write temporary config");
+
+        ensure_default_config_file(&tmp);
+        let contents = std::fs::read_to_string(&tmp).expect("should read migrated config");
+
+        assert!(contents.contains("app_scan_depth=9"));
+        assert!(contents.contains("app_scan_roots=/Applications\n"));
+        assert!(contents.contains("alias_note=Notion|Obsidian|Notes|Apple Notes|Bear|Logseq"));
+        assert_eq!(
+            contents.matches("app_scan_depth=").count(),
+            1,
+            "existing keys should not be duplicated"
+        );
+
+        let _ = std::fs::remove_file(&tmp);
     }
 }

--- a/core/engine/src/index/apps.rs
+++ b/core/engine/src/index/apps.rs
@@ -7,6 +7,15 @@ use std::sync::mpsc;
 
 const FINDER_EMBEDDED_APPS_ROOT: &str =
     "/System/Library/CoreServices/Finder.app/Contents/Applications";
+const CORE_SERVICES_APPS_ROOT: &str = "/System/Library/CoreServices/Applications";
+
+fn ensure_required_roots(roots: &mut Vec<String>) {
+    for required in [FINDER_EMBEDDED_APPS_ROOT, CORE_SERVICES_APPS_ROOT] {
+        if !roots.iter().any(|root| root == required) {
+            roots.push(required.to_string());
+        }
+    }
+}
 
 pub fn discover_installed_apps(config: &RuntimeConfig, tx: mpsc::SyncSender<Candidate>) {
     let mut roots = config.app_scan_roots.clone();
@@ -17,9 +26,7 @@ pub fn discover_installed_apps(config: &RuntimeConfig, tx: mpsc::SyncSender<Cand
         }
     }
 
-    if !roots.iter().any(|root| root == FINDER_EMBEDDED_APPS_ROOT) {
-        roots.push(FINDER_EMBEDDED_APPS_ROOT.to_string());
-    }
+    ensure_required_roots(&mut roots);
 
     for root in roots {
         walk_apps(
@@ -118,7 +125,7 @@ fn should_exclude_app_name(name: &str, app_exclude_names: &[String]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{should_exclude_app_name, should_exclude_path};
+    use super::{ensure_required_roots, should_exclude_app_name, should_exclude_path};
 
     #[test]
     fn excludes_app_paths_by_prefix() {
@@ -151,5 +158,27 @@ mod tests {
     fn path_prefix_is_boundary_aware() {
         let excludes = vec!["/Applications/Util".to_string()];
         assert!(!should_exclude_path("/Applications/Utilities", &excludes));
+    }
+
+    #[test]
+    fn required_roots_are_appended_once() {
+        let mut roots = vec!["/Applications".to_string()];
+        ensure_required_roots(&mut roots);
+        ensure_required_roots(&mut roots);
+
+        assert!(
+            roots
+                .iter()
+                .any(|root| root == "/System/Library/CoreServices/Applications")
+        );
+        assert!(roots
+            .iter()
+            .any(|root| root == "/System/Library/CoreServices/Finder.app/Contents/Applications"));
+
+        let core_services_count = roots
+            .iter()
+            .filter(|root| *root == "/System/Library/CoreServices/Applications")
+            .count();
+        assert_eq!(core_services_count, 1);
     }
 }

--- a/core/engine/src/lib.rs
+++ b/core/engine/src/lib.rs
@@ -574,7 +574,6 @@ mod tests {
             Some("file.note")
         );
     }
-
     #[test]
     fn alias_brow_does_not_promote_archive_for_arc_term() {
         let mut config = RuntimeConfig::default();

--- a/core/engine/src/lib.rs
+++ b/core/engine/src/lib.rs
@@ -627,4 +627,34 @@ mod tests {
             Some("app.arc")
         );
     }
+
+    #[test]
+    fn alias_can_match_system_settings_subtitle_terms() {
+        let mut config = RuntimeConfig::default();
+        config
+            .search_aliases
+            .insert("update".to_string(), vec!["software update".to_string()]);
+
+        let mut settings = Candidate::new(
+            "setting:update",
+            CandidateKind::App,
+            "General",
+            "x-apple.systempreferences:com.apple.preference.general",
+        );
+        settings.subtitle = Some("System Settings software update".into());
+
+        let app = Candidate::new(
+            "app.updates",
+            CandidateKind::App,
+            "General Helper",
+            "/Applications/General Helper.app",
+        );
+
+        let engine = QueryEngine::new_with_config(vec![app, settings], &config);
+        let results = engine.search_scored("update", 10);
+        assert_eq!(
+            results.first().map(|(candidate, _)| candidate.id.as_ref()),
+            Some("setting:update")
+        );
+    }
 }

--- a/core/engine/src/lib.rs
+++ b/core/engine/src/lib.rs
@@ -322,6 +322,30 @@ mod tests {
     }
 
     #[test]
+    fn keychain_query_matches_keychain_access_app() {
+        let engine = QueryEngine::new(vec![
+            Candidate::new(
+                "app:keychain",
+                CandidateKind::App,
+                "Keychain Access",
+                "/System/Library/CoreServices/Applications/Keychain Access.app",
+            ),
+            Candidate::new(
+                "app:archive",
+                CandidateKind::App,
+                "Archive Utility",
+                "/System/Library/CoreServices/Applications/Archive Utility.app",
+            ),
+        ]);
+
+        let results = engine.search_scored("keychain", 10);
+        assert_eq!(
+            results.first().map(|(candidate, _)| candidate.id.as_ref()),
+            Some("app:keychain")
+        );
+    }
+
+    #[test]
     fn empty_query_prioritizes_recent_and_frequent_apps() {
         let mut frequent_app = Candidate::new(
             "app.frequent",

--- a/core/engine/src/search.rs
+++ b/core/engine/src/search.rs
@@ -49,7 +49,6 @@ impl QueryEngine {
 
         false
     }
-
     fn alias_terms_for_query<'a>(
         &'a self,
         normalized_query: &str,

--- a/core/engine/src/search.rs
+++ b/core/engine/src/search.rs
@@ -213,11 +213,16 @@ impl QueryEngine {
             } else {
                 None
             };
+            let alias_subtitle_search = if is_system_settings_candidate(&candidate.candidate) {
+                candidate.subtitle_search.as_deref()
+            } else {
+                subtitle_search
+            };
             let alias_score = alias_terms.and_then(|terms| {
                 if candidate.candidate.kind != CandidateKind::App {
                     return None;
                 }
-                Self::alias_match_score(terms, &candidate.title_search, subtitle_search)
+                Self::alias_match_score(terms, &candidate.title_search, alias_subtitle_search)
             });
 
             let base = [

--- a/docs/apple-developer-release-guide.md
+++ b/docs/apple-developer-release-guide.md
@@ -1,0 +1,202 @@
+# Apple Developer Release Guide (look)
+
+Use this guide after joining Apple Developer to ship signed + notarized macOS releases for `look`.
+
+## Goal
+
+- remove first-run Gatekeeper workaround (`Open Anyway`)
+- ship Developer ID signed + notarized release zip
+- keep Homebrew install flow clean
+
+## 1) Create Developer ID certificate
+
+Recommended: create from Xcode (fastest)
+
+1. Open `Xcode` -> `Settings` -> `Accounts`.
+2. Select your Apple account/team.
+3. Click `Manage Certificates...`.
+4. Create `Developer ID Application` certificate.
+
+Alternative (manual CSR path):
+
+1. Open `Keychain Access`.
+2. `Certificate Assistant` -> `Request a Certificate From a Certificate Authority...`.
+3. Save CSR to disk.
+4. On Apple Developer portal, create `Developer ID Application` cert using that CSR.
+5. Download `.cer` and double-click to import into Keychain.
+
+Web-created cert note:
+
+- creating the certificate from Apple Developer website is fully supported
+- the key pair must be generated on your Mac (via CSR), then that same Mac must import the issued `.cer`
+- if cert is created on web with a CSR from a different machine, this Mac will not have the matching private key and signing identities will be invalid
+
+Notes:
+
+- choose `G2 Sub-CA (Xcode 11.4.1 or later)` when prompted
+- cert should appear in `login` keychain under `My Certificates`
+- `System Roots` is not where you export your cert
+
+## 2) Export certificate for CI
+
+1. In `Keychain Access` -> `login` -> `My Certificates`.
+2. Find `Developer ID Application: <Name> (<TEAMID>)` and confirm private key exists.
+3. Right-click -> `Export` -> save as `.p12`.
+4. Set export password (store safely).
+
+Convert `.p12` to base64:
+
+```bash
+base64 -i /path/to/developer-id.p12
+```
+
+The command prints one long string. Copy the full output into GitHub secret `APPLE_DEVELOPER_ID_CERT_BASE64`.
+
+Tip (copy directly to clipboard):
+
+```bash
+base64 -i /path/to/developer-id.p12 | pbcopy
+```
+
+## 3) Collect required values
+
+### Signing identity
+
+```bash
+security find-identity -v -p codesigning
+```
+
+Copy the value inside quotes, for example from:
+
+```text
+1) <hash> "Developer ID Application: Your Name (TEAMID)"
+```
+
+Use only:
+
+```text
+Developer ID Application: Your Name (TEAMID)
+```
+
+### Notary credentials
+
+- Apple ID email
+- app-specific password from `appleid.apple.com`
+- Apple team ID (10 chars)
+
+How to create app-specific password:
+
+1. Open `https://appleid.apple.com` and sign in.
+2. Go to `Sign-In and Security`.
+3. Under `App-Specific Passwords`, click `Generate`.
+4. Create one (for example label: `look-notary-gha`).
+5. Copy it immediately and save as `APPLE_NOTARY_APP_PASSWORD`.
+
+How to find Team ID (`APPLE_NOTARY_TEAM_ID`):
+
+1. Open `https://developer.apple.com/account` and sign in.
+2. Go to `Membership` (account details).
+3. Copy `Team ID` (10-character value, for example `AB12C3D4E5`).
+4. Save it as GitHub secret `APPLE_NOTARY_TEAM_ID`.
+
+If your Apple ID belongs to multiple teams, use the Team ID that matches the team owning your `Developer ID Application` certificate.
+
+## 4) Add GitHub Actions secrets
+
+Repo -> `Settings` -> `Secrets and variables` -> `Actions`.
+
+Required secrets:
+
+| Secret | What it is | Where to get it | Used for |
+|---|---|---|---|
+| `APPLE_DEVELOPER_ID_CERT_BASE64` | Base64-encoded `.p12` file that contains your Developer ID Application cert + private key | `base64 -i /path/to/developer-id.p12` | Imported into temporary CI keychain before codesign |
+| `APPLE_DEVELOPER_ID_CERT_PASSWORD` | Password you set when exporting the `.p12` | Chosen during Keychain export | Decrypts `.p12` during CI import |
+| `APPLE_KEYCHAIN_PASSWORD` | Password for the temporary CI keychain | Generate a strong random string | Creates/unlocks keychain in GitHub Actions runner |
+| `APPLE_DEVELOPER_ID_APPLICATION` | Exact signing identity string | `security find-identity -v -p codesigning` | Passed to `codesign --sign` |
+| `APPLE_NOTARY_APPLE_ID` | Apple ID email for notarization auth | Your Apple Developer account email | Auth for `xcrun notarytool submit` |
+| `APPLE_NOTARY_APP_PASSWORD` | Apple app-specific password (not your normal Apple ID password) | `appleid.apple.com` -> Security -> App-Specific Passwords | Auth for `xcrun notarytool submit` |
+| `APPLE_NOTARY_TEAM_ID` | 10-character Apple Team ID | Apple Developer account membership details | Team context for notarization submission |
+
+Quick notes:
+
+- keep all values in GitHub **Secrets** (not plain env vars in workflow YAML)
+- if one value is wrong, the related step fails clearly (`codesign` for signing vars, `notarytool` for notary vars)
+
+## 5) Run a test release workflow
+
+1. Open GitHub Actions -> `Release macOS App`.
+2. Run `workflow_dispatch` with a test version.
+   - include `strict` in the version text (for example `1.0.0-strict`) to require signing + notarization
+   - omit `strict` for best-effort test runs that can continue if Apple notarization queue is delayed
+3. Confirm logs show:
+   - keychain setup success
+   - `codesign --verify` success
+   - notarization accepted
+   - stapling success
+
+Workflow structure:
+
+- entrypoint: `.github/workflows/release-macos.yml`
+- implementation: `.github/workflows/reusable-release-macos.yml`
+- release workflow triggers only on manual dispatch or `v*` tags (not PR)
+
+## 6) Create production release
+
+Tag and push:
+
+```bash
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+Strict release option:
+
+- use tag text that includes `strict` (for example `v1.2.3-strict`) to enforce signing + notarization prerequisites and fail if notarization does not complete
+
+Workflow publishes:
+
+- `Look-X.Y.Z-macOS.zip`
+- `Look-X.Y.Z-manifest.txt`
+
+## 7) Update Homebrew cask
+
+1. Copy SHA256 from manifest.
+2. Update `look` cask in tap repo.
+3. Publish tap update.
+
+## 8) Verify on clean machine
+
+Install released app and validate:
+
+```bash
+spctl -a -vv "/Applications/Look.app"
+codesign --verify --deep --strict --verbose=2 "/Applications/Look.app"
+```
+
+Expected: accepted/signed/notarized app launches without bypass flow.
+
+## Troubleshooting quick hits
+
+- cert missing private key: recreate/import cert into same Mac keychain
+- `security find-identity -v -p codesigning` shows `0 valid identities`:
+  - confirm cert is in `login` -> `My Certificates` with private key attached
+  - set cert trust to `Use System Defaults` (avoid `Never Trust`)
+  - confirm `Developer ID Certification Authority` + `Apple Root CA` are present
+  - unlock keychain and recheck:
+
+  ```bash
+  security unlock-keychain ~/Library/Keychains/login.keychain-db
+  security find-identity -v -p codesigning ~/Library/Keychains/login.keychain-db
+  ```
+
+  - if still zero, recreate `Developer ID Application` cert from Xcode and remove broken duplicates
+- wrong identity string: re-run `security find-identity -v -p codesigning`
+- notary fails auth: regenerate app-specific password
+- existing users still blocked: verify they installed new notarized build, not old artifact
+
+## Scope reminder
+
+This guide is for direct distribution (GitHub Releases/Homebrew).
+
+- current path: `Developer ID Application` + notarization
+- Mac App Store later uses different cert/profile flow (Mac App Distribution + App Store Connect)

--- a/docs/backend-guide.md
+++ b/docs/backend-guide.md
@@ -78,7 +78,6 @@ Runtime file: `~/.look.config` (or `LOOK_CONFIG_PATH`).
 - `app_scan_roots`, `app_scan_depth`, `app_exclude_paths`, `app_exclude_names`
 - `file_scan_roots`, `file_scan_depth` (default: 4, range: 1-12), `file_scan_limit` (default: 4000, range: 500-50000), `file_exclude_paths`
 - `skip_dir_names`
-- `translate_allow_network`
 - `backend_log_level`
 - `launch_at_login`
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -26,7 +26,6 @@ This document tracks what `look` supports today and what is planned next.
 - in-memory clipboard history (latest text clips)
 - quick translation with `t"...`
 - dictionary lookup panel with `tw"...`
-- translation network guarded by `translate_allow_network`
 
 ### Command mode
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -42,6 +42,7 @@ This document tracks what `look` supports today and what is planned next.
 - runtime reload (`Cmd+Shift+;`)
 - 7 built-in theme presets (Catppuccin, Tokyo Night, Rose Pine, Gruvbox, Dracula, Kanagawa, Custom)
 - query alias presets in `~/.look.config` for app + System Settings intent expansion (`alias_note`, `alias_code`, `alias_term`, `alias_chat`, `alias_music`, `alias_brow`)
+- in-app config reset (`Settings > Advanced > Create Fresh Config`) with confirmation popup
 - semantic color system with auto-derived text colors in Custom mode
 - indexing, UI, privacy/logging, launch-at-login controls
 - immediate validation feedback for invalid settings input

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -16,6 +16,7 @@ Next:
 - [x] finish open Milestone G reliability tasks (error model + user fallback messaging)
 - [x] config validation and reload feedback (Cmd+Shift+; shows warnings in orange banner)
 - [x] file_scan_depth/file_scan_limit validation (clamp 1-12 / 500-50000 in both Swift and Rust)
+- [x] add `/System/Library/CoreServices/Applications` to default app scan roots and add regression test for `Keychain Access` discoverability (`keychain` query)
 
 Recently completed (current optimization cycle):
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -62,8 +62,7 @@ Clipboard mode (`c"`):
 Translation mode (`t"`/`tw"`):
 
 - supports EN/VI/JA result sections,
-- network translation is controlled by `translate_allow_network`,
-- when disabled, translation requests are blocked locally.
+- translation uses network requests.
 
 ## 5) Command mode
 
@@ -146,7 +145,7 @@ Backend-related keys:
 - `lazy_indexing_enabled`
 - `skip_dir_names`
 - `alias_<keyword>` (for app + System Settings query aliases, for example `alias_note=Notion|Obsidian|Notes|Apple Notes|Bear|Logseq`)
-- `translate_allow_network`, `backend_log_level`, `launch_at_login`
+- `backend_log_level`, `launch_at_login`
 
 Alias note:
 
@@ -191,7 +190,6 @@ Note: `Settings Blur` is stored as local app UI state (UserDefaults) and is not 
 - `Cmd+C`: copy selected file/folder
 - `Cmd+Shift+,`: toggle settings panel
 - `Cmd+Shift+;`: reload config
-- `Y`: confirm the fresh-config popup action
 - `Cmd+-`, `Cmd+=`, `Cmd+0`: temporary UI zoom out/in/reset
 
 ## 8) Troubleshooting
@@ -208,7 +206,6 @@ If hotkey does not work:
 
 If translation does not return results:
 
-- confirm `translate_allow_network=true`
 - check connectivity and retry
 
 ## 9) Related docs

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -137,6 +137,7 @@ Runtime config file:
 - path: `~/.look.config`
 - optional override: `LOOK_CONFIG_PATH=/path/to/config`
 - reload after manual edits: `Cmd+Shift+;`
+- reset to fresh defaults from UI: `Settings -> Advanced -> Create Fresh Config` (confirmation popup)
 
 Backend-related keys:
 
@@ -166,6 +167,13 @@ Preset update behavior:
 
 - presets are written automatically only when `~/.look.config` is created for the first time
 - app updates do not rewrite an existing config file, so existing users should add new `alias_*` keys manually
+
+Fresh config reset behavior:
+
+- `Create Fresh Config` replaces the current config file with the latest default template
+- reset uses the active config path (`LOOK_CONFIG_PATH` when set, otherwise `~/.look.config`)
+- existing custom values are replaced during this reset flow (use manual edit + `Cmd+Shift+;` if you only want partial changes)
+
 UI-related keys include the `ui_*` group (tint/blur/font/border values).
 
 Note: `Settings Blur` is stored as local app UI state (UserDefaults) and is not written to `~/.look.config`.
@@ -183,6 +191,7 @@ Note: `Settings Blur` is stored as local app UI state (UserDefaults) and is not 
 - `Cmd+C`: copy selected file/folder
 - `Cmd+Shift+,`: toggle settings panel
 - `Cmd+Shift+;`: reload config
+- `Y`: confirm the fresh-config popup action
 - `Cmd+-`, `Cmd+=`, `Cmd+0`: temporary UI zoom out/in/reset
 
 ## 8) Troubleshooting

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -166,7 +166,6 @@ Preset update behavior:
 
 - presets are written automatically only when `~/.look.config` is created for the first time
 - app updates do not rewrite an existing config file, so existing users should add new `alias_*` keys manually
-
 UI-related keys include the `ui_*` group (tint/blur/font/border values).
 
 Note: `Settings Blur` is stored as local app UI state (UserDefaults) and is not written to `~/.look.config`.


### PR DESCRIPTION
## Summary

- Add reset to default options, this helps user creating a brand new .config file, so when we add a new config prop, user can generate this.
- Aliases config from the prev PR
- CI update with notarized keys

## Why

- SO

## Changes

- review changed files

## Testing

- [x] `cargo check --workspace --manifest-path core/Cargo.toml`
- [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [x] `cd apps/macos/LauncherApp && swift test`
- [x] `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered
