### PR TITLE
feat: powers calc, minor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Highlights:
 - reveal selected app/file/folder in Finder with `Cmd+F`
 - command mode with `Cmd+/` (`calc`, `shell`, `kill`, `sys`)
 - force-quit flow in command mode (`kill`, including process-by-port search like `:3000`)
+- calc supports `^`, `!`, constants (`pi`, `e`), functions (`sqrt`, `abs`, `round`, `floor`, `ceil`), and `%` shorthand (`50%`, `200*15%`)
 
 ## Positioning
 

--- a/apps/macos/LauncherApp/LauncherLogicTests/CalcCommandTests.swift
+++ b/apps/macos/LauncherApp/LauncherLogicTests/CalcCommandTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import LauncherLogic
+
+final class CalcCommandTests: XCTestCase {
+    func testExponentPrecedenceUnaryMinusBindsAfterPower() {
+        assertValue("-2^2", equals: "-4.0000")
+    }
+
+    func testExponentPrecedenceSignedExponentChain() {
+        assertValue("2^-3^2", equals: "0.0020")
+    }
+
+    func testExponentIsRightAssociative() {
+        assertValue("2^3^2", equals: "512.0000")
+    }
+
+    func testFactorial() {
+        assertValue("4!", equals: "24.0000")
+        assertValue("5!", equals: "120.0000")
+    }
+
+    func testConstants() {
+        assertValue("pi", equals: "3.1416")
+        assertValue("e", equals: "2.7183")
+        assertValue("2*pi", equals: "6.2832")
+    }
+
+    func testFunctions() {
+        assertValue("abs(-5)", equals: "5.0000")
+        assertValue("round(2.6)", equals: "3.0000")
+        assertValue("floor(2.9)", equals: "2.0000")
+        assertValue("ceil(2.1)", equals: "3.0000")
+    }
+
+    func testPercentShorthand() {
+        assertValue("50%", equals: "0.5000")
+        assertValue("200*15%", equals: "30.0000")
+        assertValue("50%+10", equals: "10.5000")
+    }
+
+    func testModuloStillWorks() {
+        assertValue("10%3", equals: "1.0000")
+    }
+
+    private func assertValue(_ expression: String, equals expected: String, file: StaticString = #filePath, line: UInt = #line) {
+        let result = CalcCommand.evaluate(expression)
+
+        switch result {
+        case let .value(value):
+            XCTAssertEqual(value, expected, file: file, line: line)
+        case let .error(message):
+            XCTFail("Expression '\(expression)' expected value '\(expected)', got error: \(message)", file: file, line: line)
+        }
+    }
+}

--- a/apps/macos/LauncherApp/Package.swift
+++ b/apps/macos/LauncherApp/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
                 "Support/Launcher/BridgeErrorMapping.swift",
                 "Support/SingleInstanceLock.swift",
                 "Models/LauncherResult.swift",
+                "Views/CalcCommand.swift",
             ]
         ),
         .testTarget(

--- a/apps/macos/LauncherApp/look-app/Views/CalcCommand.swift
+++ b/apps/macos/LauncherApp/look-app/Views/CalcCommand.swift
@@ -43,11 +43,11 @@ struct CalcCommand {
         }
         if balance != 0 { return false }
 
-        if let last = trimmed.last, "+-*/%.(".contains(last) {
+        if let last = trimmed.last, "+-*/%^.(".contains(last) {
             return false
         }
 
-        let allowedPattern = "^[0-9A-Za-z_+\\-*/%().:xXvV\\s]+$"
+        let allowedPattern = "^[0-9A-Za-z_+\\-*/%^().:xXvV\\s]+$"
         guard let regex = try? NSRegularExpression(pattern: allowedPattern) else { return false }
         let full = NSRange(trimmed.startIndex..<trimmed.endIndex, in: trimmed)
         guard let match = regex.firstMatch(in: trimmed, range: full), match.range == full else {
@@ -154,19 +154,19 @@ private struct Parser {
     }
 
     private mutating func parseTerm() throws -> Double {
-        var value = try parseFactor()
+        var value = try parsePower()
         while true {
             skipWhitespace()
             if consume("*") {
-                value *= try parseFactor()
+                value *= try parsePower()
             } else if consume("/") {
-                let divisor = try parseFactor()
+                let divisor = try parsePower()
                 if divisor == 0 {
                     throw ParserError.divisionByZero
                 }
                 value /= divisor
             } else if consume("%") {
-                let divisor = try parseFactor()
+                let divisor = try parsePower()
                 if divisor == 0 {
                     throw ParserError.divisionByZero
                 }
@@ -177,24 +177,43 @@ private struct Parser {
         }
     }
 
-    private mutating func parseFactor() throws -> Double {
+    private mutating func parsePower() throws -> Double {
+        var value = try parseUnary()
+        skipWhitespace()
+        if consume("^") {
+            let exponent = try parsePower()
+            value = Foundation.pow(value, exponent)
+            if value.isNaN || value.isInfinite {
+                throw ParserError.invalidExpression
+            }
+        }
+        return value
+    }
+
+    private mutating func parseUnary() throws -> Double {
         skipWhitespace()
 
         if consume("+") {
-            return try parseFactor()
+            return try parseUnary()
         }
         if consume("-") {
-            return -(try parseFactor())
+            return -(try parseUnary())
         }
 
         if matchKeyword("sqrt") {
             _ = consumeKeyword("sqrt")
-            let inner = try parseFactor()
+            let inner = try parseUnary()
             if inner < 0 {
                 throw ParserError.invalidExpression
             }
             return Foundation.sqrt(inner)
         }
+
+        return try parsePrimary()
+    }
+
+    private mutating func parsePrimary() throws -> Double {
+        skipWhitespace()
 
         if consume("(") {
             let value = try parseExpression()

--- a/apps/macos/LauncherApp/look-app/Views/CalcCommand.swift
+++ b/apps/macos/LauncherApp/look-app/Views/CalcCommand.swift
@@ -43,11 +43,11 @@ struct CalcCommand {
         }
         if balance != 0 { return false }
 
-        if let last = trimmed.last, "+-*/%^.(".contains(last) {
+        if let last = trimmed.last, "+-*/^.(".contains(last) {
             return false
         }
 
-        let allowedPattern = "^[0-9A-Za-z_+\\-*/%^().:xXvV\\s]+$"
+        let allowedPattern = "^[0-9A-Za-z_+\\-*/%^!().:xXvV\\s]+$"
         guard let regex = try? NSRegularExpression(pattern: allowedPattern) else { return false }
         let full = NSRange(trimmed.startIndex..<trimmed.endIndex, in: trimmed)
         guard let match = regex.firstMatch(in: trimmed, range: full), match.range == full else {
@@ -154,19 +154,19 @@ private struct Parser {
     }
 
     private mutating func parseTerm() throws -> Double {
-        var value = try parsePower()
+        var value = try parseUnary()
         while true {
             skipWhitespace()
             if consume("*") {
-                value *= try parsePower()
+                value *= try parseUnary()
             } else if consume("/") {
-                let divisor = try parsePower()
+                let divisor = try parseUnary()
                 if divisor == 0 {
                     throw ParserError.divisionByZero
                 }
                 value /= divisor
             } else if consume("%") {
-                let divisor = try parsePower()
+                let divisor = try parseUnary()
                 if divisor == 0 {
                     throw ParserError.divisionByZero
                 }
@@ -178,10 +178,10 @@ private struct Parser {
     }
 
     private mutating func parsePower() throws -> Double {
-        var value = try parseUnary()
+        var value = try parsePrimary()
         skipWhitespace()
         if consume("^") {
-            let exponent = try parsePower()
+            let exponent = try parseUnary()
             value = Foundation.pow(value, exponent)
             if value.isNaN || value.isInfinite {
                 throw ParserError.invalidExpression
@@ -202,14 +202,30 @@ private struct Parser {
 
         if matchKeyword("sqrt") {
             _ = consumeKeyword("sqrt")
-            let inner = try parseUnary()
-            if inner < 0 {
-                throw ParserError.invalidExpression
-            }
-            return Foundation.sqrt(inner)
+            return try applyFunction("sqrt", to: try parseFunctionArgument())
         }
 
-        return try parsePrimary()
+        if matchKeyword("abs") {
+            _ = consumeKeyword("abs")
+            return try applyFunction("abs", to: try parseFunctionArgument())
+        }
+
+        if matchKeyword("round") {
+            _ = consumeKeyword("round")
+            return try applyFunction("round", to: try parseFunctionArgument())
+        }
+
+        if matchKeyword("floor") {
+            _ = consumeKeyword("floor")
+            return try applyFunction("floor", to: try parseFunctionArgument())
+        }
+
+        if matchKeyword("ceil") {
+            _ = consumeKeyword("ceil")
+            return try applyFunction("ceil", to: try parseFunctionArgument())
+        }
+
+        return try parsePower()
     }
 
     private mutating func parsePrimary() throws -> Double {
@@ -221,10 +237,103 @@ private struct Parser {
             guard consume(")") else {
                 throw ParserError.invalidExpression
             }
-            return value
+            return try applyPostfixOperators(to: value)
         }
 
-        return try parseNumber()
+        if index < chars.count, chars[index].isLetter {
+            let ident = parseIdentifier()
+            switch ident.lowercased() {
+            case "pi":
+                return try applyPostfixOperators(to: .pi)
+            case "e":
+                return try applyPostfixOperators(to: M_E)
+            default:
+                throw ParserError.invalidExpression
+            }
+        }
+
+        let number = try parseNumber()
+        return try applyPostfixOperators(to: number)
+    }
+
+    private mutating func applyPostfixOperators(to seed: Double) throws -> Double {
+        var value = seed
+        while true {
+            skipWhitespace()
+            if consume("!") {
+                value = try factorial(value)
+                continue
+            }
+            if shouldConsumePostfixPercent() {
+                _ = consume("%")
+                value /= 100
+                continue
+            }
+            return value
+        }
+    }
+
+    private mutating func shouldConsumePostfixPercent() -> Bool {
+        guard index < chars.count, chars[index] == "%" else { return false }
+        var lookahead = index + 1
+        while lookahead < chars.count && chars[lookahead].isWhitespace {
+            lookahead += 1
+        }
+        guard lookahead < chars.count else { return true }
+        let next = chars[lookahead]
+        if next.isNumber || next == "." || next == "(" || next.isLetter {
+            return false
+        }
+        return true
+    }
+
+    private mutating func parseFunctionArgument() throws -> Double {
+        skipWhitespace()
+        if consume("(") {
+            let value = try parseExpression()
+            skipWhitespace()
+            guard consume(")") else { throw ParserError.invalidExpression }
+            return value
+        }
+        return try parseUnary()
+    }
+
+    private func applyFunction(_ name: String, to value: Double) throws -> Double {
+        switch name {
+        case "sqrt":
+            guard value >= 0 else { throw ParserError.invalidExpression }
+            return Foundation.sqrt(value)
+        case "abs":
+            return Swift.abs(value)
+        case "round":
+            return Foundation.round(value)
+        case "floor":
+            return Foundation.floor(value)
+        case "ceil":
+            return Foundation.ceil(value)
+        default:
+            throw ParserError.invalidExpression
+        }
+    }
+
+    private func factorial(_ value: Double) throws -> Double {
+        guard value >= 0, value.rounded() == value else {
+            throw ParserError.invalidExpression
+        }
+        let n = Int(value)
+        guard n <= 170 else {
+            throw ParserError.invalidExpression
+        }
+        if n <= 1 { return 1 }
+        return (2...n).reduce(1.0) { $0 * Double($1) }
+    }
+
+    private mutating func parseIdentifier() -> String {
+        let start = index
+        while index < chars.count, chars[index].isLetter || chars[index] == "_" {
+            index += 1
+        }
+        return String(chars[start..<index])
     }
 
     private mutating func parseNumber() throws -> Double {

--- a/apps/macos/LauncherApp/look-app/Views/LauncherSubviews.swift
+++ b/apps/macos/LauncherApp/look-app/Views/LauncherSubviews.swift
@@ -71,9 +71,9 @@ struct CommandListView: View {
 
     var body: some View {
         ScrollView {
-            LazyVStack(spacing: 4) {
+            LazyVStack(spacing: 3) {
                 ForEach(commands) { command in
-                    HStack(spacing: 8) {
+                    HStack(spacing: 6) {
                         Image(systemName: command.symbolName)
                             .frame(width: 18, height: 18)
                             .foregroundStyle(themeStore.accentColor())
@@ -88,8 +88,8 @@ struct CommandListView: View {
                         Spacer(minLength: 0)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 6)
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 5)
                     .background(
                         (selectedID == command.id || activeID == command.id)
                             ? themeStore.selectionFillColor() : themeStore.controlFillColor().opacity(0.75),
@@ -100,7 +100,7 @@ struct CommandListView: View {
             }
             .padding(2)
         }
-        .padding(6)
+        .padding(5)
         .background(themeStore.panelFillColor(), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
         .frame(maxHeight: .infinity, alignment: .top)
     }

--- a/apps/macos/LauncherApp/look-app/Views/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/LauncherView.swift
@@ -52,6 +52,8 @@ struct LauncherView: View {
     @State private var lookupPreviewTask: Task<Void, Never>?
     @State private var selectedKillSuggestionIndex: Int?
     @State private var pendingKillCandidate: KillCommand.Candidate?
+    @State private var killListRefreshTick: Int = 0
+    @State private var recentlyKilledPIDs: Set<Int32> = []
     @State private var showsHelpScreen = false
     @State private var focusRequestToken: UInt64 = 0
     @State private var lookupDefinition: LookupDefinition?
@@ -353,8 +355,26 @@ struct LauncherView: View {
     }
 
     private var killSuggestions: [KillCommand.Candidate] {
+        _ = killListRefreshTick
         let searchTerm = commandArgsPart.trimmingCharacters(in: .whitespacesAndNewlines)
         return KillCommand.suggestions(searchTerm: searchTerm)
+            .filter { !recentlyKilledPIDs.contains($0.pid) }
+    }
+
+    private func scheduleKillListRefresh() {
+        killListRefreshTick &+= 1
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+            killListRefreshTick &+= 1
+            if activeCommandID == AppConstants.Launcher.Command.kill {
+                selectedKillSuggestionIndex = killSuggestions.first?.number
+            }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            killListRefreshTick &+= 1
+            if activeCommandID == AppConstants.Launcher.Command.kill {
+                selectedKillSuggestionIndex = killSuggestions.first?.number
+            }
+        }
     }
 
     private func setInitialSelection() {
@@ -475,7 +495,17 @@ struct LauncherView: View {
         activeCommandID = commandID
         commandFeedback = "Selected /\(commandID)"
 
-        if activeCommandAcceptsInput {
+        requestCommandInputFocusIfNeeded()
+    }
+
+    private func requestCommandInputFocusIfNeeded() {
+        guard isCommandMode else { return }
+        guard activeCommandAcceptsInput else {
+            isQueryFocused = false
+            return
+        }
+        DispatchQueue.main.async {
+            guard isCommandMode, activeCommandAcceptsInput else { return }
             focusActiveInput(recoveryDelays: [0.0], activateApp: false)
         }
     }
@@ -636,6 +666,16 @@ struct LauncherView: View {
         KillCommand.kill(pid: candidate.pid, name: candidate.displayName) { [self] message in
             commandFeedback = message
             logUIEvent("kill completion message='\(message)'")
+            pendingKillCandidate = nil
+            selectedKillSuggestionIndex = nil
+
+            if message.hasPrefix("Killed:") {
+                recentlyKilledPIDs.insert(candidate.pid)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 10.0) {
+                    recentlyKilledPIDs.remove(candidate.pid)
+                }
+            }
+            scheduleKillListRefresh()
         }
     }
 
@@ -1267,19 +1307,20 @@ struct LauncherView: View {
     private func selectCommand(_ commandID: String) {
         pendingKillCandidate = nil
         selectedKillSuggestionIndex = nil
+        if commandID != AppConstants.Launcher.Command.kill {
+            recentlyKilledPIDs.removeAll()
+        }
         activeCommandID = commandID
         selectedCommandID = commandID
         commandInput = ""
         commandFeedback = "Selected /\(commandID)"
-        if activeCommandAcceptsInput {
-            focusActiveInput(recoveryDelays: [0.0], activateApp: false)
-        }
+        requestCommandInputFocusIfNeeded()
     }
 
     @ViewBuilder
     private var commandModeView: some View {
         GeometryReader { proxy in
-            let splitSpacing: CGFloat = 12
+            let splitSpacing: CGFloat = 8
             let dividerWidth: CGFloat = 1
             let usableWidth = max(0, proxy.size.width - splitSpacing - dividerWidth)
             let leftWidth = max(170, usableWidth * 0.25)
@@ -1300,7 +1341,7 @@ struct LauncherView: View {
                     .frame(width: dividerWidth)
                     .padding(.vertical, 2)
 
-                VStack(alignment: .leading, spacing: 10) {
+                VStack(alignment: .leading, spacing: 6) {
                     if let activeCommand {
                         if activeCommandAcceptsInput {
                             CommandInputBar(
@@ -1370,11 +1411,13 @@ struct LauncherView: View {
 
     var body: some View {
         let windowCornerRadius = AppConstants.Launcher.windowCornerRadius
+        let contentSpacing: CGFloat = isCommandMode ? 8 : 12
+        let contentPadding: CGFloat = isCommandMode ? 10 : 14
 
         ZStack {
             themedBackground
 
-            VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: contentSpacing) {
                 if appUIState.showsThemeSettings {
                     ThemeSettingsView(settings: $themeStore.settings)
                 } else {
@@ -1465,7 +1508,7 @@ struct LauncherView: View {
                     }
                 }
             }
-            .padding(14)
+            .padding(contentPadding)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             .font(themeStore.uiFont())
             .foregroundStyle(themeStore.fontColor())
@@ -1558,6 +1601,9 @@ struct LauncherView: View {
         }
         .onChange(of: commandInput) { _, _ in
             if isCommandMode {
+                if commandArgsPart.isEmpty, activeCommandID != AppConstants.Launcher.Command.sys {
+                    commandFeedback = ""
+                }
                 if activeCommandID == AppConstants.Launcher.Command.kill {
                     if selectedKillSuggestionIndex != nil || pendingKillCandidate != nil {
                         logUIEvent("kill input changed -> clear pending/select input='\(commandArgsPart)'")
@@ -1739,13 +1785,12 @@ struct LauncherView: View {
             onSelectCommandByIndex: { [self] index in
                 guard index > 0 && index <= commandCatalog.count else { return }
                 let command = commandCatalog[index - 1]
+                pendingKillCandidate = nil
+                selectedKillSuggestionIndex = nil
                 activeCommandID = command.id
                 selectedCommandID = command.id
-                if activeCommandAcceptsInput {
-                    DispatchQueue.main.async {
-                        isQueryFocused = true
-                    }
-                }
+                commandFeedback = "Selected /\(command.id)"
+                requestCommandInputFocusIfNeeded()
             },
             onConfirmKill: { [self] in
                 if let pendingKillCandidate {

--- a/docs/features.md
+++ b/docs/features.md
@@ -31,6 +31,7 @@ This document tracks what `look` supports today and what is planned next.
 
 - `Cmd+/` command mode entry
 - built-in commands: `calc`, `shell`, `kill`, `sys`
+- calc parser supports exponent (`^`), factorial (`!`), constants (`pi`, `e`), math functions (`sqrt`, `abs`, `round`, `floor`, `ceil`), and `%` shorthand while keeping modulo
 - kill flow with explicit confirmation and process-by-port lookup (`:3000` / `port 3000`)
 - warning cue when shell input contains `sudo`
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -67,10 +67,19 @@ Enter command mode with `Cmd+/`.
 
 Built-in commands:
 
-- `calc`: evaluate expressions
+- `calc`: evaluate expressions (supports `^`, `!`, constants `pi`/`e`, functions `sqrt`/`abs`/`round`/`floor`/`ceil`, plus `%` shorthand)
 - `shell`: run shell command text
 - `kill`: force-kill a running app/process (with confirmation), supports port queries like `:3000` or `port 3000`
 - `sys`: show system information
+
+`calc` quick examples:
+
+- `2^3` -> `8`
+- `-2^2` -> `-4`
+- `4!` -> `24`
+- `2*pi` -> `6.2832`
+- `200*15%` -> `30`
+- `10%3` -> `1` (`%` remains modulo when used between operands)
 
 Behavior:
 


### PR DESCRIPTION
## Summary

- Powers for calc, and other forms
- decrease spaces between panels in cmds list

## Why

-

## Changes

- 2^2 = 4
- `-2^2` -> `-4`
- `4!` -> `24`
- `2*pi` -> `6.2832`
- `200*15%` -> `30`
- `10%3` -> `1` (`%` remains modulo when used between operands)

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [ ] `cd apps/macos/LauncherApp && swift test`
- [x] `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered
