### PR TITLE
chore: quick access command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ apps/macos/LauncherApp/RustBuild/
 docs/release-private.local.md
 docs/release-secrets.md
 docs/tmp-issue-tracker.md
+
+# internal feature specs — maintainer-only design notes; user docs live in docs/
+specs/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,8 @@ Please include:
 - alternatives considered
 - impact/risk (perf, UX, safety)
 
+User-facing feature documentation lives in `docs/` (`features.md`, `user-guide.md`) and is enough for end users and most contributors. Maintainers may also keep internal design specs under `specs/` (purpose, behavior, edge cases, non-goals); that directory is `.gitignore`d and not required reading.
+
 ## Development setup
 
 Prerequisites:

--- a/apps/macos/LauncherApp/look-app/Views/Commands/SystemInfoCommand.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/SystemInfoCommand.swift
@@ -1,6 +1,7 @@
 import Foundation
 import AppKit
 import IOKit
+import IOKit.ps
 import SwiftUI
 
 struct SystemInfoItem: Identifiable {
@@ -11,8 +12,9 @@ struct SystemInfoItem: Identifiable {
 }
 
 struct SystemInfoView: View {
-    let items: [SystemInfoItem]
     let themeStore: ThemeStore
+    @State private var items: [SystemInfoItem] = SystemInfoCommand.snapshot()
+    @State private var refreshTask: Task<Void, Never>?
 
     var body: some View {
         ScrollView {
@@ -43,11 +45,30 @@ struct SystemInfoView: View {
             .padding(4)
         }
         .frame(maxHeight: .infinity, alignment: .top)
+        .onAppear {
+            startRefreshing()
+        }
+        .onDisappear {
+            refreshTask?.cancel()
+            refreshTask = nil
+        }
     }
 
-    static func buildItems() -> [SystemInfoItem] {
-        var items: [SystemInfoItem] = []
+    private func startRefreshing() {
+        refreshTask?.cancel()
+        refreshTask = Task { @MainActor in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                if Task.isCancelled { break }
+                items = SystemInfoCommand.snapshot()
+            }
+        }
+    }
+}
 
+enum SystemInfoCommand {
+    static func snapshot() -> [SystemInfoItem] {
+        var items: [SystemInfoItem] = []
         items.append(SystemInfoItem(label: "", value: "System Info", isHeader: true))
         items.append(contentsOf: getSystemOverviewItems())
         items.append(contentsOf: getMemoryItems())
@@ -57,8 +78,26 @@ struct SystemInfoView: View {
         }
         items.append(contentsOf: getUptimeItems())
         items.append(contentsOf: getDiskItems())
-
         return items
+    }
+
+    static func getSystemInfo() -> String {
+        let items = snapshot()
+        var lines: [String] = []
+        for item in items {
+            if item.isHeader {
+                lines.append(item.value)
+            } else if item.label.isEmpty {
+                lines.append(item.value)
+            } else {
+                lines.append("\(item.label): \(item.value)")
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    static func getSystemInfoItems() -> [SystemInfoItem] {
+        snapshot()
     }
 
     private static func getSystemOverviewItems() -> [SystemInfoItem] {
@@ -163,85 +202,78 @@ struct SystemInfoView: View {
         ]
     }
 
-    private static func getCPUUsage() -> String {
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/top")
-        task.arguments = ["-l", "1", "-n", "0"]
+    // host_cpu_load_info gives cumulative ticks since boot; usage % needs the
+    // delta between two samples. First call after launch has no prior sample
+    // and returns "—".
+    private static var lastCPULoad: host_cpu_load_info?
 
-        let pipe = Pipe()
-        task.standardOutput = pipe
-        task.standardError = FileHandle.nullDevice
-
-        do {
-            try task.run()
-            task.waitUntilExit()
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            guard let output = String(data: data, encoding: .utf8) else {
-                return "N/A"
+    private static func sampleCPULoad() -> host_cpu_load_info? {
+        var load = host_cpu_load_info()
+        var count = mach_msg_type_number_t(MemoryLayout<host_cpu_load_info>.size / MemoryLayout<integer_t>.size)
+        let result = withUnsafeMutablePointer(to: &load) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                host_statistics(mach_host_self(), HOST_CPU_LOAD_INFO, $0, &count)
             }
-
-            guard let cpuLine = output
-                .components(separatedBy: "\n")
-                .first(where: { $0.lowercased().contains("cpu usage") })
-            else {
-                return "N/A"
-            }
-
-            let pattern = "([0-9]+(?:\\.[0-9]+)?)% user,\\s*([0-9]+(?:\\.[0-9]+)?)% sys"
-            guard let regex = try? NSRegularExpression(pattern: pattern) else {
-                return "N/A"
-            }
-            let range = NSRange(cpuLine.startIndex..<cpuLine.endIndex, in: cpuLine)
-            guard let match = regex.firstMatch(in: cpuLine, range: range),
-                  let userRange = Range(match.range(at: 1), in: cpuLine),
-                  let sysRange = Range(match.range(at: 2), in: cpuLine),
-                  let user = Double(cpuLine[userRange]),
-                  let sys = Double(cpuLine[sysRange]) else {
-                return "N/A"
-            }
-
-            return String(format: "%.1f", user + sys)
-        } catch {
-            return "N/A"
         }
+        return result == KERN_SUCCESS ? load : nil
+    }
+
+    private static func getCPUUsage() -> String {
+        guard let current = sampleCPULoad() else { return "N/A" }
+        defer { lastCPULoad = current }
+        guard let last = lastCPULoad else { return "—" }
+
+        let userDelta = Double(current.cpu_ticks.0 &- last.cpu_ticks.0)
+        let systemDelta = Double(current.cpu_ticks.1 &- last.cpu_ticks.1)
+        let idleDelta = Double(current.cpu_ticks.2 &- last.cpu_ticks.2)
+        let niceDelta = Double(current.cpu_ticks.3 &- last.cpu_ticks.3)
+
+        let total = userDelta + systemDelta + idleDelta + niceDelta
+        guard total > 0 else { return "0.0" }
+        let usage = (userDelta + systemDelta + niceDelta) / total * 100
+        return String(format: "%.1f", usage)
     }
 
     private static func getBatteryItems() -> [SystemInfoItem]? {
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/pmset")
-        task.arguments = ["-g", "batt"]
-
-        let pipe = Pipe()
-        task.standardOutput = pipe
-        task.standardError = FileHandle.nullDevice
-
-        do {
-            try task.run()
-            task.waitUntilExit()
-
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            if let output = String(data: data, encoding: .utf8) {
-                let lines = output.components(separatedBy: "\n")
-                var items: [SystemInfoItem] = [SystemInfoItem(label: "", value: "Battery", isHeader: true)]
-
-                for line in lines {
-                    let trimmed = line.trimmingCharacters(in: .whitespaces)
-                    if trimmed.contains("%") && !trimmed.hasPrefix("Now") {
-                        let parts = trimmed.components(separatedBy: " ").filter { !$0.isEmpty }
-                        for part in parts {
-                            if part.contains("%") {
-                                items.append(SystemInfoItem(label: "Charge", value: part, isHeader: false))
-                            } else if part == "charging" || part == "discharging" || part == "charged" {
-                                items.append(SystemInfoItem(label: "Status", value: part.capitalized, isHeader: false))
-                            }
-                        }
-                    }
-                }
-
-                return items.isEmpty ? nil : items
-            }
-        } catch {
+        guard let snapshotRef = IOPSCopyPowerSourcesInfo()?.takeRetainedValue() else {
             return nil
+        }
+        guard let sources = IOPSCopyPowerSourcesList(snapshotRef)?.takeRetainedValue() as? [CFTypeRef] else {
+            return nil
+        }
+
+        for source in sources {
+            guard let desc = IOPSGetPowerSourceDescription(snapshotRef, source)?.takeUnretainedValue() as? [String: Any] else {
+                continue
+            }
+            guard let type = desc[kIOPSTypeKey as String] as? String,
+                  type == kIOPSInternalBatteryType as String
+            else { continue }
+
+            var items: [SystemInfoItem] = [SystemInfoItem(label: "", value: "Battery", isHeader: true)]
+
+            if let current = desc[kIOPSCurrentCapacityKey as String] as? Int,
+               let maxCap = desc[kIOPSMaxCapacityKey as String] as? Int, maxCap > 0 {
+                let pct = Int(Double(current) / Double(maxCap) * 100)
+                items.append(SystemInfoItem(label: "Charge", value: "\(pct)%", isHeader: false))
+            }
+
+            let status: String
+            let isCharging = desc[kIOPSIsChargingKey as String] as? Bool ?? false
+            let isCharged = desc[kIOPSIsChargedKey as String] as? Bool ?? false
+            let powerState = desc[kIOPSPowerSourceStateKey as String] as? String ?? ""
+            if isCharged {
+                status = "Charged"
+            } else if isCharging {
+                status = "Charging"
+            } else if powerState == kIOPSACPowerValue as String {
+                status = "AC"
+            } else {
+                status = "Discharging"
+            }
+            items.append(SystemInfoItem(label: "Status", value: status, isHeader: false))
+
+            return items
         }
 
         return nil
@@ -296,26 +328,5 @@ struct SystemInfoView: View {
         }
 
         return items
-    }
-}
-
-struct SystemInfoCommand {
-    static func getSystemInfo() -> String {
-        let items = SystemInfoView.buildItems()
-        var lines: [String] = []
-        for item in items {
-            if item.isHeader {
-                lines.append(item.value)
-            } else if item.label.isEmpty {
-                lines.append(item.value)
-            } else {
-                lines.append("\(item.label): \(item.value)")
-            }
-        }
-        return lines.joined(separator: "\n")
-    }
-
-    static func getSystemInfoItems() -> [SystemInfoItem] {
-        return SystemInfoView.buildItems()
     }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Commands/SystemInfoCommand.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/SystemInfoCommand.swift
@@ -13,7 +13,8 @@ struct SystemInfoItem: Identifiable {
 
 struct SystemInfoView: View {
     let themeStore: ThemeStore
-    @State private var items: [SystemInfoItem] = SystemInfoCommand.snapshot()
+    @State private var items: [SystemInfoItem] = []
+    @State private var lastCPULoad: host_cpu_load_info?
     @State private var refreshTask: Task<Void, Never>?
 
     var body: some View {
@@ -57,32 +58,54 @@ struct SystemInfoView: View {
     private func startRefreshing() {
         refreshTask?.cancel()
         refreshTask = Task { @MainActor in
+            // first paint immediately so the panel never shows empty
+            await refreshOnce()
             while !Task.isCancelled {
                 try? await Task.sleep(nanoseconds: 2_000_000_000)
                 if Task.isCancelled { break }
-                items = SystemInfoCommand.snapshot()
+                await refreshOnce()
             }
         }
+    }
+
+    @MainActor
+    private func refreshOnce() async {
+        let previous = lastCPULoad
+        let snapshot = await Task.detached(priority: .utility) {
+            SystemInfoCommand.snapshot(previousCPULoad: previous)
+        }.value
+        items = snapshot.items
+        lastCPULoad = snapshot.cpuLoad
     }
 }
 
 enum SystemInfoCommand {
-    static func snapshot() -> [SystemInfoItem] {
+    struct Snapshot {
+        let items: [SystemInfoItem]
+        let cpuLoad: host_cpu_load_info?
+    }
+
+    // Pure function — safe to call off the main actor. The caller owns the
+    // previous CPU sample so we don't need shared mutable state.
+    static func snapshot(previousCPULoad: host_cpu_load_info?) -> Snapshot {
         var items: [SystemInfoItem] = []
         items.append(SystemInfoItem(label: "", value: "System Info", isHeader: true))
         items.append(contentsOf: getSystemOverviewItems())
         items.append(contentsOf: getMemoryItems())
-        items.append(contentsOf: getCPUItems())
+
+        let currentLoad = sampleCPULoad()
+        items.append(contentsOf: getCPUItems(currentLoad: currentLoad, previousLoad: previousCPULoad))
+
         if let batteryItems = getBatteryItems() {
             items.append(contentsOf: batteryItems)
         }
         items.append(contentsOf: getUptimeItems())
         items.append(contentsOf: getDiskItems())
-        return items
+        return Snapshot(items: items, cpuLoad: currentLoad)
     }
 
     static func getSystemInfo() -> String {
-        let items = snapshot()
+        let items = snapshot(previousCPULoad: nil).items
         var lines: [String] = []
         for item in items {
             if item.isHeader {
@@ -97,7 +120,7 @@ enum SystemInfoCommand {
     }
 
     static func getSystemInfoItems() -> [SystemInfoItem] {
-        snapshot()
+        snapshot(previousCPULoad: nil).items
     }
 
     private static func getSystemOverviewItems() -> [SystemInfoItem] {
@@ -171,7 +194,7 @@ enum SystemInfoCommand {
         ]
     }
 
-    private static func getCPUItems() -> [SystemInfoItem] {
+    private static func getCPUItems(currentLoad: host_cpu_load_info?, previousLoad: host_cpu_load_info?) -> [SystemInfoItem] {
         var cpuBrand = "Unknown"
         let cpuCount = ProcessInfo.processInfo.processorCount
         let cpuCores = ProcessInfo.processInfo.activeProcessorCount
@@ -192,7 +215,7 @@ enum SystemInfoCommand {
             cpuBrand = String(cString: machine)
         }
 
-        let usage = getCPUUsage()
+        let usage = formatCPUUsage(current: currentLoad, previous: previousLoad)
 
         return [
             SystemInfoItem(label: "", value: "CPU", isHeader: true),
@@ -202,12 +225,7 @@ enum SystemInfoCommand {
         ]
     }
 
-    // host_cpu_load_info gives cumulative ticks since boot; usage % needs the
-    // delta between two samples. First call after launch has no prior sample
-    // and returns "—".
-    private static var lastCPULoad: host_cpu_load_info?
-
-    private static func sampleCPULoad() -> host_cpu_load_info? {
+    static func sampleCPULoad() -> host_cpu_load_info? {
         var load = host_cpu_load_info()
         var count = mach_msg_type_number_t(MemoryLayout<host_cpu_load_info>.size / MemoryLayout<integer_t>.size)
         let result = withUnsafeMutablePointer(to: &load) {
@@ -218,15 +236,17 @@ enum SystemInfoCommand {
         return result == KERN_SUCCESS ? load : nil
     }
 
-    private static func getCPUUsage() -> String {
-        guard let current = sampleCPULoad() else { return "N/A" }
-        defer { lastCPULoad = current }
-        guard let last = lastCPULoad else { return "—" }
+    // host_cpu_load_info gives cumulative ticks since boot; usage % needs the
+    // delta between two samples. The first refresh after the panel opens has
+    // no prior sample and shows "—".
+    private static func formatCPUUsage(current: host_cpu_load_info?, previous: host_cpu_load_info?) -> String {
+        guard let current else { return "N/A" }
+        guard let previous else { return "—" }
 
-        let userDelta = Double(current.cpu_ticks.0 &- last.cpu_ticks.0)
-        let systemDelta = Double(current.cpu_ticks.1 &- last.cpu_ticks.1)
-        let idleDelta = Double(current.cpu_ticks.2 &- last.cpu_ticks.2)
-        let niceDelta = Double(current.cpu_ticks.3 &- last.cpu_ticks.3)
+        let userDelta = Double(current.cpu_ticks.0 &- previous.cpu_ticks.0)
+        let systemDelta = Double(current.cpu_ticks.1 &- previous.cpu_ticks.1)
+        let idleDelta = Double(current.cpu_ticks.2 &- previous.cpu_ticks.2)
+        let niceDelta = Double(current.cpu_ticks.3 &- previous.cpu_ticks.3)
 
         let total = userDelta + systemDelta + idleDelta + niceDelta
         guard total > 0 else { return "0.0" }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+CommandMode.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+CommandMode.swift
@@ -40,6 +40,37 @@ extension LauncherView {
         focusActiveInput(recoveryDelays: [0.0, 0.04], activateApp: false)
     }
 
+    func enterCommandMode(commandID: String, prefilledInput: String) {
+        showsHelpScreen = false
+        query = ""
+        isCommandMode = true
+        commandFeedback = ""
+        activeCommandID = commandID
+        selectedCommandID = commandID
+        commandInput = prefilledInput
+        focusActiveInput(recoveryDelays: [0.0, 0.04], activateApp: false)
+    }
+
+    // Detects `:cmdid<space>...` (live trigger) and bare `:cmdid` (submit-only
+    // trigger). Returns nil if `input` doesn't begin with `:` or the id after
+    // `:` (up to the first whitespace) isn't an exact match for a command in
+    // the catalog. `hasSpace` distinguishes the two trigger paths.
+    func extractInlineCommand(from input: String) -> (id: String, args: String, hasSpace: Bool)? {
+        guard input.hasPrefix(":") else { return nil }
+        let body = input.dropFirst()
+
+        if let spaceIdx = body.firstIndex(where: { $0.isWhitespace }) {
+            let id = String(body[..<spaceIdx]).lowercased()
+            guard !id.isEmpty, commandCatalog.contains(where: { $0.id == id }) else { return nil }
+            let args = String(body[body.index(after: spaceIdx)...])
+            return (id, args, true)
+        }
+
+        let id = String(body).lowercased()
+        guard !id.isEmpty, commandCatalog.contains(where: { $0.id == id }) else { return nil }
+        return (id, "", false)
+    }
+
     func exitCommandMode() {
         guard isCommandMode else { return }
         isCommandMode = false
@@ -68,7 +99,9 @@ extension LauncherView {
             }
         } else {
             let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-            if let translationCommand = extractTranslationQuery(from: trimmed) {
+            if let cmd = extractInlineCommand(from: trimmed), !cmd.hasSpace {
+                enterCommandMode(commandID: cmd.id, prefilledInput: "")
+            } else if let translationCommand = extractTranslationQuery(from: trimmed) {
                 handleTranslation(command: translationCommand)
                 isQueryFocused = true
             } else {
@@ -255,7 +288,7 @@ extension LauncherView {
                             }
                             .padding(8)
                         } else if activeCommandID == AppConstants.Launcher.Command.sys {
-                            SystemInfoView(items: SystemInfoCommand.getSystemInfoItems(), themeStore: themeStore)
+                            SystemInfoView(themeStore: themeStore)
                                 .padding(8)
                         } else {
                             VStack(alignment: .leading, spacing: 0) {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -560,6 +560,10 @@ struct LauncherView: View {
             clipboardStore.setMonitoringMode(.background)
         }
         .onChange(of: query) { _, _ in
+            if !isCommandMode, let cmd = extractInlineCommand(from: query), cmd.hasSpace {
+                enterCommandMode(commandID: cmd.id, prefilledInput: cmd.args)
+                return
+            }
             previewLookupDefinition(for: query)
             if !isCommandMode {
                 if showsHelpScreen {

--- a/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Shortcuts.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Shortcuts.swift
@@ -45,6 +45,7 @@ enum ShortcutDocs {
                 ShortcutItem(keys: "Cmd+F", action: "Reveal selected app/file/folder in Finder"),
                 ShortcutItem(keys: "Cmd+Enter", action: "Search query on Google"),
                 ShortcutItem(keys: "Cmd+/", action: "Enter command mode"),
+                ShortcutItem(keys: ":cmd", action: "Jump to a command from home (e.g. :calc 2+2, :kill chrome, :sys)"),
                 ShortcutItem(keys: "Cmd+Shift+,", action: "Open/close settings panel"),
                 ShortcutItem(keys: "Cmd+Shift+;", action: "Reload .look.config"),
                 ShortcutItem(keys: "Cmd+H", action: "Toggle in-window keyboard help screen"),

--- a/docs/features.md
+++ b/docs/features.md
@@ -30,7 +30,7 @@ This document tracks what `look` supports today and what is planned next.
 
 ### Command mode
 
-- `Cmd+/` command mode entry
+- `Cmd+/` command mode entry, or inline `:cmdid` shortcut from the home screen (e.g. `:calc 2+2`, `:kill chrome`); space after a known command id triggers a live switch with args pre-filled
 - built-in commands: `calc`, `shell`, `kill`, `sys`
 - calc parser supports exponent (`^`), factorial (`!`), constants (`pi`, `e`), math functions (`sqrt`, `abs`, `round`, `floor`, `ceil`), and `%` shorthand while keeping modulo
 - kill flow with explicit confirmation and process-by-port lookup (`:3000` / `port 3000`)

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -154,6 +154,9 @@ Windows immediate execution queue (current):
 - [x] **Add preset: Kanagawa** ([#54](https://github.com/kunkka19xx/look/issues/54))
 - [x] **Config validation**: validate config file on reload (Cmd+Shift+;), show warnings for invalid values with orange banner + copy button; clamp file_scan_depth (1-12) and file_scan_limit (500-50000) in both Swift and Rust
 - [ ] **Theme codegen pipeline (future)**: define a shared theme token source and generate typed platform code at build time
+- [ ] **Quick Look file previews** *(pending perf validation, ships off by default)*: replace icon-only preview pane with macOS Quick Look rendering (PDF, text, code, audio/video poster, archives, office docs, etc.); requires debounced two-tier rendering, falls back to icon + metadata for unsupported/unreadable. Internal spec: `specs/quicklook-file-preview.md` (maintainer-only, gitignored)
+- [ ] **Pomodoro command** (`/pomo`): focus timer in command mode with start/pause/stop, completion notification, and active-session indicator. Internal spec: `specs/pomodoro.md` (maintainer-only, gitignored)
+- [ ] **Browser bookmark + history suggestions**: index the user's default browser (Safari/Chrome/Arc/Brave/Edge/Firefox) and surface bookmarks + recent pages as ranked launcher results. Internal spec: `specs/browser-suggestions.md` (maintainer-only, gitignored)
 - [ ] **Homebrew release**: Package app for homebrew installation
 - [x] **Build script**: Create release build and curl installer script
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -72,7 +72,13 @@ Translation mode (`t"`/`tw"`):
 
 ## Command mode
 
-Enter command mode with `Cmd+/`.
+Enter command mode with `Cmd+/`, or jump straight to a specific command from the home screen with the `:` prefix:
+
+- `:calc` then `Enter` — open `/calc` with empty input
+- `:calc 2+2` — opens `/calc` with `2+2` already typed (the space after the command id is the trigger; you can keep typing without pressing Enter)
+- Same pattern for `:shell`, `:kill`, `:sys`
+
+The `:` prefix only triggers when the word right after it is a known command id (`calc`, `shell`, `kill`, `sys`); anything else (`:foo`, `:Users/me/...`) stays in normal search.
 
 Built-in commands:
 
@@ -206,6 +212,7 @@ Note: `Settings Blur` is stored as local app UI state (UserDefaults) and is not 
 - `Tab` / `Shift+Tab`: next/previous result (app list) or command (command mode)
 - `Up` / `Down`: move selection (and in `kill`, move process selection)
 - `Cmd+/`: command mode
+- `:cmd` (e.g. `:calc 2+2`, `:kill chrome`, `:sys`): jump to a command directly from the home screen
 - `Cmd+1` / `Cmd+2` / `Cmd+3` / `Cmd+4`: direct command switch
 - `Escape`: back/close (context dependent)
 - `Shift+Escape`: hide launcher


### PR DESCRIPTION
## Summary

- Quick access any commands from main screen. (this app is designed to be lazy, fast!)

## Changes

- add :command like in vim, user can access to specified command by command id (calc, shell, kill,...) 
- update docs
- hide specs

## Testing

- [x] `cargo check --workspace --manifest-path core/Cargo.toml`
- [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [x] `cd apps/macos/LauncherApp && swift test`
- [x] `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
