### PR TITLE
Fix: ranking issue for windows

### DIFF
--- a/apps/windows/LauncherApp/Bridge/FfiBindings.cs
+++ b/apps/windows/LauncherApp/Bridge/FfiBindings.cs
@@ -21,6 +21,17 @@ public static class FfiBindings
     [return: MarshalAs(UnmanagedType.I1)]
     public static extern bool look_reload_config();
 
+    [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+    [return: MarshalAs(UnmanagedType.I1)]
+    public static extern bool look_record_usage(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string candidateId,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string action);
+
+    [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+    [return: MarshalAs(UnmanagedType.I1)]
+    public static extern bool look_seed_uwp_apps_json(
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string json);
+
     [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
     public static extern IntPtr look_translate_json(IntPtr text, IntPtr targetLang);
 }

--- a/apps/windows/LauncherApp/LauncherApp.csproj
+++ b/apps/windows/LauncherApp/LauncherApp.csproj
@@ -106,4 +106,14 @@
     <Copy SourceFiles="$(RustFfiDll)" DestinationFiles="$(TargetDir)look_ffi.dll" SkipUnchangedFiles="true" />
     <Copy SourceFiles="$(RustFfiDll)" DestinationFiles="$(TargetDir)AppX\look_ffi.dll" SkipUnchangedFiles="true" ContinueOnError="WarnAndContinue" Condition="Exists('$(TargetDir)AppX')" />
   </Target>
+
+  <!-- Without this, `dotnet publish` (and therefore `make app-run-dev`) leaves the publish
+       directory's look_ffi.dll at whatever was committed before the last C# rebuild — a
+       brand new FFI export will compile and copy into bin\<plat>\Debug\... but never reach
+       bin\Debug\...\publish\, so the dev install runs against a stale DLL whose missing
+       entrypoint silently fails (EntryPointNotFoundException, swallowed at the call site). -->
+  <Target Name="CopyRustFfiDllToPublish" AfterTargets="Publish" Condition="'$(OS)' == 'Windows_NT' and Exists('$(RustFfiDll)')">
+    <Message Importance="high" Text="Copying look_ffi.dll to publish output ($(PublishDir))" />
+    <Copy SourceFiles="$(RustFfiDll)" DestinationFiles="$(PublishDir)look_ffi.dll" SkipUnchangedFiles="false" />
+  </Target>
 </Project>

--- a/apps/windows/LauncherApp/MainWindow.Keyboard.cs
+++ b/apps/windows/LauncherApp/MainWindow.Keyboard.cs
@@ -31,6 +31,12 @@ public sealed partial class MainWindow
         return key == (VirtualKey)188 && IsCtrlPressed() && IsShiftPressed();
     }
 
+    // VK_OEM_1 (`;`) + Ctrl + Shift mirrors macOS Cmd+Shift+; in look_appApp.swift:162.
+    private bool IsReloadConfigShortcut(VirtualKey key)
+    {
+        return key == (VirtualKey)186 && IsCtrlPressed() && IsShiftPressed();
+    }
+
     private bool IsCommandModeShortcut(KeyRoutedEventArgs e)
     {
         if (!IsCtrlPressed())
@@ -276,6 +282,13 @@ public sealed partial class MainWindow
             return;
         }
 
+        if (IsReloadConfigShortcut(e.Key))
+        {
+            HandleReloadConfigShortcut();
+            e.Handled = true;
+            return;
+        }
+
         if (!IsSettingsToggleShortcut(e.Key))
         {
             return;
@@ -283,6 +296,24 @@ public sealed partial class MainWindow
 
         ToggleSettingsMode();
         e.Handled = true;
+    }
+
+    private void HandleReloadConfigShortcut()
+    {
+        bool ok;
+        try
+        {
+            ok = FfiBindings.look_reload_config();
+        }
+        catch
+        {
+            ok = false;
+        }
+
+        ShowBanner(
+            ok ? "Config reloaded" : "Config reload failed",
+            ok ? BannerStyle.Info : BannerStyle.Error,
+            durationSeconds: ok ? 1.4 : 3.0);
     }
 
     private void QueryInput_OnPreviewKeyDown(object sender, KeyRoutedEventArgs e)

--- a/apps/windows/LauncherApp/MainWindow.Search.cs
+++ b/apps/windows/LauncherApp/MainWindow.Search.cs
@@ -11,9 +11,10 @@ using LauncherApp.Services;
 
 namespace LauncherApp;
 
-// Search pipeline: query routing (ResolveMode / IsNonAppScopedQuery), async backend fetch +
-// UWP merge (QueryInput_OnTextChanged), rendering (RefreshResults), and the de-dup/noise
-// filters that trim Rust results before showing them.
+// Search pipeline: query routing (ResolveMode), async Rust backend fetch (QueryInput_OnTextChanged),
+// rendering (RefreshResults), and the dedup/noise filters that trim Rust results before display.
+// UWP entries live in the Rust candidates table (seeded by UwpAppService at startup) so there's no
+// separate UWP search path here — the engine ranks them alongside System32 / Start Menu apps.
 public sealed partial class MainWindow
 {
     private (LauncherMode mode, string normalizedQuery) ResolveMode(string rawQuery)
@@ -36,20 +37,6 @@ public sealed partial class MainWindow
         }
 
         return (LauncherMode.Search, query);
-    }
-
-    // Returns true for f"/d"/r" scoped queries — scopes that by definition exclude UWP apps.
-    // The Rust engine parses the same prefixes (ParsedQuery::from_input), so raw passthrough
-    // handles the filtering server-side; we only use this to decide whether to merge UWP
-    // results on top of the Rust results.
-    private static bool IsNonAppScopedQuery(string raw)
-    {
-        if (string.IsNullOrEmpty(raw) || raw.Length < 2 || raw[1] != '"')
-        {
-            return false;
-        }
-        char prefix = char.ToLowerInvariant(raw[0]);
-        return prefix == 'f' || prefix == 'd' || prefix == 'r';
     }
 
     private async void QueryInput_OnTextChanged(object sender, Microsoft.UI.Xaml.Controls.TextChangedEventArgs e)
@@ -93,17 +80,7 @@ public sealed partial class MainWindow
             try
             {
                 string searchQuery = resolvedQuery;
-                bool skipUwp = IsNonAppScopedQuery(searchQuery);
-                backendResults = await Task.Run(() =>
-                {
-                    var rust = _searchLogic.Search(searchQuery, 120);
-                    if (skipUwp)
-                    {
-                        return rust;
-                    }
-                    var uwp = _uwpAppService.Search(searchQuery, 30);
-                    return MergeBackendAndUwpResults(rust, uwp);
-                });
+                backendResults = await Task.Run(() => _searchLogic.Search(searchQuery, 120));
             }
             catch (Exception ex)
             {
@@ -312,22 +289,6 @@ public sealed partial class MainWindow
             .Where(item => !ShouldHideSearchResult(item))
             .Take(limit)
             .ToList();
-    }
-
-    private static IReadOnlyList<LauncherResult> MergeBackendAndUwpResults(
-        IReadOnlyList<LauncherResult> rust,
-        IReadOnlyList<LauncherResult> uwp)
-    {
-        if (uwp.Count == 0)
-        {
-            return rust;
-        }
-
-        var merged = new List<LauncherResult>(rust.Count + uwp.Count);
-        merged.AddRange(uwp);
-        merged.AddRange(rust);
-        merged.Sort((a, b) => b.Score.CompareTo(a.Score));
-        return merged;
     }
 
     private static IReadOnlyList<LauncherResult> DeduplicatePairedAppEntries(IReadOnlyList<LauncherResult> source)

--- a/apps/windows/LauncherApp/Services/ActionDispatcher.cs
+++ b/apps/windows/LauncherApp/Services/ActionDispatcher.cs
@@ -31,6 +31,7 @@ public sealed class ActionDispatcher
         if (!forceNewWindow && kind == LauncherActionKind.App && TryActivateExistingAppWindow(result.Path, result.Title))
         {
             Log("Dispatch activate-existing succeeded");
+            RecordUsage(result, kind);
             return true;
         }
 
@@ -45,10 +46,17 @@ public sealed class ActionDispatcher
         };
 
         if (opened)
+        {
+            RecordUsage(result, kind);
             return true;
+        }
 
         bool fallback = _shellExecute.Open(result.Path);
         Log($"Dispatch fallback open result={fallback}");
+        if (fallback)
+        {
+            RecordUsage(result, kind);
+        }
         return fallback;
     }
 
@@ -218,6 +226,42 @@ public sealed class ActionDispatcher
         return LauncherActionKind.Unknown;
     }
 
+    // Records a successful launch so the Rust engine's rank_score (core/ranking/src/lib.rs)
+    // sees the use_count bump. UWP entries are seeded into sqlite as `app:uwp:<AUMID>` by
+    // UwpAppService on startup, so they go through this same FFI path with no special-casing.
+    private static void RecordUsage(LauncherResult result, LauncherActionKind kind)
+    {
+        if (string.IsNullOrWhiteSpace(result.Id))
+        {
+            Log("Dispatch record_usage skipped: empty id");
+            return;
+        }
+
+        string? action = kind switch
+        {
+            LauncherActionKind.App => "open_app",
+            LauncherActionKind.File => "open_file",
+            LauncherActionKind.Folder => "open_folder",
+            LauncherActionKind.Setting => "open",
+            _ => null,
+        };
+
+        if (action is null)
+        {
+            return;
+        }
+
+        try
+        {
+            bool ok = LauncherApp.Bridge.FfiBindings.look_record_usage(result.Id, action);
+            Log($"Dispatch record_usage: id='{result.Id}' action='{action}' ok={ok}");
+        }
+        catch (Exception ex)
+        {
+            Log($"Dispatch record_usage threw: {ex.Message}");
+        }
+    }
+
     private bool OpenSetting(string path)
     {
         if (string.IsNullOrWhiteSpace(path))
@@ -233,6 +277,17 @@ public sealed class ActionDispatcher
     {
         if (string.IsNullOrWhiteSpace(path))
             return false;
+
+        // UWP entries: shell:AppsFolder\<PackageFamilyName>!<AppId>. Process.GetProcessesByName(title)
+        // misses these whenever the AppX display name and the executable basename diverge —
+        // Windows Terminal ("Terminal" vs "WindowsTerminal.exe"), Photos, Snipping Tool, etc.
+        // So we scan all running processes and match the WindowsApps install dir's package
+        // name prefix against MainModule.FileName, which always contains the package full name
+        // (e.g. C:\Program Files\WindowsApps\Microsoft.WindowsTerminal_<ver>_<arch>__<hash>\WindowsTerminal.exe).
+        if (TryActivateUwpByAumid(path))
+        {
+            return true;
+        }
 
         string resolved = ResolveExecutablePath(path);
         string normalizedPath = NormalizePath(resolved);
@@ -293,6 +348,88 @@ public sealed class ActionDispatcher
             {
                 ActivateWindow(fallbackWindow);
                 return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryActivateUwpByAumid(string path)
+    {
+        const string prefix = "shell:AppsFolder\\";
+        if (!path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        string aumid = path.Substring(prefix.Length).Trim();
+        int bang = aumid.IndexOf('!');
+        if (bang <= 0)
+        {
+            return false;
+        }
+        // Family name is "<Name>_<PublisherHash>" (e.g. Microsoft.WindowsTerminal_8wekyb3d8bbwe).
+        // The installed package directory under WindowsApps is "<Name>_<Version>_<Arch>__<PublisherHash>",
+        // so MainModule paths always contain BOTH "<Name>_" as a prefix segment AND "_<PublisherHash>\"
+        // as a tail segment of the directory. Match on both for robustness.
+        string familyName = aumid.Substring(0, bang);
+        int lastUnderscore = familyName.LastIndexOf('_');
+        if (lastUnderscore <= 0 || lastUnderscore == familyName.Length - 1)
+        {
+            return false;
+        }
+        string packageName = familyName.Substring(0, lastUnderscore);
+        string publisherHash = familyName.Substring(lastUnderscore + 1);
+
+        Process[] processes;
+        try
+        {
+            processes = Process.GetProcesses();
+        }
+        catch
+        {
+            return false;
+        }
+
+        foreach (var process in processes)
+        {
+            try
+            {
+                if (process.MainWindowHandle == IntPtr.Zero)
+                    continue;
+
+                string? processPath;
+                try
+                {
+                    processPath = process.MainModule?.FileName;
+                }
+                catch
+                {
+                    // Access-denied on processes from other users / elevated; skip.
+                    continue;
+                }
+
+                if (string.IsNullOrWhiteSpace(processPath))
+                    continue;
+
+                if (processPath.IndexOf("\\WindowsApps\\", StringComparison.OrdinalIgnoreCase) < 0)
+                    continue;
+
+                if (processPath.IndexOf(packageName + "_", StringComparison.OrdinalIgnoreCase) < 0)
+                    continue;
+
+                if (processPath.IndexOf("_" + publisherHash, StringComparison.OrdinalIgnoreCase) < 0)
+                    continue;
+
+                ActivateWindow(process.MainWindowHandle);
+                return true;
+            }
+            catch
+            {
+            }
+            finally
+            {
+                try { process.Dispose(); } catch { }
             }
         }
 

--- a/apps/windows/LauncherApp/Services/ActionDispatcher.cs
+++ b/apps/windows/LauncherApp/Services/ActionDispatcher.cs
@@ -362,24 +362,11 @@ public sealed class ActionDispatcher
             return false;
         }
 
-        string aumid = path.Substring(prefix.Length).Trim();
-        int bang = aumid.IndexOf('!');
-        if (bang <= 0)
+        string targetAumid = path.Substring(prefix.Length).Trim();
+        if (targetAumid.IndexOf('!') <= 0)
         {
             return false;
         }
-        // Family name is "<Name>_<PublisherHash>" (e.g. Microsoft.WindowsTerminal_8wekyb3d8bbwe).
-        // The installed package directory under WindowsApps is "<Name>_<Version>_<Arch>__<PublisherHash>",
-        // so MainModule paths always contain BOTH "<Name>_" as a prefix segment AND "_<PublisherHash>\"
-        // as a tail segment of the directory. Match on both for robustness.
-        string familyName = aumid.Substring(0, bang);
-        int lastUnderscore = familyName.LastIndexOf('_');
-        if (lastUnderscore <= 0 || lastUnderscore == familyName.Length - 1)
-        {
-            return false;
-        }
-        string packageName = familyName.Substring(0, lastUnderscore);
-        string publisherHash = familyName.Substring(lastUnderscore + 1);
 
         Process[] processes;
         try
@@ -391,6 +378,12 @@ public sealed class ActionDispatcher
             return false;
         }
 
+        // Exact-match by full AUMID (PackageFamilyName!AppId) via GetApplicationUserModelId
+        // on each candidate process. Matching only on the package family name was ambiguous
+        // when a single package exposes multiple AppIds (e.g. utilities that ship a "Settings"
+        // entry alongside the main app) — selecting one would activate the other's window
+        // and report success. Pre-filter by `\WindowsApps\` in the exe path so we only call
+        // the kernel32 API on processes that could plausibly host a UWP entrypoint.
         foreach (var process in processes)
         {
             try
@@ -415,10 +408,11 @@ public sealed class ActionDispatcher
                 if (processPath.IndexOf("\\WindowsApps\\", StringComparison.OrdinalIgnoreCase) < 0)
                     continue;
 
-                if (processPath.IndexOf(packageName + "_", StringComparison.OrdinalIgnoreCase) < 0)
+                string? processAumid = TryGetProcessAumid(process.Id);
+                if (processAumid is null)
                     continue;
 
-                if (processPath.IndexOf("_" + publisherHash, StringComparison.OrdinalIgnoreCase) < 0)
+                if (!string.Equals(processAumid, targetAumid, StringComparison.OrdinalIgnoreCase))
                     continue;
 
                 ActivateWindow(process.MainWindowHandle);
@@ -434,6 +428,47 @@ public sealed class ActionDispatcher
         }
 
         return false;
+    }
+
+    private static string? TryGetProcessAumid(int processId)
+    {
+        IntPtr handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, (uint)processId);
+        if (handle == IntPtr.Zero)
+        {
+            return null;
+        }
+
+        try
+        {
+            uint length = 0;
+            int sizeProbeRc = GetApplicationUserModelId(handle, ref length, null);
+            // ERROR_INSUFFICIENT_BUFFER (122) is the only path that gives us the real length
+            // for non-empty AUMIDs. Anything else (APPMODEL_ERROR_NO_APPLICATION = 15700,
+            // success with length=0, etc.) means there's no AUMID to match against.
+            if (sizeProbeRc != ERROR_INSUFFICIENT_BUFFER || length == 0)
+            {
+                return null;
+            }
+
+            char[] buffer = new char[length];
+            int rc = GetApplicationUserModelId(handle, ref length, buffer);
+            if (rc != 0 || length == 0)
+            {
+                return null;
+            }
+
+            // Returned length includes the trailing null terminator; trim it.
+            int actual = (int)length;
+            if (actual > 0 && buffer[actual - 1] == '\0')
+            {
+                actual -= 1;
+            }
+            return actual <= 0 ? null : new string(buffer, 0, actual);
+        }
+        finally
+        {
+            CloseHandle(handle);
+        }
     }
 
     private static IEnumerable<string> EnumerateProcessNameCandidates(string? normalizedExePath, string? title)
@@ -547,6 +582,9 @@ public sealed class ActionDispatcher
 
     private const int SW_RESTORE = 9;
 
+    private const uint PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
+    private const int ERROR_INSUFFICIENT_BUFFER = 122;
+
     [DllImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool SetForegroundWindow(IntPtr hWnd);
@@ -558,4 +596,17 @@ public sealed class ActionDispatcher
     [DllImport("user32.dll")]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool IsIconic(IntPtr hWnd);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern IntPtr OpenProcess(uint dwDesiredAccess, bool bInheritHandle, uint dwProcessId);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CloseHandle(IntPtr hObject);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern int GetApplicationUserModelId(
+        IntPtr hProcess,
+        ref uint applicationUserModelIdLength,
+        [Out] char[]? applicationUserModelId);
 }

--- a/apps/windows/LauncherApp/Services/UwpAppService.cs
+++ b/apps/windows/LauncherApp/Services/UwpAppService.cs
@@ -1,29 +1,23 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
+using System.IO;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 using System.Threading.Tasks;
 using LauncherApp.Bridge;
 
 namespace LauncherApp.Services;
 
+// Rust doesn't enumerate shell:AppsFolder (no equivalent of macOS Spotlight on Windows),
+// so we walk it once via Shell.Application COM at app start and forward each entry to
+// the Rust candidates table via look_seed_uwp_apps_json. After that, the Rust engine
+// owns ranking, scoring, use_count, and recency for UWP entries — there's no parallel
+// C# scoring path. The seed is idempotent (upsert preserves use_count via ON CONFLICT)
+// so re-running on every launch is safe and refreshes the install list cheaply.
 public sealed class UwpAppService
 {
-    private readonly object _cacheLock = new();
-    private List<LauncherResult> _cache = [];
-    private bool _populated;
-
-    public bool IsReady
-    {
-        get
-        {
-            lock (_cacheLock)
-            {
-                return _populated;
-            }
-        }
-    }
+    private static readonly string LogPath = Path.Combine(Path.GetTempPath(), "look-open.log");
 
     public void BeginInitialize()
     {
@@ -31,102 +25,49 @@ public sealed class UwpAppService
         {
             try
             {
-                var apps = EnumerateAppsFolder();
-                lock (_cacheLock)
+                var entries = EnumerateAppsFolder();
+                Log($"UwpAppService.BeginInitialize: enumerated {entries.Count} apps");
+                if (entries.Count == 0)
                 {
-                    _cache = apps;
-                    _populated = true;
+                    return;
                 }
-                Debug.WriteLine($"[UwpAppService] loaded {apps.Count} apps");
+
+                string json = JsonSerializer.Serialize(entries);
+                Log($"UwpAppService.BeginInitialize: json length={json.Length} preview={json.Substring(0, Math.Min(json.Length, 240))}");
+
+                bool ok = false;
+                try
+                {
+                    ok = FfiBindings.look_seed_uwp_apps_json(json);
+                }
+                catch (Exception ex)
+                {
+                    Log($"UwpAppService.BeginInitialize: seed FFI threw: {ex.GetType().Name} {ex.Message}");
+                }
+
+                Log($"UwpAppService.BeginInitialize: seeded {entries.Count} apps ok={ok}");
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"[UwpAppService] init failed: {ex.Message}");
-                lock (_cacheLock)
-                {
-                    _populated = true;
-                }
+                Log($"UwpAppService.BeginInitialize: failed {ex.GetType().Name} {ex.Message}");
             }
         });
     }
 
-    public IReadOnlyList<LauncherResult> Search(string query, int limit)
+    private static void Log(string message)
     {
-        List<LauncherResult> snapshot;
-        lock (_cacheLock)
+        try
         {
-            snapshot = _cache;
+            File.AppendAllText(LogPath, $"[{DateTime.Now:HH:mm:ss.fff}] {message}{Environment.NewLine}");
         }
-
-        if (snapshot.Count == 0)
+        catch
         {
-            return Array.Empty<LauncherResult>();
         }
-
-        if (string.IsNullOrWhiteSpace(query))
-        {
-            return snapshot.Take(limit).ToList();
-        }
-
-        var filtered = new List<(LauncherResult Result, int Score)>();
-        foreach (var app in snapshot)
-        {
-            int score = MatchScore(app.Title, query);
-            if (score <= 0)
-            {
-                continue;
-            }
-
-            filtered.Add((
-                new LauncherResult
-                {
-                    Id = app.Id,
-                    Kind = app.Kind,
-                    Title = app.Title,
-                    Subtitle = app.Subtitle,
-                    Path = app.Path,
-                    Score = score,
-                },
-                score));
-        }
-
-        return filtered
-            .OrderByDescending(x => x.Score)
-            .Take(limit)
-            .Select(x => x.Result)
-            .ToList();
     }
 
-    private static int MatchScore(string title, string query)
+    private static List<UwpAppEntry> EnumerateAppsFolder()
     {
-        if (string.IsNullOrEmpty(title) || string.IsNullOrEmpty(query))
-        {
-            return 0;
-        }
-
-        if (title.Equals(query, StringComparison.OrdinalIgnoreCase))
-        {
-            return 1500;
-        }
-
-        if (title.StartsWith(query, StringComparison.OrdinalIgnoreCase))
-        {
-            return 1400;
-        }
-
-        int idx = title.IndexOf(query, StringComparison.OrdinalIgnoreCase);
-        if (idx < 0)
-        {
-            return 0;
-        }
-
-        int wordBoundaryBonus = idx > 0 && !char.IsLetterOrDigit(title[idx - 1]) ? 100 : 0;
-        return 1000 + wordBoundaryBonus;
-    }
-
-    private static List<LauncherResult> EnumerateAppsFolder()
-    {
-        var results = new List<LauncherResult>();
+        var results = new List<UwpAppEntry>();
 
         Type? shellType = Type.GetTypeFromProgID("Shell.Application");
         if (shellType is null)
@@ -164,7 +105,8 @@ public sealed class UwpAppService
                     }
 
                     // AUMIDs contain "!" separating PackageFamilyName from AppId.
-                    // Entries without "!" are Win32 shortcuts already indexed by the Rust backend.
+                    // Entries without "!" are Win32 shortcuts already indexed by the
+                    // Rust backend's Start Menu scan and shouldn't be duplicated here.
                     if (!path.Contains('!'))
                     {
                         continue;
@@ -175,14 +117,11 @@ public sealed class UwpAppService
                         continue;
                     }
 
-                    results.Add(new LauncherResult
-                    {
-                        Id = "uwp:" + path,
-                        Kind = "app",
-                        Title = name,
-                        Path = "shell:AppsFolder\\" + path,
-                        Score = 800,
-                    });
+                    // Anonymous type with lowercase fields → JSON exactly matches the
+                    // serde keys in bridge/ffi/src/seed_api.rs (`aumid`, `title`). Avoids
+                    // any chance of a default-options PascalCase mismatch (`Aumid`/`Title`)
+                    // that would silently make the Rust deserializer drop every entry.
+                    results.Add(new UwpAppEntry { aumid = path, title = name });
                 }
                 catch (Exception ex)
                 {
@@ -209,5 +148,14 @@ public sealed class UwpAppService
         }
 
         return results;
+    }
+
+    // Public so System.Text.Json's reflection serializer always sees it regardless of
+    // assembly access modifiers, and lowercase property names so the emitted JSON keys
+    // exactly match seed_api::UwpAppPayload's serde fields with no naming-policy assumptions.
+    public sealed class UwpAppEntry
+    {
+        public string aumid { get; set; } = string.Empty;
+        public string title { get; set; } = string.Empty;
     }
 }

--- a/apps/windows/LauncherApp/Views/Settings/SettingsTabsView.xaml
+++ b/apps/windows/LauncherApp/Views/Settings/SettingsTabsView.xaml
@@ -13,12 +13,15 @@
             <Setter Property="Foreground" Value="#F1F6FF" />
             <Setter Property="BorderBrush" Value="{StaticResource LauncherBorderBrush}" />
             <Setter Property="BorderThickness" Value="1" />
-            <Setter Property="CornerRadius" Value="8" />
-            <Setter Property="Height" Value="36" />
-            <Setter Property="Padding" Value="10,0" />
-            <Setter Property="HorizontalAlignment" Value="Stretch" />
+            <Setter Property="CornerRadius" Value="6" />
+            <Setter Property="Height" Value="26" />
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="FontSize" Value="12" />
             <Setter Property="FontWeight" Value="SemiBold" />
             <Setter Property="Background" Value="{StaticResource LauncherPanelAltBrush}" />
+            <Setter Property="HorizontalAlignment" Value="Stretch" />
+            <Setter Property="HorizontalContentAlignment" Value="Center" />
+            <Setter Property="VerticalAlignment" Value="Center" />
         </Style>
     </UserControl.Resources>
 
@@ -52,8 +55,8 @@
                 Text="Esc or Ctrl+Shift+, to close" />
 
             <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
-                <Button MinWidth="110" Height="Auto" Content="Save Config" Click="SaveConfigButton_OnClick" />
-                <Button MinWidth="140" Height="Auto" Content="Back to Launcher" Click="BackToLauncherButton_OnClick" />
+                <Button MinWidth="110" Height="26" Padding="14,0" FontSize="12" Content="Save Config" Click="SaveConfigButton_OnClick" />
+                <Button MinWidth="140" Height="26" Padding="14,0" FontSize="12" Content="Back to Launcher" Click="BackToLauncherButton_OnClick" />
             </StackPanel>
             </Grid>
         </Grid>
@@ -64,8 +67,12 @@
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
 
-            <Border Padding="0" Background="Transparent" CornerRadius="0">
-                <Grid ColumnSpacing="6">
+            <Border
+                Padding="0"
+                Margin="20,2,20,4"
+                Background="Transparent"
+                CornerRadius="0">
+                <Grid ColumnSpacing="4">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="*" />

--- a/apps/windows/LauncherApp/Views/Settings/SettingsTabsView.xaml.cs
+++ b/apps/windows/LauncherApp/Views/Settings/SettingsTabsView.xaml.cs
@@ -19,7 +19,61 @@ public sealed partial class SettingsTabsView : UserControl
         this.InitializeComponent();
         _selectedTabBrush = ResolveBrush("LauncherAccentBrush", Windows.UI.Color.FromArgb(170, 86, 126, 173));
         _idleTabBrush = ResolveBrush("LauncherPanelAltBrush", Windows.UI.Color.FromArgb(120, 35, 50, 69));
+        AdvancedTabContent.FreshConfigRequested += AdvancedTabContent_OnFreshConfigRequested;
         SelectTab("appearance");
+    }
+
+    private void AdvancedTabContent_OnFreshConfigRequested(object? sender, EventArgs e)
+    {
+        // Order matters: rewrite Application.Resources from the on-disk defaults BEFORE
+        // asking either tab to reload, so AppearanceSettingsTabView.InitializeFromCurrentTheme
+        // reads the freshly-bootstrapped colors / font / blur instead of the pre-reset values
+        // that are still in resources.
+        try
+        {
+            LauncherApp.Services.ThemeBootstrap.ApplyFromConfig();
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"[SettingsTabsView] ThemeBootstrap.ApplyFromConfig failed: {ex.Message}");
+        }
+
+        try
+        {
+            AppearanceTabContent.ReloadFromConfig();
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"[SettingsTabsView] AppearanceTabContent.ReloadFromConfig failed: {ex.Message}");
+        }
+
+        // Default config has no ui_background_image, so Backdrop's loader returns early
+        // without clearing what's currently shown — clear it explicitly here.
+        if (global::LauncherApp.App.MainAppWindow is global::LauncherApp.MainWindow window)
+        {
+            try
+            {
+                window.ApplyBackgroundImage(null, "fill", 35, 8);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[SettingsTabsView] clear background image failed: {ex.Message}");
+            }
+        }
+
+        try
+        {
+            FfiBindings.look_reload_config();
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"[SettingsTabsView] look_reload_config (fresh) failed: {ex.Message}");
+        }
+
+        if (global::LauncherApp.App.MainAppWindow is global::LauncherApp.MainWindow w)
+        {
+            w.ShowBanner("Reset to default settings", global::LauncherApp.MainWindow.BannerStyle.Success);
+        }
     }
 
     private static Brush ResolveBrush(string key, Windows.UI.Color fallback)

--- a/apps/windows/LauncherApp/Views/Settings/Tabs/AdvancedSettingsTabView.xaml.cs
+++ b/apps/windows/LauncherApp/Views/Settings/Tabs/AdvancedSettingsTabView.xaml.cs
@@ -12,12 +12,14 @@ namespace LauncherApp.Views.Settings.Tabs;
 
 public sealed partial class AdvancedSettingsTabView : UserControl
 {
+    public event System.EventHandler? FreshConfigRequested;
+
     private readonly ObservableCollection<string> _excludedFolders = [];
     private readonly ObservableCollection<string> _scanRoots = [];
     private string? _backgroundImagePath;
 
     private const string DefaultConfigContents = "# look configuration\n"
-        + "# Generated on first launch. Edit values and press Cmd+Shift+; to reload.\n\n"
+        + "# Generated on first launch. Edit values and press Ctrl+Shift+; to reload.\n\n"
         + "# Backend indexing (file_scan_depth: 1-12, file_scan_limit: 500-50000)\n"
         + "app_scan_roots=\n"
         + "app_scan_depth=3\n"
@@ -39,7 +41,7 @@ public sealed partial class AdvancedSettingsTabView : UserControl
         + "ui_tint_opacity=0.55\n"
         + "ui_blur_material=balanced\n"
         + "ui_blur_opacity=0.95\n"
-        + "ui_font_name=SF Pro Text\n"
+        + "ui_font_name=Segoe UI\n"
         + "ui_font_size=14\n"
         + "ui_font_red=0.96\n"
         + "ui_font_green=0.96\n"
@@ -227,23 +229,27 @@ public sealed partial class AdvancedSettingsTabView : UserControl
             }
 
             EnsureDefaultConfigFileExists(path);
-            LoadFromConfig();
-            RefreshExcludedFoldersState();
-            RefreshScanRootsState();
-            try
-            {
-                global::LauncherApp.Bridge.FfiBindings.look_reload_config();
-            }
-            catch
-            {
-                // swallow - UI message below is enough
-            }
+            // Hand off to SettingsTabsView so it can also re-bootstrap the theme resources,
+            // reload the Appearance tab, clear any background image, and reload the backend.
+            // Falling back to a local-only reload would leave Appearance sliders and the
+            // running window's brushes / borders / fonts pinned to the pre-reset values
+            // even though the file on disk is the new default.
+            FreshConfigRequested?.Invoke(this, System.EventArgs.Empty);
+            ReloadFromConfig();
             FreshConfigStatusText.Text = "Fresh config created.";
         }
         catch
         {
             FreshConfigStatusText.Text = "Failed to recreate config.";
         }
+    }
+
+    public void ReloadFromConfig()
+    {
+        LoadFromConfig();
+        RefreshExcludedFoldersState();
+        RefreshScanRootsState();
+        ApplyBackgroundImageLive();
     }
 
     private async void ChooseBackgroundImageButton_OnClick(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)

--- a/apps/windows/LauncherApp/Views/Settings/Tabs/AppearanceSettingsTabView.xaml.cs
+++ b/apps/windows/LauncherApp/Views/Settings/Tabs/AppearanceSettingsTabView.xaml.cs
@@ -390,6 +390,33 @@ public sealed partial class AppearanceSettingsTabView : UserControl
         ApplyBlurStyle();
     }
 
+    // Re-reads the current Application.Resources state into the controls so that after
+    // ThemeBootstrap.ApplyFromConfig() rewrites resources from a fresh config, the
+    // Appearance sliders / blur style / typography reflect the new defaults instead of
+    // the stale pre-reset values. Reset the "applied" trackers so ApplyTypographyPreview
+    // and ApplyBlurStyle won't short-circuit when the new value happens to match the
+    // last one we pushed to MainWindow.
+    public void ReloadFromConfig()
+    {
+        _isInitializing = true;
+        try
+        {
+            _appliedFontName = string.Empty;
+            _appliedFontSize = -1;
+            _appliedBlurStyle = string.Empty;
+            _textSecondaryOverride = null;
+            _textMutedOverride = null;
+            InitializeFromCurrentTheme();
+        }
+        finally
+        {
+            _isInitializing = false;
+        }
+
+        ApplyThemePreview();
+        ApplyBlurStyle();
+    }
+
     // Writes all appearance/theme keys to ~/.look.config. Mirrors macOS's ThemeStore save path
     // so custom tints, fonts, borders, and blur opacity survive restarts. Called by the Save
     // Config button in SettingsTabsView.

--- a/bridge/ffi/src/lib.rs
+++ b/bridge/ffi/src/lib.rs
@@ -443,7 +443,9 @@ mod tests {
                 results.iter().any(|item| {
                     item.get("id")
                         .and_then(|value| value.as_str())
-                        .is_some_and(|id| id == "app:uwp:Microsoft.WindowsTerminal_8wekyb3d8bbwe!App")
+                        .is_some_and(|id| {
+                            id == "app:uwp:Microsoft.WindowsTerminal_8wekyb3d8bbwe!App"
+                        })
                 })
             });
         assert!(

--- a/bridge/ffi/src/lib.rs
+++ b/bridge/ffi/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod runtime_config;
 mod search_api;
+mod seed_api;
 mod state;
 mod translate_api;
 mod usage_api;
@@ -66,6 +67,14 @@ pub extern "C" fn look_reload_config() -> bool {
         state::refresh_engine_cache();
         state::clear_index_dirty();
         true
+    }))
+    .unwrap_or(false)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn look_seed_uwp_apps_json(json: *const c_char) -> bool {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        seed_api::look_seed_uwp_apps_json_impl(json)
     }))
     .unwrap_or(false)
 }
@@ -374,5 +383,92 @@ mod tests {
             .map(|d| d.as_nanos())
             .unwrap_or(0);
         env::temp_dir().join(format!("look-ffi-config-smoke-{nanos}.config"))
+    }
+
+    #[test]
+    fn ffi_seed_uwp_apps_json_inserts_and_search_finds() {
+        let lock = TEST_MUTEX.get_or_init(|| Mutex::new(()));
+        let _guard = lock.lock().expect("test lock poisoned");
+
+        let db_path = unique_test_db_path();
+        let _ = fs::remove_file(&db_path);
+
+        unsafe {
+            env::set_var("LOOK_DB_PATH", db_path.as_os_str());
+        }
+        assert!(look_reload_config());
+
+        // Mirror the JSON format the C# UwpAppService produces (System.Text.Json with
+        // [JsonPropertyName] attributes → snake_case keys).
+        let json = CString::new(
+            r#"[
+                {"aumid": "Microsoft.WindowsTerminal_8wekyb3d8bbwe!App", "title": "Terminal"},
+                {"aumid": "Microsoft.WindowsNotepad_8wekyb3d8bbwe!App", "title": "Notepad"}
+            ]"#,
+        )
+        .expect("seed json");
+        assert!(look_seed_uwp_apps_json(json.as_ptr()));
+
+        // Round-trip via sqlite — make sure the rows actually persisted with the right shape.
+        let stored = SqliteStore::open(&db_path)
+            .expect("reopen sqlite")
+            .load_candidates(None)
+            .expect("load candidates");
+        let terminal = stored
+            .iter()
+            .find(|c| c.id.as_ref() == "app:uwp:Microsoft.WindowsTerminal_8wekyb3d8bbwe!App")
+            .expect("seeded terminal candidate");
+        assert_eq!(terminal.title.as_ref(), "Terminal");
+        assert_eq!(
+            terminal.path.as_ref(),
+            "shell:AppsFolder\\Microsoft.WindowsTerminal_8wekyb3d8bbwe!App"
+        );
+        assert_eq!(terminal.use_count, 0);
+        assert_eq!(terminal.last_used_at_unix_s, None);
+
+        // Search has to surface the seeded entry — without this, the user can't find Terminal
+        // via the launcher even though it sits in the DB.
+        let query = CString::new("terminal").expect("query");
+        let ptr = look_search_json(query.as_ptr(), 10);
+        assert!(!ptr.is_null());
+        let raw = unsafe { CStr::from_ptr(ptr) }
+            .to_string_lossy()
+            .into_owned();
+        look_free_cstring(ptr);
+        let payload: serde_json::Value = serde_json::from_str(&raw).expect("valid search payload");
+        let has_terminal = payload
+            .get("results")
+            .and_then(|value| value.as_array())
+            .is_some_and(|results| {
+                results.iter().any(|item| {
+                    item.get("id")
+                        .and_then(|value| value.as_str())
+                        .is_some_and(|id| id == "app:uwp:Microsoft.WindowsTerminal_8wekyb3d8bbwe!App")
+                })
+            });
+        assert!(
+            has_terminal,
+            "expected seeded UWP Terminal in search results, got: {raw}"
+        );
+
+        // Re-seeding must be idempotent and preserve use_count after a launch.
+        let id = CString::new("app:uwp:Microsoft.WindowsTerminal_8wekyb3d8bbwe!App").expect("id");
+        let action = CString::new("open_app").expect("action");
+        assert!(look_record_usage(id.as_ptr(), action.as_ptr()));
+        assert!(look_seed_uwp_apps_json(json.as_ptr())); // second seed
+        let after = SqliteStore::open(&db_path)
+            .expect("reopen")
+            .load_candidates(None)
+            .expect("load");
+        let after_terminal = after
+            .iter()
+            .find(|c| c.id.as_ref() == "app:uwp:Microsoft.WindowsTerminal_8wekyb3d8bbwe!App")
+            .expect("still here");
+        assert_eq!(
+            after_terminal.use_count, 1,
+            "re-seeding must preserve use_count via ON CONFLICT"
+        );
+
+        let _ = fs::remove_file(&db_path);
     }
 }

--- a/bridge/ffi/src/lib.rs
+++ b/bridge/ffi/src/lib.rs
@@ -471,6 +471,27 @@ mod tests {
             "re-seeding must preserve use_count via ON CONFLICT"
         );
 
+        // Re-seed with Notepad omitted — simulates the user uninstalling that UWP app
+        // between runs. The vanished row must be pruned so it doesn't keep showing up
+        // in search forever (delete_stale_candidates can't reach rows written with
+        // indexed_at_unix_s = i64::MAX).
+        let json_terminal_only = CString::new(
+            r#"[{"aumid": "Microsoft.WindowsTerminal_8wekyb3d8bbwe!App", "title": "Terminal"}]"#,
+        )
+        .expect("seed json terminal only");
+        assert!(look_seed_uwp_apps_json(json_terminal_only.as_ptr()));
+
+        let after_prune = SqliteStore::open(&db_path)
+            .expect("reopen for prune check")
+            .load_candidates(None)
+            .expect("load after prune");
+        let ids_after_prune: Vec<&str> = after_prune.iter().map(|c| c.id.as_ref()).collect();
+        assert!(ids_after_prune.contains(&"app:uwp:Microsoft.WindowsTerminal_8wekyb3d8bbwe!App"));
+        assert!(
+            !ids_after_prune.contains(&"app:uwp:Microsoft.WindowsNotepad_8wekyb3d8bbwe!App"),
+            "Notepad should have been pruned after disappearing from the seed"
+        );
+
         let _ = fs::remove_file(&db_path);
     }
 }

--- a/bridge/ffi/src/seed_api.rs
+++ b/bridge/ffi/src/seed_api.rs
@@ -1,0 +1,77 @@
+use crate::state::{cstr_to_string, default_db_path, refresh_engine_cache};
+use look_indexing::{Candidate, CandidateKind};
+use look_storage::SqliteStore;
+use serde::Deserialize;
+use std::os::raw::c_char;
+
+#[derive(Deserialize)]
+struct UwpAppPayload {
+    aumid: String,
+    title: String,
+}
+
+// Seeds UWP shell:AppsFolder entries into the Rust candidates table so they
+// participate in normal ranking (rank_score, kind_bias, recency, use_count) instead
+// of going through a parallel C# scoring path. C# UwpAppService enumerates AppsFolder
+// once on app start and posts the results here as JSON: [{"aumid": "...", "title": "..."}, ...]
+//
+// Each entry is upserted as:
+//   id    = app:uwp:<AUMID>          — `app:` prefix so look_record_usage accepts it
+//   kind  = App
+//   title = <DisplayName>            — e.g. "Terminal", "Notepad"
+//   path  = shell:AppsFolder\<AUMID> — ShellExecuteService dispatches via explorer.exe
+//
+// indexed_at_unix_s is set to i64::MAX so QueryEngine::bootstrap_sqlite's
+// `delete_stale_candidates(run_started_at)` sweep (core/engine/src/lib.rs:163) leaves
+// these rows alone — the Rust app discovery stream never produces UWP entries, so
+// without the MAX sentinel they'd be pruned on every index refresh.
+pub(crate) fn look_seed_uwp_apps_json_impl(json: *const c_char) -> bool {
+    let json = cstr_to_string(json);
+    if json.trim().is_empty() {
+        return false;
+    }
+
+    let entries: Vec<UwpAppPayload> = match serde_json::from_str(&json) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+
+    let mut candidates: Vec<Candidate> = Vec::with_capacity(entries.len());
+    for e in entries {
+        let aumid = e.aumid.trim();
+        let title = e.title.trim();
+        if aumid.is_empty() || title.is_empty() || !aumid.contains('!') {
+            continue;
+        }
+        candidates.push(Candidate {
+            id: format!("app:uwp:{}", aumid).into(),
+            kind: CandidateKind::App,
+            title: title.into(),
+            subtitle: None,
+            path: format!("shell:AppsFolder\\{}", aumid).into(),
+            // use_count and last_used_at_unix_s are preserved by the ON CONFLICT
+            // clause in upsert_candidates_indexed, so re-seeding on every app start
+            // doesn't reset the user's launch history.
+            use_count: 0,
+            last_used_at_unix_s: None,
+        });
+    }
+
+    if candidates.is_empty() {
+        return false;
+    }
+
+    let Ok(mut store) = SqliteStore::open(default_db_path()) else {
+        return false;
+    };
+
+    if store
+        .upsert_candidates_indexed(&candidates, Some(i64::MAX))
+        .is_err()
+    {
+        return false;
+    }
+
+    refresh_engine_cache();
+    true
+}

--- a/bridge/ffi/src/seed_api.rs
+++ b/bridge/ffi/src/seed_api.rs
@@ -2,7 +2,10 @@ use crate::state::{cstr_to_string, default_db_path, refresh_engine_cache};
 use look_indexing::{Candidate, CandidateKind};
 use look_storage::SqliteStore;
 use serde::Deserialize;
+use std::collections::HashSet;
 use std::os::raw::c_char;
+
+const UWP_ID_PREFIX: &str = "app:uwp:";
 
 #[derive(Deserialize)]
 struct UwpAppPayload {
@@ -37,14 +40,17 @@ pub(crate) fn look_seed_uwp_apps_json_impl(json: *const c_char) -> bool {
     };
 
     let mut candidates: Vec<Candidate> = Vec::with_capacity(entries.len());
+    let mut kept_ids: Vec<String> = Vec::with_capacity(entries.len());
     for e in entries {
         let aumid = e.aumid.trim();
         let title = e.title.trim();
         if aumid.is_empty() || title.is_empty() || !aumid.contains('!') {
             continue;
         }
+        let id = format!("{}{}", UWP_ID_PREFIX, aumid);
+        kept_ids.push(id.clone());
         candidates.push(Candidate {
-            id: format!("app:uwp:{}", aumid).into(),
+            id: id.into(),
             kind: CandidateKind::App,
             title: title.into(),
             subtitle: None,
@@ -71,6 +77,13 @@ pub(crate) fn look_seed_uwp_apps_json_impl(json: *const c_char) -> bool {
     {
         return false;
     }
+
+    // Drop rows for UWP apps that vanished from AppsFolder since the last seed
+    // (uninstalls / package renames). Without this, those rows would persist
+    // forever — `delete_stale_candidates` skips them because their indexed_at is
+    // i64::MAX, and they'd keep showing in search with their old usage weight.
+    let keep_set: HashSet<&str> = kept_ids.iter().map(|s| s.as_str()).collect();
+    let _ = store.delete_candidates_by_prefix_except(UWP_ID_PREFIX, &keep_set);
 
     refresh_engine_cache();
     true

--- a/core/storage/src/lib.rs
+++ b/core/storage/src/lib.rs
@@ -1,6 +1,6 @@
 use look_indexing::{Candidate, CandidateKind};
 use rusqlite::{Connection, params};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::{Display, Formatter};
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -362,6 +362,44 @@ impl SqliteStore {
         Ok(removed)
     }
 
+    /// Deletes every candidate whose `id` starts with `prefix` and is NOT in `keep_ids`,
+    /// along with its usage_events rows. Returned value is the number of candidate rows
+    /// removed. Used by the UWP seed path (bridge/ffi/src/seed_api.rs) to age out apps
+    /// that disappeared from `shell:AppsFolder` between runs — those rows can't be
+    /// pruned by `delete_stale_candidates` because they're written with
+    /// `indexed_at_unix_s = i64::MAX` to survive the regular index-refresh sweep.
+    pub fn delete_candidates_by_prefix_except(
+        &mut self,
+        prefix: &str,
+        keep_ids: &HashSet<&str>,
+    ) -> StorageResult<usize> {
+        let tx = self.conn.transaction()?;
+        let like_pattern = format!("{}%", prefix.replace('\\', "\\\\").replace('%', "\\%"));
+
+        let stale_ids: Vec<String> = {
+            let mut stmt = tx.prepare("SELECT id FROM candidates WHERE id LIKE ?1 ESCAPE '\\'")?;
+            let rows = stmt.query_map(params![like_pattern], |row| row.get::<_, String>(0))?;
+            let mut out = Vec::new();
+            for row in rows {
+                let id = row?;
+                if !keep_ids.contains(id.as_str()) {
+                    out.push(id);
+                }
+            }
+            out
+        };
+
+        for id in &stale_ids {
+            tx.execute(
+                "DELETE FROM usage_events WHERE candidate_id = ?1",
+                params![id],
+            )?;
+            tx.execute("DELETE FROM candidates WHERE id = ?1", params![id])?;
+        }
+        tx.commit()?;
+        Ok(stale_ids.len())
+    }
+
     pub fn prune_usage_events_older_than(&mut self, cutoff_unix_s: i64) -> StorageResult<usize> {
         let removed = self.conn.execute(
             "DELETE FROM usage_events WHERE used_at_unix_s < ?1",
@@ -684,6 +722,85 @@ mod tests {
 
         let loaded = store.load_candidates(None).expect("load candidates");
         assert!(loaded.is_empty());
+    }
+
+    #[test]
+    fn delete_candidates_by_prefix_except_removes_vanished_rows_and_preserves_kept() {
+        let mut store = SqliteStore::open_in_memory().expect("open sqlite in memory");
+        let kept = candidate(
+            "app:uwp:Microsoft.WindowsTerminal_8wekyb3d8bbwe!App",
+            "Terminal",
+            "shell:AppsFolder\\Microsoft.WindowsTerminal_8wekyb3d8bbwe!App",
+        );
+        let stale = candidate(
+            "app:uwp:Old.PackageThatGotUninstalled_abc!App",
+            "Old App",
+            "shell:AppsFolder\\Old.PackageThatGotUninstalled_abc!App",
+        );
+        let win32 = candidate(
+            "app:edge_c:/programdata/microsoft/windows/start menu/programs/microsoft edge.lnk",
+            "Microsoft Edge",
+            "C:/ProgramData/Microsoft/Windows/Start Menu/Programs/Microsoft Edge.lnk",
+        );
+
+        store
+            .upsert_candidates_indexed(&[kept, stale.clone(), win32], Some(i64::MAX))
+            .expect("seed candidates");
+
+        // Record usage on the stale row so we can verify usage_events are also removed.
+        store
+            .record_usage_event(stale.id.as_ref(), "open_app")
+            .expect("record stale usage");
+
+        let mut keep_set = HashSet::new();
+        keep_set.insert("app:uwp:Microsoft.WindowsTerminal_8wekyb3d8bbwe!App");
+
+        let removed = store
+            .delete_candidates_by_prefix_except("app:uwp:", &keep_set)
+            .expect("prune");
+        assert_eq!(removed, 1);
+
+        let loaded = store.load_candidates(None).expect("load");
+        let ids: Vec<&str> = loaded.iter().map(|c| c.id.as_ref()).collect();
+        assert!(ids.contains(&"app:uwp:Microsoft.WindowsTerminal_8wekyb3d8bbwe!App"));
+        assert!(!ids.contains(&"app:uwp:Old.PackageThatGotUninstalled_abc!App"));
+        // The non-uwp `app:` row must be untouched even though it shares the broader
+        // `app:` prefix — only `app:uwp:` rows are eligible for this sweep.
+        assert!(ids.contains(
+            &"app:edge_c:/programdata/microsoft/windows/start menu/programs/microsoft edge.lnk"
+        ));
+
+        // usage_events for the deleted candidate should also be cleaned up.
+        let usage_count: i64 = store
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM usage_events WHERE candidate_id = ?1",
+                params![stale.id.as_ref()],
+                |row| row.get(0),
+            )
+            .expect("count usage events");
+        assert_eq!(usage_count, 0);
+    }
+
+    #[test]
+    fn delete_candidates_by_prefix_except_is_noop_when_all_kept() {
+        let mut store = SqliteStore::open_in_memory().expect("open sqlite in memory");
+        let cand = candidate(
+            "app:uwp:Microsoft.Notepad_8wekyb3d8bbwe!App",
+            "Notepad",
+            "shell:AppsFolder\\Microsoft.Notepad_8wekyb3d8bbwe!App",
+        );
+        store
+            .upsert_candidates_indexed(&[cand], Some(i64::MAX))
+            .expect("seed");
+
+        let mut keep_set = HashSet::new();
+        keep_set.insert("app:uwp:Microsoft.Notepad_8wekyb3d8bbwe!App");
+
+        let removed = store
+            .delete_candidates_by_prefix_except("app:uwp:", &keep_set)
+            .expect("prune");
+        assert_eq!(removed, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Windows doesn't ranking apps well (with app like terminal, weather, ...)

## Why

- 

## Changes

-

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
