### PR TITLE
fix: app crashing

### DIFF
--- a/apps/windows/LauncherApp/LauncherApp.csproj
+++ b/apps/windows/LauncherApp/LauncherApp.csproj
@@ -46,6 +46,26 @@
     <PackageReference Include="System.Drawing.Common" Version="10.0.0" />
   </ItemGroup>
 
+  <!-- WinUI 3 instantiates code-only controls (e.g. CommandCardView, a ToggleButton
+       subclass referenced only from CommandPanelsView.xaml) reflectively at XAML-parse
+       time. With PublishTrimmed=true the linker can drop the parameterless ctor
+       metadata even though the type itself is kept, which surfaces in production as
+       `XamlParseException: Cannot create instance of type ...` on first launch (v0.4.0
+       release zip crashed on Alt+Space here). Rooting our own assembly preserves all
+       metadata for LauncherApp types without disabling trimming for the framework
+       dependencies that account for nearly all of the zip-size savings. -->
+  <ItemGroup>
+    <TrimmerRootAssembly Include="LauncherApp" />
+    <!-- Without this, the trimmer strips CsWinRT's vtable-lookup metadata for
+         Microsoft.UI.Xaml types, which surfaces as InvalidCastException when a
+         .NET-instantiated UIElement (e.g. StackPanel constructed in CommandCardView's
+         ctor) is assigned to a projected object-typed property like
+         ContentControl.Content or DependencyObject.SetValue. Rooting the WinUI
+         projection assembly preserves those marshalers; the rest of the trim pass
+         still runs on the BCL and other framework deps. -->
+    <TrimmerRootAssembly Include="Microsoft.WinUI" />
+  </ItemGroup>
+
   <!--
     Defining the "HasPackageAndPublishMenuAddedByProject" property here allows the Solution
     Explorer "Package and Publish" context menu entry to be enabled for this project even if
@@ -66,6 +86,21 @@
          throws REGDB_E_CLASSNOTREG before App() even constructs. Adds ~50MB to
          the publish output but makes the release zip drop-in runnable. -->
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <!-- Trimming sets the runtime default to false, which makes
+         JsonSerializer.Deserialize<T>(...) without an explicit TypeInfoResolver
+         throw InvalidOperationException at first use. EngineBridge.Search and
+         friends fall through that path, killing the app the moment the user
+         types into the launcher. Re-enable reflection-based JSON: cheaper than
+         migrating every call site to System.Text.Json source generators and
+         the metadata cost is small relative to the trimmed BCL. -->
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
+    <!-- ShellIconProvider and UwpAppService rely on [ComImport] interfaces
+         (IShellItem, IEnumShellItems, IShellLinkW, IShellItemImageFactory).
+         The trimmer disables built-in COM interop by default, which kills the
+         RCW creation that backs `[MarshalAs(UnmanagedType.Interface)] out
+         object` on shell32 P/Invokes — UWP apps fail to seed and shortcut
+         icons fail to resolve. Re-enable. -->
+    <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/apps/windows/LauncherApp/Services/UwpAppService.cs
+++ b/apps/windows/LauncherApp/Services/UwpAppService.cs
@@ -10,7 +10,7 @@ using LauncherApp.Bridge;
 namespace LauncherApp.Services;
 
 // Rust doesn't enumerate shell:AppsFolder (no equivalent of macOS Spotlight on Windows),
-// so we walk it once via Shell.Application COM at app start and forward each entry to
+// so we walk it once via direct shell COM at app start and forward each entry to
 // the Rust candidates table via look_seed_uwp_apps_json. After that, the Rust engine
 // owns ranking, scoring, use_count, and recency for UWP entries — there's no parallel
 // C# scoring path. The seed is idempotent (upsert preserves use_count via ON CONFLICT)
@@ -65,67 +65,93 @@ public sealed class UwpAppService
         }
     }
 
+    // Walks shell:AppsFolder via direct IShellItem / IEnumShellItems COM. The previous
+    // implementation used `dynamic` over the Shell.Application IDispatch object; the
+    // .NET 10 trimmer strips the Microsoft.CSharp.RuntimeBinder.ComInterop ITypeInfo
+    // marshaling stubs even with BuiltInComInteropSupport=true and TrimmerRootAssembly
+    // on Microsoft.CSharp, which surfaces as a 0xC0000005 access violation on the
+    // first dynamic property access. Early-bound [ComImport] interfaces sidestep the
+    // runtime binder entirely and are trim-safe.
     private static List<UwpAppEntry> EnumerateAppsFolder()
     {
         var results = new List<UwpAppEntry>();
 
-        Type? shellType = Type.GetTypeFromProgID("Shell.Application");
-        if (shellType is null)
-        {
-            Debug.WriteLine("[UwpAppService] Shell.Application ProgID not found");
-            return results;
-        }
-
-        dynamic? shell = null;
+        IShellItem? appsFolder = null;
+        IEnumShellItems? enumerator = null;
         try
         {
-            shell = Activator.CreateInstance(shellType);
-            if (shell is null)
+            Guid iidShellItem = IID_IShellItem;
+            int hr = SHCreateItemFromParsingName("shell:AppsFolder", IntPtr.Zero, ref iidShellItem, out object? folderObj);
+            if (hr != 0 || folderObj is not IShellItem folder)
             {
+                Debug.WriteLine($"[UwpAppService] SHCreateItemFromParsingName(shell:AppsFolder) hr=0x{hr:X}");
                 return results;
             }
+            appsFolder = folder;
 
-            dynamic appsFolder = shell.NameSpace("shell:AppsFolder");
-            dynamic items = appsFolder.Items();
-            int count = (int)items.Count;
+            Guid bhidEnumItems = BHID_EnumItems;
+            Guid iidEnumShellItems = IID_IEnumShellItems;
+            hr = appsFolder.BindToHandler(IntPtr.Zero, ref bhidEnumItems, ref iidEnumShellItems, out object? enumObj);
+            if (hr != 0 || enumObj is not IEnumShellItems iter)
+            {
+                Debug.WriteLine($"[UwpAppService] BindToHandler(BHID_EnumItems) hr=0x{hr:X}");
+                return results;
+            }
+            enumerator = iter;
 
             var seenAumids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            IShellItem[] buffer = new IShellItem[1];
 
-            for (int i = 0; i < count; i++)
+            while (true)
             {
+                hr = enumerator.Next(1, buffer, out uint fetched);
+                if (hr != 0 || fetched == 0)
+                {
+                    break;
+                }
+
+                IShellItem item = buffer[0];
+                buffer[0] = null!;
                 try
                 {
-                    dynamic item = items.Item(i);
-                    string? name = item.Name as string;
-                    string? path = item.Path as string;
+                    string? name = TryGetDisplayName(item, SIGDN_NORMALDISPLAY);
+                    string? aumid = TryGetDisplayName(item, SIGDN_PARENTRELATIVEPARSING);
 
-                    if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(path))
+                    if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(aumid))
                     {
                         continue;
+                    }
+
+                    // Strip the "shell:AppsFolder\" prefix if some shell provider hands us
+                    // back a desktop-absolute path instead of the parent-relative one.
+                    const string prefix = "shell:AppsFolder\\";
+                    if (aumid.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        aumid = aumid.Substring(prefix.Length);
                     }
 
                     // AUMIDs contain "!" separating PackageFamilyName from AppId.
                     // Entries without "!" are Win32 shortcuts already indexed by the
                     // Rust backend's Start Menu scan and shouldn't be duplicated here.
-                    if (!path.Contains('!'))
+                    if (!aumid.Contains('!'))
                     {
                         continue;
                     }
 
-                    if (!seenAumids.Add(path))
+                    if (!seenAumids.Add(aumid))
                     {
                         continue;
                     }
 
-                    // Anonymous type with lowercase fields → JSON exactly matches the
-                    // serde keys in bridge/ffi/src/seed_api.rs (`aumid`, `title`). Avoids
-                    // any chance of a default-options PascalCase mismatch (`Aumid`/`Title`)
-                    // that would silently make the Rust deserializer drop every entry.
-                    results.Add(new UwpAppEntry { aumid = path, title = name });
+                    results.Add(new UwpAppEntry { aumid = aumid, title = name });
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine($"[UwpAppService] item {i} failed: {ex.Message}");
+                    Debug.WriteLine($"[UwpAppService] item read failed: {ex.Message}");
+                }
+                finally
+                {
+                    Marshal.ReleaseComObject(item);
                 }
             }
         }
@@ -135,19 +161,42 @@ public sealed class UwpAppService
         }
         finally
         {
-            if (shell is not null)
+            if (enumerator is not null)
             {
-                try
-                {
-                    Marshal.FinalReleaseComObject(shell);
-                }
-                catch
-                {
-                }
+                try { Marshal.ReleaseComObject(enumerator); } catch { }
+            }
+            if (appsFolder is not null)
+            {
+                try { Marshal.ReleaseComObject(appsFolder); } catch { }
             }
         }
 
         return results;
+    }
+
+    private static string? TryGetDisplayName(IShellItem item, uint sigdnForm)
+    {
+        IntPtr pszName = IntPtr.Zero;
+        try
+        {
+            int hr = item.GetDisplayName(sigdnForm, out pszName);
+            if (hr != 0 || pszName == IntPtr.Zero)
+            {
+                return null;
+            }
+            return Marshal.PtrToStringUni(pszName);
+        }
+        catch
+        {
+            return null;
+        }
+        finally
+        {
+            if (pszName != IntPtr.Zero)
+            {
+                Marshal.FreeCoTaskMem(pszName);
+            }
+        }
     }
 
     // Public so System.Text.Json's reflection serializer always sees it regardless of
@@ -157,5 +206,51 @@ public sealed class UwpAppService
     {
         public string aumid { get; set; } = string.Empty;
         public string title { get; set; } = string.Empty;
+    }
+
+    private static readonly Guid IID_IShellItem = new("43826D1E-E718-42EE-BC55-A1E261C37BFE");
+    private static readonly Guid IID_IEnumShellItems = new("70629033-E363-4A28-A567-0DB78006E6D7");
+    private static readonly Guid BHID_EnumItems = new("94f60519-2850-4924-aa5a-d15e84868039");
+
+    private const uint SIGDN_NORMALDISPLAY = 0x00000000;
+    private const uint SIGDN_PARENTRELATIVEPARSING = 0x80018001;
+
+    [DllImport("shell32.dll", CharSet = CharSet.Unicode, ExactSpelling = true, PreserveSig = true)]
+    private static extern int SHCreateItemFromParsingName(
+        [MarshalAs(UnmanagedType.LPWStr)] string pszPath,
+        IntPtr pbc,
+        [In] ref Guid riid,
+        [MarshalAs(UnmanagedType.Interface)] out object? ppv);
+
+    [ComImport]
+    [Guid("43826D1E-E718-42EE-BC55-A1E261C37BFE")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IShellItem
+    {
+        [PreserveSig]
+        int BindToHandler(IntPtr pbc, [In] ref Guid bhid, [In] ref Guid riid, [MarshalAs(UnmanagedType.Interface)] out object? ppv);
+        [PreserveSig]
+        int GetParent(out IShellItem ppsi);
+        [PreserveSig]
+        int GetDisplayName(uint sigdnName, out IntPtr ppszName);
+        [PreserveSig]
+        int GetAttributes(uint sfgaoMask, out uint psfgaoAttribs);
+        [PreserveSig]
+        int Compare(IShellItem psi, uint hint, out int piOrder);
+    }
+
+    [ComImport]
+    [Guid("70629033-E363-4A28-A567-0DB78006E6D7")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IEnumShellItems
+    {
+        [PreserveSig]
+        int Next(uint celt, [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)] IShellItem[] rgelt, out uint pceltFetched);
+        [PreserveSig]
+        int Skip(uint celt);
+        [PreserveSig]
+        int Reset();
+        [PreserveSig]
+        int Clone(out IEnumShellItems ppenum);
     }
 }


### PR DESCRIPTION
## Summary

- Fix app crashing 

## Why

- WinUI 3 instantiates code-only controls (e.g. CommandCardView, a ToggleButton
       subclass referenced only from CommandPanelsView.xaml) reflectively at XAML-parse
       time. With PublishTrimmed=true the linker can drop the parameterless ctor
       metadata even though the type itself is kept, which surfaces in production as
       `XamlParseException: Cannot create instance of type ...` on first launch (v0.4.0
       release zip crashed on Alt+Space here). Rooting our own assembly preserves all
       metadata for LauncherApp types without disabling trimming for the framework
       dependencies that account for nearly all of the zip-size savings.

## Changes

-

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
