### PR TITLE
chore: App icon and constant dirs

### DIFF
--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -65,6 +65,12 @@ enum AppConstants {
                 QuickFolderDefinition(title: "Desktop", relativePath: "Desktop"),
                 QuickFolderDefinition(title: "Documents", relativePath: "Documents"),
                 QuickFolderDefinition(title: "Downloads", relativePath: "Downloads"),
+                QuickFolderDefinition(title: "Pictures", relativePath: "Pictures"),
+                // macOS names this folder "Movies" (Windows calls the equivalent "Videos");
+                // each platform's QuickFolder uses the OS-native folder name so typing what
+                // the user sees in Finder/Explorer pins it.
+                QuickFolderDefinition(title: "Movies", relativePath: "Movies"),
+                QuickFolderDefinition(title: "Music", relativePath: "Music"),
             ]
         }
 

--- a/apps/windows/LauncherApp/Features/Search/LauncherSearchLogic.cs
+++ b/apps/windows/LauncherApp/Features/Search/LauncherSearchLogic.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using LauncherApp.Bridge;
 
@@ -14,6 +15,75 @@ public sealed class LauncherSearchLogic
 
     public IReadOnlyList<LauncherResult> Search(string query, int limit = 40)
     {
-        return _searchProvider.Search(query, limit);
+        IReadOnlyList<LauncherResult> backend = _searchProvider.Search(query, limit);
+
+        IReadOnlyList<LauncherResult> quickFolders = BuildQuickFolderResults(query);
+        if (quickFolders.Count == 0)
+        {
+            return backend;
+        }
+
+        var combined = new List<LauncherResult>(quickFolders.Count + backend.Count);
+        var seenPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (LauncherResult entry in quickFolders)
+        {
+            if (seenPaths.Add(entry.Path))
+            {
+                combined.Add(entry);
+            }
+        }
+
+        // Engine indexing typically skips the file_scan_roots themselves (see
+        // core/engine/src/index/files.rs walk_files), so duplicates are unlikely — but
+        // belt-and-braces drop any backend folder row that already matches a pinned path
+        // so we don't render two rows for the same `~/Documents`.
+        foreach (LauncherResult entry in backend)
+        {
+            if (entry.Kind == "folder" && seenPaths.Contains(entry.Path))
+            {
+                continue;
+            }
+            combined.Add(entry);
+        }
+
+        return combined;
+    }
+
+    // Mirrors apps/macos/.../LauncherView.swift:quickFolderPinnedResults. The macOS view
+    // gates this on a `pinnedLookupScope` derived from query prefixes (`d"`, `f"`, `a"`)
+    // — Windows doesn't expose those prefixes, so a bare substring/prefix match against
+    // the entry titles is enough.
+    public static IReadOnlyList<LauncherResult> BuildQuickFolderResults(string rawQuery)
+    {
+        string normalized = (rawQuery ?? string.Empty).Trim().ToLowerInvariant();
+        if (normalized.Length == 0)
+        {
+            return Array.Empty<LauncherResult>();
+        }
+
+        var matches = new List<LauncherResult>();
+        foreach (QuickFolderCatalog.QuickFolderEntry entry in QuickFolderCatalog.Entries)
+        {
+            string titleLower = entry.Title.ToLowerInvariant();
+            bool isMatch = titleLower.Contains(normalized)
+                || (titleLower.StartsWith(normalized)
+                    && normalized.Length >= QuickFolderCatalog.MinPrefixMatchLength);
+            if (!isMatch)
+            {
+                continue;
+            }
+
+            matches.Add(new LauncherResult
+            {
+                Id = QuickFolderCatalog.IdPrefix + titleLower,
+                Kind = "folder",
+                Title = entry.Title,
+                Subtitle = QuickFolderCatalog.PinnedSubtitle,
+                Path = entry.Path,
+                Score = QuickFolderCatalog.PinnedScore,
+            });
+        }
+
+        return matches;
     }
 }

--- a/apps/windows/LauncherApp/Features/Search/QuickFolderCatalog.cs
+++ b/apps/windows/LauncherApp/Features/Search/QuickFolderCatalog.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace LauncherApp.Features.Search;
+
+// Mirrors AppConstants.Launcher.QuickFolder on macOS (apps/macos/.../AppConstants.swift).
+// The Rust file walker (core/engine/src/index/files.rs) deliberately skips the file_scan
+// roots themselves — it emits children but never the root directory — so typing
+// "Documents", "Downloads", or "Desktop" in Look never returns those user folders from
+// the engine. macOS compensates by injecting synthetic LauncherResult rows in the Swift
+// view (LauncherView.swift quickFolderPinnedResults); this file is the Windows analog.
+//
+// Paths come from Environment.SpecialFolder (or SHGetKnownFolderPath for Downloads, which
+// has no SpecialFolder enum entry) so OneDrive-redirected user folders resolve to the real
+// `C:\Users\<user>\OneDrive\Desktop` path instead of an empty `C:\Users\<user>\Desktop`.
+public static class QuickFolderCatalog
+{
+    public const string IdPrefix = "quickfolder:";
+    public const string PinnedSubtitle = "Pinned home folder";
+    public const int MinPrefixMatchLength = 2;
+    public const int PinnedScore = 999_999;
+
+    public sealed record QuickFolderEntry(string Title, string Path);
+
+    private static readonly Lazy<IReadOnlyList<QuickFolderEntry>> CachedEntries = new(ResolveEntries);
+
+    public static IReadOnlyList<QuickFolderEntry> Entries => CachedEntries.Value;
+
+    private static IReadOnlyList<QuickFolderEntry> ResolveEntries()
+    {
+        var list = new List<QuickFolderEntry>(6);
+        TryAdd(list, "Desktop", Environment.GetFolderPath(Environment.SpecialFolder.Desktop));
+        TryAdd(list, "Documents", Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments));
+        TryAdd(list, "Downloads", ResolveDownloadsPath());
+        TryAdd(list, "Pictures", Environment.GetFolderPath(Environment.SpecialFolder.MyPictures));
+        TryAdd(list, "Videos", Environment.GetFolderPath(Environment.SpecialFolder.MyVideos));
+        TryAdd(list, "Music", Environment.GetFolderPath(Environment.SpecialFolder.MyMusic));
+        return list;
+    }
+
+    private static void TryAdd(List<QuickFolderEntry> list, string title, string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+        if (!Directory.Exists(path))
+        {
+            return;
+        }
+        list.Add(new QuickFolderEntry(title, path));
+    }
+
+    private static string? ResolveDownloadsPath()
+    {
+        // Environment.SpecialFolder has no Downloads value (the Vista-era KNOWNFOLDERID was
+        // never backported to the enum). SHGetKnownFolderPath honors OneDrive redirection
+        // the same way Explorer's Quick Access entry does — `C:\Users\<user>\Downloads`
+        // when local, `C:\Users\<user>\OneDrive\Downloads` when the user enabled the
+        // "Back up your folders" toggle in OneDrive.
+        IntPtr ptr = IntPtr.Zero;
+        try
+        {
+            int hr = SHGetKnownFolderPath(FolderIdDownloads, 0, IntPtr.Zero, out ptr);
+            if (hr != 0 || ptr == IntPtr.Zero)
+            {
+                return null;
+            }
+            return Marshal.PtrToStringUni(ptr);
+        }
+        catch
+        {
+            return null;
+        }
+        finally
+        {
+            if (ptr != IntPtr.Zero)
+            {
+                Marshal.FreeCoTaskMem(ptr);
+            }
+        }
+    }
+
+    private static readonly Guid FolderIdDownloads = new("374DE290-123F-4565-9164-39C4925E467B");
+
+    [DllImport("shell32.dll", CharSet = CharSet.Unicode, ExactSpelling = true, PreserveSig = true)]
+    private static extern int SHGetKnownFolderPath(
+        [MarshalAs(UnmanagedType.LPStruct)] Guid rfid,
+        uint dwFlags,
+        IntPtr hToken,
+        out IntPtr ppszPath);
+}

--- a/apps/windows/LauncherApp/LauncherApp.csproj
+++ b/apps/windows/LauncherApp/LauncherApp.csproj
@@ -5,6 +5,7 @@
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>LauncherApp</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <ApplicationIcon>Assets\look.ico</ApplicationIcon>
     <Platforms>x64;ARM64</Platforms>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>


### PR DESCRIPTION
## Summary

- Add app icon
- Constant dirs like Docs, Desktop, ... should be available

## Why

-

## Changes

-

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
