### PR TITLE
Fix: Windows sqlite creation issue

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,12 @@
+# Static-link the MSVC C runtime into Windows binaries (look_ffi.dll, etc.) so
+# they don't import VCRUNTIME140.dll / MSVCP140.dll at load time. Without this,
+# a fresh Windows machine without the Microsoft Visual C++ Redistributable
+# fails to LoadLibrary the FFI dll, every C# DllImport throws
+# DllNotFoundException, bootstrap_sqlite never runs, and look.db never gets
+# created — surfacing as "search returns nothing" with no other signal.
+# Target-scoped so macOS/Linux builds are unaffected.
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/apps/windows/LauncherApp/App.xaml.cs
+++ b/apps/windows/LauncherApp/App.xaml.cs
@@ -63,7 +63,7 @@ namespace LauncherApp
             e.SetObserved();
         }
 
-        private static void WriteCrashLog(string origin, Exception? ex)
+        internal static void WriteCrashLog(string origin, Exception? ex)
         {
             try
             {

--- a/apps/windows/LauncherApp/Features/Search/FfiSearchProvider.cs
+++ b/apps/windows/LauncherApp/Features/Search/FfiSearchProvider.cs
@@ -21,12 +21,35 @@ public sealed class FfiSearchProvider : ISearchProvider
                 Debug.WriteLine("[FfiSearchProvider] Initializing FFI...");
                 bool reloadResult = FfiBindings.look_reload_config();
                 Debug.WriteLine($"[FfiSearchProvider] look_reload_config: {reloadResult}");
-                
+
                 bool refreshResult = FfiBindings.look_request_index_refresh();
                 Debug.WriteLine($"[FfiSearchProvider] look_request_index_refresh: {refreshResult}");
             }
+            catch (DllNotFoundException ex)
+            {
+                // Most common cause on a fresh Windows install: look_ffi.dll loaded but
+                // failed to resolve VCRUNTIME140.dll / MSVCP140.dll because the Visual
+                // C++ Redistributable isn't installed. Without this log, every search
+                // silently returns [] and look.db never gets created — see
+                // EngineBridge.Search where the same exception type is caught per-call.
+                App.WriteCrashLog(
+                    "FfiSearchProvider.Init",
+                    new Exception(
+                        "look_ffi.dll failed to load. Likely missing Microsoft Visual C++ Redistributable (vcruntime140.dll). " +
+                        "Original: " + ex.Message,
+                        ex));
+                Debug.WriteLine($"[FfiSearchProvider] DllNotFound: {ex.Message}");
+            }
+            catch (BadImageFormatException ex)
+            {
+                // Architecture mismatch (e.g. ARM64 host loading an x64 dll) lands here
+                // instead of DllNotFoundException — also worth surfacing.
+                App.WriteCrashLog("FfiSearchProvider.Init", ex);
+                Debug.WriteLine($"[FfiSearchProvider] BadImageFormat: {ex.Message}");
+            }
             catch (Exception ex)
             {
+                App.WriteCrashLog("FfiSearchProvider.Init", ex);
                 Debug.WriteLine($"[FfiSearchProvider] Error: {ex.Message}");
             }
         }


### PR DESCRIPTION
## Summary

- Fix dll error that might cause db creation issue

## Why

-

## Changes

-

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
