### PR TITLE
fix: crashing on win10 with lnk app

### DIFF
--- a/apps/windows/LauncherApp/Commands/KillCommand.cs
+++ b/apps/windows/LauncherApp/Commands/KillCommand.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Text;
+using LauncherApp.Services;
 
 namespace LauncherApp.Commands;
 
@@ -673,7 +674,7 @@ public static class KillCommand
             {
                 try
                 {
-                    if (!TryResolveShortcutTarget(shortcutPath, out string targetPath))
+                    if (!ShortcutResolver.TryResolveShortcutTarget(shortcutPath, out string targetPath))
                     {
                         continue;
                     }
@@ -704,35 +705,6 @@ public static class KillCommand
         }
 
         return map;
-    }
-
-    private static bool TryResolveShortcutTarget(string shortcutPath, out string targetPath)
-    {
-        targetPath = string.Empty;
-        IShellLinkW? shellLink = null;
-        IPersistFile? persistFile = null;
-        try
-        {
-            shellLink = (IShellLinkW)new ShellLink();
-            persistFile = (IPersistFile)shellLink;
-            persistFile.Load(shortcutPath, 0);
-
-            var pathBuffer = new StringBuilder(32768);
-            shellLink.GetPath(pathBuffer, pathBuffer.Capacity, IntPtr.Zero, 0);
-            targetPath = pathBuffer.ToString().Trim();
-            return !string.IsNullOrWhiteSpace(targetPath);
-        }
-        catch
-        {
-            return false;
-        }
-        finally
-        {
-            if (persistFile != null)
-                Marshal.ReleaseComObject(persistFile);
-            if (shellLink != null)
-                Marshal.ReleaseComObject(shellLink);
-        }
     }
 
     private static string NormalizePath(string path)
@@ -858,49 +830,5 @@ public static class KillCommand
         public uint RemotePort;
         public uint State;
         public uint OwningPid;
-    }
-
-    [ComImport]
-    [Guid("00021401-0000-0000-C000-000000000046")]
-    private class ShellLink
-    {
-    }
-
-    [ComImport]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    [Guid("000214F9-0000-0000-C000-000000000046")]
-    private interface IShellLinkW
-    {
-        void GetPath([Out] StringBuilder pszFile, int cch, IntPtr pfd, uint fFlags);
-        void GetIDList(out IntPtr ppidl);
-        void SetIDList(IntPtr pidl);
-        void GetDescription([Out] StringBuilder pszName, int cch);
-        void SetDescription([MarshalAs(UnmanagedType.LPWStr)] string pszName);
-        void GetWorkingDirectory([Out] StringBuilder pszDir, int cch);
-        void SetWorkingDirectory([MarshalAs(UnmanagedType.LPWStr)] string pszDir);
-        void GetArguments([Out] StringBuilder pszArgs, int cch);
-        void SetArguments([MarshalAs(UnmanagedType.LPWStr)] string pszArgs);
-        void GetHotkey(out short wHotkey);
-        void SetHotkey(short wHotkey);
-        void GetShowCmd(out int iShowCmd);
-        void SetShowCmd(int iShowCmd);
-        void GetIconLocation([Out] StringBuilder pszIconPath, int cch, out int iIcon);
-        void SetIconLocation([MarshalAs(UnmanagedType.LPWStr)] string pszIconPath, int iIcon);
-        void SetRelativePath([MarshalAs(UnmanagedType.LPWStr)] string pszPathRel, uint dwReserved);
-        void Resolve(IntPtr hwnd, uint fFlags);
-        void SetPath([MarshalAs(UnmanagedType.LPWStr)] string pszFile);
-    }
-
-    [ComImport]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    [Guid("0000010b-0000-0000-C000-000000000046")]
-    private interface IPersistFile
-    {
-        void GetClassID(out Guid pClassID);
-        void IsDirty();
-        void Load([MarshalAs(UnmanagedType.LPWStr)] string pszFileName, uint dwMode);
-        void Save([MarshalAs(UnmanagedType.LPWStr)] string pszFileName, bool fRemember);
-        void SaveCompleted([MarshalAs(UnmanagedType.LPWStr)] string pszFileName);
-        void GetCurFile([MarshalAs(UnmanagedType.LPWStr)] out string ppszFileName);
     }
 }

--- a/apps/windows/LauncherApp/Services/ActionDispatcher.cs
+++ b/apps/windows/LauncherApp/Services/ActionDispatcher.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading.Tasks;
 using LauncherApp.Bridge;
 using Windows.ApplicationModel.DataTransfer;
@@ -513,47 +512,13 @@ public sealed class ActionDispatcher
         if (!normalized.EndsWith(".lnk", StringComparison.OrdinalIgnoreCase))
             return normalized;
 
-        // Resolved via IShellLinkW directly. The previous WScript.Shell + `dynamic`
-        // implementation crashed the process on some Windows 10 installs: the DLR's
-        // IDispatch type-info scan hit an uncatchable failure inside
-        // Microsoft.CSharp.RuntimeBinder.ComInterop.GetTypeAttrForTypeInfo.
-        if (TryResolveShortcutTarget(normalized, out string targetPath)
+        if (ShortcutResolver.TryResolveShortcutTarget(normalized, out string targetPath)
             && !string.IsNullOrWhiteSpace(targetPath))
         {
             return NormalizePath(targetPath);
         }
 
         return normalized;
-    }
-
-    private static bool TryResolveShortcutTarget(string shortcutPath, out string targetPath)
-    {
-        targetPath = string.Empty;
-
-        IShellLinkW? shellLink = null;
-        IPersistFile? persistFile = null;
-        try
-        {
-            shellLink = (IShellLinkW)new ShellLink();
-            persistFile = (IPersistFile)shellLink;
-            persistFile.Load(shortcutPath, 0);
-
-            var buffer = new StringBuilder(32768);
-            shellLink.GetPath(buffer, buffer.Capacity, IntPtr.Zero, 0);
-            targetPath = buffer.ToString().Trim();
-            return targetPath.Length > 0;
-        }
-        catch
-        {
-            return false;
-        }
-        finally
-        {
-            if (persistFile != null)
-                Marshal.ReleaseComObject(persistFile);
-            if (shellLink != null)
-                Marshal.ReleaseComObject(shellLink);
-        }
     }
 
     private static bool IsLikelySingleAppAlias(string originalPath, string resolvedExePath, string? title)
@@ -631,48 +596,4 @@ public sealed class ActionDispatcher
         IntPtr hProcess,
         ref uint applicationUserModelIdLength,
         [Out] char[]? applicationUserModelId);
-
-    [ComImport]
-    [Guid("00021401-0000-0000-C000-000000000046")]
-    private class ShellLink
-    {
-    }
-
-    [ComImport]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    [Guid("000214F9-0000-0000-C000-000000000046")]
-    private interface IShellLinkW
-    {
-        void GetPath([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszFile, int cchMaxPath, IntPtr pfd, uint fFlags);
-        void GetIDList(out IntPtr ppidl);
-        void SetIDList(IntPtr pidl);
-        void GetDescription([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszName, int cchMaxName);
-        void SetDescription([MarshalAs(UnmanagedType.LPWStr)] string pszName);
-        void GetWorkingDirectory([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszDir, int cchMaxPath);
-        void SetWorkingDirectory([MarshalAs(UnmanagedType.LPWStr)] string pszDir);
-        void GetArguments([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszArgs, int cchMaxPath);
-        void SetArguments([MarshalAs(UnmanagedType.LPWStr)] string pszArgs);
-        void GetHotkey(out short pwHotkey);
-        void SetHotkey(short wHotkey);
-        void GetShowCmd(out int piShowCmd);
-        void SetShowCmd(int iShowCmd);
-        void GetIconLocation([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszIconPath, int cchIconPath, out int piIcon);
-        void SetIconLocation([MarshalAs(UnmanagedType.LPWStr)] string pszIconPath, int iIcon);
-        void SetRelativePath([MarshalAs(UnmanagedType.LPWStr)] string pszPathRel, uint dwReserved);
-        void Resolve(IntPtr hwnd, uint fFlags);
-        void SetPath([MarshalAs(UnmanagedType.LPWStr)] string pszFile);
-    }
-
-    [ComImport]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    [Guid("0000010B-0000-0000-C000-000000000046")]
-    private interface IPersistFile
-    {
-        void GetClassID(out Guid pClassID);
-        void IsDirty();
-        void Load([MarshalAs(UnmanagedType.LPWStr)] string pszFileName, int dwMode);
-        void Save([MarshalAs(UnmanagedType.LPWStr)] string pszFileName, bool fRemember);
-        void SaveCompleted([MarshalAs(UnmanagedType.LPWStr)] string pszFileName);
-        void GetCurFile([MarshalAs(UnmanagedType.LPWStr)] out string ppszFileName);
-    }
 }

--- a/apps/windows/LauncherApp/Services/ActionDispatcher.cs
+++ b/apps/windows/LauncherApp/Services/ActionDispatcher.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading.Tasks;
 using LauncherApp.Bridge;
 using Windows.ApplicationModel.DataTransfer;
@@ -512,26 +513,47 @@ public sealed class ActionDispatcher
         if (!normalized.EndsWith(".lnk", StringComparison.OrdinalIgnoreCase))
             return normalized;
 
-        try
+        // Resolved via IShellLinkW directly. The previous WScript.Shell + `dynamic`
+        // implementation crashed the process on some Windows 10 installs: the DLR's
+        // IDispatch type-info scan hit an uncatchable failure inside
+        // Microsoft.CSharp.RuntimeBinder.ComInterop.GetTypeAttrForTypeInfo.
+        if (TryResolveShortcutTarget(normalized, out string targetPath)
+            && !string.IsNullOrWhiteSpace(targetPath))
         {
-            var shellType = Type.GetTypeFromProgID("WScript.Shell");
-            if (shellType == null)
-                return normalized;
-
-            dynamic? shell = Activator.CreateInstance(shellType);
-            if (shell == null)
-                return normalized;
-
-            dynamic shortcut = shell.CreateShortcut(normalized);
-            string targetPath = shortcut.TargetPath;
-            if (!string.IsNullOrWhiteSpace(targetPath))
-                return NormalizePath(targetPath);
-        }
-        catch
-        {
+            return NormalizePath(targetPath);
         }
 
         return normalized;
+    }
+
+    private static bool TryResolveShortcutTarget(string shortcutPath, out string targetPath)
+    {
+        targetPath = string.Empty;
+
+        IShellLinkW? shellLink = null;
+        IPersistFile? persistFile = null;
+        try
+        {
+            shellLink = (IShellLinkW)new ShellLink();
+            persistFile = (IPersistFile)shellLink;
+            persistFile.Load(shortcutPath, 0);
+
+            var buffer = new StringBuilder(32768);
+            shellLink.GetPath(buffer, buffer.Capacity, IntPtr.Zero, 0);
+            targetPath = buffer.ToString().Trim();
+            return targetPath.Length > 0;
+        }
+        catch
+        {
+            return false;
+        }
+        finally
+        {
+            if (persistFile != null)
+                Marshal.ReleaseComObject(persistFile);
+            if (shellLink != null)
+                Marshal.ReleaseComObject(shellLink);
+        }
     }
 
     private static bool IsLikelySingleAppAlias(string originalPath, string resolvedExePath, string? title)
@@ -609,4 +631,48 @@ public sealed class ActionDispatcher
         IntPtr hProcess,
         ref uint applicationUserModelIdLength,
         [Out] char[]? applicationUserModelId);
+
+    [ComImport]
+    [Guid("00021401-0000-0000-C000-000000000046")]
+    private class ShellLink
+    {
+    }
+
+    [ComImport]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [Guid("000214F9-0000-0000-C000-000000000046")]
+    private interface IShellLinkW
+    {
+        void GetPath([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszFile, int cchMaxPath, IntPtr pfd, uint fFlags);
+        void GetIDList(out IntPtr ppidl);
+        void SetIDList(IntPtr pidl);
+        void GetDescription([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszName, int cchMaxName);
+        void SetDescription([MarshalAs(UnmanagedType.LPWStr)] string pszName);
+        void GetWorkingDirectory([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszDir, int cchMaxPath);
+        void SetWorkingDirectory([MarshalAs(UnmanagedType.LPWStr)] string pszDir);
+        void GetArguments([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszArgs, int cchMaxPath);
+        void SetArguments([MarshalAs(UnmanagedType.LPWStr)] string pszArgs);
+        void GetHotkey(out short pwHotkey);
+        void SetHotkey(short wHotkey);
+        void GetShowCmd(out int piShowCmd);
+        void SetShowCmd(int iShowCmd);
+        void GetIconLocation([Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszIconPath, int cchIconPath, out int piIcon);
+        void SetIconLocation([MarshalAs(UnmanagedType.LPWStr)] string pszIconPath, int iIcon);
+        void SetRelativePath([MarshalAs(UnmanagedType.LPWStr)] string pszPathRel, uint dwReserved);
+        void Resolve(IntPtr hwnd, uint fFlags);
+        void SetPath([MarshalAs(UnmanagedType.LPWStr)] string pszFile);
+    }
+
+    [ComImport]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [Guid("0000010B-0000-0000-C000-000000000046")]
+    private interface IPersistFile
+    {
+        void GetClassID(out Guid pClassID);
+        void IsDirty();
+        void Load([MarshalAs(UnmanagedType.LPWStr)] string pszFileName, int dwMode);
+        void Save([MarshalAs(UnmanagedType.LPWStr)] string pszFileName, bool fRemember);
+        void SaveCompleted([MarshalAs(UnmanagedType.LPWStr)] string pszFileName);
+        void GetCurFile([MarshalAs(UnmanagedType.LPWStr)] out string ppszFileName);
+    }
 }

--- a/apps/windows/LauncherApp/Services/ShortcutResolver.cs
+++ b/apps/windows/LauncherApp/Services/ShortcutResolver.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace LauncherApp.Services;
+
+// Resolves .lnk shortcut targets via early-bound IShellLinkW / IPersistFile COM.
+// The previous WScript.Shell + `dynamic` implementation crashed the process on
+// some Windows 10 installs: the DLR's IDispatch type-info scan hit an uncatchable
+// failure inside Microsoft.CSharp.RuntimeBinder.ComInterop.GetTypeAttrForTypeInfo
+// during ITypeInfo.ReleaseTypeAttr. Early-bound ComImport interfaces sidestep the
+// runtime binder entirely.
+//
+// ShellLink COM activation requires an STA apartment. WinUI UI-thread callers are
+// fine; if a future caller runs on the thread pool, activation will throw and the
+// catch will return false (no resolution, no crash).
+internal static class ShortcutResolver
+{
+    public static bool TryResolveShortcutTarget(string shortcutPath, out string targetPath)
+    {
+        targetPath = string.Empty;
+
+        IShellLinkW? shellLink = null;
+        IPersistFile? persistFile = null;
+        try
+        {
+            shellLink = (IShellLinkW)new ShellLink();
+            persistFile = (IPersistFile)shellLink;
+            persistFile.Load(shortcutPath, 0);
+
+            var buffer = new StringBuilder(32768);
+            shellLink.GetPath(buffer, buffer.Capacity, IntPtr.Zero, 0);
+            targetPath = buffer.ToString().Trim();
+            return targetPath.Length > 0;
+        }
+        catch
+        {
+            return false;
+        }
+        finally
+        {
+            if (persistFile != null)
+                Marshal.ReleaseComObject(persistFile);
+            if (shellLink != null)
+                Marshal.ReleaseComObject(shellLink);
+        }
+    }
+
+    [ComImport]
+    [Guid("00021401-0000-0000-C000-000000000046")]
+    private class ShellLink
+    {
+    }
+
+    [ComImport]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [Guid("000214F9-0000-0000-C000-000000000046")]
+    private interface IShellLinkW
+    {
+        void GetPath([Out] StringBuilder pszFile, int cchMaxPath, IntPtr pfd, uint fFlags);
+        void GetIDList(out IntPtr ppidl);
+        void SetIDList(IntPtr pidl);
+        void GetDescription([Out] StringBuilder pszName, int cchMaxName);
+        void SetDescription([MarshalAs(UnmanagedType.LPWStr)] string pszName);
+        void GetWorkingDirectory([Out] StringBuilder pszDir, int cchMaxPath);
+        void SetWorkingDirectory([MarshalAs(UnmanagedType.LPWStr)] string pszDir);
+        void GetArguments([Out] StringBuilder pszArgs, int cchMaxPath);
+        void SetArguments([MarshalAs(UnmanagedType.LPWStr)] string pszArgs);
+        void GetHotkey(out short pwHotkey);
+        void SetHotkey(short wHotkey);
+        void GetShowCmd(out int piShowCmd);
+        void SetShowCmd(int iShowCmd);
+        void GetIconLocation([Out] StringBuilder pszIconPath, int cchIconPath, out int piIcon);
+        void SetIconLocation([MarshalAs(UnmanagedType.LPWStr)] string pszIconPath, int iIcon);
+        void SetRelativePath([MarshalAs(UnmanagedType.LPWStr)] string pszPathRel, uint dwReserved);
+        void Resolve(IntPtr hwnd, uint fFlags);
+        void SetPath([MarshalAs(UnmanagedType.LPWStr)] string pszFile);
+    }
+
+    [ComImport]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [Guid("0000010B-0000-0000-C000-000000000046")]
+    private interface IPersistFile
+    {
+        void GetClassID(out Guid pClassID);
+        void IsDirty();
+        void Load([MarshalAs(UnmanagedType.LPWStr)] string pszFileName, uint dwMode);
+        void Save([MarshalAs(UnmanagedType.LPWStr)] string pszFileName, bool fRemember);
+        void SaveCompleted([MarshalAs(UnmanagedType.LPWStr)] string pszFileName);
+        void GetCurFile([MarshalAs(UnmanagedType.LPWStr)] out string ppszFileName);
+    }
+}


### PR DESCRIPTION
## Summary

- Event 1000 matches: exception code 0xC000027B = STATUS_STOWED_EXCEPTION, the marker Windows uses when a managed exception escapes a WinRT/XAML event handler unhandled. 

So the crash is dynamic shell.CreateShortcut(...) in ActionDispatcher.cs:521-528, blowing up inside the DLR's IDispatch type-info scan. The try { } catch { } around it doesn't catch — GetTypeAttrForTypeInfo is hitting an unrecoverable failure (most likely an AccessViolationException while walking ITypeInfo, which .NET 5+ does not let us catch even with bare catch). Edge/Settings don't go through ResolveExecutablePath because their paths aren't .lnk.

## Fix

drop dynamic + WScript.Shell entirely. Already have native IShellLinkW/IPersistFile in ShellIconProvider.TryResolveShortcut (ShellIconProvider.cs:309-345). Extract those COM interfaces into a small helper used by both files, and rewrite ResolveExecutablePath to call it. That removes the DLR/Microsoft.CSharp dependency from the launch path and the crash with it.


## Why

<img width="1104" height="641" alt="image" src="https://github.com/user-attachments/assets/1949a135-c80b-4a6f-b48d-149a80322d77" />
<img width="1124" height="554" alt="image" src="https://github.com/user-attachments/assets/33d80209-4236-49d0-859d-17b4424a6ee9" />



## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
