### PR TITLE
fix: translation error due to Windows's curl

### DIFF
--- a/bridge/ffi/src/translate_api.rs
+++ b/bridge/ffi/src/translate_api.rs
@@ -15,7 +15,12 @@ const TRANSLATE_URL_PREFIX: &str =
 const TRANSLATE_URL_MIDDLE: &str = "&dt=t&q=";
 const CURL_BIN: &str = "curl";
 const CURL_USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
-const CURL_ARGS_PREFIX: [&str; 9] = [
+// `--compressed` was dropped: the curl shipped in C:\Windows\System32 on some
+// Windows 10 builds lacks zlib support and exits non-zero with "the installed
+// libcurl version doesn't support this", surfacing as "Translation request
+// failed". Translation responses are ~hundreds of bytes; the bandwidth saving
+// isn't worth a platform fork.
+const CURL_ARGS_PREFIX: [&str; 8] = [
     "-s",
     "-m",
     "3",
@@ -24,7 +29,6 @@ const CURL_ARGS_PREFIX: [&str; 9] = [
     "--tlsv1.2",
     "-H",
     "Accept-Language: en-US,en;q=0.9",
-    "--compressed",
 ];
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
## Summary

- Windows 10 uses a diff libcurl... causes translation issue

## Why

-

## Changes

-

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
