### PR TITLE
Linows: apps list screen basic functions

### DIFF
--- a/apps/linows/TASKS.md
+++ b/apps/linows/TASKS.md
@@ -28,13 +28,14 @@ Based on macOS app as source of truth. Organized by phase.
 - [x] `css/reset.css` — CSS reset
 - [x] `css/theme.css` — CSS custom properties (colors, spacing, typography)
 - [x] `css/layout.css` — Window layout, search bar, content area
-- [x] `css/components.css` — Result rows, panels
+- [x] `css/components/` — Per-component CSS (results, preview, picked)
 - [x] `js/ipc.js` — Tauri invoke wrapper
 - [x] `js/app.js` — Main controller, mode switching
-- [x] `js/search.js` — Debounced search (70ms), query → invoke → render
-- [x] `js/results.js` — DOM rendering of result rows (icon, title, kind subtitle)
-- [x] `js/keyboard.js` — Arrow/Tab/Shift+Tab navigation, Enter to open, Escape to hide, wrap-around
-- [x] `js/preview.js` — Preview panel (icon, title, badge, metadata, image preview)
+- [x] `js/search.js` — Debounced search (70ms), query → invoke → render, quick folders
+- [x] `js/components/results.js` — Result rows, icons, pick state management
+- [x] `js/components/preview.js` — Preview panel (icon, title, badge, metadata, image preview)
+- [x] `js/components/picked.js` — Picked items panel (header, list, remove buttons)
+- [x] `js/keyboard.js` — Arrow/Tab/Shift+Tab navigation, Enter/Ctrl+Enter, Escape, wrap-around
 
 ### Window & System
 - [x] Global hotkey (Alt+Space) via tauri-plugin-global-shortcut
@@ -49,14 +50,15 @@ Based on macOS app as source of truth. Organized by phase.
 
 ### Screens
 - [x] Result preview panel — file metadata (size, modified, path), image preview, app version
-- [ ] Picked items panel — list of multi-selected items with remove buttons
+- [x] Picked items panel — list of multi-selected items with remove buttons
 
 ### Features
 - [x] Quick folders (Desktop, Documents, Downloads, Pictures, Videos, Music)
-- [ ] Multi-pick (Ctrl+Click to toggle selection)
-- [ ] Clipboard write (picked items as paths + text)
+- [x] Multi-pick (Ctrl+P toggle, Ctrl+Shift+P clear all)
+- [x] Clipboard write — Ctrl+C copies file/folder (pasteable in file managers), auto-copy on pick
 - [x] Reveal in file manager (Ctrl+F)
 - [x] Hint bar (bottom status text)
+- [x] Web search (Ctrl+Enter) — opens Google search in default browser
 
 ---
 

--- a/apps/linows/src-tauri/src/commands.rs
+++ b/apps/linows/src-tauri/src/commands.rs
@@ -327,7 +327,18 @@ pub fn copy_files_to_clipboard(paths: Vec<String>) -> Result<(), String> {
     if paths.is_empty() {
         return Ok(());
     }
-    let uris: Vec<String> = paths.iter().map(|p| format!("file://{p}")).collect();
+    // Percent-encode each path into a valid file:// URI.
+    // Paths may contain spaces, #, %, or unicode which would break
+    // the x-special/gnome-copied-files clipboard format if left raw.
+    // e.g. "/tmp/a #b.txt" → "file:///tmp/a%20%23b.txt"
+    let uris: Vec<String> = paths.iter().map(|p| {
+        let encoded: String = p.bytes().map(|b| match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9'
+            | b'-' | b'.' | b'_' | b'~' | b'/' => (b as char).to_string(),
+            _ => format!("%{b:02X}"),
+        }).collect();
+        format!("file://{encoded}")
+    }).collect();
     let uri = format!("copy\n{}", uris.join("\n"));
 
     // Use sh -c with a pipe to fully detach from our process

--- a/apps/linows/src-tauri/src/commands.rs
+++ b/apps/linows/src-tauri/src/commands.rs
@@ -91,17 +91,34 @@ pub fn open_path(
     kind: Option<String>,
     id: Option<String>,
 ) -> Result<(), String> {
-    let result = if kind.as_deref() == Some("app") && !path.contains("://") {
-        launch_app(&path, id.as_deref())
-    } else {
-        open::that(&path).map_err(|e| format!("Failed to open: {e}"))
-    };
-
-    if result.is_ok() {
+    if kind.as_deref() == Some("app") && !path.contains("://") {
+        let result = launch_app(&path, id.as_deref());
+        if result.is_ok() {
+            let _ = window.hide();
+        }
+        result
+    } else if kind.as_deref() == Some("browser") {
+        // Open URL and try to focus the browser window
         let _ = window.hide();
+        std::thread::spawn(move || {
+            let _ = open::that(&path);
+            // Try to focus browser via i3
+            for class in &["Brave-browser", "firefox", "chromium", "Google-chrome"] {
+                if try_focus_window(class) {
+                    break;
+                }
+            }
+        });
+        Ok(())
+    } else {
+        // open::that() calls xdg-open which blocks until the app closes.
+        // Spawn in a background thread to avoid freezing Look.
+        let _ = window.hide();
+        std::thread::spawn(move || {
+            let _ = open::that(&path);
+        });
+        Ok(())
     }
-
-    result
 }
 
 fn launch_app(exec: &str, id: Option<&str>) -> Result<(), String> {
@@ -303,6 +320,36 @@ pub fn toggle_window(window: tauri::WebviewWindow) {
         let _ = window.show();
         let _ = window.set_focus();
     }
+}
+
+#[tauri::command]
+pub fn copy_files_to_clipboard(paths: Vec<String>) -> Result<(), String> {
+    if paths.is_empty() {
+        return Ok(());
+    }
+    let uris: Vec<String> = paths.iter().map(|p| format!("file://{p}")).collect();
+    let uri = format!("copy\n{}", uris.join("\n"));
+
+    // Use sh -c with a pipe to fully detach from our process
+    // xclip stays alive to serve the X11 clipboard, so it must be detached
+    let script = format!(
+        "echo -n '{}' | xclip -selection clipboard -t x-special/gnome-copied-files 2>/dev/null || \
+         echo -n '{}' | wl-copy -t x-special/gnome-copied-files 2>/dev/null",
+        uri.replace('\'', "'\\''"),
+        uri.replace('\'', "'\\''"),
+    );
+
+    // setsid detaches xclip into its own session so it doesn't
+    // interfere with Look's X11 event loop
+    let result = std::process::Command::new("setsid")
+        .args(["sh", "-c", &script])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn();
+
+    result.map_err(|e| format!("Failed to copy: {e}"))?;
+    Ok(())
 }
 
 #[tauri::command]

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -128,6 +128,7 @@ fn main() {
             commands::reload_config,
             commands::request_index_refresh,
             commands::toggle_window,
+            commands::copy_files_to_clipboard,
             commands::get_home_dir,
             commands::hide_window,
             commands::get_file_meta,

--- a/apps/linows/src/css/components/picked.css
+++ b/apps/linows/src/css/components/picked.css
@@ -1,0 +1,107 @@
+/* Picked items panel */
+.picked-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.picked-label {
+  font-weight: 600;
+  font-size: calc(var(--font-size) - 1px);
+  color: var(--font-color);
+}
+
+.picked-clear {
+  background: none;
+  border: none;
+  font: inherit;
+  font-size: calc(var(--font-size) - 2px);
+  color: var(--color-danger);
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.picked-clear:hover {
+  background: var(--selection-fill);
+}
+
+.picked-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.picked-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  background: var(--control-fill);
+  border-radius: var(--control-radius);
+}
+
+.picked-icon {
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--on-accent-color);
+  background: var(--accent-color);
+}
+
+.picked-icon img {
+  width: 100%;
+  height: 100%;
+  border-radius: 4px;
+  object-fit: contain;
+}
+
+.picked-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.picked-title {
+  font-size: calc(var(--font-size) - 1px);
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--font-color);
+}
+
+.picked-path {
+  font-size: calc(var(--font-size) - 4px);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--font-muted);
+}
+
+.picked-remove {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  font: inherit;
+  font-size: 16px;
+  color: var(--font-muted);
+  cursor: pointer;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+}
+
+.picked-remove:hover {
+  color: var(--color-danger);
+  background: var(--selection-fill);
+}

--- a/apps/linows/src/css/components/results.css
+++ b/apps/linows/src/css/components/results.css
@@ -88,6 +88,20 @@
 .result-badge.kind-folder { color: var(--color-warning); }
 .result-badge.kind-setting { color: var(--color-info); }
 
+/* Pick checkmark */
+.pick-check {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  font-size: 11px;
+  color: var(--on-accent-color);
+  background: var(--accent-color);
+}
+
 /* Empty state */
 .empty-state {
   display: flex;

--- a/apps/linows/src/index.html
+++ b/apps/linows/src/index.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="css/layout.css" />
   <link rel="stylesheet" href="css/components/results.css" />
   <link rel="stylesheet" href="css/components/preview.css" />
+  <link rel="stylesheet" href="css/components/picked.css" />
 </head>
 <body>
   <div id="app" class="launcher-window">
@@ -30,7 +31,7 @@
     </div>
 
     <div class="hint-bar" id="hint-bar">
-      <span>Enter open &bull; Ctrl+F reveal &bull; &uarr;&darr; navigate &bull; Esc hide</span>
+      <span>Enter open &bull; Ctrl+Enter search web &bull; Ctrl+P pick &bull; Ctrl+C copy &bull; Ctrl+F reveal &bull; Esc hide</span>
     </div>
   </div>
 

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -2,7 +2,8 @@ import * as results from './components/results.js';
 import * as search from './search.js';
 import * as keyboard from './keyboard.js';
 import * as preview from './components/preview.js';
-import { onWindowShown, getHomeDir } from './ipc.js';
+import * as picked from './components/picked.js';
+import { onWindowShown, getHomeDir, copyFilesToClipboard } from './ipc.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   const queryInput = document.getElementById('query');
@@ -13,10 +14,34 @@ document.addEventListener('DOMContentLoaded', () => {
   results.init(resultsList);
   keyboard.init(queryInput);
   preview.init(previewPanel);
+  picked.init(previewPanel, {
+    onRemoveItem: (key) => results.removePick(key),
+    onClearAll: () => results.clearPicks(),
+  });
 
-  // Update preview when selection changes
+  // Update right panel when selection changes
   results.setOnSelectionChange((item) => {
-    preview.update(item);
+    if (!results.hasPickedItems()) {
+      preview.update(item);
+    }
+  });
+
+  // Update right panel when picks change + auto-copy
+  results.setOnPickChange((pickedItems) => {
+    if (pickedItems.length > 0) {
+      preview.clear();
+      picked.update(pickedItems);
+      // Auto-copy picked files to clipboard
+      const paths = pickedItems
+        .filter((i) => i.kind === 'file' || i.kind === 'folder')
+        .map((i) => i.path);
+      if (paths.length > 0) {
+        copyFilesToClipboard(paths).catch(() => {});
+      }
+    } else {
+      picked.update([]);
+      preview.update(results.getSelected());
+    }
   });
 
   // Wire search → results

--- a/apps/linows/src/js/components/picked.js
+++ b/apps/linows/src/js/components/picked.js
@@ -1,0 +1,93 @@
+import { getIcon } from '../ipc.js';
+
+let panel = null;
+let onRemove = null;
+let onClear = null;
+
+export function init(panelEl, { onRemoveItem, onClearAll }) {
+  panel = panelEl;
+  onRemove = onRemoveItem;
+  onClear = onClearAll;
+}
+
+export function update(pickedItems) {
+  if (!pickedItems || pickedItems.length === 0) {
+    panel.hidden = true;
+    panel.innerHTML = '';
+    return;
+  }
+
+  panel.hidden = false;
+  panel.innerHTML = '';
+
+  // Header
+  const header = document.createElement('div');
+  header.className = 'picked-header';
+
+  const label = document.createElement('span');
+  label.className = 'picked-label';
+  label.textContent = `Picked (${pickedItems.length})`;
+  header.appendChild(label);
+
+  const clearBtn = document.createElement('button');
+  clearBtn.className = 'picked-clear';
+  clearBtn.textContent = 'Clear all';
+  clearBtn.addEventListener('click', () => {
+    if (onClear) onClear();
+  });
+  header.appendChild(clearBtn);
+
+  panel.appendChild(header);
+
+  // Items list
+  const list = document.createElement('div');
+  list.className = 'picked-list';
+
+  for (const item of pickedItems) {
+    const row = document.createElement('div');
+    row.className = 'picked-item';
+
+    const icon = document.createElement('div');
+    icon.className = 'picked-icon';
+    icon.textContent = item.title.charAt(0).toUpperCase();
+    row.appendChild(icon);
+
+    getIcon(item.kind, item.path, item.id).then((res) => {
+      if (res?.data_url) {
+        const img = document.createElement('img');
+        img.src = res.data_url;
+        img.alt = '';
+        icon.textContent = '';
+        icon.style.background = 'none';
+        icon.appendChild(img);
+      }
+    });
+
+    const text = document.createElement('div');
+    text.className = 'picked-text';
+
+    const title = document.createElement('div');
+    title.className = 'picked-title';
+    title.textContent = item.title;
+    text.appendChild(title);
+
+    const path = document.createElement('div');
+    path.className = 'picked-path';
+    path.textContent = item.path;
+    text.appendChild(path);
+
+    row.appendChild(text);
+
+    const removeBtn = document.createElement('button');
+    removeBtn.className = 'picked-remove';
+    removeBtn.innerHTML = '&times;';
+    removeBtn.addEventListener('click', () => {
+      if (onRemove) onRemove(item.key);
+    });
+    row.appendChild(removeBtn);
+
+    list.appendChild(row);
+  }
+
+  panel.appendChild(list);
+}

--- a/apps/linows/src/js/components/results.js
+++ b/apps/linows/src/js/components/results.js
@@ -1,11 +1,13 @@
 import { getIcon } from '../ipc.js';
 
 const iconCache = new Map();
+const pickedMap = new Map(); // key → result
 
 let currentResults = [];
 let selectedIndex = -1;
 let container = null;
 let onSelectionChange = null;
+let onPickChange = null;
 
 export function init(containerEl) {
   container = containerEl;
@@ -13,6 +15,10 @@ export function init(containerEl) {
 
 export function setOnSelectionChange(callback) {
   onSelectionChange = callback;
+}
+
+export function setOnPickChange(callback) {
+  onPickChange = callback;
 }
 
 export function render(results) {
@@ -71,6 +77,69 @@ export function select(index) {
   }
 }
 
+// --- Pick management ---
+
+function pickKey(item) {
+  return `${item.kind}|${item.path}`;
+}
+
+export function togglePick(item) {
+  if (!item) return;
+  const key = pickKey(item);
+  if (pickedMap.has(key)) {
+    pickedMap.delete(key);
+  } else {
+    pickedMap.set(key, item);
+  }
+  updatePickedIndicators();
+  if (onPickChange) onPickChange(getPickedItems());
+}
+
+export function removePick(key) {
+  pickedMap.delete(key);
+  updatePickedIndicators();
+  if (onPickChange) onPickChange(getPickedItems());
+}
+
+export function clearPicks() {
+  pickedMap.clear();
+  updatePickedIndicators();
+  if (onPickChange) onPickChange(getPickedItems());
+}
+
+export function isPicked(item) {
+  return pickedMap.has(pickKey(item));
+}
+
+export function getPickedItems() {
+  return [...pickedMap.entries()].map(([key, item]) => ({ key, ...item }));
+}
+
+export function hasPickedItems() {
+  return pickedMap.size > 0;
+}
+
+function updatePickedIndicators() {
+  const rows = container.querySelectorAll('.result-row');
+  rows.forEach((row, i) => {
+    const result = currentResults[i];
+    if (!result) return;
+    const check = row.querySelector('.pick-check');
+    if (pickedMap.has(pickKey(result))) {
+      if (!check) {
+        const el = document.createElement('div');
+        el.className = 'pick-check';
+        el.innerHTML = '&#10003;';
+        row.appendChild(el);
+      }
+    } else if (check) {
+      check.remove();
+    }
+  });
+}
+
+// --- Row creation ---
+
 function createRow(result, index) {
   const row = document.createElement('div');
   row.className = 'result-row';
@@ -107,6 +176,14 @@ function createRow(result, index) {
 
   row.appendChild(text);
 
+  // Picked indicator
+  if (pickedMap.has(pickKey(result))) {
+    const el = document.createElement('div');
+    el.className = 'pick-check';
+    el.innerHTML = '&#10003;';
+    row.appendChild(el);
+  }
+
   row.addEventListener('click', () => {
     select(index);
     row.dispatchEvent(new CustomEvent('result-activate', { bubbles: true }));
@@ -118,7 +195,6 @@ function createRow(result, index) {
 function loadIcon(iconEl, kind, path, id) {
   const cacheKey = `${kind}:${path}`;
 
-  // Check JS cache first
   if (iconCache.has(cacheKey)) {
     const dataUrl = iconCache.get(cacheKey);
     if (dataUrl) {

--- a/apps/linows/src/js/ipc.js
+++ b/apps/linows/src/js/ipc.js
@@ -41,6 +41,10 @@ export async function getAppVersion(path) {
   return invoke('get_app_version', { path });
 }
 
+export async function copyFilesToClipboard(paths) {
+  return invoke('copy_files_to_clipboard', { paths });
+}
+
 export async function getHomeDir() {
   return invoke('get_home_dir');
 }

--- a/apps/linows/src/js/keyboard.js
+++ b/apps/linows/src/js/keyboard.js
@@ -1,5 +1,5 @@
 import * as results from './components/results.js';
-import { openPath, recordUsage, revealPath, hideWindow } from './ipc.js';
+import { openPath, recordUsage, revealPath, hideWindow, copyFilesToClipboard } from './ipc.js';
 
 let queryInput = null;
 let shiftHeld = false;
@@ -51,7 +51,11 @@ function handleKeyDown(e) {
 
     case 'Enter':
       e.preventDefault();
-      openSelected();
+      if (e.ctrlKey) {
+        searchWeb();
+      } else {
+        openSelected();
+      }
       break;
 
     case 'Escape':
@@ -63,6 +67,24 @@ function handleKeyDown(e) {
       if (e.ctrlKey) {
         e.preventDefault();
         revealSelected();
+      }
+      break;
+
+    case 'c':
+      if (e.ctrlKey && !window.getSelection()?.toString()) {
+        e.preventDefault();
+        copySelectedPath();
+      }
+      break;
+
+    case 'p':
+    case 'P':
+      if (e.ctrlKey && (e.shiftKey || shiftHeld)) {
+        e.preventDefault();
+        results.clearPicks();
+      } else if (e.ctrlKey) {
+        e.preventDefault();
+        results.togglePick(results.getSelected());
       }
       break;
   }
@@ -85,6 +107,28 @@ async function openSelected() {
     await recordUsage(item.id, action);
   } catch (err) {
     console.error('Failed to open:', err);
+  }
+}
+
+function searchWeb() {
+  const query = queryInput.value.trim();
+  if (!query) return;
+  const url = `https://www.google.com/search?q=${encodeURIComponent(query)}`;
+  openPath(url, 'browser');
+}
+
+async function copySelectedPath() {
+  const item = results.getSelected();
+  if (!item) return;
+
+  try {
+    if (item.kind === 'file' || item.kind === 'folder') {
+      await copyFilesToClipboard([item.path]);
+    } else {
+      await navigator.clipboard.writeText(item.path);
+    }
+  } catch (err) {
+    console.error('Failed to copy:', err);
   }
 }
 


### PR DESCRIPTION
## Summary

- Apps list screen basic functions:
1. copy
2. multiple selection
3. search web
4. reveal in file manageer
5. fix issue with file manager

## Why

-

## Changes

-

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
