### PR TITLE
Chore: lucide icons for linux

### DIFF
--- a/apps/linows/src/css/components/commands.css
+++ b/apps/linows/src/css/components/commands.css
@@ -34,12 +34,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 10px;
-  font-weight: 700;
   color: var(--accent-color);
-  font-family: var(--font-mono);
-  border: 1.5px solid var(--accent-color);
-  border-radius: 50%;
+}
+
+.cmd-row-icon svg {
+  width: 16px;
+  height: 16px;
 }
 
 .cmd-row-text {
@@ -109,9 +109,14 @@
 
 .cmd-input-bar-icon {
   color: var(--accent-color);
-  font-size: 14px;
   flex-shrink: 0;
-  font-family: var(--font-mono);
+  display: flex;
+  align-items: center;
+}
+
+.cmd-input-bar-icon svg {
+  width: 14px;
+  height: 14px;
 }
 
 .cmd-input-bar input {
@@ -394,7 +399,13 @@
   background: var(--control-fill);
   color: var(--font-secondary);
   padding: 5px 8px;
-  font-size: 16px;
+  display: flex;
+  align-items: center;
+}
+
+.cmd-pomo-btn-settings svg {
+  width: 16px;
+  height: 16px;
 }
 
 /* Settings panel */
@@ -451,8 +462,14 @@
 
 .cmd-pomo-music-icon {
   color: var(--accent-color);
-  font-size: 14px;
   flex-shrink: 0;
+  display: flex;
+  align-items: center;
+}
+
+.cmd-pomo-music-icon svg {
+  width: 14px;
+  height: 14px;
 }
 
 .cmd-pomo-music-track {
@@ -477,10 +494,15 @@
   border: none;
   cursor: pointer;
   color: var(--font-secondary);
-  font-size: 14px;
   padding: 2px 5px;
   border-radius: 4px;
-  line-height: 1;
+  display: flex;
+  align-items: center;
+}
+
+.cmd-pomo-music-btn svg {
+  width: 14px;
+  height: 14px;
 }
 
 .cmd-pomo-music-btn:hover {
@@ -548,8 +570,14 @@
 }
 
 .cmd-pomo-chevron {
-  font-size: 10px;
+  display: flex;
+  align-items: center;
   transition: transform 0.2s;
+}
+
+.cmd-pomo-chevron svg {
+  width: 12px;
+  height: 12px;
 }
 
 .cmd-pomo-chevron.open {

--- a/apps/linows/src/css/components/preview.css
+++ b/apps/linows/src/css/components/preview.css
@@ -125,6 +125,14 @@
   cursor: pointer;
   background: var(--color-danger, #e55);
   color: #fff;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.preview-clip-delete svg {
+  width: 14px;
+  height: 14px;
 }
 
 .preview-clip-delete:hover {

--- a/apps/linows/src/html/screens/commands/calc.html
+++ b/apps/linows/src/html/screens/commands/calc.html
@@ -1,6 +1,6 @@
 <div class="cmd-panel" id="cmd-panel-calc" hidden>
   <div class="cmd-input-bar">
-    <span class="cmd-input-bar-icon">f(x)</span>
+    <span class="cmd-input-bar-icon" id="cmd-calc-header-icon"></span>
     <input id="cmd-calc-input" type="text" placeholder="Type math expression" spellcheck="false" autocomplete="off" />
     <span class="cmd-pill">/calc</span>
   </div>

--- a/apps/linows/src/html/screens/commands/kill.html
+++ b/apps/linows/src/html/screens/commands/kill.html
@@ -1,6 +1,6 @@
 <div class="cmd-panel" id="cmd-panel-kill" hidden>
   <div class="cmd-input-bar">
-    <span class="cmd-input-bar-icon">&#x2718;</span>
+    <span class="cmd-input-bar-icon" id="cmd-kill-header-icon"></span>
     <input id="cmd-kill-input" type="text" placeholder="Type app name, or :3000" spellcheck="false" autocomplete="off" />
     <span class="cmd-pill">/kill</span>
   </div>

--- a/apps/linows/src/html/screens/commands/pomo.html
+++ b/apps/linows/src/html/screens/commands/pomo.html
@@ -1,7 +1,7 @@
 <div class="cmd-panel" id="cmd-panel-pomo" hidden>
   <!-- Header -->
   <div class="cmd-header-bar">
-    <span class="cmd-input-bar-icon">&#x23F1;</span>
+    <span class="cmd-input-bar-icon" id="cmd-pomo-header-icon"></span>
     <span class="cmd-subtitle" id="cmd-pomo-header">6 sessions planned</span>
     <span class="cmd-pill">/pomo</span>
   </div>
@@ -19,7 +19,7 @@
     <button class="cmd-pomo-btn cmd-pomo-btn-toggle" id="cmd-pomo-toggle">Start (Space)</button>
     <button class="cmd-pomo-btn cmd-pomo-btn-skip" id="cmd-pomo-skip" hidden>Skip</button>
     <button class="cmd-pomo-btn cmd-pomo-btn-reset" id="cmd-pomo-reset" hidden>Reset (R)</button>
-    <button class="cmd-pomo-btn cmd-pomo-btn-settings" id="cmd-pomo-settings-btn" title="Timer style">&#x2699;</button>
+    <button class="cmd-pomo-btn cmd-pomo-btn-settings" id="cmd-pomo-settings-btn" title="Timer style"></button>
   </div>
 
   <!-- Settings panel (timer style picker) -->
@@ -33,7 +33,7 @@
   <!-- Session list -->
   <div class="cmd-pomo-sessions" id="cmd-pomo-sessions">
     <div class="cmd-pomo-sessions-header" id="cmd-pomo-sessions-toggle">
-      <span class="cmd-pomo-chevron" id="cmd-pomo-chevron">&#x25B6;</span>
+      <span class="cmd-pomo-chevron" id="cmd-pomo-chevron"></span>
       <span id="cmd-pomo-sessions-label">Session List</span>
       <div class="cmd-pomo-sessions-actions" id="cmd-pomo-sessions-actions">
         <button class="cmd-pomo-add-btn" id="cmd-pomo-add-focus">+ Focus</button>
@@ -46,16 +46,16 @@
   <!-- Music player — pinned to bottom -->
   <div class="cmd-pomo-music" id="cmd-pomo-music">
     <div class="cmd-pomo-music-row">
-      <span class="cmd-pomo-music-icon">&#x266B;</span>
+      <span class="cmd-pomo-music-icon" id="cmd-pomo-music-icon"></span>
       <span class="cmd-pomo-music-track" id="cmd-pomo-music-track">Pick a folder to enable music</span>
       <div class="cmd-pomo-music-controls" id="cmd-pomo-music-controls" style="display:none">
-        <button class="cmd-pomo-music-btn" id="cmd-pomo-music-prev" title="Previous">&#x23EE;</button>
-        <button class="cmd-pomo-music-btn" id="cmd-pomo-music-toggle" title="Play/Pause">&#x25B6;</button>
-        <button class="cmd-pomo-music-btn" id="cmd-pomo-music-next" title="Next">&#x23ED;</button>
+        <button class="cmd-pomo-music-btn" id="cmd-pomo-music-prev" title="Previous"></button>
+        <button class="cmd-pomo-music-btn" id="cmd-pomo-music-toggle" title="Play/Pause"></button>
+        <button class="cmd-pomo-music-btn" id="cmd-pomo-music-next" title="Next"></button>
       </div>
     </div>
     <div class="cmd-pomo-music-row cmd-pomo-music-folder-row">
-      <span class="cmd-pomo-music-icon">&#x1F4C1;</span>
+      <span class="cmd-pomo-music-icon" id="cmd-pomo-folder-icon"></span>
       <span class="cmd-pomo-music-folder-path" id="cmd-pomo-music-folder-path"></span>
       <button class="cmd-pomo-music-folder-btn" id="cmd-pomo-music-choose">Choose…</button>
       <button class="cmd-pomo-music-folder-btn cmd-pomo-music-clear" id="cmd-pomo-music-clear" style="display:none">Clear</button>

--- a/apps/linows/src/html/screens/commands/shell.html
+++ b/apps/linows/src/html/screens/commands/shell.html
@@ -1,6 +1,6 @@
 <div class="cmd-panel" id="cmd-panel-shell" hidden>
   <div class="cmd-input-bar">
-    <span class="cmd-input-bar-icon">&#x25B8;</span>
+    <span class="cmd-input-bar-icon" id="cmd-shell-header-icon"></span>
     <input id="cmd-shell-input" type="text" placeholder="Type shell command..." spellcheck="false" autocomplete="off" />
     <span class="cmd-pill">/shell</span>
   </div>

--- a/apps/linows/src/html/screens/commands/sys.html
+++ b/apps/linows/src/html/screens/commands/sys.html
@@ -1,6 +1,6 @@
 <div class="cmd-panel" id="cmd-panel-sys" hidden>
   <div class="cmd-header-bar">
-    <span class="cmd-input-bar-icon">&#x24D8;</span>
+    <span class="cmd-input-bar-icon" id="cmd-sys-header-icon"></span>
     <span class="cmd-subtitle">Read-only command</span>
     <span class="cmd-pill">/sys</span>
   </div>

--- a/apps/linows/src/js/components/preview.js
+++ b/apps/linows/src/js/components/preview.js
@@ -1,4 +1,5 @@
 import { getIcon, getFileMeta, getAppVersion, deleteClipboardEntry } from '../ipc.js';
+import { clipboard as clipboardIcon, trash as trashIcon, appIcon, fileIcon, folderIcon, settingIcon } from '../icons.js';
 
 let panel = null;
 let currentPath = null;
@@ -38,7 +39,11 @@ export function update(result) {
 
   const iconWrap = document.createElement('div');
   iconWrap.className = 'preview-icon';
-  iconWrap.textContent = result.title.charAt(0).toUpperCase();
+  const isSettings = result.path?.startsWith('settings://') || result.subtitle?.toLowerCase().startsWith('settings');
+  const fallbacks = { file: fileIcon, folder: folderIcon, setting: settingIcon };
+  iconWrap.innerHTML = isSettings ? settingIcon : (fallbacks[result.kind] || appIcon);
+  iconWrap.style.background = 'var(--control-fill)';
+  iconWrap.style.color = 'var(--font-secondary)';
   header.appendChild(iconWrap);
 
   getIcon(result.kind, result.path, result.id).then((res) => {
@@ -46,8 +51,9 @@ export function update(result) {
       const img = document.createElement('img');
       img.src = res.data_url;
       img.alt = '';
-      iconWrap.textContent = '';
+      iconWrap.innerHTML = '';
       iconWrap.style.background = 'none';
+      iconWrap.style.color = '';
       iconWrap.appendChild(img);
     }
   });
@@ -92,9 +98,9 @@ function renderClipboardPreview(result) {
 
   const iconWrap = document.createElement('div');
   iconWrap.className = 'preview-icon';
-  iconWrap.textContent = '\u{1F4CB}';
-  iconWrap.style.fontSize = '22px';
+  iconWrap.innerHTML = clipboardIcon;
   iconWrap.style.background = 'var(--control-fill)';
+  iconWrap.style.color = 'var(--font-secondary)';
   header.appendChild(iconWrap);
 
   const headerText = document.createElement('div');
@@ -115,7 +121,7 @@ function renderClipboardPreview(result) {
   // Delete button
   const delBtn = document.createElement('button');
   delBtn.className = 'preview-clip-delete';
-  delBtn.innerHTML = '\u{1F5D1} Delete';
+  delBtn.innerHTML = trashIcon + ' Delete';
   delBtn.addEventListener('click', async () => {
     await deleteClipboardEntry(result.clipIndex);
     if (onClipDelete) onClipDelete();

--- a/apps/linows/src/js/components/results.js
+++ b/apps/linows/src/js/components/results.js
@@ -1,4 +1,5 @@
 import { getIcon } from '../ipc.js';
+import { clipboard as clipboardIcon, check as checkIcon, appIcon, fileIcon, folderIcon, settingIcon } from '../icons.js';
 
 const iconCache = new Map();
 const pickedMap = new Map(); // key → result
@@ -129,7 +130,7 @@ function updatePickedIndicators() {
       if (!check) {
         const el = document.createElement('div');
         el.className = 'pick-check';
-        el.innerHTML = '&#10003;';
+        el.innerHTML = checkIcon;
         row.appendChild(el);
       }
     } else if (check) {
@@ -145,17 +146,17 @@ function createRow(result, index) {
   row.className = 'result-row';
   row.dataset.index = index;
 
-  // Icon (first letter fallback, async-load real icon)
+  // Icon (kind-based SVG fallback, async-load real icon)
   const icon = document.createElement('div');
   icon.className = 'result-icon';
-  icon.textContent = result.title.charAt(0).toUpperCase();
+  const isSettings = result.path?.startsWith('settings://') || result.subtitle?.toLowerCase().startsWith('settings');
+  const fallbacks = { file: fileIcon, folder: folderIcon, setting: settingIcon, clipboard: clipboardIcon };
+  icon.innerHTML = isSettings ? settingIcon : (fallbacks[result.kind] || appIcon);
+  icon.style.background = 'var(--control-fill)';
+  icon.style.color = 'var(--font-secondary)';
   row.appendChild(icon);
 
-  if (result.kind === 'clipboard') {
-    icon.textContent = '\u{1F4CB}';
-    icon.style.fontSize = '16px';
-    icon.style.background = 'var(--control-fill)';
-  } else {
+  if (result.kind !== 'clipboard') {
     loadIcon(icon, result.kind, result.path, result.id);
   }
 
@@ -188,7 +189,7 @@ function createRow(result, index) {
   if (pickedMap.has(pickKey(result))) {
     const el = document.createElement('div');
     el.className = 'pick-check';
-    el.innerHTML = '&#10003;';
+    el.innerHTML = checkIcon;
     row.appendChild(el);
   }
 

--- a/apps/linows/src/js/components/translate.js
+++ b/apps/linows/src/js/components/translate.js
@@ -1,4 +1,5 @@
 import { translate, copyToClipboard } from '../ipc.js';
+import { globeLg, copy as copyIcon, link as linkIcon, externalLink } from '../icons.js';
 
 const LANGUAGES = [
   { code: 'vi', label: 'TIẾNG VIỆT' },
@@ -24,7 +25,7 @@ export function showPlaceholder() {
   panel.className = 'translate-panel';
   const placeholder = document.createElement('div');
   placeholder.className = 'translate-placeholder';
-  placeholder.innerHTML = '<div class="translate-placeholder-icon">\u{1F310}</div>' +
+  placeholder.innerHTML = '<div class="translate-placeholder-icon">' + globeLg + '</div>' +
     '<div class="translate-placeholder-text">Press Enter after finishing input to translate on web</div>';
   panel.appendChild(placeholder);
   container.appendChild(panel);
@@ -83,7 +84,7 @@ export async function perform(text) {
     const copyBtn = document.createElement('button');
     copyBtn.className = 'translate-icon-btn';
     copyBtn.title = 'Copy';
-    copyBtn.innerHTML = '\u{1F4CB}';
+    copyBtn.innerHTML = copyIcon;
     copyBtn.disabled = true;
     actions.appendChild(copyBtn);
 
@@ -107,9 +108,9 @@ export async function perform(text) {
     window.__TAURI__.core.invoke('open_path', { path: url, kind: 'browser', id: '' });
   });
   footer.innerHTML =
-    '<span class="translate-footer-icon">\u{1F517}</span>' +
+    '<span class="translate-footer-icon">' + linkIcon + '</span>' +
     '<span class="translate-footer-text">Open in Browser</span>' +
-    '<span class="translate-footer-arrow">\u2197</span>';
+    '<span class="translate-footer-arrow">' + externalLink + '</span>';
   panel.appendChild(footer);
 
   // Translate all 3 in parallel

--- a/apps/linows/src/js/icons.js
+++ b/apps/linows/src/js/icons.js
@@ -1,0 +1,44 @@
+// Lucide-based inline SVG icons (MIT license)
+// Only the icons we need, ~200-400 bytes each
+
+const s = (d, size = 16) =>
+  `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">${d}</svg>`;
+
+// Command sidebar
+export const calculator = s('<rect x="4" y="2" width="16" height="20" rx="2"/><line x1="8" y1="6" x2="16" y2="6"/><line x1="16" y1="14" x2="16" y2="18"/><line x1="8" y1="14" x2="8" y2="14.01"/><line x1="12" y1="14" x2="12" y2="14.01"/><line x1="8" y1="18" x2="8" y2="18.01"/><line x1="12" y1="18" x2="12" y2="18.01"/>');
+export const timer = s('<circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>');
+export const xCircle = s('<circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/>');
+export const terminal = s('<polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/>');
+export const info = s('<circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/>');
+
+// Music player
+export const play = s('<polygon points="5 3 19 12 5 21 5 3"/>');
+export const pause = s('<rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/>');
+export const skipBack = s('<polygon points="19 20 9 12 19 4 19 20"/><line x1="5" y1="19" x2="5" y2="5"/>');
+export const skipForward = s('<polygon points="5 4 15 12 5 20 5 4"/><line x1="19" y1="5" x2="19" y2="19"/>');
+export const music = s('<path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/>');
+export const folder = s('<path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>');
+export const settings = s('<circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/>');
+
+// Clipboard & content
+export const clipboard = s('<path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/><rect x="8" y="2" width="8" height="4" rx="1" ry="1"/>');
+export const trash = s('<polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/>');
+export const copy = s('<rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>');
+export const check = s('<polyline points="20 6 9 17 4 12"/>');
+
+// Translate
+export const globe = s('<circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>');
+export const externalLink = s('<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/>');
+export const link = s('<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>');
+
+// Fallback result icons
+export const appIcon = s('<rect x="2" y="2" width="20" height="20" rx="5"/><circle cx="12" cy="12" r="1"/>');
+export const fileIcon = s('<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/>');
+export const folderIcon = s('<path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>');
+export const settingIcon = s('<circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/>');
+
+// Navigation
+export const chevronRight = s('<polyline points="9 18 15 12 9 6"/>');
+
+// Sized variants
+export const globeLg = s('<circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>', 36);

--- a/apps/linows/src/js/screens/commands/index.js
+++ b/apps/linows/src/js/screens/commands/index.js
@@ -3,13 +3,14 @@ import * as pomo from './pomo.js';
 import * as kill from './kill.js';
 import * as shell from './shell.js';
 import * as sys from './sys.js';
+import { calculator, timer, xCircle, terminal, info } from '../../icons.js';
 
 const COMMANDS = [
-  { id: 'calc', label: '/calc', shortcut: '1', detail: 'Evaluate math...', icon: 'f(x)', module: calc },
-  { id: 'pomo', label: '/pomo', shortcut: '2', detail: 'Pomodoro focus...', icon: '\u23F1', module: pomo },
-  { id: 'kill', label: '/kill', shortcut: '3', detail: 'Force kill app...', icon: '\u2718', module: kill },
-  { id: 'shell', label: '/shell', shortcut: '4', detail: 'Run a shell co...', icon: '\u25B8', module: shell },
-  { id: 'sys', label: '/sys', shortcut: '5', detail: 'Show system in...', icon: '\u24D8', module: sys },
+  { id: 'calc', label: '/calc', shortcut: '1', detail: 'Evaluate math...', icon: calculator, module: calc },
+  { id: 'pomo', label: '/pomo', shortcut: '2', detail: 'Pomodoro focus...', icon: timer, module: pomo },
+  { id: 'kill', label: '/kill', shortcut: '3', detail: 'Force kill app...', icon: xCircle, module: kill },
+  { id: 'shell', label: '/shell', shortcut: '4', detail: 'Run a shell co...', icon: terminal, module: shell },
+  { id: 'sys', label: '/sys', shortcut: '5', detail: 'Show system in...', icon: info, module: sys },
 ];
 
 let screen = null;
@@ -37,6 +38,12 @@ export function init(contentAreaEl, inputEl, { onExitMode, onExecuteCommand, onG
   kill.init(onExecuteCommand, onGetIcon);
   shell.init(onExecuteCommand);
   sys.init(onExecuteCommand);
+
+  // Set header bar icons
+  document.getElementById('cmd-calc-header-icon').innerHTML = calculator;
+  document.getElementById('cmd-kill-header-icon').innerHTML = xCircle;
+  document.getElementById('cmd-shell-header-icon').innerHTML = terminal;
+  document.getElementById('cmd-sys-header-icon').innerHTML = info;
 
   buildSidebar();
 }

--- a/apps/linows/src/js/screens/commands/pomo.js
+++ b/apps/linows/src/js/screens/commands/pomo.js
@@ -3,6 +3,7 @@ import {
   musicPlay as ipcPlay, musicPauseBackend, musicResumeBackend,
   musicStopBackend, musicIsFinished,
 } from '../../ipc.js';
+import { timer, settings, chevronRight, music, folder, play, pause, skipBack, skipForward } from '../../icons.js';
 
 // --- Default sessions ---
 const DEFAULT_SESSIONS = [
@@ -133,6 +134,16 @@ export function init() {
   // Restore saved music folder
   const savedFolder = localStorage.getItem(STORAGE_KEY_MUSIC_FOLDER);
   if (savedFolder) musicRestoreFolder(savedFolder);
+
+  // Set SVG icons
+  document.getElementById('cmd-pomo-header-icon').innerHTML = timer;
+  settingsBtn.innerHTML = settings;
+  chevronEl.innerHTML = chevronRight;
+  document.getElementById('cmd-pomo-music-icon').innerHTML = music;
+  document.getElementById('cmd-pomo-folder-icon').innerHTML = folder;
+  document.getElementById('cmd-pomo-music-prev').innerHTML = skipBack;
+  document.getElementById('cmd-pomo-music-next').innerHTML = skipForward;
+  musicToggleBtn.innerHTML = play;
 
   // Idle restore events
   panel.addEventListener('click', restoreFromIdle);
@@ -784,12 +795,12 @@ function updateMusicUI() {
 
   if (musicPlaying && musicIndex >= 0) {
     musicTrackEl.textContent = trackName(musicTracks[musicIndex]);
-    musicToggleBtn.innerHTML = '&#x23F8;'; // pause
+    musicToggleBtn.innerHTML = pause;
   } else if (musicIndex >= 0) {
     musicTrackEl.textContent = trackName(musicTracks[musicIndex]);
-    musicToggleBtn.innerHTML = '&#x25B6;'; // play
+    musicToggleBtn.innerHTML = play;
   } else {
     musicTrackEl.textContent = '(press play)';
-    musicToggleBtn.innerHTML = '&#x25B6;';
+    musicToggleBtn.innerHTML = play;
   }
 }


### PR DESCRIPTION
## Summary

- Linux (minimal nixos, ... ) icons aren't fit with our needs...  -> We use lucide icons

## Why

- #117 

## Changes

-

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
