### PR TITLE
Feat: Gnome x11

### DIFF
--- a/apps/linows/README.md
+++ b/apps/linows/README.md
@@ -48,6 +48,15 @@ The WinUI3 app remains in `apps/windows/` (bug fixes only) until this migration 
 - Folder picker via `tauri-plugin-dialog` — cross-platform native dialogs
 - Tauri v2 capabilities in `capabilities/default.json` for event/dialog permissions
 
+## Linux Desktop Environments
+
+| Environment    | Status    |
+|----------------|-----------|
+| GNOME Xorg     | Testing   |
+| i3 X11         | Testing   |
+| GNOME Wayland  | Untested  |
+| Sway           | Untested  |
+
 ## Build
 
 ```bash

--- a/apps/linows/src-tauri/Cargo.lock
+++ b/apps/linows/src-tauri/Cargo.lock
@@ -96,6 +96,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "as-raw-xcb-connection"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,6 +2445,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-single-instance",
+ "x11rb",
 ]
 
 [[package]]
@@ -6021,7 +6028,9 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
+ "as-raw-xcb-connection",
  "gethostname",
+ "libc",
  "rustix",
  "x11rb-protocol",
 ]

--- a/apps/linows/src-tauri/Cargo.toml
+++ b/apps/linows/src-tauri/Cargo.toml
@@ -21,6 +21,9 @@ arboard = "3"
 dirs = "6"
 tauri-plugin-dialog = "2"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+x11rb = { version = "0.13", features = ["allow-unsafe-code"] }
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 

--- a/apps/linows/src-tauri/Cargo.toml
+++ b/apps/linows/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 license = "MIT"
 
 [dependencies]
-tauri = { version = "2", features = ["tray-icon", "devtools", "protocol-asset"] }
+tauri = { version = "2", features = ["tray-icon", "protocol-asset"] }
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-single-instance = "2"
 look-engine = { path = "../../../core/engine" }
@@ -29,3 +29,11 @@ tauri-build = { version = "2", features = [] }
 
 [features]
 custom-protocol = ["tauri/custom-protocol"]
+devtools = ["tauri/devtools"]
+
+[profile.release]
+strip = true
+lto = true
+codegen-units = 1
+opt-level = "s"
+panic = "abort"

--- a/apps/linows/src-tauri/src/commands.rs
+++ b/apps/linows/src-tauri/src/commands.rs
@@ -103,10 +103,14 @@ pub fn open_path(
             // D-Bus activation: works on GNOME, properly focuses the window.
             let dbus_ok = std::process::Command::new("gdbus")
                 .args([
-                    "call", "--session",
-                    "--dest", "org.gnome.Settings",
-                    "--object-path", "/org/gnome/Settings",
-                    "--method", "org.freedesktop.Application.ActivateAction",
+                    "call",
+                    "--session",
+                    "--dest",
+                    "org.gnome.Settings",
+                    "--object-path",
+                    "/org/gnome/Settings",
+                    "--method",
+                    "org.freedesktop.Application.ActivateAction",
                     "launch-panel",
                     &format!("[<'{panel}'>, <@av []>]"),
                     "{}",

--- a/apps/linows/src-tauri/src/commands.rs
+++ b/apps/linows/src-tauri/src/commands.rs
@@ -155,19 +155,23 @@ pub fn open_path(
     } else {
         let _ = window.hide();
         std::thread::spawn(move || {
-            // Clear LD_LIBRARY_PATH so child processes use system libraries.
-            // On NixOS, the Tauri dev shell may set paths that conflict with
-            // system apps (glibc version mismatch).
-            // Clear LD_LIBRARY_PATH so child processes use system libraries.
-            // On NixOS, the Tauri dev shell may set paths that conflict with
-            // system apps (glibc version mismatch).
-            let _ = std::process::Command::new("xdg-open")
-                .arg(&path)
-                .env_remove("LD_LIBRARY_PATH")
-                .stdin(std::process::Stdio::null())
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .spawn();
+            #[cfg(target_os = "linux")]
+            {
+                // Clear LD_LIBRARY_PATH so child processes use system libraries.
+                // On NixOS, the Tauri dev shell may set paths that conflict with
+                // system apps (glibc version mismatch).
+                let _ = std::process::Command::new("xdg-open")
+                    .arg(&path)
+                    .env_remove("LD_LIBRARY_PATH")
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .spawn();
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                let _ = open::that(&path);
+            }
         });
         Ok(())
     }

--- a/apps/linows/src-tauri/src/commands.rs
+++ b/apps/linows/src-tauri/src/commands.rs
@@ -94,6 +94,43 @@ pub fn open_path(
     kind: Option<String>,
     id: Option<String>,
 ) -> Result<(), String> {
+    // Linux system settings: settings://panel → gnome-control-center panel
+    #[cfg(target_os = "linux")]
+    if let Some(panel) = path.strip_prefix("settings://") {
+        let _ = window.hide();
+        let panel = panel.to_string();
+        std::thread::spawn(move || {
+            // D-Bus activation: works on GNOME, properly focuses the window.
+            let dbus_ok = std::process::Command::new("gdbus")
+                .args([
+                    "call", "--session",
+                    "--dest", "org.gnome.Settings",
+                    "--object-path", "/org/gnome/Settings",
+                    "--method", "org.freedesktop.Application.ActivateAction",
+                    "launch-panel",
+                    &format!("[<'{panel}'>, <@av []>]"),
+                    "{}",
+                ])
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false);
+
+            // Fallback: direct command (KDE, non-GNOME desktops)
+            if !dbus_ok {
+                let _ = std::process::Command::new("gnome-control-center")
+                    .arg(&panel)
+                    .stdin(std::process::Stdio::null())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .spawn();
+            }
+        });
+        return Ok(());
+    }
+
     if kind.as_deref() == Some("app") && !path.contains("://") {
         let result = launch_app(&path, id.as_deref());
         if result.is_ok() {
@@ -250,6 +287,7 @@ fn launch_app(exec: &str, id: Option<&str>) -> Result<(), String> {
 }
 
 fn try_focus_window(wm_class: &str) -> bool {
+    // i3 window manager
     if let Ok(output) = std::process::Command::new("i3-msg")
         .arg(format!("[class=\"(?i){wm_class}\"] focus"))
         .stdout(std::process::Stdio::piped())
@@ -262,21 +300,10 @@ fn try_focus_window(wm_class: &str) -> bool {
         }
     }
 
-    if let Ok(output) = std::process::Command::new("xdotool")
-        .args(["search", "--class", wm_class])
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
-        .output()
-    {
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        if let Some(wid) = stdout.lines().next() {
-            let _ = std::process::Command::new("xdotool")
-                .args(["windowactivate", wid])
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .spawn();
-            return true;
-        }
+    // Linux: xdotool → wmctrl → xprop (covers GNOME, KDE, NixOS, etc.)
+    #[cfg(target_os = "linux")]
+    if crate::linux_window_focus::try_focus(wm_class) {
+        return true;
     }
 
     false

--- a/apps/linows/src-tauri/src/commands.rs
+++ b/apps/linows/src-tauri/src/commands.rs
@@ -151,7 +151,19 @@ pub fn open_path(
     } else {
         let _ = window.hide();
         std::thread::spawn(move || {
-            let _ = open::that(&path);
+            // Clear LD_LIBRARY_PATH so child processes use system libraries.
+            // On NixOS, the Tauri dev shell may set paths that conflict with
+            // system apps (glibc version mismatch).
+            // Clear LD_LIBRARY_PATH so child processes use system libraries.
+            // On NixOS, the Tauri dev shell may set paths that conflict with
+            // system apps (glibc version mismatch).
+            let _ = std::process::Command::new("xdg-open")
+                .arg(&path)
+                .env_remove("LD_LIBRARY_PATH")
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn();
         });
         Ok(())
     }

--- a/apps/linows/src-tauri/src/linux_transparency.rs
+++ b/apps/linows/src-tauri/src/linux_transparency.rs
@@ -22,7 +22,7 @@ pub fn has_compositor() -> bool {
 /// and non-systemd setups) and `XDG_SESSION_TYPE`.
 #[cfg(target_os = "linux")]
 pub fn is_wayland() -> bool {
-    if std::env::var("WAYLAND_DISPLAY").map_or(false, |v| !v.is_empty()) {
+    if std::env::var("WAYLAND_DISPLAY").is_ok_and(|v| !v.is_empty()) {
         return true;
     }
     std::env::var("XDG_SESSION_TYPE")

--- a/apps/linows/src-tauri/src/linux_transparency.rs
+++ b/apps/linows/src-tauri/src/linux_transparency.rs
@@ -1,0 +1,80 @@
+//! Linux-specific compositor and transparency detection.
+//!
+//! Centralises the logic so that both `main.rs` (startup) and `platform.rs`
+//! (runtime query) share the same detection code.
+
+/// Returns `true` when the current Linux session has a compositor that can
+/// render transparent windows (RGBA visuals / alpha blending).
+#[cfg(target_os = "linux")]
+pub fn has_compositor() -> bool {
+    if is_wayland() {
+        return true;
+    }
+    // Desktop environments that always ship a compositor on X11
+    if desktop_has_builtin_compositor() {
+        return true;
+    }
+    // X11 with a standalone compositor (picom, compton, etc.)
+    x11_has_standalone_compositor()
+}
+
+/// Wayland detection – checks both `WAYLAND_DISPLAY` (more reliable on NixOS
+/// and non-systemd setups) and `XDG_SESSION_TYPE`.
+#[cfg(target_os = "linux")]
+pub fn is_wayland() -> bool {
+    if std::env::var("WAYLAND_DISPLAY").map_or(false, |v| !v.is_empty()) {
+        return true;
+    }
+    std::env::var("XDG_SESSION_TYPE")
+        .map(|v| v == "wayland")
+        .unwrap_or(false)
+}
+
+/// Desktop environments that embed a compositor (GNOME→mutter, KDE→kwin,
+/// Cinnamon→muffin, Deepin→kwin, Budgie→mutter, COSMIC, Pantheon→gala).
+/// Detected via `XDG_CURRENT_DESKTOP` which is set reliably on all distros.
+#[cfg(target_os = "linux")]
+fn desktop_has_builtin_compositor() -> bool {
+    const COMPOSITED_DESKTOPS: &[&str] = &[
+        "GNOME",
+        "KDE",
+        "Cinnamon",
+        "Deepin",
+        "Budgie",
+        "COSMIC",
+        "Pantheon",
+    ];
+
+    let desktop = match std::env::var("XDG_CURRENT_DESKTOP") {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+
+    // XDG_CURRENT_DESKTOP can be colon-separated (e.g. "ubuntu:GNOME")
+    desktop.split(':').any(|segment| {
+        let s = segment.trim();
+        COMPOSITED_DESKTOPS.iter().any(|&d| s.eq_ignore_ascii_case(d))
+    })
+}
+
+/// Scan for standalone X11 compositors via `pgrep -f` (matches against the
+/// full command line). This works on NixOS where process names are wrapped
+/// and `pgrep -x` fails to match.
+#[cfg(target_os = "linux")]
+fn x11_has_standalone_compositor() -> bool {
+    const COMPOSITORS: &[&str] = &[
+        "picom", "compton", "compiz", "xfwm4", "marco",
+    ];
+
+    for name in COMPOSITORS {
+        let ok = std::process::Command::new("pgrep")
+            .args(["-f", name])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if ok {
+            return true;
+        }
+    }
+    false
+}

--- a/apps/linows/src-tauri/src/linux_transparency.rs
+++ b/apps/linows/src-tauri/src/linux_transparency.rs
@@ -36,13 +36,7 @@ pub fn is_wayland() -> bool {
 #[cfg(target_os = "linux")]
 fn desktop_has_builtin_compositor() -> bool {
     const COMPOSITED_DESKTOPS: &[&str] = &[
-        "GNOME",
-        "KDE",
-        "Cinnamon",
-        "Deepin",
-        "Budgie",
-        "COSMIC",
-        "Pantheon",
+        "GNOME", "KDE", "Cinnamon", "Deepin", "Budgie", "COSMIC", "Pantheon",
     ];
 
     let desktop = match std::env::var("XDG_CURRENT_DESKTOP") {
@@ -53,7 +47,9 @@ fn desktop_has_builtin_compositor() -> bool {
     // XDG_CURRENT_DESKTOP can be colon-separated (e.g. "ubuntu:GNOME")
     desktop.split(':').any(|segment| {
         let s = segment.trim();
-        COMPOSITED_DESKTOPS.iter().any(|&d| s.eq_ignore_ascii_case(d))
+        COMPOSITED_DESKTOPS
+            .iter()
+            .any(|&d| s.eq_ignore_ascii_case(d))
     })
 }
 
@@ -62,9 +58,7 @@ fn desktop_has_builtin_compositor() -> bool {
 /// and `pgrep -x` fails to match.
 #[cfg(target_os = "linux")]
 fn x11_has_standalone_compositor() -> bool {
-    const COMPOSITORS: &[&str] = &[
-        "picom", "compton", "compiz", "xfwm4", "marco",
-    ];
+    const COMPOSITORS: &[&str] = &["picom", "compton", "compiz", "xfwm4", "marco"];
 
     for name in COMPOSITORS {
         let ok = std::process::Command::new("pgrep")

--- a/apps/linows/src-tauri/src/linux_window_focus.rs
+++ b/apps/linows/src-tauri/src/linux_window_focus.rs
@@ -90,7 +90,12 @@ fn find_window_by_class(wm_class: &str) -> Option<u32> {
 }
 
 fn get_client_list(conn: &impl Connection, root: Window) -> Option<Vec<Window>> {
-    let atom = conn.intern_atom(false, b"_NET_CLIENT_LIST").ok()?.reply().ok()?.atom;
+    let atom = conn
+        .intern_atom(false, b"_NET_CLIENT_LIST")
+        .ok()?
+        .reply()
+        .ok()?
+        .atom;
     let reply = conn
         .get_property(false, root, atom, AtomEnum::WINDOW, 0, 1024)
         .ok()?
@@ -107,14 +112,24 @@ fn wm_class_matches(conn: &impl Connection, wid: Window, target: &str) -> bool {
     let Ok(reply) = cookie.reply() else {
         return false;
     };
-    String::from_utf8_lossy(&reply.value).to_lowercase().contains(target)
+    String::from_utf8_lossy(&reply.value)
+        .to_lowercase()
+        .contains(target)
 }
 
 fn bump_user_time(conn: &impl Connection, root: Window, our_wid: Window) {
-    let Ok(time_cookie) = conn.intern_atom(false, b"_NET_WM_USER_TIME") else { return };
-    let Ok(time_atom) = time_cookie.reply() else { return };
-    let Ok(active_cookie) = conn.intern_atom(false, b"_NET_ACTIVE_WINDOW") else { return };
-    let Ok(active_atom) = active_cookie.reply() else { return };
+    let Ok(time_cookie) = conn.intern_atom(false, b"_NET_WM_USER_TIME") else {
+        return;
+    };
+    let Ok(time_atom) = time_cookie.reply() else {
+        return;
+    };
+    let Ok(active_cookie) = conn.intern_atom(false, b"_NET_ACTIVE_WINDOW") else {
+        return;
+    };
+    let Ok(active_atom) = active_cookie.reply() else {
+        return;
+    };
 
     let active_wid = conn
         .get_property(false, root, active_atom.atom, AtomEnum::WINDOW, 0, 1)
@@ -147,8 +162,12 @@ fn bump_user_time(conn: &impl Connection, root: Window, our_wid: Window) {
 }
 
 fn activate_window(conn: &impl Connection, root: Window, wid: Window) -> bool {
-    let Ok(cookie) = conn.intern_atom(false, b"_NET_ACTIVE_WINDOW") else { return false };
-    let Ok(atom) = cookie.reply() else { return false };
+    let Ok(cookie) = conn.intern_atom(false, b"_NET_ACTIVE_WINDOW") else {
+        return false;
+    };
+    let Ok(atom) = cookie.reply() else {
+        return false;
+    };
 
     let event = ClientMessageEvent::new(32, wid, atom.atom, [2u32, 0, 0, 0, 0]);
     let mask = EventMask::SUBSTRUCTURE_REDIRECT | EventMask::SUBSTRUCTURE_NOTIFY;
@@ -194,8 +213,12 @@ where
         );
         let _ = conn.flush();
 
-        let Ok(active_cookie) = conn.intern_atom(false, b"_NET_ACTIVE_WINDOW") else { return };
-        let Ok(active_atom) = active_cookie.reply() else { return };
+        let Ok(active_cookie) = conn.intern_atom(false, b"_NET_ACTIVE_WINDOW") else {
+            return;
+        };
+        let Ok(active_atom) = active_cookie.reply() else {
+            return;
+        };
 
         loop {
             // Process any pending X11 events

--- a/apps/linows/src-tauri/src/linux_window_focus.rs
+++ b/apps/linows/src-tauri/src/linux_window_focus.rs
@@ -4,19 +4,43 @@
 //! `_NET_ACTIVE_WINDOW` client message to the window manager.
 //! Works on GNOME, KDE, and any EWMH-compliant WM — including NixOS
 //! where `xdotool` / `wmctrl` are typically not installed.
+//!
+//! Also provides a background monitor that:
+//! - Retries focus activation after show (handles GNOME's async mapping)
+//! - Auto-hides Look when another window becomes active
 
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use x11rb::connection::Connection;
 use x11rb::protocol::xproto::*;
 
 /// Cached X11 window ID for Look's own window, resolved once at startup.
 static SELF_WID: AtomicU32 = AtomicU32::new(0);
 
+/// Set to true when Look is shown and needs focus.
+/// The monitor thread will retry activation until focus is granted.
+static NEEDS_FOCUS: AtomicBool = AtomicBool::new(false);
+
+/// Set to true once Look has confirmed focus (via _NET_ACTIVE_WINDOW).
+/// Auto-hide only fires when this transitions from true → false.
+static HAS_FOCUS: AtomicBool = AtomicBool::new(false);
+
 /// Call once after the window is mapped to cache Look's X11 window ID.
 pub fn cache_self_window() {
     if let Some(wid) = find_window_by_class("look-desktop") {
-        SELF_WID.store(wid, Ordering::Relaxed);
+        SELF_WID.store(wid, Ordering::SeqCst);
     }
+}
+
+/// Notify that Look was just shown and needs focus activation.
+pub fn notify_shown() {
+    HAS_FOCUS.store(false, Ordering::SeqCst);
+    NEEDS_FOCUS.store(true, Ordering::SeqCst);
+}
+
+/// Notify that Look was hidden (cancel any pending focus retry).
+pub fn notify_hidden() {
+    NEEDS_FOCUS.store(false, Ordering::SeqCst);
+    HAS_FOCUS.store(false, Ordering::SeqCst);
 }
 
 /// Activate Look's own window, bypassing Mutter's focus-stealing prevention
@@ -32,10 +56,7 @@ pub fn activate_self() -> bool {
     };
     let root = conn.setup().roots[screen_num].root;
 
-    // Bypass focus-stealing prevention: set our _NET_WM_USER_TIME
-    // to be newer than the currently focused window's timestamp.
     bump_user_time(&conn, root, wid);
-
     activate_window(&conn, root, wid)
 }
 
@@ -89,17 +110,12 @@ fn wm_class_matches(conn: &impl Connection, wid: Window, target: &str) -> bool {
     String::from_utf8_lossy(&reply.value).to_lowercase().contains(target)
 }
 
-/// Read _NET_WM_USER_TIME from the currently active window and set ours
-/// to that value + 1.  This convinces Mutter that our window has had more
-/// recent user activity than the focused window, bypassing focus-stealing
-/// prevention.
 fn bump_user_time(conn: &impl Connection, root: Window, our_wid: Window) {
     let Ok(time_cookie) = conn.intern_atom(false, b"_NET_WM_USER_TIME") else { return };
     let Ok(time_atom) = time_cookie.reply() else { return };
     let Ok(active_cookie) = conn.intern_atom(false, b"_NET_ACTIVE_WINDOW") else { return };
     let Ok(active_atom) = active_cookie.reply() else { return };
 
-    // Get the currently active window
     let active_wid = conn
         .get_property(false, root, active_atom.atom, AtomEnum::WINDOW, 0, 1)
         .ok()
@@ -107,7 +123,6 @@ fn bump_user_time(conn: &impl Connection, root: Window, our_wid: Window) {
         .and_then(|r| r.value32().and_then(|mut v| v.next()))
         .unwrap_or(0);
 
-    // Read its _NET_WM_USER_TIME
     let their_time = if active_wid != 0 {
         conn.get_property(false, active_wid, time_atom.atom, AtomEnum::CARDINAL, 0, 1)
             .ok()
@@ -118,7 +133,6 @@ fn bump_user_time(conn: &impl Connection, root: Window, our_wid: Window) {
         1
     };
 
-    // Set our timestamp to theirs + 1
     let our_time = their_time.wrapping_add(1);
     let _ = conn.change_property(
         PropMode::REPLACE,
@@ -139,6 +153,94 @@ fn activate_window(conn: &impl Connection, root: Window, wid: Window) -> bool {
     let event = ClientMessageEvent::new(32, wid, atom.atom, [2u32, 0, 0, 0, 0]);
     let mask = EventMask::SUBSTRUCTURE_REDIRECT | EventMask::SUBSTRUCTURE_NOTIFY;
     let _ = conn.send_event(false, root, mask, event);
+    let _ = conn.set_input_focus(InputFocus::PARENT, wid, x11rb::CURRENT_TIME);
     let _ = conn.flush();
     true
+}
+
+fn read_active_window(conn: &impl Connection, root: Window, atom: Atom) -> u32 {
+    conn.get_property(false, root, atom, AtomEnum::WINDOW, 0, 1)
+        .ok()
+        .and_then(|c| c.reply().ok())
+        .and_then(|r| r.value32().and_then(|mut v| v.next()))
+        .unwrap_or(0)
+}
+
+// --- Active window monitor ---
+
+static MONITOR_RUNNING: AtomicBool = AtomicBool::new(false);
+
+/// Start a background thread that:
+/// 1. Retries focus activation after show until focus is confirmed
+/// 2. Auto-hides Look when another window becomes active (focus lost)
+pub fn start_active_window_monitor<F>(on_lost_focus: F)
+where
+    F: Fn() + Send + 'static,
+{
+    if MONITOR_RUNNING.swap(true, Ordering::SeqCst) {
+        return;
+    }
+
+    std::thread::spawn(move || {
+        let Ok((conn, screen_num)) = x11rb::connect(None) else {
+            MONITOR_RUNNING.store(false, Ordering::SeqCst);
+            return;
+        };
+        let root = conn.setup().roots[screen_num].root;
+
+        let _ = conn.change_window_attributes(
+            root,
+            &ChangeWindowAttributesAux::new().event_mask(EventMask::PROPERTY_CHANGE),
+        );
+        let _ = conn.flush();
+
+        let Ok(active_cookie) = conn.intern_atom(false, b"_NET_ACTIVE_WINDOW") else { return };
+        let Ok(active_atom) = active_cookie.reply() else { return };
+
+        loop {
+            // Process any pending X11 events
+            while let Ok(Some(event)) = conn.poll_for_event() {
+                if let x11rb::protocol::Event::PropertyNotify(ev) = event {
+                    if ev.atom == active_atom.atom {
+                        handle_active_change(&conn, root, active_atom.atom, &on_lost_focus);
+                    }
+                }
+            }
+
+            // If Look was just shown and needs focus, retry activation
+            if NEEDS_FOCUS.load(Ordering::SeqCst) {
+                let our_wid = SELF_WID.load(Ordering::Relaxed);
+                let active = read_active_window(&conn, root, active_atom.atom);
+
+                if active == our_wid {
+                    // Focus confirmed — stop retrying
+                    NEEDS_FOCUS.store(false, Ordering::SeqCst);
+                    HAS_FOCUS.store(true, Ordering::SeqCst);
+                } else {
+                    // Retry activation
+                    bump_user_time(&conn, root, our_wid);
+                    activate_window(&conn, root, our_wid);
+                }
+            }
+
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+    });
+}
+
+fn handle_active_change<F>(conn: &impl Connection, root: Window, atom: Atom, on_lost_focus: &F)
+where
+    F: Fn(),
+{
+    let our_wid = SELF_WID.load(Ordering::Relaxed);
+    let active = read_active_window(conn, root, atom);
+
+    if active == our_wid {
+        // We gained focus
+        NEEDS_FOCUS.store(false, Ordering::SeqCst);
+        HAS_FOCUS.store(true, Ordering::SeqCst);
+    } else if active != 0 && HAS_FOCUS.swap(false, Ordering::SeqCst) {
+        // We HAD focus and now lost it — auto-hide
+        on_lost_focus();
+    }
 }

--- a/apps/linows/src-tauri/src/linux_window_focus.rs
+++ b/apps/linows/src-tauri/src/linux_window_focus.rs
@@ -8,6 +8,9 @@
 //! Also provides a background monitor that:
 //! - Retries focus activation after show (handles GNOME's async mapping)
 //! - Auto-hides Look when another window becomes active
+//!
+//! Tested: GNOME Xorg, i3 X11.
+//! Not yet tested: GNOME Wayland (auto-hide disabled there; see TODO in main.rs).
 
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use x11rb::connection::Connection;
@@ -81,12 +84,9 @@ fn find_window_by_class(wm_class: &str) -> Option<u32> {
     let target = wm_class.to_lowercase();
 
     let windows = get_client_list(&conn, root)?;
-    for wid in windows {
-        if wm_class_matches(&conn, wid, &target) {
-            return Some(wid);
-        }
-    }
-    None
+    windows
+        .into_iter()
+        .find(|&wid| wm_class_matches(&conn, wid, &target))
 }
 
 fn get_client_list(conn: &impl Connection, root: Window) -> Option<Vec<Window>> {
@@ -189,6 +189,20 @@ fn read_active_window(conn: &impl Connection, root: Window, atom: Atom) -> u32 {
 
 static MONITOR_RUNNING: AtomicBool = AtomicBool::new(false);
 
+/// Returns true for WMs that use focus-follows-mouse (i3, sway, etc.)
+/// where auto-hide on focus loss would fight the WM's focus policy.
+fn is_focus_follows_mouse_wm() -> bool {
+    // I3SOCK is always set when running under i3
+    if std::env::var("I3SOCK").is_ok() {
+        return true;
+    }
+    // SWAYSOCK for sway
+    if std::env::var("SWAYSOCK").is_ok() {
+        return true;
+    }
+    false
+}
+
 /// Start a background thread that:
 /// 1. Retries focus activation after show until focus is confirmed
 /// 2. Auto-hides Look when another window becomes active (focus lost)
@@ -206,6 +220,7 @@ where
             return;
         };
         let root = conn.setup().roots[screen_num].root;
+        let skip_auto_hide = is_focus_follows_mouse_wm();
 
         let _ = conn.change_window_attributes(
             root,
@@ -223,10 +238,16 @@ where
         loop {
             // Process any pending X11 events
             while let Ok(Some(event)) = conn.poll_for_event() {
-                if let x11rb::protocol::Event::PropertyNotify(ev) = event {
-                    if ev.atom == active_atom.atom {
-                        handle_active_change(&conn, root, active_atom.atom, &on_lost_focus);
-                    }
+                if let x11rb::protocol::Event::PropertyNotify(ev) = event
+                    && ev.atom == active_atom.atom
+                {
+                    handle_active_change(
+                        &conn,
+                        root,
+                        active_atom.atom,
+                        &on_lost_focus,
+                        skip_auto_hide,
+                    );
                 }
             }
 
@@ -251,8 +272,13 @@ where
     });
 }
 
-fn handle_active_change<F>(conn: &impl Connection, root: Window, atom: Atom, on_lost_focus: &F)
-where
+fn handle_active_change<F>(
+    conn: &impl Connection,
+    root: Window,
+    atom: Atom,
+    on_lost_focus: &F,
+    skip_auto_hide: bool,
+) where
     F: Fn(),
 {
     let our_wid = SELF_WID.load(Ordering::Relaxed);
@@ -263,7 +289,21 @@ where
         NEEDS_FOCUS.store(false, Ordering::SeqCst);
         HAS_FOCUS.store(true, Ordering::SeqCst);
     } else if active != 0 && HAS_FOCUS.swap(false, Ordering::SeqCst) {
-        // We HAD focus and now lost it — auto-hide
-        on_lost_focus();
+        // We HAD focus and now lost it — auto-hide.
+        if skip_auto_hide {
+            // On focus-follows-mouse WMs (i3, sway), only auto-hide when
+            // the user clicked outside (mouse button is still pressed).
+            // Moving the mouse away just changes focus passively.
+            let clicked = conn
+                .query_pointer(root)
+                .ok()
+                .and_then(|c| c.reply().ok())
+                .is_some_and(|r| u16::from(r.mask) & 0x700 != 0);
+            if clicked {
+                on_lost_focus();
+            }
+        } else {
+            on_lost_focus();
+        }
     }
 }

--- a/apps/linows/src-tauri/src/linux_window_focus.rs
+++ b/apps/linows/src-tauri/src/linux_window_focus.rs
@@ -189,6 +189,12 @@ fn read_active_window(conn: &impl Connection, root: Window, atom: Atom) -> u32 {
 
 static MONITOR_RUNNING: AtomicBool = AtomicBool::new(false);
 
+/// Returns true when the X11 active-window monitor is running.
+/// Used to skip Tauri's `Focused(false)` handler on X11 (unreliable on GNOME).
+pub fn is_monitor_running() -> bool {
+    MONITOR_RUNNING.load(Ordering::SeqCst)
+}
+
 /// Start a background thread that:
 /// 1. Retries focus activation after show until focus is confirmed
 /// 2. Auto-hides Look when another window becomes active (focus lost)

--- a/apps/linows/src-tauri/src/linux_window_focus.rs
+++ b/apps/linows/src-tauri/src/linux_window_focus.rs
@@ -189,12 +189,6 @@ fn read_active_window(conn: &impl Connection, root: Window, atom: Atom) -> u32 {
 
 static MONITOR_RUNNING: AtomicBool = AtomicBool::new(false);
 
-/// Returns true when the X11 active-window monitor is running.
-/// Used to skip Tauri's `Focused(false)` handler on X11 (unreliable on GNOME).
-pub fn is_monitor_running() -> bool {
-    MONITOR_RUNNING.load(Ordering::SeqCst)
-}
-
 /// Start a background thread that:
 /// 1. Retries focus activation after show until focus is confirmed
 /// 2. Auto-hides Look when another window becomes active (focus lost)

--- a/apps/linows/src-tauri/src/linux_window_focus.rs
+++ b/apps/linows/src-tauri/src/linux_window_focus.rs
@@ -1,0 +1,144 @@
+//! Linux-specific window focusing via X11.
+//!
+//! Uses `x11rb` to find windows by WM_CLASS and send a proper
+//! `_NET_ACTIVE_WINDOW` client message to the window manager.
+//! Works on GNOME, KDE, and any EWMH-compliant WM — including NixOS
+//! where `xdotool` / `wmctrl` are typically not installed.
+
+use std::sync::atomic::{AtomicU32, Ordering};
+use x11rb::connection::Connection;
+use x11rb::protocol::xproto::*;
+
+/// Cached X11 window ID for Look's own window, resolved once at startup.
+static SELF_WID: AtomicU32 = AtomicU32::new(0);
+
+/// Call once after the window is mapped to cache Look's X11 window ID.
+pub fn cache_self_window() {
+    if let Some(wid) = find_window_by_class("look-desktop") {
+        SELF_WID.store(wid, Ordering::Relaxed);
+    }
+}
+
+/// Activate Look's own window, bypassing Mutter's focus-stealing prevention
+/// by updating `_NET_WM_USER_TIME` before sending the activation request.
+pub fn activate_self() -> bool {
+    let wid = SELF_WID.load(Ordering::Relaxed);
+    if wid == 0 {
+        return false;
+    }
+
+    let Ok((conn, screen_num)) = x11rb::connect(None) else {
+        return false;
+    };
+    let root = conn.setup().roots[screen_num].root;
+
+    // Bypass focus-stealing prevention: set our _NET_WM_USER_TIME
+    // to be newer than the currently focused window's timestamp.
+    bump_user_time(&conn, root, wid);
+
+    activate_window(&conn, root, wid)
+}
+
+/// Try to focus an existing window whose `WM_CLASS` matches `wm_class`.
+pub fn try_focus(wm_class: &str) -> bool {
+    let Some(wid) = find_window_by_class(wm_class) else {
+        return false;
+    };
+
+    let Ok((conn, screen_num)) = x11rb::connect(None) else {
+        return false;
+    };
+    let root = conn.setup().roots[screen_num].root;
+    activate_window(&conn, root, wid)
+}
+
+// --- internals ---
+
+fn find_window_by_class(wm_class: &str) -> Option<u32> {
+    let (conn, screen_num) = x11rb::connect(None).ok()?;
+    let root = conn.setup().roots[screen_num].root;
+    let target = wm_class.to_lowercase();
+
+    let windows = get_client_list(&conn, root)?;
+    for wid in windows {
+        if wm_class_matches(&conn, wid, &target) {
+            return Some(wid);
+        }
+    }
+    None
+}
+
+fn get_client_list(conn: &impl Connection, root: Window) -> Option<Vec<Window>> {
+    let atom = conn.intern_atom(false, b"_NET_CLIENT_LIST").ok()?.reply().ok()?.atom;
+    let reply = conn
+        .get_property(false, root, atom, AtomEnum::WINDOW, 0, 1024)
+        .ok()?
+        .reply()
+        .ok()?;
+    Some(reply.value32()?.collect())
+}
+
+fn wm_class_matches(conn: &impl Connection, wid: Window, target: &str) -> bool {
+    let Ok(cookie) = conn.get_property(false, wid, AtomEnum::WM_CLASS, AtomEnum::STRING, 0, 256)
+    else {
+        return false;
+    };
+    let Ok(reply) = cookie.reply() else {
+        return false;
+    };
+    String::from_utf8_lossy(&reply.value).to_lowercase().contains(target)
+}
+
+/// Read _NET_WM_USER_TIME from the currently active window and set ours
+/// to that value + 1.  This convinces Mutter that our window has had more
+/// recent user activity than the focused window, bypassing focus-stealing
+/// prevention.
+fn bump_user_time(conn: &impl Connection, root: Window, our_wid: Window) {
+    let Ok(time_cookie) = conn.intern_atom(false, b"_NET_WM_USER_TIME") else { return };
+    let Ok(time_atom) = time_cookie.reply() else { return };
+    let Ok(active_cookie) = conn.intern_atom(false, b"_NET_ACTIVE_WINDOW") else { return };
+    let Ok(active_atom) = active_cookie.reply() else { return };
+
+    // Get the currently active window
+    let active_wid = conn
+        .get_property(false, root, active_atom.atom, AtomEnum::WINDOW, 0, 1)
+        .ok()
+        .and_then(|c| c.reply().ok())
+        .and_then(|r| r.value32().and_then(|mut v| v.next()))
+        .unwrap_or(0);
+
+    // Read its _NET_WM_USER_TIME
+    let their_time = if active_wid != 0 {
+        conn.get_property(false, active_wid, time_atom.atom, AtomEnum::CARDINAL, 0, 1)
+            .ok()
+            .and_then(|c| c.reply().ok())
+            .and_then(|r| r.value32().and_then(|mut v| v.next()))
+            .unwrap_or(1)
+    } else {
+        1
+    };
+
+    // Set our timestamp to theirs + 1
+    let our_time = their_time.wrapping_add(1);
+    let _ = conn.change_property(
+        PropMode::REPLACE,
+        our_wid,
+        time_atom.atom,
+        AtomEnum::CARDINAL,
+        32,
+        1,
+        &our_time.to_ne_bytes(),
+    );
+    let _ = conn.flush();
+}
+
+fn activate_window(conn: &impl Connection, root: Window, wid: Window) -> bool {
+    let Ok(cookie) = conn.intern_atom(false, b"_NET_ACTIVE_WINDOW") else { return false };
+    let Ok(atom) = cookie.reply() else { return false };
+
+    let event = ClientMessageEvent::new(32, wid, atom.atom, [2u32, 0, 0, 0, 0]);
+    let mask = EventMask::SUBSTRUCTURE_REDIRECT | EventMask::SUBSTRUCTURE_NOTIFY;
+    let _ = conn.send_event(false, root, mask, event);
+    let _ = conn.flush();
+    true
+}

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -6,6 +6,10 @@ mod clipboard;
 mod commands;
 mod config;
 mod files;
+#[cfg(target_os = "linux")]
+mod linux_transparency;
+#[cfg(target_os = "linux")]
+mod linux_window_focus;
 mod music;
 mod platform;
 mod process;
@@ -37,22 +41,7 @@ fn supports_transparency() -> bool {
 
     #[cfg(target_os = "linux")]
     {
-        // Wayland compositors generally support transparency
-        if std::env::var("XDG_SESSION_TYPE")
-            .map(|v| v == "wayland")
-            .unwrap_or(false)
-        {
-            return true;
-        }
-        // X11: only if a compositor is running
-        std::process::Command::new("sh")
-            .args([
-                "-c",
-                "pgrep -x picom || pgrep -x compton || pgrep -x compiz",
-            ])
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
+        linux_transparency::has_compositor()
     }
 }
 
@@ -105,15 +94,8 @@ fn main() {
                             let _ = window.hide();
                         } else {
                             LAST_SHOWN_AT.store(now_ms(), Ordering::Relaxed);
+                            let _ = window.set_always_on_top(true);
                             let _ = window.show();
-                            let _ = window.set_focus();
-                            // Ensure search input gets focus inside the webview
-                            let w = window.clone();
-                            std::thread::spawn(move || {
-                                std::thread::sleep(std::time::Duration::from_millis(50));
-                                let _ = w.set_focus();
-                                let _ = w.eval("document.getElementById('query')?.focus()");
-                            });
                             if let Ok(Some(monitor)) = window.current_monitor() {
                                 let screen = monitor.size();
                                 let scale = monitor.scale_factor();
@@ -125,9 +107,22 @@ fn main() {
                                 let _ = window.set_position(PhysicalPosition::new(x, y));
                             }
                             let _ = window.emit("window-shown", ());
+
+                            // On Linux, bypass Mutter's focus-stealing prevention
+                            // by bumping _NET_WM_USER_TIME before activation.
+                            // Called directly (no idle callback) to avoid races
+                            // with a quick Alt+Space hide toggle.
+                            #[cfg(target_os = "linux")]
+                            linux_window_focus::activate_self();
+
+                            let _ = window.set_focus();
                         }
                     }
                 })?;
+
+            // Cache Look's X11 window ID for later focus activation
+            #[cfg(target_os = "linux")]
+            linux_window_focus::cache_self_window();
 
             // Scale window for current monitor on startup
             let window = app.get_webview_window("main").unwrap();
@@ -147,19 +142,43 @@ fn main() {
             if supports_transparency {
                 let _ = window
                     .eval("document.documentElement.setAttribute('data-transparent', 'true')");
-                // Auto-hide on focus loss (works on macOS/Windows/Wayland)
-                let w = window.clone();
-                window.on_window_event(move |event| {
-                    if let tauri::WindowEvent::Focused(false) = event
-                        && now_ms() - LAST_SHOWN_AT.load(Ordering::Relaxed) > 300
-                    {
-                        let _ = w.hide();
-                    }
-                });
             } else {
                 let _ = window
                     .eval("document.documentElement.setAttribute('data-transparent', 'false')");
             }
+
+            // On GNOME X11, the WM fires Focused(false) before the global
+            // shortcut handler runs, so auto-hide must be disabled there.
+            #[cfg(target_os = "linux")]
+            let gnome_x11 = {
+                let is_gnome = std::env::var("XDG_CURRENT_DESKTOP")
+                    .map(|v| v.split(':').any(|s| s.trim().eq_ignore_ascii_case("GNOME")))
+                    .unwrap_or(false);
+                is_gnome && !linux_transparency::is_wayland()
+            };
+            #[cfg(not(target_os = "linux"))]
+            let gnome_x11 = false;
+
+            // Window event handler
+            let w = window.clone();
+            window.on_window_event(move |event| {
+                match event {
+                    // When the window gains focus, ensure the search input is focused.
+                    tauri::WindowEvent::Focused(true) => {
+                        let _ = w.eval("{ let q = document.getElementById('query'); if (q) { q.focus(); q.select(); } }");
+                    }
+                    // Auto-hide on focus loss (click outside, Alt+Tab, etc.).
+                    // Disabled on GNOME X11: the WM fires Focused(false) BEFORE
+                    // the global shortcut handler runs, making Alt+Space toggle
+                    // impossible.  On i3 and other WMs this race doesn't exist.
+                    tauri::WindowEvent::Focused(false) if !gnome_x11 => {
+                        if now_ms() - LAST_SHOWN_AT.load(Ordering::Relaxed) > 300 {
+                            let _ = w.hide();
+                        }
+                    }
+                    _ => {}
+                }
+            });
 
             Ok(())
         })

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -176,14 +176,10 @@ fn main() {
                     tauri::WindowEvent::Focused(true) => {
                         let _ = w.eval("{ let q = document.getElementById('query'); if (q) { q.focus(); q.select(); } }");
                     }
+                    // On Linux, auto-hide is handled by the X11 active-window
+                    // monitor (more reliable than Focused events on GNOME).
+                    #[cfg(not(target_os = "linux"))]
                     tauri::WindowEvent::Focused(false) => {
-                        // On Linux X11, auto-hide is handled by the X11 active-window
-                        // monitor (more reliable than Focused events on GNOME).
-                        // Fall back to this handler on Wayland or when X11 is unavailable.
-                        #[cfg(target_os = "linux")]
-                        if linux_window_focus::is_monitor_running() {
-                            return;
-                        }
                         if now_ms() - LAST_SHOWN_AT.load(Ordering::Relaxed) > 300 {
                             LAST_AUTO_HIDDEN_AT.store(now_ms(), Ordering::Relaxed);
                             let _ = w.hide();

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -176,10 +176,14 @@ fn main() {
                     tauri::WindowEvent::Focused(true) => {
                         let _ = w.eval("{ let q = document.getElementById('query'); if (q) { q.focus(); q.select(); } }");
                     }
-                    // On Linux, auto-hide is handled by the X11 active-window
-                    // monitor (more reliable than Focused events on GNOME).
-                    #[cfg(not(target_os = "linux"))]
                     tauri::WindowEvent::Focused(false) => {
+                        // On Linux X11, auto-hide is handled by the X11 active-window
+                        // monitor (more reliable than Focused events on GNOME).
+                        // Fall back to this handler on Wayland or when X11 is unavailable.
+                        #[cfg(target_os = "linux")]
+                        if linux_window_focus::is_monitor_running() {
+                            return;
+                        }
                         if now_ms() - LAST_SHOWN_AT.load(Ordering::Relaxed) > 300 {
                             LAST_AUTO_HIDDEN_AT.store(now_ms(), Ordering::Relaxed);
                             let _ = w.hide();

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -137,7 +137,7 @@ fn main() {
             #[cfg(target_os = "linux")]
             {
                 linux_window_focus::cache_self_window();
-                let w_monitor = app.get_webview_window("main").unwrap();
+                let w_monitor = app.get_webview_window("main").expect("main window missing");
                 linux_window_focus::start_active_window_monitor(move || {
                     if now_ms() - LAST_SHOWN_AT.load(Ordering::Relaxed) > 300 {
                         LAST_AUTO_HIDDEN_AT.store(now_ms(), Ordering::Relaxed);
@@ -147,7 +147,7 @@ fn main() {
             }
 
             // Scale window for current monitor on startup
-            let window = app.get_webview_window("main").unwrap();
+            let window = app.get_webview_window("main").expect("main window missing");
             if let Ok(Some(monitor)) = window.current_monitor() {
                 let screen = monitor.size();
                 let scale = monitor.scale_factor();
@@ -176,8 +176,10 @@ fn main() {
                     tauri::WindowEvent::Focused(true) => {
                         let _ = w.eval("{ let q = document.getElementById('query'); if (q) { q.focus(); q.select(); } }");
                     }
-                    // On Linux, auto-hide is handled by the X11 active-window
-                    // monitor (more reliable than Focused events on GNOME).
+                    // On Linux, Focused(false) fires on mouse-leave (GNOME/Mutter
+                    // with undecorated always-on-top windows), so auto-hide is
+                    // handled entirely by the X11 active-window monitor instead.
+                    // TODO: add Wayland auto-hide when Wayland support is added.
                     #[cfg(not(target_os = "linux"))]
                     tauri::WindowEvent::Focused(false) => {
                         if now_ms() - LAST_SHOWN_AT.load(Ordering::Relaxed) > 300 {

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -83,6 +83,7 @@ fn main() {
         .manage(AppState::new())
         .manage(platform::IconCache::new())
         .setup(|app| {
+            AppState::init_app_handle(app);
             clipboard::start_monitor();
             let app_handle = app.handle().clone();
 

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -25,6 +25,10 @@ use tauri::{Emitter, Manager, PhysicalPosition};
 
 /// Timestamp (ms) of last window show, used to debounce focus-loss auto-hide.
 static LAST_SHOWN_AT: AtomicU64 = AtomicU64::new(0);
+/// Timestamp (ms) of last auto-hide.  When Alt+Space fires and the window is
+/// already hidden, we check this to avoid re-showing a window that auto-hide
+/// just closed (the GNOME X11 race: Focused(false) fires before the shortcut).
+static LAST_AUTO_HIDDEN_AT: AtomicU64 = AtomicU64::new(0);
 
 fn now_ms() -> u64 {
     SystemTime::now()
@@ -91,8 +95,14 @@ fn main() {
                     }
                     if let Some(window) = app_handle.get_webview_window("main") {
                         if window.is_visible().unwrap_or(false) {
+                            #[cfg(target_os = "linux")]
+                            linux_window_focus::notify_hidden();
                             let _ = window.hide();
-                        } else {
+                        } else if now_ms() - LAST_AUTO_HIDDEN_AT.load(Ordering::Relaxed) > 200 {
+                            // Only show if auto-hide didn't JUST fire.
+                            // On GNOME X11, Focused(false) races with this handler —
+                            // auto-hide hides the window before we run, so is_visible
+                            // is false.  The 200ms guard prevents re-showing.
                             LAST_SHOWN_AT.store(now_ms(), Ordering::Relaxed);
                             let _ = window.set_always_on_top(true);
                             let _ = window.show();
@@ -110,19 +120,30 @@ fn main() {
 
                             // On Linux, bypass Mutter's focus-stealing prevention
                             // by bumping _NET_WM_USER_TIME before activation.
-                            // Called directly (no idle callback) to avoid races
-                            // with a quick Alt+Space hide toggle.
                             #[cfg(target_os = "linux")]
-                            linux_window_focus::activate_self();
+                            {
+                                linux_window_focus::activate_self();
+                                linux_window_focus::notify_shown();
+                            }
 
                             let _ = window.set_focus();
                         }
                     }
                 })?;
 
-            // Cache Look's X11 window ID for later focus activation
+            // Cache Look's X11 window ID for later focus activation,
+            // and start monitoring _NET_ACTIVE_WINDOW for auto-hide.
             #[cfg(target_os = "linux")]
-            linux_window_focus::cache_self_window();
+            {
+                linux_window_focus::cache_self_window();
+                let w_monitor = app.get_webview_window("main").unwrap();
+                linux_window_focus::start_active_window_monitor(move || {
+                    if now_ms() - LAST_SHOWN_AT.load(Ordering::Relaxed) > 300 {
+                        LAST_AUTO_HIDDEN_AT.store(now_ms(), Ordering::Relaxed);
+                        let _ = w_monitor.hide();
+                    }
+                });
+            }
 
             // Scale window for current monitor on startup
             let window = app.get_webview_window("main").unwrap();
@@ -147,32 +168,19 @@ fn main() {
                     .eval("document.documentElement.setAttribute('data-transparent', 'false')");
             }
 
-            // On GNOME X11, the WM fires Focused(false) before the global
-            // shortcut handler runs, so auto-hide must be disabled there.
-            #[cfg(target_os = "linux")]
-            let gnome_x11 = {
-                let is_gnome = std::env::var("XDG_CURRENT_DESKTOP")
-                    .map(|v| v.split(':').any(|s| s.trim().eq_ignore_ascii_case("GNOME")))
-                    .unwrap_or(false);
-                is_gnome && !linux_transparency::is_wayland()
-            };
-            #[cfg(not(target_os = "linux"))]
-            let gnome_x11 = false;
-
             // Window event handler
             let w = window.clone();
             window.on_window_event(move |event| {
                 match event {
-                    // When the window gains focus, ensure the search input is focused.
                     tauri::WindowEvent::Focused(true) => {
                         let _ = w.eval("{ let q = document.getElementById('query'); if (q) { q.focus(); q.select(); } }");
                     }
-                    // Auto-hide on focus loss (click outside, Alt+Tab, etc.).
-                    // Disabled on GNOME X11: the WM fires Focused(false) BEFORE
-                    // the global shortcut handler runs, making Alt+Space toggle
-                    // impossible.  On i3 and other WMs this race doesn't exist.
-                    tauri::WindowEvent::Focused(false) if !gnome_x11 => {
+                    // On Linux, auto-hide is handled by the X11 active-window
+                    // monitor (more reliable than Focused events on GNOME).
+                    #[cfg(not(target_os = "linux"))]
+                    tauri::WindowEvent::Focused(false) => {
                         if now_ms() - LAST_SHOWN_AT.load(Ordering::Relaxed) > 300 {
+                            LAST_AUTO_HIDDEN_AT.store(now_ms(), Ordering::Relaxed);
                             let _ = w.hide();
                         }
                     }

--- a/apps/linows/src-tauri/src/platform.rs
+++ b/apps/linows/src-tauri/src/platform.rs
@@ -356,23 +356,7 @@ pub fn get_platform() -> PlatformInfo {
     let os = std::env::consts::OS.to_string();
 
     #[cfg(target_os = "linux")]
-    let has_compositor = {
-        let is_wayland = std::env::var("XDG_SESSION_TYPE")
-            .map(|v| v == "wayland")
-            .unwrap_or(false);
-        if is_wayland {
-            true
-        } else {
-            std::process::Command::new("sh")
-                .args([
-                    "-c",
-                    "pgrep -x picom || pgrep -x compton || pgrep -x compiz || pgrep -x kwin || pgrep -x mutter",
-                ])
-                .output()
-                .map(|o| o.status.success())
-                .unwrap_or(false)
-        }
-    };
+    let has_compositor = crate::linux_transparency::has_compositor();
 
     #[cfg(not(target_os = "linux"))]
     let has_compositor = true;

--- a/apps/linows/src-tauri/src/state.rs
+++ b/apps/linows/src-tauri/src/state.rs
@@ -5,9 +5,12 @@ use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use std::env;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Mutex, RwLock, mpsc};
+use std::sync::{Mutex, OnceLock, RwLock, mpsc};
 use std::thread;
 use std::time::Instant;
+use tauri::{Emitter, Manager};
+
+static APP_HANDLE: OnceLock<tauri::AppHandle> = OnceLock::new();
 
 pub struct AppState {
     engine: RwLock<QueryEngine>,
@@ -20,7 +23,7 @@ pub struct AppState {
 impl AppState {
     pub fn new() -> Self {
         let path = default_db_path();
-        let engine = QueryEngine::from_sqlite(&path).unwrap_or_else(|_| QueryEngine::demo_seed());
+        let engine = QueryEngine::from_sqlite(&path).unwrap_or_else(|_| QueryEngine::new(vec![]));
 
         let state = Self {
             engine: RwLock::new(engine),
@@ -33,6 +36,10 @@ impl AppState {
         state.start_background_bootstrap();
         state.start_index_watchers();
         state
+    }
+
+    pub fn init_app_handle(app: &tauri::App) {
+        let _ = APP_HANDLE.set(app.handle().clone());
     }
 
     pub fn with_engine<T>(&self, f: impl FnOnce(&QueryEngine) -> T) -> T {
@@ -138,6 +145,11 @@ impl AppState {
                             "look: bootstrap ok elapsed_ms={}",
                             started_at.elapsed().as_millis()
                         );
+                        if let Some(handle) = APP_HANDLE.get() {
+                            if let Some(w) = handle.get_webview_window("main") {
+                                let _ = w.emit("index-ready", ());
+                            }
+                        }
                     }
                     Err(err) => {
                         change_version.fetch_add(1, Ordering::AcqRel);

--- a/apps/linows/src-tauri/src/state.rs
+++ b/apps/linows/src-tauri/src/state.rs
@@ -145,10 +145,10 @@ impl AppState {
                             "look: bootstrap ok elapsed_ms={}",
                             started_at.elapsed().as_millis()
                         );
-                        if let Some(handle) = APP_HANDLE.get() {
-                            if let Some(w) = handle.get_webview_window("main") {
-                                let _ = w.emit("index-ready", ());
-                            }
+                        if let Some(handle) = APP_HANDLE.get()
+                            && let Some(w) = handle.get_webview_window("main")
+                        {
+                            let _ = w.emit("index-ready", ());
                         }
                     }
                     Err(err) => {

--- a/apps/linows/src-tauri/tauri.conf.json
+++ b/apps/linows/src-tauri/tauri.conf.json
@@ -28,7 +28,7 @@
       "csp": null,
       "assetProtocol": {
         "enable": true,
-        "scope": ["**"]
+        "scope": ["$HOME/**", "/usr/share/**", "/nix/**", "/run/**", "/tmp/**"]
       }
     }
   },

--- a/apps/linows/src/html/screens/settings.html
+++ b/apps/linows/src/html/screens/settings.html
@@ -69,15 +69,15 @@
         <!-- Blur -->
         <div class="settings-section-header"><span class="settings-section-arrow">&#9654;</span><span>Blur</span></div>
         <div class="settings-section">
-          <div class="settings-row" data-key="ui_blur_radius">
-            <label class="settings-label">Blur Radius</label>
-            <input type="range" class="settings-slider" min="0" max="40" step="1" value="0" />
-            <span class="settings-slider-value">0</span>
-          </div>
           <div class="settings-row" data-key="ui_blur_opacity">
             <label class="settings-label">Blur Opacity</label>
             <input type="range" class="settings-slider" min="0" max="1" step="0.01" value="0.95" />
             <span class="settings-slider-value">0.95</span>
+          </div>
+          <div class="settings-row" data-key="settings_blur_multiplier">
+            <label class="settings-label">Settings Blur</label>
+            <input type="range" class="settings-slider" min="0.4" max="1" step="0.01" value="0.5" />
+            <span class="settings-slider-value">0.50</span>
           </div>
           <div class="settings-row">
             <label class="settings-label">Blur Style</label>

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -186,6 +186,17 @@ document.addEventListener('DOMContentLoaded', async () => {
     queryInput.select();
   });
 
+  // Guard: if focus drifts to another element on the main screen,
+  // pull it back to the search input.
+  document.addEventListener('focusin', (e) => {
+    if (e.target !== queryInput
+        && !commands.isActive()
+        && !settings.isActive()
+        && !helpScreen?.contains(e.target)) {
+      queryInput.focus();
+    }
+  });
+
   // Load home dir for quick folders, then initial search
   getHomeDir().then((home) => {
     if (home) search.setHomeDir(home);

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -10,7 +10,7 @@ import * as translatePanel from './components/translate.js';
 import * as platform from './platform.js';
 import { load } from './html-loader.js';
 import {
-  onWindowShown, getHomeDir, copyFilesToClipboard,
+  onWindowShown, onIndexReady, getHomeDir, copyFilesToClipboard,
   evalCalc, runShellCommand, getSystemInfo,
   listProcesses, listProcessesOnPort, killProcess, getIcon,
   copyToClipboard, deleteClipboardEntry,
@@ -184,6 +184,10 @@ document.addEventListener('DOMContentLoaded', async () => {
   onWindowShown(() => {
     queryInput.focus();
     queryInput.select();
+  });
+
+  onIndexReady(() => {
+    search.handleQueryInput(queryInput.value);
   });
 
   // Guard: if focus drifts to another element on the main screen,

--- a/apps/linows/src/js/ipc.js
+++ b/apps/linows/src/js/ipc.js
@@ -133,6 +133,10 @@ export async function onWindowShown(callback) {
   return listen('window-shown', callback);
 }
 
+export async function onIndexReady(callback) {
+  return listen('index-ready', callback);
+}
+
 export async function musicPlay(path) {
   return invoke('music_play', { path });
 }

--- a/apps/linows/src/js/screens/settings.js
+++ b/apps/linows/src/js/screens/settings.js
@@ -12,9 +12,9 @@ const TABS = ['appearance', 'shortcuts', 'advanced'];
 // Maps config keys to CSS custom property update functions.
 // Each slider with data-key drives live CSS + config persistence.
 const BLUR_PRESETS = {
-  high_contrast: { ui_blur_radius: 12, ui_blur_opacity: 0.95 },
-  balanced: { ui_blur_radius: 20, ui_blur_opacity: 0.80 },
-  soft: { ui_blur_radius: 32, ui_blur_opacity: 0.60 },
+  high_contrast: { ui_blur_opacity: 0.95 },
+  balanced: { ui_blur_opacity: 0.80 },
+  soft: { ui_blur_opacity: 0.60 },
 };
 
 const CSS_MAP = {
@@ -28,12 +28,8 @@ const CSS_MAP = {
   ui_bg_blur: (v) => {
     document.documentElement.style.setProperty('--bg-image-blur', parseFloat(v).toFixed(1) + 'px');
   },
-  ui_blur_radius: (v) => {
-    // Use platform-aware blur (native on Windows, CSS on Linux)
-    const style = getCurrentBlurStyle();
-    platform.applyBlur(parseFloat(v), style);
-  },
   ui_blur_opacity: applyBlurOpacity,
+  settings_blur_multiplier: applyBlurOpacity,
   ui_font_size: (v) => {
     document.documentElement.style.setProperty('--font-size', Math.round(parseFloat(v)) + 'px');
   },
@@ -144,8 +140,6 @@ export function init(exitFn) {
           valueEl.textContent = formatValue(key, val);
         }
       }
-      // Apply blur via platform module
-      platform.applyBlur(preset.ui_blur_radius, style);
       if (platform.hasCompositor()) applytint();
       saveConfig({ ...preset, ui_blur_style: style });
     }
@@ -472,11 +466,6 @@ export async function reloadFromFile() {
     // Border thickness
     if (map.ui_border_thickness) CSS_MAP.ui_border_thickness(map.ui_border_thickness);
 
-    // Blur
-    if (map.ui_blur_radius) {
-      platform.applyBlur(parseFloat(map.ui_blur_radius), map.ui_blur_style || 'high_contrast');
-    }
-
     // Background image
     if (map.ui_bg_image) {
       applyBackgroundImage(map.ui_bg_image);
@@ -563,11 +552,6 @@ export async function restoreOnStartup() {
     }
 
     // Blur
-    if (map.ui_blur_radius) {
-      const blurStyle = map.ui_blur_style || 'high_contrast';
-      platform.applyBlur(parseFloat(map.ui_blur_radius), blurStyle);
-    }
-
     // Border thickness
     if (map.ui_border_thickness) {
       CSS_MAP.ui_border_thickness(map.ui_border_thickness);
@@ -809,7 +793,8 @@ function applytint() {
   }
   const tintA = getSliderVal('ui_tint_opacity');
   const blurA = getSliderVal('ui_blur_opacity') || 0.95;
-  const a = tintA * blurA;
+  const settingsBlur = active ? (getSliderVal('settings_blur_multiplier') || 0.5) : 1.0;
+  const a = tintA * blurA * settingsBlur;
   document.documentElement.style.setProperty('--bg-tint', `rgba(${r}, ${g}, ${b}, ${a.toFixed(2)})`);
 }
 
@@ -845,6 +830,7 @@ function applyTintFromMap(map) {
   }
   const tintA = parseFloat(map.ui_tint_opacity ?? 0.95);
   const blurA = parseFloat(map.ui_blur_opacity ?? 0.95);
+  const settingsBlur = parseFloat(map.settings_blur_multiplier ?? 0.5);
   const a = tintA * blurA;
   document.documentElement.style.setProperty('--bg-tint', `rgba(${r}, ${g}, ${b}, ${a.toFixed(2)})`);
 }
@@ -892,7 +878,6 @@ function applyBgLayout(layout) {
 }
 
 function formatValue(key, v) {
-  if (key === 'ui_blur_radius') return Math.round(v).toString();
   return v.toFixed(2);
 }
 

--- a/core/engine/src/lib.rs
+++ b/core/engine/src/lib.rs
@@ -111,13 +111,6 @@ impl QueryEngine {
         let runtime_config = RuntimeConfig::load();
         let store = SqliteStore::open(path)?;
         let candidates = store.load_candidates(None)?;
-        if candidates.is_empty() {
-            return Ok(Self::new_with_config(
-                Self::demo_candidates(),
-                &runtime_config,
-            ));
-        }
-
         Ok(Self::new_with_config(candidates, &runtime_config))
     }
 

--- a/core/engine/src/platform/linux/settings_catalog.rs
+++ b/core/engine/src/platform/linux/settings_catalog.rs
@@ -1,64 +1,155 @@
 use crate::platform::SettingsCatalogEntry;
 
 pub(crate) static SETTINGS_CATALOG: &[SettingsCatalogEntry] = &[
+    // Connectivity
     SettingsCatalogEntry {
         title: "Wi-Fi",
         target: "wifi",
         candidate_id_suffix: "wifi",
-        aliases: "network wireless internet settings",
+        aliases: "network wireless internet connection settings",
     },
     SettingsCatalogEntry {
         title: "Bluetooth",
         target: "bluetooth",
         candidate_id_suffix: "bluetooth",
-        aliases: "bluetooth devices settings",
+        aliases: "bluetooth devices pair settings",
     },
+    SettingsCatalogEntry {
+        title: "Network",
+        target: "network",
+        candidate_id_suffix: "network",
+        aliases: "network ethernet vpn proxy wired connection settings",
+    },
+    // Devices
     SettingsCatalogEntry {
         title: "Display",
         target: "display",
         candidate_id_suffix: "display",
-        aliases: "monitor screen resolution brightness settings",
+        aliases: "monitor screen resolution brightness night light scale settings",
     },
     SettingsCatalogEntry {
         title: "Sound",
         target: "sound",
         candidate_id_suffix: "sound",
-        aliases: "audio volume speaker microphone settings",
+        aliases: "audio volume speaker microphone output input settings",
     },
     SettingsCatalogEntry {
         title: "Power",
         target: "power",
         candidate_id_suffix: "power",
-        aliases: "battery power suspend sleep settings",
+        aliases: "battery power suspend sleep screen blank automatic settings",
     },
     SettingsCatalogEntry {
         title: "Keyboard",
         target: "keyboard",
         candidate_id_suffix: "keyboard",
-        aliases: "keyboard input layout shortcuts settings",
+        aliases: "keyboard input layout shortcuts keybinding settings",
     },
     SettingsCatalogEntry {
-        title: "Mouse",
+        title: "Mouse & Touchpad",
         target: "mouse",
         candidate_id_suffix: "mouse",
-        aliases: "mouse pointer touchpad settings",
+        aliases: "mouse pointer touchpad trackpad scroll speed acceleration settings",
     },
     SettingsCatalogEntry {
         title: "Printers",
         target: "printers",
         candidate_id_suffix: "printers",
-        aliases: "printer scanner devices settings",
+        aliases: "printer scanner print devices settings",
     },
+    // Personalization
+    SettingsCatalogEntry {
+        title: "Background",
+        target: "background",
+        candidate_id_suffix: "background",
+        aliases: "wallpaper background desktop picture settings",
+    },
+    SettingsCatalogEntry {
+        title: "Appearance",
+        target: "background",
+        candidate_id_suffix: "appearance",
+        aliases: "appearance theme dark light style color settings",
+    },
+    SettingsCatalogEntry {
+        title: "Notifications",
+        target: "notifications",
+        candidate_id_suffix: "notifications",
+        aliases: "notifications alerts do not disturb settings",
+    },
+    SettingsCatalogEntry {
+        title: "Multitasking",
+        target: "multitasking",
+        candidate_id_suffix: "multitasking",
+        aliases: "multitasking workspaces hot corner edge tiling settings",
+    },
+    // Apps & Online
+    SettingsCatalogEntry {
+        title: "Applications",
+        target: "applications",
+        candidate_id_suffix: "applications",
+        aliases: "applications default apps file handler settings",
+    },
+    SettingsCatalogEntry {
+        title: "Online Accounts",
+        target: "online-accounts",
+        candidate_id_suffix: "online-accounts",
+        aliases: "online accounts google microsoft email cloud settings",
+    },
+    SettingsCatalogEntry {
+        title: "Search",
+        target: "search",
+        candidate_id_suffix: "search",
+        aliases: "search providers results settings",
+    },
+    // Privacy & Security
+    SettingsCatalogEntry {
+        title: "Privacy & Security",
+        target: "privacy",
+        candidate_id_suffix: "privacy",
+        aliases: "privacy security screen lock location camera microphone permissions settings",
+    },
+    SettingsCatalogEntry {
+        title: "Sharing",
+        target: "sharing",
+        candidate_id_suffix: "sharing",
+        aliases: "sharing remote desktop media screen file settings",
+    },
+    // Accessibility
+    SettingsCatalogEntry {
+        title: "Accessibility",
+        target: "universal-access",
+        candidate_id_suffix: "universal-access",
+        aliases: "accessibility universal access zoom large text high contrast cursor size settings",
+    },
+    // System
     SettingsCatalogEntry {
         title: "Users",
         target: "users",
         candidate_id_suffix: "users",
-        aliases: "user accounts login password settings",
+        aliases: "user accounts login password fingerprint settings",
     },
     SettingsCatalogEntry {
         title: "Date & Time",
         target: "datetime",
         candidate_id_suffix: "datetime",
-        aliases: "date time timezone clock settings",
+        aliases: "date time timezone clock automatic format settings",
+    },
+    SettingsCatalogEntry {
+        title: "System",
+        target: "system",
+        candidate_id_suffix: "system",
+        aliases: "system about region language software updates remote desktop settings",
+    },
+    SettingsCatalogEntry {
+        title: "Color",
+        target: "color",
+        candidate_id_suffix: "color",
+        aliases: "color profile calibration display monitor settings",
+    },
+    SettingsCatalogEntry {
+        title: "Wellbeing",
+        target: "wellbeing",
+        candidate_id_suffix: "wellbeing",
+        aliases: "wellbeing screen time break reminder digital health settings",
     },
 ];

--- a/core/engine/src/platform/linux/settings_catalog.rs
+++ b/core/engine/src/platform/linux/settings_catalog.rs
@@ -66,7 +66,7 @@ pub(crate) static SETTINGS_CATALOG: &[SettingsCatalogEntry] = &[
     },
     SettingsCatalogEntry {
         title: "Appearance",
-        target: "background",
+        target: "appearance",
         candidate_id_suffix: "appearance",
         aliases: "appearance theme dark light style color settings",
     },


### PR DESCRIPTION
## Summary

- Testing and Adjustment for Gnome X11 (Nixos base)

## Why

- #117 

## Changes

- Transparent
- Background and blur effects
- Testing on gnome

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
