### PR TITLE
Feat: Gnome wayland

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -26,3 +26,6 @@ jobs:
 
       - name: Build
         run: nix build ./apps/linows#default
+
+      - name: Verify version
+        run: ./result/bin/lookapp --version

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -19,7 +19,10 @@ jobs:
 
       - uses: DeterminateSystems/nix-installer-action@main
 
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: cachix/cachix-action@v15
+        with:
+          name: look
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Build
         run: nix build ./apps/linows#default

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -1,0 +1,25 @@
+name: CI Nix Build
+
+on:
+  pull_request:
+    paths:
+      - "core/**"
+      - "apps/linows/**"
+  push:
+    branches: [main]
+    paths:
+      - "core/**"
+      - "apps/linows/**"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Build
+        run: nix build ./apps/linows#default

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -108,3 +108,29 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: dist/*
+
+  nix-build:
+    name: Build and push Nix package to Cachix
+    runs-on: ubuntu-latest
+    needs: build-release
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set version in tauri.conf.json
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          sed -i "s/\"version\": \".*\"/\"version\": \"${VERSION}\"/" apps/linows/src-tauri/tauri.conf.json
+
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - uses: cachix/cachix-action@v15
+        with:
+          name: look
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build
+        run: nix build ./apps/linows#default
+
+      - name: Verify version
+        run: ./result/bin/lookapp --version

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist/
 
 target/
 **/target/
+result
 
 .env
 .env.*

--- a/README.md
+++ b/README.md
@@ -61,9 +61,25 @@ sudo dpkg -r look-desktop
 rm Look_*.AppImage
 ```
 
-> **NixOS:** AppImage does not work on NixOS due to the non-FHS filesystem layout. Build from source instead: `cd apps/linows && nix develop -c cargo tauri build`. A flake package (`nix run`) is planned.
+**NixOS (flake):**
 
-More install methods coming soon (AUR, NixOS flake). To build from source, see [apps/linows/BUILDING.md](apps/linows/BUILDING.md).
+```bash
+# Run directly
+nix run github:kunkka19xx/look?dir=apps/linows
+
+# Install to profile
+nix profile install github:kunkka19xx/look?dir=apps/linows
+```
+
+Declarative (in your NixOS/Home Manager flake):
+
+```nix
+inputs.look.url = "github:kunkka19xx/look?dir=apps/linows";
+# then in config:
+environment.systemPackages = [ inputs.look.packages.${system}.default ];
+```
+
+More install methods coming soon (AUR). To build from source, see [apps/linows/BUILDING.md](apps/linows/BUILDING.md).
 
 <details>
 <summary>Other install options (curl, pin version, update/uninstall)</summary>

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Uninstall:
 
 ```bash
 # Ubuntu/Debian
-sudo dpkg -r look-desktop
+sudo dpkg -r lookapp
 
 # AppImage — just delete the file
 rm Look_*.AppImage
@@ -71,12 +71,17 @@ nix run github:kunkka19xx/look?dir=apps/linows
 nix profile install github:kunkka19xx/look?dir=apps/linows
 ```
 
-Declarative (in your NixOS/Home Manager flake):
+Declarative (NixOS flake):
 
 ```nix
+# flake.nix
 inputs.look.url = "github:kunkka19xx/look?dir=apps/linows";
-# then in config:
-environment.systemPackages = [ inputs.look.packages.${system}.default ];
+
+# In your nixosConfigurations modules list:
+modules = [
+  look.nixosModules.default
+  { programs.lookapp.enable = true; }
+];
 ```
 
 More install methods coming soon (AUR). To build from source, see [apps/linows/BUILDING.md](apps/linows/BUILDING.md).

--- a/apps/linows/BUILDING.md
+++ b/apps/linows/BUILDING.md
@@ -108,15 +108,38 @@ Steps to implement:
 
 ### NixOS (flake)
 
-**Target:** `nix run github:kunkka19xx/look#look-desktop`
+**Status:** Available now.
 
-Steps to implement:
-1. Extend `flake.nix` with `packages.default` output
-2. Use `rustPlatform.buildRustPackage` with `cargoLock.lockFile`
-3. Use `wrapGAppsHook` for GTK runtime wrapping
-4. Filter source to `core/` + `apps/linows/` (monorepo path deps)
-5. `postInstall`: install .desktop file + icon
-6. Test: `nix build .#default` from `apps/linows/`
+```bash
+# Run directly
+nix run github:kunkka19xx/look?dir=apps/linows
+
+# Install to profile
+nix profile install github:kunkka19xx/look?dir=apps/linows
+
+# Build locally
+cd apps/linows
+nix build .#default
+./result/bin/look-desktop
+```
+
+**Declarative install** (NixOS configuration or Home Manager):
+
+```nix
+# flake.nix — add to inputs
+inputs.look.url = "github:kunkka19xx/look?dir=apps/linows";
+
+# Option A: use package directly
+environment.systemPackages = [ inputs.look.packages.${system}.default ];
+
+# Option B: use overlay
+nixpkgs.overlays = [ inputs.look.overlays.default ];
+environment.systemPackages = [ pkgs.look-desktop ];
+```
+
+The package uses `wrapGAppsHook3` to wrap the binary with all GTK/GIO runtime deps and CLI tools (`gsettings`, `xdg-open`, `fc-list`, `curl`, etc.) in PATH.
+
+**Build speed note:** First build compiles all dependencies from source (~5-10 min). Subsequent builds with unchanged `Cargo.lock` use the cached vendor derivation and only recompile the app code. For CI, use `cachix` or `attic` to push build artifacts so users get pre-built binaries.
 
 ### AppImage (universal)
 

--- a/apps/linows/BUILDING.md
+++ b/apps/linows/BUILDING.md
@@ -57,15 +57,15 @@ WEBKIT_DISABLE_COMPOSITING_MODE=1 cargo tauri dev
 
 ## Runtime Dependencies
 
-| Dependency | Purpose |
-|------------|---------|
-| WebKitGTK 4.1 | WebView rendering |
-| GTK 3 | UI toolkit |
-| libsoup 3 | HTTP (WebKitGTK dep) |
-| dbus | System bus |
-| ALSA (libasound) | Audio playback (Pomodoro music) |
-| xdg-desktop-portal | File picker dialogs |
-| xclip / wl-copy | Clipboard file copy |
+| Dependency         | Purpose                         |
+| ------------------ | ------------------------------- |
+| WebKitGTK 4.1      | WebView rendering               |
+| GTK 3              | UI toolkit                      |
+| libsoup 3          | HTTP (WebKitGTK dep)            |
+| dbus               | System bus                      |
+| ALSA (libasound)   | Audio playback (Pomodoro music) |
+| xdg-desktop-portal | File picker dialogs             |
+| xclip / wl-copy    | Clipboard file copy             |
 
 ---
 
@@ -84,20 +84,22 @@ For now, build from source using the instructions above.
 
 ### Ubuntu / Debian (.deb)
 
-**Target:** `sudo dpkg -i look-desktop_*.deb` or download from GitHub Releases.
+**Target:** `sudo dpkg -i lookapp_*.deb` or download from GitHub Releases.
 
 Steps to implement:
+
 1. Generate multi-size icons from `icon.png` (`cargo tauri icon`)
 2. Add `bundle` section to `tauri.conf.json` with deb runtime deps
-3. Create `.desktop` file at `apps/linows/assets/look-desktop.desktop`
+3. Create `.desktop` file at `apps/linows/assets/lookapp.desktop`
 4. Create CI workflow (`.github/workflows/release-linux.yml`, ubuntu-22.04 runner)
 5. Test: `cargo tauri build` → install .deb on Ubuntu → verify launch + hotkey
 
 ### Arch Linux (AUR)
 
-**Target:** `yay -S look-desktop`
+**Target:** `yay -S lookapp`
 
 Steps to implement:
+
 1. Create `apps/linows/packaging/PKGBUILD` (source build from GitHub tarball)
 2. `makedepends`: rust, cargo, cargo-tauri, pkg-config, openssl, librsvg
 3. `depends`: webkit2gtk-4.1, gtk3, libsoup3, alsa-lib, dbus, xdg-desktop-portal, xclip
@@ -120,32 +122,54 @@ nix profile install github:kunkka19xx/look?dir=apps/linows
 # Build locally
 cd apps/linows
 nix build .#default
-./result/bin/look-desktop
+./result/bin/lookapp
 ```
 
-**Declarative install** (NixOS configuration or Home Manager):
+**Declarative install** (recommended):
 
 ```nix
-# flake.nix — add to inputs
-inputs.look.url = "github:kunkka19xx/look?dir=apps/linows";
+# flake.nix
+{
+  inputs.look.url = "github:kunkka19xx/look?dir=apps/linows";
 
-# Option A: use package directly
-environment.systemPackages = [ inputs.look.packages.${system}.default ];
-
-# Option B: use overlay
-nixpkgs.overlays = [ inputs.look.overlays.default ];
-environment.systemPackages = [ pkgs.look-desktop ];
+  outputs = { nixpkgs, look, ... }: {
+    nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
+      modules = [
+        look.nixosModules.default
+        {
+          programs.lookapp.enable = true;
+          # Binary cache is enabled by default.
+          # To disable: programs.lookapp.cachix = false;
+        }
+      ];
+    };
+  };
+}
 ```
 
-The package uses `wrapGAppsHook3` to wrap the binary with all GTK/GIO runtime deps and CLI tools (`gsettings`, `xdg-open`, `fc-list`, `curl`, etc.) in PATH.
+That's it — the module installs the package and configures the binary cache automatically.
 
-**Build speed note:** First build compiles all dependencies from source (~5-10 min). Subsequent builds with unchanged `Cargo.lock` use the cached vendor derivation and only recompile the app code. For CI, use `cachix` or `attic` to push build artifacts so users get pre-built binaries.
+**Other install methods:**
+
+```nix
+# Use the package directly
+environment.systemPackages = [ inputs.look.packages.${system}.default ];
+
+# Or use the overlay
+nixpkgs.overlays = [ inputs.look.overlays.default ];
+environment.systemPackages = [ pkgs.lookapp ];
+```
+
+For non-NixOS Nix users: `cachix use look` then `nix profile install`.
+
+> **Note:** The NixOS module requires a NixOS system configuration. Home Manager is not currently supported — use `nix profile install` or the overlay instead. Contributions to add Look to [nixpkgs](https://github.com/NixOS/nixpkgs) or a Home Manager module are welcome.
 
 ### AppImage (universal)
 
-**Target:** Download from GitHub Releases, `chmod +x && ./look-desktop_*.AppImage`
+**Target:** Download from GitHub Releases, `chmod +x && ./lookapp_*.AppImage`
 
 Steps to implement:
+
 1. Add `"appimage"` to `bundle.targets` in `tauri.conf.json`
 2. Built automatically alongside .deb by `cargo tauri build`
 3. CI uploads to GitHub Releases

--- a/apps/linows/README.md
+++ b/apps/linows/README.md
@@ -54,7 +54,7 @@ The WinUI3 app remains in `apps/windows/` (bug fixes only) until this migration 
 |----------------|-----------|
 | GNOME Xorg     | Testing   |
 | i3 X11         | Testing   |
-| GNOME Wayland  | Untested  |
+| GNOME Wayland  | Testing   |
 | Sway           | Untested  |
 
 ## Build

--- a/apps/linows/flake.nix
+++ b/apps/linows/flake.nix
@@ -26,8 +26,10 @@
         }
       );
 
+      nixosModules.default = import ./nix/module.nix;
+
       overlays.default = final: _prev: {
-        look-desktop = final.callPackage ./nix/package.nix { };
+        lookapp = final.callPackage ./nix/package.nix { };
       };
 
       devShells = forAllSystems (

--- a/apps/linows/flake.nix
+++ b/apps/linows/flake.nix
@@ -12,12 +12,24 @@
       systems = [
         "x86_64-linux"
         "aarch64-linux"
-        "x86_64-darwin"
-        "aarch64-darwin"
       ];
       forAllSystems = nixpkgs.lib.genAttrs systems;
     in
     {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          default = pkgs.callPackage ./nix/package.nix { };
+        }
+      );
+
+      overlays.default = final: _prev: {
+        look-desktop = final.callPackage ./nix/package.nix { };
+      };
+
       devShells = forAllSystems (
         system:
         let

--- a/apps/linows/nix/module.nix
+++ b/apps/linows/nix/module.nix
@@ -1,0 +1,32 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.lookapp;
+  lookPkg = pkgs.callPackage ./package.nix { };
+in
+{
+  options.programs.lookapp = {
+    enable = lib.mkEnableOption "Look — keyboard-first desktop launcher";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = lookPkg;
+      description = "The lookapp package to install.";
+    };
+
+    cachix = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Whether to add the Look binary cache (look.cachix.org) for pre-built binaries.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    nix.settings = lib.mkIf cfg.cachix {
+      substituters = [ "https://look.cachix.org" ];
+      trusted-public-keys = [ "look.cachix.org-1:8eIPCeSVBzIDZXqIRKBK9GyLIK/Hoe1xiWZF0ir7uX4=" ];
+    };
+  };
+}

--- a/apps/linows/nix/package.nix
+++ b/apps/linows/nix/package.nix
@@ -24,7 +24,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "lookapp";
-  version = "0.1.0";
+  version = (builtins.fromJSON (builtins.readFile ../src-tauri/tauri.conf.json)).version;
 
   src = lib.cleanSourceWith {
     src = ../../..;

--- a/apps/linows/nix/package.nix
+++ b/apps/linows/nix/package.nix
@@ -1,0 +1,109 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  pkg-config,
+  wrapGAppsHook3,
+  webkitgtk_4_1,
+  gtk3,
+  libsoup_3,
+  glib,
+  cairo,
+  pango,
+  gdk-pixbuf,
+  harfbuzz,
+  alsa-lib,
+  dbus,
+  openssl,
+  libappindicator-gtk3,
+  xdg-utils,
+  fontconfig,
+  curl,
+  procps,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "look-desktop";
+  version = "0.1.0";
+
+  src = lib.cleanSourceWith {
+    src = ../../..;
+    filter =
+      path: _type:
+      let
+        basePath = toString ../../..;
+        relPath = lib.removePrefix basePath (toString path);
+      in
+      relPath == "/apps"
+      || lib.hasPrefix "/apps/linows" relPath
+      || lib.hasPrefix "/core" relPath;
+  };
+
+  cargoRoot = "apps/linows/src-tauri";
+  cargoHash = "sha256-c/P5VpjhAhfvpyaTbOFftjKOEOZ0wpypYagiYDfJVbY=";
+
+  buildAndTestSubdir = "apps/linows/src-tauri";
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    webkitgtk_4_1
+    gtk3
+    libsoup_3
+    glib
+    cairo
+    pango
+    gdk-pixbuf
+    harfbuzz
+    alsa-lib
+    dbus
+    openssl
+    libappindicator-gtk3
+  ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : ${lib.makeBinPath [
+        xdg-utils
+        fontconfig
+        curl
+        procps
+        glib
+      ]}
+    )
+  '';
+
+  postInstall = ''
+    # Desktop file
+    mkdir -p $out/share/applications
+    cat > $out/share/applications/look-desktop.desktop <<EOF
+    [Desktop Entry]
+    Name=Look
+    Comment=Keyboard-first desktop launcher
+    Exec=look-desktop
+    Icon=look
+    Type=Application
+    Categories=Utility;
+    StartupWMClass=Look
+    EOF
+
+    # Icons
+    for size in 32 128 256; do
+      icon="$src/apps/linows/src-tauri/icons/''${size}x''${size}.png"
+      if [ -f "$icon" ]; then
+        mkdir -p $out/share/icons/hicolor/''${size}x''${size}/apps
+        cp "$icon" $out/share/icons/hicolor/''${size}x''${size}/apps/look.png
+      fi
+    done
+  '';
+
+  meta = {
+    description = "Keyboard-first desktop launcher";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "look-desktop";
+  };
+}

--- a/apps/linows/nix/package.nix
+++ b/apps/linows/nix/package.nix
@@ -23,7 +23,7 @@
 }:
 
 rustPlatform.buildRustPackage {
-  pname = "look-desktop";
+  pname = "lookapp";
   version = "0.1.0";
 
   src = lib.cleanSourceWith {
@@ -79,16 +79,16 @@ rustPlatform.buildRustPackage {
   postInstall = ''
     # Desktop file
     mkdir -p $out/share/applications
-    cat > $out/share/applications/look-desktop.desktop <<EOF
-    [Desktop Entry]
-    Name=Look
-    Comment=Keyboard-first desktop launcher
-    Exec=look-desktop
-    Icon=look
-    Type=Application
-    Categories=Utility;
-    StartupWMClass=Look
-    EOF
+    cat > $out/share/applications/lookapp.desktop <<'EOF'
+[Desktop Entry]
+Name=Look
+Comment=Keyboard-first desktop launcher
+Exec=lookapp
+Icon=look
+Type=Application
+Categories=Utility;
+StartupWMClass=Look
+EOF
 
     # Icons
     for size in 32 128 256; do
@@ -104,6 +104,6 @@ rustPlatform.buildRustPackage {
     description = "Keyboard-first desktop launcher";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    mainProgram = "look-desktop";
+    mainProgram = "lookapp";
   };
 }

--- a/apps/linows/nix/package.nix
+++ b/apps/linows/nix/package.nix
@@ -40,7 +40,7 @@ rustPlatform.buildRustPackage {
   };
 
   cargoRoot = "apps/linows/src-tauri";
-  cargoHash = "sha256-c/P5VpjhAhfvpyaTbOFftjKOEOZ0wpypYagiYDfJVbY=";
+  cargoHash = "sha256-0+WqxYoeXLxRzGg9pLrMQUxUnqyfU3AFC/9uww2ibcM=";
 
   buildAndTestSubdir = "apps/linows/src-tauri";
 

--- a/apps/linows/result
+++ b/apps/linows/result
@@ -1,1 +1,0 @@
-/nix/store/ac9wm8gp436vr9jf392g5y4vq5kx9ym0-look-desktop-0.1.0

--- a/apps/linows/result
+++ b/apps/linows/result
@@ -1,0 +1,1 @@
+/nix/store/ac9wm8gp436vr9jf392g5y4vq5kx9ym0-look-desktop-0.1.0

--- a/apps/linows/src-tauri/Cargo.lock
+++ b/apps/linows/src-tauri/Cargo.lock
@@ -2445,7 +2445,9 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-single-instance",
+ "tokio",
  "x11rb",
+ "zbus",
 ]
 
 [[package]]

--- a/apps/linows/src-tauri/Cargo.lock
+++ b/apps/linows/src-tauri/Cargo.lock
@@ -2426,31 +2426,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "look-desktop"
-version = "0.1.0"
-dependencies = [
- "arboard",
- "base64 0.22.1",
- "dirs",
- "look-engine",
- "look-indexing",
- "look-storage",
- "notify",
- "open",
- "rodio",
- "serde",
- "serde_json",
- "tauri",
- "tauri-build",
- "tauri-plugin-dialog",
- "tauri-plugin-global-shortcut",
- "tauri-plugin-single-instance",
- "tokio",
- "x11rb",
- "zbus",
-]
-
-[[package]]
 name = "look-engine"
 version = "0.1.0"
 dependencies = [
@@ -2490,6 +2465,31 @@ version = "0.1.0"
 dependencies = [
  "look-indexing",
  "rusqlite",
+]
+
+[[package]]
+name = "lookapp"
+version = "0.1.0"
+dependencies = [
+ "arboard",
+ "base64 0.22.1",
+ "dirs",
+ "look-engine",
+ "look-indexing",
+ "look-storage",
+ "notify",
+ "open",
+ "rodio",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-build",
+ "tauri-plugin-dialog",
+ "tauri-plugin-global-shortcut",
+ "tauri-plugin-single-instance",
+ "tokio",
+ "x11rb",
+ "zbus",
 ]
 
 [[package]]

--- a/apps/linows/src-tauri/Cargo.toml
+++ b/apps/linows/src-tauri/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "look-desktop"
+name = "lookapp"
 version = "0.1.0"
 edition = "2024"
 license = "MIT"

--- a/apps/linows/src-tauri/Cargo.toml
+++ b/apps/linows/src-tauri/Cargo.toml
@@ -23,6 +23,8 @@ tauri-plugin-dialog = "2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 x11rb = { version = "0.13", features = ["allow-unsafe-code"] }
+zbus = "5"
+tokio = { version = "1", features = ["rt"] }
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/apps/linows/src-tauri/build.rs
+++ b/apps/linows/src-tauri/build.rs
@@ -1,3 +1,13 @@
 fn main() {
+    // Read version from tauri.conf.json so --version matches release tags
+    let conf = std::fs::read_to_string("tauri.conf.json").expect("tauri.conf.json");
+    let version = conf
+        .lines()
+        .find(|l| l.contains("\"version\""))
+        .and_then(|l| l.split('"').nth(3))
+        .expect("version field in tauri.conf.json");
+    println!("cargo:rustc-env=APP_VERSION={version}");
+    println!("cargo:rerun-if-changed=tauri.conf.json");
+
     tauri_build::build()
 }

--- a/apps/linows/src-tauri/src/commands.rs
+++ b/apps/linows/src-tauri/src/commands.rs
@@ -263,9 +263,7 @@ fn launch_app(exec: &str, id: Option<&str>) -> Result<(), String> {
                     .file_name()
                     .and_then(|f| f.to_str())
                     .unwrap_or("");
-                if !desktop_id.is_empty()
-                    && crate::linux_gnome_ext::try_focus_app(desktop_id)
-                {
+                if !desktop_id.is_empty() && crate::linux_gnome_ext::try_focus_app(desktop_id) {
                     return Ok(());
                 }
             }
@@ -352,7 +350,6 @@ fn try_focus_window(wm_class: &str) -> bool {
 
     false
 }
-
 
 fn parse_desktop_field(path: &str, field: &str) -> Option<String> {
     let content = std::fs::read_to_string(path).ok()?;

--- a/apps/linows/src-tauri/src/commands.rs
+++ b/apps/linows/src-tauri/src/commands.rs
@@ -247,18 +247,42 @@ fn launch_app(exec: &str, id: Option<&str>) -> Result<(), String> {
         .and_then(|id| id.strip_prefix("app:"))
         .and_then(find_desktop_file);
 
+    // Try to focus an existing window before launching a new instance.
+    #[cfg(target_os = "linux")]
+    let is_wayland = crate::linux_transparency::is_wayland();
+    #[cfg(not(target_os = "linux"))]
+    let is_wayland = false;
+
     if let Some(ref real_path) = desktop_file {
-        if let Some(wm_class) = parse_desktop_field(real_path, "StartupWMClass")
-            && try_focus_window(&wm_class)
-        {
-            return Ok(());
-        }
-        if let Some(name) = std::path::Path::new(real_path)
-            .file_stem()
-            .and_then(|f| f.to_str())
-            && try_focus_window(name)
-        {
-            return Ok(());
+        if is_wayland {
+            // Wayland: use GNOME Shell extension to focus existing windows.
+            // Same mechanism GNOME's own Activities search uses internally.
+            #[cfg(target_os = "linux")]
+            {
+                let desktop_id = std::path::Path::new(real_path)
+                    .file_name()
+                    .and_then(|f| f.to_str())
+                    .unwrap_or("");
+                if !desktop_id.is_empty()
+                    && crate::linux_gnome_ext::try_focus_app(desktop_id)
+                {
+                    return Ok(());
+                }
+            }
+        } else {
+            // X11: focus by WM_CLASS via x11rb
+            if let Some(wm_class) = parse_desktop_field(real_path, "StartupWMClass")
+                && try_focus_window(&wm_class)
+            {
+                return Ok(());
+            }
+            if let Some(name) = std::path::Path::new(real_path)
+                .file_stem()
+                .and_then(|f| f.to_str())
+                && try_focus_window(name)
+            {
+                return Ok(());
+            }
         }
     }
 
@@ -328,6 +352,7 @@ fn try_focus_window(wm_class: &str) -> bool {
 
     false
 }
+
 
 fn parse_desktop_field(path: &str, field: &str) -> Option<String> {
     let content = std::fs::read_to_string(path).ok()?;

--- a/apps/linows/src-tauri/src/gnome-shell-extension/extension.js
+++ b/apps/linows/src-tauri/src/gnome-shell-extension/extension.js
@@ -1,0 +1,61 @@
+import Gio from 'gi://Gio';
+import Shell from 'gi://Shell';
+import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
+
+const IFACE = `
+<node>
+  <interface name="com.look.ShellIntegration">
+    <method name="FocusApp">
+      <arg type="s" direction="in" name="desktop_id"/>
+      <arg type="b" direction="out" name="success"/>
+    </method>
+  </interface>
+</node>`;
+
+export default class LookIntegration extends Extension {
+    enable() {
+        this._dbus = Gio.DBusExportedObject.wrapJSObject(IFACE, this);
+        this._dbus.export(Gio.DBus.session, '/com/look/ShellIntegration');
+        this._owner = Gio.bus_own_name(
+            Gio.BusType.SESSION,
+            'com.look.ShellIntegration',
+            Gio.BusNameOwnerFlags.NONE,
+            null, null, null,
+        );
+    }
+
+    disable() {
+        if (this._dbus) {
+            this._dbus.unexport();
+            this._dbus = null;
+        }
+        if (this._owner) {
+            Gio.bus_unown_name(this._owner);
+            this._owner = null;
+        }
+    }
+
+    FocusApp(desktop_id) {
+        if (!desktop_id.endsWith('.desktop'))
+            desktop_id += '.desktop';
+
+        const appSys = Shell.AppSystem.get_default();
+        const app = appSys.lookup_app(desktop_id);
+
+        if (app && app.get_n_windows() > 0) {
+            // Use activate_window with current timestamp to bypass
+            // Mutter's focus-stealing prevention (same as Activities does)
+            const wins = app.get_windows();
+            const mostRecent = wins[0];
+            if (mostRecent) {
+                const workspace = mostRecent.get_workspace();
+                if (workspace)
+                    workspace.activate_with_focus(mostRecent, global.get_current_time());
+                else
+                    mostRecent.activate(global.get_current_time());
+            }
+            return true;
+        }
+        return false;
+    }
+}

--- a/apps/linows/src-tauri/src/gnome-shell-extension/metadata.json
+++ b/apps/linows/src-tauri/src/gnome-shell-extension/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Look Desktop Integration",
+  "description": "Allows Look launcher to focus existing app windows on GNOME Wayland",
+  "uuid": "look-integration@look-desktop",
+  "shell-version": ["45", "46", "47", "48"],
+  "url": ""
+}

--- a/apps/linows/src-tauri/src/linux_gnome_ext.rs
+++ b/apps/linows/src-tauri/src/linux_gnome_ext.rs
@@ -1,0 +1,137 @@
+//! Auto-install and communicate with the Look GNOME Shell extension.
+//!
+//! The extension exposes a single D-Bus method `FocusApp(desktop_id)` that
+//! uses gnome-shell's internal `Shell.App.activate()` to focus existing
+//! windows — the same mechanism GNOME's own Activities search uses.
+
+use std::path::PathBuf;
+
+const EXT_UUID: &str = "look-integration@look-desktop";
+const DBUS_NAME: &str = "com.look.ShellIntegration";
+const DBUS_PATH: &str = "/com/look/ShellIntegration";
+const DBUS_IFACE: &str = "com.look.ShellIntegration";
+
+const METADATA_JSON: &str = include_str!("gnome-shell-extension/metadata.json");
+const EXTENSION_JS: &str = include_str!("gnome-shell-extension/extension.js");
+
+/// Install the GNOME Shell extension if not already present, then enable it.
+pub fn ensure_installed() {
+    let ext_dir = extension_dir();
+    let metadata_path = ext_dir.join("metadata.json");
+    let extension_path = ext_dir.join("extension.js");
+
+    // Check if already installed with current version
+    let needs_install = if metadata_path.exists() && extension_path.exists() {
+        let existing = std::fs::read_to_string(&extension_path).unwrap_or_default();
+        existing != EXTENSION_JS
+    } else {
+        true
+    };
+
+    if needs_install {
+        if let Err(e) = std::fs::create_dir_all(&ext_dir) {
+            eprintln!("[look] Failed to create extension dir: {e}");
+            return;
+        }
+        if let Err(e) = std::fs::write(&metadata_path, METADATA_JSON) {
+            eprintln!("[look] Failed to write metadata.json: {e}");
+            return;
+        }
+        if let Err(e) = std::fs::write(&extension_path, EXTENSION_JS) {
+            eprintln!("[look] Failed to write extension.js: {e}");
+            return;
+        }
+        eprintln!("[look] Installed GNOME Shell extension: {EXT_UUID}");
+
+        // Enable the extension via gsettings
+        enable_extension();
+
+        eprintln!("[look] Extension will activate on next GNOME Shell restart (or log out/in)");
+    }
+}
+
+/// Try to focus an app by its desktop file ID using the GNOME Shell extension.
+/// Returns true if the app was focused (had existing windows).
+///
+/// Uses zbus to call directly from Look's process (which has focus),
+/// so GNOME trusts the activation request without showing a "ready" popup.
+pub fn try_focus_app(desktop_id: &str) -> bool {
+    // Build the tokio runtime inline — this is called from a sync context
+    // and needs to complete quickly.
+    let id = desktop_id.to_string();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build();
+    let Ok(rt) = rt else { return false };
+
+    rt.block_on(async {
+        let conn = zbus::Connection::session().await.ok()?;
+        let reply: (bool,) = conn
+            .call_method(
+                Some(DBUS_NAME),
+                DBUS_PATH,
+                Some(DBUS_IFACE),
+                "FocusApp",
+                &id,
+            )
+            .await
+            .ok()?
+            .body()
+            .deserialize()
+            .ok()?;
+        Some(reply.0)
+    })
+    .unwrap_or(false)
+}
+
+fn extension_dir() -> PathBuf {
+    dirs::data_dir()
+        .unwrap_or_else(|| PathBuf::from("~/.local/share"))
+        .join("gnome-shell/extensions")
+        .join(EXT_UUID)
+}
+
+fn enable_extension() {
+    // Read current enabled extensions
+    let output = std::process::Command::new("gsettings")
+        .args(["get", "org.gnome.shell", "enabled-extensions"])
+        .output();
+
+    let current = output
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .unwrap_or_default();
+    let current = current.trim();
+
+    if current.contains(EXT_UUID) {
+        return; // Already enabled
+    }
+
+    // Parse and add our extension
+    let mut extensions: Vec<String> = if current == "@as []" || current == "[]" {
+        Vec::new()
+    } else {
+        current
+            .trim_start_matches('[')
+            .trim_end_matches(']')
+            .split(',')
+            .map(|s| s.trim().trim_matches('\'').trim_matches('"').to_string())
+            .filter(|s| !s.is_empty())
+            .collect()
+    };
+
+    extensions.push(EXT_UUID.to_string());
+
+    let new_value = format!(
+        "[{}]",
+        extensions
+            .iter()
+            .map(|e| format!("'{e}'"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+
+    let _ = std::process::Command::new("gsettings")
+        .args(["set", "org.gnome.shell", "enabled-extensions", &new_value])
+        .output();
+}

--- a/apps/linows/src-tauri/src/linux_wayland_shortcut.rs
+++ b/apps/linows/src-tauri/src/linux_wayland_shortcut.rs
@@ -15,7 +15,8 @@ const DBUS_NAME: &str = "com.look.Desktop";
 const DBUS_PATH: &str = "/com/look/Desktop";
 const DBUS_IFACE: &str = "com.look.Desktop";
 
-const KEYBINDING_PATH: &str = "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/look-toggle/";
+const KEYBINDING_PATH: &str =
+    "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/look-toggle/";
 const KEYBINDING_SCHEMA: &str = "org.gnome.settings-daemon.plugins.media-keys.custom-keybinding";
 const MEDIA_KEYS_SCHEMA: &str = "org.gnome.settings-daemon.plugins.media-keys";
 
@@ -46,8 +47,7 @@ fn ensure_gnome_keybinding() {
     let existing = gsettings_get(MEDIA_KEYS_SCHEMA, "custom-keybindings");
     if existing.contains(KEYBINDING_PATH) {
         // Already registered, verify the binding is still correct
-        let current_binding =
-            gsettings_get_at(KEYBINDING_SCHEMA, "binding", KEYBINDING_PATH);
+        let current_binding = gsettings_get_at(KEYBINDING_SCHEMA, "binding", KEYBINDING_PATH);
         if current_binding.contains("<Alt>space") {
             return;
         }
@@ -59,8 +59,18 @@ fn ensure_gnome_keybinding() {
     );
 
     gsettings_set_at(KEYBINDING_SCHEMA, "name", "'Look Toggle'", KEYBINDING_PATH);
-    gsettings_set_at(KEYBINDING_SCHEMA, "command", &format!("'{toggle_cmd}'"), KEYBINDING_PATH);
-    gsettings_set_at(KEYBINDING_SCHEMA, "binding", "'<Alt>space'", KEYBINDING_PATH);
+    gsettings_set_at(
+        KEYBINDING_SCHEMA,
+        "command",
+        &format!("'{toggle_cmd}'"),
+        KEYBINDING_PATH,
+    );
+    gsettings_set_at(
+        KEYBINDING_SCHEMA,
+        "binding",
+        "'<Alt>space'",
+        KEYBINDING_PATH,
+    );
 
     // Add our path to the custom-keybindings list
     let mut paths: Vec<String> = parse_gsettings_array(&existing);
@@ -77,6 +87,29 @@ fn ensure_gnome_keybinding() {
     );
     gsettings_set(MEDIA_KEYS_SCHEMA, "custom-keybindings", &new_value);
     eprintln!("[look] Registered GNOME keybinding: Alt+Space → Look toggle");
+}
+
+/// Remove the GNOME custom keybinding registered by Look.
+pub fn cleanup_gnome_keybinding() {
+    let existing = gsettings_get(MEDIA_KEYS_SCHEMA, "custom-keybindings");
+    let paths: Vec<String> = parse_gsettings_array(&existing)
+        .into_iter()
+        .filter(|p| p != KEYBINDING_PATH)
+        .collect();
+    let new_value = if paths.is_empty() {
+        "@as []".to_string()
+    } else {
+        format!(
+            "[{}]",
+            paths
+                .iter()
+                .map(|p| format!("'{p}'"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    };
+    gsettings_set(MEDIA_KEYS_SCHEMA, "custom-keybindings", &new_value);
+    eprintln!("[look] Removed GNOME keybinding for Alt+Space");
 }
 
 /// Run a D-Bus service that listens for Toggle method calls.

--- a/apps/linows/src-tauri/src/linux_wayland_shortcut.rs
+++ b/apps/linows/src-tauri/src/linux_wayland_shortcut.rs
@@ -1,0 +1,161 @@
+//! Wayland global shortcut via GNOME custom keybinding + D-Bus service.
+//!
+//! On Wayland, apps cannot grab global hotkeys directly (unlike X11).
+//! The XDG GlobalShortcuts portal is not yet fully functional on GNOME 48.
+//!
+//! Instead, we:
+//! 1. Register a D-Bus service (`com.look.Desktop`) that listens for `Toggle` calls
+//! 2. Set up a GNOME custom keybinding (Alt+Space) that calls our D-Bus service
+//!
+//! This is the same approach used by other launchers (ulauncher, etc.) on GNOME Wayland.
+
+use std::process::Command;
+
+const DBUS_NAME: &str = "com.look.Desktop";
+const DBUS_PATH: &str = "/com/look/Desktop";
+const DBUS_IFACE: &str = "com.look.Desktop";
+
+const KEYBINDING_PATH: &str = "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/look-toggle/";
+const KEYBINDING_SCHEMA: &str = "org.gnome.settings-daemon.plugins.media-keys.custom-keybinding";
+const MEDIA_KEYS_SCHEMA: &str = "org.gnome.settings-daemon.plugins.media-keys";
+
+/// Start a background thread that:
+/// 1. Registers a D-Bus service to listen for Toggle calls
+/// 2. Ensures a GNOME custom keybinding exists for Alt+Space
+pub fn start<F>(on_toggle: F)
+where
+    F: Fn() + Send + Sync + 'static,
+{
+    ensure_gnome_keybinding();
+
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("failed to create tokio runtime for D-Bus service");
+
+        if let Err(e) = rt.block_on(run_dbus_service(on_toggle)) {
+            eprintln!("[look] D-Bus service error: {e}");
+        }
+    });
+}
+
+/// Register a GNOME custom keybinding for Alt+Space → dbus-send to our service.
+fn ensure_gnome_keybinding() {
+    // Check if our keybinding already exists
+    let existing = gsettings_get(MEDIA_KEYS_SCHEMA, "custom-keybindings");
+    if existing.contains(KEYBINDING_PATH) {
+        // Already registered, verify the binding is still correct
+        let current_binding =
+            gsettings_get_at(KEYBINDING_SCHEMA, "binding", KEYBINDING_PATH);
+        if current_binding.contains("<Alt>space") {
+            return;
+        }
+    }
+
+    // Set up the custom keybinding
+    let toggle_cmd = format!(
+        "dbus-send --session --type=method_call --dest={DBUS_NAME} {DBUS_PATH} {DBUS_IFACE}.Toggle"
+    );
+
+    gsettings_set_at(KEYBINDING_SCHEMA, "name", "'Look Toggle'", KEYBINDING_PATH);
+    gsettings_set_at(KEYBINDING_SCHEMA, "command", &format!("'{toggle_cmd}'"), KEYBINDING_PATH);
+    gsettings_set_at(KEYBINDING_SCHEMA, "binding", "'<Alt>space'", KEYBINDING_PATH);
+
+    // Add our path to the custom-keybindings list
+    let mut paths: Vec<String> = parse_gsettings_array(&existing);
+    if !paths.iter().any(|p| p == KEYBINDING_PATH) {
+        paths.push(KEYBINDING_PATH.to_string());
+    }
+    let new_value = format!(
+        "[{}]",
+        paths
+            .iter()
+            .map(|p| format!("'{p}'"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    gsettings_set(MEDIA_KEYS_SCHEMA, "custom-keybindings", &new_value);
+    eprintln!("[look] Registered GNOME keybinding: Alt+Space → Look toggle");
+}
+
+/// Run a D-Bus service that listens for Toggle method calls.
+async fn run_dbus_service<F>(on_toggle: F) -> Result<(), Box<dyn std::error::Error>>
+where
+    F: Fn() + Send + Sync + 'static,
+{
+    struct LookService<F: Fn() + Send + Sync + 'static> {
+        on_toggle: F,
+    }
+
+    #[zbus::interface(name = "com.look.Desktop")]
+    impl<F: Fn() + Send + Sync + 'static> LookService<F> {
+        fn toggle(&self) {
+            (self.on_toggle)();
+        }
+    }
+
+    let service = LookService { on_toggle };
+    let _conn = zbus::connection::Builder::session()?
+        .name(DBUS_NAME)?
+        .serve_at(DBUS_PATH, service)?
+        .build()
+        .await?;
+
+    eprintln!("[look] D-Bus service listening on {DBUS_NAME}");
+
+    // Keep the service alive
+    std::future::pending::<()>().await;
+    Ok(())
+}
+
+// --- gsettings helpers ---
+
+fn gsettings_get(schema: &str, key: &str) -> String {
+    Command::new("gsettings")
+        .args(["get", schema, key])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .unwrap_or_default()
+        .trim()
+        .to_string()
+}
+
+fn gsettings_set(schema: &str, key: &str, value: &str) {
+    let _ = Command::new("gsettings")
+        .args(["set", schema, key, value])
+        .output();
+}
+
+fn gsettings_get_at(schema: &str, key: &str, path: &str) -> String {
+    Command::new("gsettings")
+        .args(["get", &format!("{schema}:{path}"), key])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .unwrap_or_default()
+        .trim()
+        .to_string()
+}
+
+fn gsettings_set_at(schema: &str, key: &str, value: &str, path: &str) {
+    let _ = Command::new("gsettings")
+        .args(["set", &format!("{schema}:{path}"), key, value])
+        .output();
+}
+
+fn parse_gsettings_array(s: &str) -> Vec<String> {
+    // Parse "@as []" or "['path1', 'path2']"
+    let trimmed = s.trim();
+    if trimmed == "@as []" || trimmed == "[]" {
+        return Vec::new();
+    }
+    trimmed
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .split(',')
+        .map(|p| p.trim().trim_matches('\'').trim_matches('"').to_string())
+        .filter(|p| !p.is_empty())
+        .collect()
+}

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -119,6 +119,11 @@ fn is_wayland() -> bool {
 }
 
 fn main() {
+    if std::env::args().any(|a| a == "--version" || a == "-V") {
+        println!("lookapp {}", env!("APP_VERSION"));
+        return;
+    }
+
     let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
             // Focus the main window when a second instance is launched

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -285,6 +285,14 @@ fn main() {
             music::music_stop,
             music::music_is_finished,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running look desktop");
+        .build(tauri::generate_context!())
+        .expect("error while building look desktop")
+        .run(|_app, event| {
+            #[cfg(target_os = "linux")]
+            if let tauri::RunEvent::Exit = event
+                && is_wayland()
+            {
+                linux_wayland_shortcut::cleanup_gnome_keybinding();
+            }
+        });
 }

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -7,6 +7,8 @@ mod commands;
 mod config;
 mod files;
 #[cfg(target_os = "linux")]
+mod linux_gnome_ext;
+#[cfg(target_os = "linux")]
 mod linux_transparency;
 #[cfg(target_os = "linux")]
 mod linux_wayland_shortcut;
@@ -147,9 +149,12 @@ fn main() {
             let app_handle = app.handle().clone();
 
             if use_wayland {
-                // Wayland: register Alt+Space via XDG Desktop Portal
+                // Wayland: register Alt+Space via GNOME custom keybinding + D-Bus
                 #[cfg(target_os = "linux")]
                 {
+                    // Install GNOME Shell extension for window focusing
+                    linux_gnome_ext::ensure_installed();
+
                     let handle = app_handle.clone();
                     linux_wayland_shortcut::start(move || {
                         toggle_window(&handle);

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -9,6 +9,8 @@ mod files;
 #[cfg(target_os = "linux")]
 mod linux_transparency;
 #[cfg(target_os = "linux")]
+mod linux_wayland_shortcut;
+#[cfg(target_os = "linux")]
 mod linux_window_focus;
 mod music;
 mod platform;
@@ -69,8 +71,53 @@ fn scaled_window_size(screen_w: u32, screen_h: u32, scale: f64) -> (u32, u32) {
     (w, h)
 }
 
+/// Toggle the main window: hide if visible, show (centered) if hidden.
+fn toggle_window(app_handle: &tauri::AppHandle) {
+    let Some(window) = app_handle.get_webview_window("main") else {
+        return;
+    };
+    if window.is_visible().unwrap_or(false) {
+        #[cfg(target_os = "linux")]
+        linux_window_focus::notify_hidden();
+        let _ = window.hide();
+    } else if now_ms() - LAST_AUTO_HIDDEN_AT.load(Ordering::Relaxed) > 200 {
+        // Only show if auto-hide didn't JUST fire.
+        // On GNOME X11, Focused(false) races with this handler —
+        // auto-hide hides the window before we run, so is_visible
+        // is false.  The 200ms guard prevents re-showing.
+        LAST_SHOWN_AT.store(now_ms(), Ordering::Relaxed);
+        let _ = window.set_always_on_top(true);
+        let _ = window.show();
+        if let Ok(Some(monitor)) = window.current_monitor() {
+            let screen = monitor.size();
+            let scale = monitor.scale_factor();
+            let (win_w, win_h) = scaled_window_size(screen.width, screen.height, scale);
+            let _ = window.set_size(tauri::PhysicalSize::new(win_w, win_h));
+            let x = ((screen.width as f64 - win_w as f64) / 2.0) as i32;
+            let y = ((screen.height as f64 - win_h as f64) / 2.0) as i32;
+            let _ = window.set_position(PhysicalPosition::new(x, y));
+        }
+        let _ = window.emit("window-shown", ());
+
+        // On Linux/X11, bypass Mutter's focus-stealing prevention
+        // by bumping _NET_WM_USER_TIME before activation.
+        #[cfg(target_os = "linux")]
+        if !linux_transparency::is_wayland() {
+            linux_window_focus::activate_self();
+            linux_window_focus::notify_shown();
+        }
+
+        let _ = window.set_focus();
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn is_wayland() -> bool {
+    linux_transparency::is_wayland()
+}
+
 fn main() {
-    tauri::Builder::default()
+    let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
             // Focus the main window when a second instance is launched
             if let Some(window) = app.get_webview_window("main") {
@@ -78,64 +125,55 @@ fn main() {
                 let _ = window.set_focus();
             }
         }))
-        .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
         .manage(AppState::new())
-        .manage(platform::IconCache::new())
-        .setup(|app| {
+        .manage(platform::IconCache::new());
+
+    // On X11 (or non-Linux), register the global shortcut plugin.
+    // On Wayland, we use the XDG Desktop Portal instead (set up in .setup()).
+    #[cfg(target_os = "linux")]
+    let use_wayland = is_wayland();
+    #[cfg(not(target_os = "linux"))]
+    let use_wayland = false;
+
+    if !use_wayland {
+        builder = builder.plugin(tauri_plugin_global_shortcut::Builder::new().build());
+    }
+
+    builder
+        .setup(move |app| {
             AppState::init_app_handle(app);
             clipboard::start_monitor();
             let app_handle = app.handle().clone();
 
-            // Register Alt+Space global hotkey
-            use tauri_plugin_global_shortcut::GlobalShortcutExt;
-            app.global_shortcut()
-                .on_shortcut("Alt+Space", move |_app, _shortcut, event| {
-                    if event.state != tauri_plugin_global_shortcut::ShortcutState::Pressed {
-                        return;
-                    }
-                    if let Some(window) = app_handle.get_webview_window("main") {
-                        if window.is_visible().unwrap_or(false) {
-                            #[cfg(target_os = "linux")]
-                            linux_window_focus::notify_hidden();
-                            let _ = window.hide();
-                        } else if now_ms() - LAST_AUTO_HIDDEN_AT.load(Ordering::Relaxed) > 200 {
-                            // Only show if auto-hide didn't JUST fire.
-                            // On GNOME X11, Focused(false) races with this handler —
-                            // auto-hide hides the window before we run, so is_visible
-                            // is false.  The 200ms guard prevents re-showing.
-                            LAST_SHOWN_AT.store(now_ms(), Ordering::Relaxed);
-                            let _ = window.set_always_on_top(true);
-                            let _ = window.show();
-                            if let Ok(Some(monitor)) = window.current_monitor() {
-                                let screen = monitor.size();
-                                let scale = monitor.scale_factor();
-                                let (win_w, win_h) =
-                                    scaled_window_size(screen.width, screen.height, scale);
-                                let _ = window.set_size(tauri::PhysicalSize::new(win_w, win_h));
-                                let x = ((screen.width as f64 - win_w as f64) / 2.0) as i32;
-                                let y = ((screen.height as f64 - win_h as f64) / 2.0) as i32;
-                                let _ = window.set_position(PhysicalPosition::new(x, y));
-                            }
-                            let _ = window.emit("window-shown", ());
-
-                            // On Linux, bypass Mutter's focus-stealing prevention
-                            // by bumping _NET_WM_USER_TIME before activation.
-                            #[cfg(target_os = "linux")]
-                            {
-                                linux_window_focus::activate_self();
-                                linux_window_focus::notify_shown();
-                            }
-
-                            let _ = window.set_focus();
+            if use_wayland {
+                // Wayland: register Alt+Space via XDG Desktop Portal
+                #[cfg(target_os = "linux")]
+                {
+                    let handle = app_handle.clone();
+                    linux_wayland_shortcut::start(move || {
+                        toggle_window(&handle);
+                    });
+                }
+            } else {
+                // X11 / macOS / Windows: use tauri-plugin-global-shortcut
+                let handle = app_handle.clone();
+                use tauri_plugin_global_shortcut::GlobalShortcutExt;
+                app.global_shortcut()
+                    .on_shortcut("Alt+Space", move |_app, _shortcut, event| {
+                        if event.state
+                            != tauri_plugin_global_shortcut::ShortcutState::Pressed
+                        {
+                            return;
                         }
-                    }
-                })?;
+                        toggle_window(&handle);
+                    })?;
+            }
 
             // Cache Look's X11 window ID for later focus activation,
             // and start monitoring _NET_ACTIVE_WINDOW for auto-hide.
             #[cfg(target_os = "linux")]
-            {
+            if !use_wayland {
                 linux_window_focus::cache_self_window();
                 let w_monitor = app.get_webview_window("main").expect("main window missing");
                 linux_window_focus::start_active_window_monitor(move || {


### PR DESCRIPTION
## Summary

- Workaround with wayland
  - Global key
  - Apps focus process

## Why

- #117 and 
- #128 

## Changes

-

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
