### PR TITLE
Fix: Xclip and bootstrap

### DIFF
--- a/apps/linows/BUILDING.md
+++ b/apps/linows/BUILDING.md
@@ -65,7 +65,6 @@ WEBKIT_DISABLE_COMPOSITING_MODE=1 cargo tauri dev
 | dbus               | System bus                      |
 | ALSA (libasound)   | Audio playback (Pomodoro music) |
 | xdg-desktop-portal | File picker dialogs             |
-| xclip / wl-copy    | Clipboard file copy             |
 
 ---
 
@@ -102,7 +101,7 @@ Steps to implement:
 
 1. Create `apps/linows/packaging/PKGBUILD` (source build from GitHub tarball)
 2. `makedepends`: rust, cargo, cargo-tauri, pkg-config, openssl, librsvg
-3. `depends`: webkit2gtk-4.1, gtk3, libsoup3, alsa-lib, dbus, xdg-desktop-portal, xclip
+3. `depends`: webkit2gtk-4.1, gtk3, libsoup3, alsa-lib, dbus, xdg-desktop-portal
 4. Build step: `cargo tauri build --bundles none` (binary only, pacman handles install)
 5. Install: binary → `/usr/bin/`, .desktop → `/usr/share/applications/`, icon → `/usr/share/icons/`
 6. Generate `.SRCINFO` and push to AUR git repo

--- a/apps/linows/README.md
+++ b/apps/linows/README.md
@@ -50,18 +50,23 @@ The WinUI3 app remains in `apps/windows/` (bug fixes only) until this migration 
 
 ## Linux Desktop Environments
 
-| Environment    | Status    |
-|----------------|-----------|
-| GNOME Xorg     | Testing   |
-| i3 X11         | Testing   |
-| GNOME Wayland  | Testing   |
-| Sway           | Untested  |
+| Environment   | Distro | Status   | Notes                                                   |
+| ------------- | ------ | -------- | ------------------------------------------------------- |
+| GNOME Xorg    | NixOS  | Testing  | Full support                                            |
+| GNOME Wayland | Ubuntu | Testing  | Dock icon visible while Look is open (see Known Issues) |
+| GNOME Wayland | NixOS  | Testing  | Full support                                            |
+| i3 X11        | NixOS  | Testing  | No system settings entries                              |
+| Sway          |        | Untested | No system settings entries                              |
+| KDE Plasma    |        | Untested |                                                         |
+
+**System settings** (Appearance, Wi-Fi, Sound, etc.) are only shown when `gnome-control-center`
+is detected. On i3, sway, or minimal distros without GNOME, these entries are skipped.
 
 ## Optional Dependencies
 
-| Package | Used for | Fallback |
-|---------|----------|----------|
-| `xclip` | Copy files to clipboard (X11) | Shows "Copy failed" banner |
+| Package        | Used for                          | Fallback                   |
+| -------------- | --------------------------------- | -------------------------- |
+| `xclip`        | Copy files to clipboard (X11)     | Shows "Copy failed" banner |
 | `wl-clipboard` | Copy files to clipboard (Wayland) | Shows "Copy failed" banner |
 
 Text clipboard (copy path, clipboard history) works without any external tools.
@@ -144,7 +149,19 @@ lookapp                                    # launch from terminal to see logs
 
 **GNOME Shell extension** requires log out/in after first install to load.
 
+**Keyboard shortcuts:**
+
+| Shortcut     | Action                  |
+| ------------ | ----------------------- |
+| Alt+Space    | Toggle Look window      |
+| Esc          | Hide Look               |
+| Alt+Shift+Q  | Quit Look               |
+| Ctrl+Shift+, | Open settings           |
+| Ctrl+Shift+; | Reload config from file |
+| Ctrl+H       | Help screen             |
+
 **Known issues on Ubuntu:**
+
 - GNOME's default Alt+Space (window menu) is auto-disabled by Look on Wayland; restored when Look exits
 - **GNOME Wayland: dock icon visible while Look is open.** Tauri sets `skip_taskbar_hint`
   asynchronously after the GTK window is mapped, so GNOME's dock ignores it. Native GTK apps

--- a/apps/linows/README.md
+++ b/apps/linows/README.md
@@ -99,7 +99,7 @@ scp -O src-tauri/target/release/bundle/deb/Look_*.deb ubuntu@192.168.122.x:/tmp/
 
 ```bash
 sudo dpkg -r look                          # remove old version
-sudo apt install -f                        # install missing deps (xclip etc.)
+sudo apt install -f                        # install missing deps
 sudo dpkg -i /tmp/Look_*.deb              # install new version
 ```
 

--- a/apps/linows/README.md
+++ b/apps/linows/README.md
@@ -57,6 +57,30 @@ The WinUI3 app remains in `apps/windows/` (bug fixes only) until this migration 
 | GNOME Wayland  | Testing   |
 | Sway           | Untested  |
 
+## Optional Dependencies
+
+| Package | Used for | Fallback |
+|---------|----------|----------|
+| `xclip` | Copy files to clipboard (X11) | Shows "Copy failed" banner |
+| `wl-clipboard` | Copy files to clipboard (Wayland) | Shows "Copy failed" banner |
+
+Text clipboard (copy path, clipboard history) works without any external tools.
+File clipboard (copy a file to paste into a file manager) needs one of the above.
+
+```bash
+# Debian/Ubuntu
+sudo apt install xclip              # X11
+sudo apt install wl-clipboard       # Wayland
+
+# Fedora
+sudo dnf install xclip              # X11
+sudo dnf install wl-clipboard       # Wayland
+
+# Arch
+sudo pacman -S xclip                # X11
+sudo pacman -S wl-clipboard         # Wayland
+```
+
 ## Build
 
 ```bash
@@ -89,25 +113,25 @@ ip addr | grep inet
 # Look for 192.168.122.x on enp1s0
 ```
 
-**Copy .deb to VM** (from host):
+**Prerequisites on VM** (first time only):
 
 ```bash
-scp -O src-tauri/target/release/bundle/deb/Look_*.deb ubuntu@192.168.122.x:/tmp/
+sudo apt install openssh-server patchelf
+```
+
+**Deploy** (from host, run as one script):
+
+```bash
+scp -O apps/linows/src-tauri/target/release/bundle/deb/Look_*.deb kunkka@192.168.122.x:/tmp/
 ```
 
 **Install on VM:**
 
 ```bash
-sudo dpkg -r look                          # remove old version
-sudo apt install -f                        # install missing deps
-sudo dpkg -i /tmp/Look_*.deb              # install new version
-```
-
-**NixOS-built binaries need patching** (NixOS linker path doesn't exist on Ubuntu):
-
-```bash
-sudo apt install patchelf
+pkill lookapp                              # stop running instance
+sudo dpkg -r look && sudo dpkg -i /tmp/Look_*.deb
 sudo patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 /usr/bin/lookapp
+lookapp                                    # launch from terminal to see logs
 ```
 
 > **Why?** NixOS builds link against `/nix/store/.../ld-linux-x86-64.so.2` which doesn't
@@ -121,8 +145,25 @@ sudo patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 /usr/bin/lookapp
 **GNOME Shell extension** requires log out/in after first install to load.
 
 **Known issues on Ubuntu:**
-- D-Bus activated apps (e.g. Ptyxis terminal) may need 2 launch attempts — first call registers the D-Bus service, second opens the window
 - GNOME's default Alt+Space (window menu) is auto-disabled by Look on Wayland; restored when Look exits
+- **GNOME Wayland: dock icon visible while Look is open.** Tauri sets `skip_taskbar_hint`
+  asynchronously after the GTK window is mapped, so GNOME's dock ignores it. Native GTK apps
+  like Ulauncher set this hint in the constructor (before mapping), which works. On X11, the
+  hint works correctly. The icon disappears when Look is hidden (Esc / Alt+Space).
+  **Contributions welcome** — if you know a way to set GTK hints before Tauri maps the window,
+  please open a PR!
+
+  **Workaround — hide running app indicators from the dock:**
+
+  ```bash
+  # Ubuntu Dock
+  gsettings set org.gnome.shell.extensions.ubuntu-dock show-running false
+
+  # Dash to Dock
+  gsettings set org.gnome.shell.extensions.dash-to-dock show-running false
+
+  # Undo: replace 'false' with 'true'
+  ```
 
 **For dev in VM (nixos)**
 

--- a/apps/linows/TASKS.md
+++ b/apps/linows/TASKS.md
@@ -20,8 +20,8 @@ Based on macOS app as source of truth. Organized by phase.
 - [x] `commands.rs` — reload_config(), request_index_refresh()
 - [x] `commands.rs` — get_file_meta(path), get_app_version(path), get_home_dir()
 - [x] `platform.rs` — Icon extraction (freedesktop theme + XDG_DATA_DIRS, .desktop Icon= parsing)
-- [x] App launching — gio launch → gtk-launch → direct spawn, focus existing window via i3-msg/xdotool
-- [x] Settings URL handling — settings:// paths routed through xdg-open
+- [x] App launching — gtk-launch → gio launch → direct spawn, focus existing window via i3-msg/x11rb/GNOME ext
+- [x] Settings URL handling — settings:// paths routed through gnome-control-center (D-Bus + fallback)
 
 ### Frontend (HTML/CSS/JS)
 - [x] `index.html` — Main window structure
@@ -55,7 +55,7 @@ Based on macOS app as source of truth. Organized by phase.
 ### Features
 - [x] Quick folders (Desktop, Documents, Downloads, Pictures, Videos, Music)
 - [x] Multi-pick (Ctrl+P toggle, Ctrl+Shift+P clear all)
-- [x] Clipboard write — Ctrl+C copies file/folder (pasteable in file managers), auto-copy on pick
+- [x] Clipboard write — Ctrl+C copies file/folder (wl-copy/xclip, pasteable in file managers), auto-copy on pick
 - [x] Reveal in file manager (Ctrl+F)
 - [x] Hint bar (bottom status text)
 - [x] Web search (Ctrl+Enter) — opens Google search in default browser
@@ -120,18 +120,20 @@ Based on macOS app as source of truth. Organized by phase.
 - [x] Config file persistence (.look.config format, shared with macOS)
 - [x] Dynamic window scaling — 1.0x at 1080p, 1.2x at 1440p, 1.3x max
 - [x] Auto-start registration (Linux .desktop autostart, enabled by default on first launch)
+- [x] Quit shortcut (Alt+Shift+Q) — works on both X11 and Wayland
+- [x] Lazy indexing — file watcher auto-refresh (2s debounce) + always refresh on window-show
+- [x] System settings detection — only show settings entries when gnome-control-center is available
 - [ ] UWP app seeding (Windows — enumerate shell:AppsFolder via PowerShell)
 
 ---
 
 ## Backlog / Improvements
 
-- [ ] Linux settings handling — detect DE (GNOME/KDE/minimal):
-  - GNOME/KDE: `settings://` URLs work via `gnome-control-center` / `systemsettings`
-  - Minimal (i3/sway/X11 bare): map to standalone tools (pavucontrol, arandr, blueman-manager, etc.) or hide settings entries
-  - Detect via `XDG_CURRENT_DESKTOP`, `DESKTOP_SESSION`, or presence of `gnome-control-center`
+- [x] Linux settings handling — detect `gnome-control-center` at index time; skip settings on i3/sway/minimal
+- [ ] KDE settings support — detect `systemsettings` and add KDE-specific settings catalog
+- [ ] Minimal DE settings — map to standalone tools (pavucontrol, arandr, blueman-manager) on i3/sway
 - [ ] Some DBUS single-instance apps (blueman-manager, fcitx5-config) fail to launch — known limitation
-- [ ] D-Bus activated apps (Ptyxis/Terminal on Ubuntu 26.04) need 2x `gio launch` — first call registers service, second opens window. Workaround: retry `gio launch` if no window appears within ~500ms
+- [ ] GNOME Wayland: dock icon visible while Look is open — Tauri sets skip_taskbar_hint async (too late). Contributions welcome.
 - [ ] macOS: dynamic window scaling based on monitor resolution (match linows — 1.0x at 1080p, 1.2x at 1440p, 1.3x max)
 - [ ] Configurable global hotkey — let users change the toggle shortcut (default Alt+Space) via settings
 - [ ] Structured logging — wire up Backend Log Level setting (error/warn/info/debug) to control output; replace `eprintln!` with proper log macros

--- a/apps/linows/nix/package.nix
+++ b/apps/linows/nix/package.nix
@@ -40,7 +40,7 @@ rustPlatform.buildRustPackage {
   };
 
   cargoRoot = "apps/linows/src-tauri";
-  cargoHash = "sha256-0+WqxYoeXLxRzGg9pLrMQUxUnqyfU3AFC/9uww2ibcM=";
+  cargoHash = "sha256-6keXhsef7HDdyjGv58zwv+YVKRz7kSWXV5ROuyrvWAk=";
 
   buildAndTestSubdir = "apps/linows/src-tauri";
 

--- a/apps/linows/src-tauri/Cargo.lock
+++ b/apps/linows/src-tauri/Cargo.lock
@@ -770,7 +770,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf 0.13.1",
+ "phf",
  "smallvec",
 ]
 
@@ -3069,22 +3069,12 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros 0.13.1",
- "phf_shared 0.13.1",
+ "phf_macros",
+ "phf_shared",
  "serde",
 ]
 
@@ -3094,18 +3084,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared 0.11.3",
- "rand",
+ "phf_generator",
+ "phf_shared",
 ]
 
 [[package]]
@@ -3115,20 +3095,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "phf_shared",
 ]
 
 [[package]]
@@ -3137,20 +3104,11 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -3378,21 +3336,6 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "raw-window-handle"
@@ -3685,7 +3628,7 @@ dependencies = [
  "derive_more",
  "log",
  "new_debug_unreachable",
- "phf 0.13.1",
+ "phf",
  "phf_codegen",
  "precomputed-hash",
  "rustc-hash",
@@ -3995,7 +3938,7 @@ checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared 0.13.1",
+ "phf_shared",
  "precomputed-hash",
 ]
 
@@ -4005,8 +3948,8 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
 ]
@@ -4190,9 +4133,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d059f2527558d9dba6f186dec4772610e1aecfd3f94002397613e7e648752b66"
+checksum = "b93bd86d231f0a8138f11a02a584769fe4b703dc36ae133d783228dbc4801405"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4242,9 +4185,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9aa8c59a894f76c29a002501c589de5eb4987a5913d62a6e0a47f320901988"
+checksum = "3a318b234cc2dea65f575467bafcfb76286bce228ebc3778e337d61d03213007"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -4263,9 +4206,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e4e8230d565106aa19dfbaa01a7ed01abf78047fe0577a83377224bd1bf20e"
+checksum = "6bd11644962add2549a60b7e7c6800f17d7020156e02f516021d8103e80cc528"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -4290,9 +4233,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8de2cddbbc33dbdf4c84f170121886595efdbcc9cb4b3d76342b79d082cedc"
+checksum = "fed9d3742a37a355d2e47c9af924e9fbc112abb76f9835d35d4780e318419502"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -4392,9 +4335,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e42bbcb76237351fbaa02f08d808c537dc12eb5a6eabbf3e517b50056334d95"
+checksum = "8fef478ba1d2ac21c2d528740b24d0cb315e1e8b1111aae53fafac34804371fc"
 dependencies = [
  "cookie",
  "dpi",
@@ -4417,9 +4360,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cadb13dad0c681e1e0a2c49ae488f0e2906ded3d57e7a0017f4aaf46e387117"
+checksum = "a3989df2ae1c476404fe0a2e8ffc4cfbde97e51efd613c2bb5355fbc9ab52cf0"
 dependencies = [
  "gtk",
  "http",
@@ -4443,9 +4386,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f61d2bf7188fbcf2b0ed095b67a6bc498f713c939314bb19eb700118a573b7"
+checksum = "d57200389a2f82b4b0a40ae29ca19b6978116e8f4d4e974c3234ce40c0ffbdec"
 dependencies = [
  "anyhow",
  "brotli",
@@ -4459,7 +4402,7 @@ dependencies = [
  "json-patch",
  "log",
  "memchr",
- "phf 0.11.3",
+ "phf",
  "plist",
  "proc-macro2",
  "quote",
@@ -4625,9 +4568,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -5213,7 +5156,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
 dependencies = [
- "phf 0.13.1",
+ "phf",
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",

--- a/apps/linows/src-tauri/Cargo.toml
+++ b/apps/linows/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 license = "MIT"
 
 [dependencies]
-tauri = { version = "2", features = ["tray-icon", "protocol-asset"] }
+tauri = { version = "2.11.1", features = ["tray-icon", "protocol-asset"] }
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-single-instance = "2"
 look-engine = { path = "../../../core/engine" }
@@ -24,7 +24,7 @@ tauri-plugin-dialog = "2"
 [target.'cfg(target_os = "linux")'.dependencies]
 x11rb = { version = "0.13", features = ["allow-unsafe-code"] }
 zbus = "5"
-tokio = { version = "1", features = ["rt"] }
+tokio = { version = "1.52.3", features = ["rt"] }
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/apps/linows/src-tauri/src/commands.rs
+++ b/apps/linows/src-tauri/src/commands.rs
@@ -226,6 +226,12 @@ pub fn force_index_refresh(state: State<'_, AppState>) -> bool {
 }
 
 #[tauri::command]
+pub fn quit_app(app: tauri::AppHandle) {
+    eprintln!("look: quit via Alt+Shift+Q");
+    app.exit(0);
+}
+
+#[tauri::command]
 pub fn toggle_window(window: tauri::WebviewWindow) {
     if window.is_visible().unwrap_or(false) {
         let _ = window.hide();
@@ -284,46 +290,80 @@ fn launch_app(exec: &str, id: Option<&str>) -> Result<(), String> {
         }
     }
 
-    if let Some(ref real_path) = desktop_file {
-        let result = std::process::Command::new("gio")
-            .args(["launch", real_path])
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn();
-        if result.is_ok() {
-            return Ok(());
-        }
-    }
-
-    if let Some(desktop_name) = id
+    // Build the launch chain: gtk-launch → gio launch → direct exec.
+    // gtk-launch is preferred because gio launch uses D-Bus activation
+    // which can silently fail to show a window on first invocation.
+    let desktop_path = desktop_file.clone();
+    let desktop_name = id
         .and_then(|id| id.strip_prefix("app:"))
         .and_then(|p| std::path::Path::new(p).file_name())
         .and_then(|f| f.to_str())
         .and_then(|f| f.strip_suffix(".desktop"))
-    {
-        let result = std::process::Command::new("gtk-launch")
-            .arg(desktop_name)
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn();
-        if result.is_ok() {
-            return Ok(());
+        .map(String::from);
+    let exec_cmd = exec.to_string();
+
+    std::thread::spawn(move || {
+        if let Some(ref name) = desktop_name {
+            eprintln!("[launch] trying gtk-launch {name}");
+            let result = std::process::Command::new("gtk-launch")
+                .arg(name)
+                .env_remove("LD_LIBRARY_PATH")
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::piped())
+                .output();
+            match &result {
+                Ok(output) if output.status.success() => {
+                    eprintln!("[launch] gtk-launch succeeded");
+                    return;
+                }
+                Ok(output) => {
+                    let err = String::from_utf8_lossy(&output.stderr);
+                    eprintln!("[launch] gtk-launch failed (exit {}): {err}", output.status);
+                }
+                Err(e) => eprintln!("[launch] gtk-launch not found: {e}"),
+            }
         }
-    }
 
-    let mut parts = exec.split_whitespace();
-    let cmd = parts.next().ok_or("Empty exec command")?;
-    let args: Vec<&str> = parts.filter(|s| !s.starts_with('%')).collect();
+        if let Some(ref real_path) = desktop_path {
+            eprintln!("[launch] trying gio launch {real_path}");
+            let result = std::process::Command::new("gio")
+                .args(["launch", real_path])
+                .env_remove("LD_LIBRARY_PATH")
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::piped())
+                .output();
+            match &result {
+                Ok(output) if output.status.success() => {
+                    eprintln!("[launch] gio launch succeeded");
+                    return;
+                }
+                Ok(output) => {
+                    let err = String::from_utf8_lossy(&output.stderr);
+                    eprintln!("[launch] gio launch failed (exit {}): {err}", output.status);
+                }
+                Err(e) => eprintln!("[launch] gio not found: {e}"),
+            }
+        }
 
-    std::process::Command::new(cmd)
-        .args(&args)
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-        .map_err(|e| format!("Failed to launch {cmd}: {e}"))?;
+        let mut parts = exec_cmd.split_whitespace();
+        if let Some(cmd) = parts.next() {
+            let args: Vec<&str> = parts.filter(|s| !s.starts_with('%')).collect();
+            eprintln!("[launch] trying direct exec: {cmd} {}", args.join(" "));
+            match std::process::Command::new(cmd)
+                .args(&args)
+                .env_remove("LD_LIBRARY_PATH")
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()
+            {
+                Ok(_) => eprintln!("[launch] direct exec spawned"),
+                Err(e) => eprintln!("[launch] direct exec failed: {e}"),
+            }
+        }
+    });
 
     Ok(())
 }

--- a/apps/linows/src-tauri/src/files.rs
+++ b/apps/linows/src-tauri/src/files.rs
@@ -64,38 +64,12 @@ pub fn copy_files_to_clipboard(paths: Vec<String>) -> Result<(), String> {
         return Ok(());
     }
     crate::clipboard::mark_self_write();
-    let uris: Vec<String> = paths
-        .iter()
-        .map(|p| {
-            let encoded: String = p
-                .bytes()
-                .map(|b| match b {
-                    b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'/' => {
-                        (b as char).to_string()
-                    }
-                    _ => format!("%{b:02X}"),
-                })
-                .collect();
-            format!("file://{encoded}")
-        })
-        .collect();
-    let uri = format!("copy\n{}", uris.join("\n"));
-
-    let script = format!(
-        "echo -n '{}' | xclip -selection clipboard -t x-special/gnome-copied-files 2>/dev/null || \
-         echo -n '{}' | wl-copy -t x-special/gnome-copied-files 2>/dev/null",
-        uri.replace('\'', "'\\''"),
-        uri.replace('\'', "'\\''"),
-    );
-
-    let result = std::process::Command::new("setsid")
-        .args(["sh", "-c", &script])
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn();
-
-    result.map_err(|e| format!("Failed to copy: {e}"))?;
+    let path_refs: Vec<std::path::PathBuf> = paths.iter().map(std::path::PathBuf::from).collect();
+    let mut clipboard = arboard::Clipboard::new().map_err(|e| format!("Failed to copy: {e}"))?;
+    clipboard
+        .set()
+        .file_list(&path_refs)
+        .map_err(|e| format!("Failed to copy: {e}"))?;
     Ok(())
 }
 

--- a/apps/linows/src-tauri/src/files.rs
+++ b/apps/linows/src-tauri/src/files.rs
@@ -64,13 +64,60 @@ pub fn copy_files_to_clipboard(paths: Vec<String>) -> Result<(), String> {
         return Ok(());
     }
     crate::clipboard::mark_self_write();
-    let path_refs: Vec<std::path::PathBuf> = paths.iter().map(std::path::PathBuf::from).collect();
-    let mut clipboard = arboard::Clipboard::new().map_err(|e| format!("Failed to copy: {e}"))?;
-    clipboard
-        .set()
-        .file_list(&path_refs)
-        .map_err(|e| format!("Failed to copy: {e}"))?;
-    Ok(())
+    let uris: Vec<String> = paths
+        .iter()
+        .map(|p| {
+            let encoded: String = p
+                .bytes()
+                .map(|b| match b {
+                    b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'/' => {
+                        (b as char).to_string()
+                    }
+                    _ => format!("%{b:02X}"),
+                })
+                .collect();
+            format!("file://{encoded}")
+        })
+        .collect();
+    let payload = format!("copy\n{}", uris.join("\n"));
+    let mime = "x-special/gnome-copied-files";
+
+    // Try wl-copy (Wayland) first, then xclip (X11) — no hard dependency on either
+    let result = std::process::Command::new("wl-copy")
+        .args(["-t", mime])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            if let Some(ref mut stdin) = child.stdin {
+                stdin.write_all(payload.as_bytes())?;
+            }
+            child.wait()
+        });
+
+    if result.is_ok() {
+        return Ok(());
+    }
+
+    let result = std::process::Command::new("xclip")
+        .args(["-selection", "clipboard", "-t", mime])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            if let Some(ref mut stdin) = child.stdin {
+                stdin.write_all(payload.as_bytes())?;
+            }
+            child.wait()
+        });
+
+    result
+        .map(|_| ())
+        .map_err(|e| format!("Failed to copy files: {e}. Install xclip or wl-clipboard."))
 }
 
 #[tauri::command]

--- a/apps/linows/src-tauri/src/linux_window_focus.rs
+++ b/apps/linows/src-tauri/src/linux_window_focus.rs
@@ -27,11 +27,45 @@ static NEEDS_FOCUS: AtomicBool = AtomicBool::new(false);
 /// Auto-hide only fires when this transitions from true → false.
 static HAS_FOCUS: AtomicBool = AtomicBool::new(false);
 
-/// Call once after the window is mapped to cache Look's X11 window ID.
+/// Call once after the window is mapped to cache Look's X11 window ID
+/// and hide from GNOME dock/taskbar.
 pub fn cache_self_window() {
     if let Some(wid) = find_window_by_class("lookapp") {
         SELF_WID.store(wid, Ordering::SeqCst);
+        set_skip_taskbar(wid);
     }
+}
+
+/// Set _NET_WM_STATE_SKIP_TASKBAR so Look doesn't appear in the GNOME dock.
+fn set_skip_taskbar(wid: Window) {
+    let Ok((conn, screen_num)) = x11rb::connect(None) else {
+        return;
+    };
+    let root = conn.setup().roots[screen_num].root;
+
+    let Ok(state_cookie) = conn.intern_atom(false, b"_NET_WM_STATE") else {
+        return;
+    };
+    let Ok(skip_cookie) = conn.intern_atom(false, b"_NET_WM_STATE_SKIP_TASKBAR") else {
+        return;
+    };
+    let Ok(state_atom) = state_cookie.reply() else {
+        return;
+    };
+    let Ok(skip_atom) = skip_cookie.reply() else {
+        return;
+    };
+
+    // Send _NET_WM_STATE client message: action=1 (add), atom=SKIP_TASKBAR
+    let data = ClientMessageData::from([1u32, skip_atom.atom, 0, 0, 0]);
+    let event = ClientMessageEvent::new(32, wid, state_atom.atom, data);
+    let _ = conn.send_event(
+        false,
+        root,
+        EventMask::SUBSTRUCTURE_REDIRECT | EventMask::SUBSTRUCTURE_NOTIFY,
+        event,
+    );
+    let _ = conn.flush();
 }
 
 /// Notify that Look was just shown and needs focus activation.

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -200,6 +200,16 @@ fn main() {
                         }
                         toggle_window(&handle);
                     })?;
+                app.global_shortcut()
+                    .on_shortcut("Alt+Shift+Q", |app, _shortcut, event| {
+                        if event.state
+                            != tauri_plugin_global_shortcut::ShortcutState::Pressed
+                        {
+                            return;
+                        }
+                        eprintln!("look: quit via Alt+Shift+Q");
+                        app.exit(0);
+                    })?;
             }
 
             // Cache Look's X11 window ID for later focus activation,
@@ -274,6 +284,7 @@ fn main() {
             commands::force_index_refresh,
             commands::toggle_window,
             commands::hide_window,
+            commands::quit_app,
             // Config
             config::get_config,
             config::set_config,

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -171,6 +171,7 @@ fn main() {
     builder
         .setup(move |app| {
             AppState::init_app_handle(app);
+            app.state::<AppState>().start_bootstrap();
             clipboard::start_monitor();
             let app_handle = app.handle().clone();
 

--- a/apps/linows/src-tauri/src/state.rs
+++ b/apps/linows/src-tauri/src/state.rs
@@ -269,42 +269,41 @@ impl AppState {
                     }
 
                     // Auto-refresh after debounce period
-                    if let Some(t) = last_dirty_at {
-                        if t.elapsed() >= debounce
-                            && in_progress
-                                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-                                .is_ok()
-                        {
-                            last_dirty_at = None;
-                            let dirty_snapshot = change_version.load(Ordering::Acquire);
-                            let db_path = default_db_path();
-                            eprintln!("[watcher] auto-refreshing index...");
+                    if let Some(t) = last_dirty_at
+                        && t.elapsed() >= debounce
+                        && in_progress
+                            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                            .is_ok()
+                    {
+                        last_dirty_at = None;
+                        let dirty_snapshot = change_version.load(Ordering::Acquire);
+                        let db_path = default_db_path();
+                        eprintln!("[watcher] auto-refreshing index...");
 
-                            match QueryEngine::bootstrap_sqlite(&db_path) {
-                                Ok(()) => {
-                                    if let Ok(new_engine) = QueryEngine::from_sqlite(&db_path) {
-                                        let mut guard = engine_lock
-                                            .write()
-                                            .unwrap_or_else(|poisoned| poisoned.into_inner());
-                                        *guard = new_engine;
-                                    }
-                                    if change_version.load(Ordering::Acquire) == dirty_snapshot {
-                                        cleared_version.store(dirty_snapshot, Ordering::Release);
-                                    }
-                                    eprintln!("[watcher] auto-refresh done");
-                                    if let Some(handle) = APP_HANDLE.get()
-                                        && let Some(w) = handle.get_webview_window("main")
-                                    {
-                                        let _ = w.emit("index-ready", ());
-                                    }
+                        match QueryEngine::bootstrap_sqlite(&db_path) {
+                            Ok(()) => {
+                                if let Ok(new_engine) = QueryEngine::from_sqlite(&db_path) {
+                                    let mut guard = engine_lock
+                                        .write()
+                                        .unwrap_or_else(|poisoned| poisoned.into_inner());
+                                    *guard = new_engine;
                                 }
-                                Err(err) => {
-                                    change_version.fetch_add(1, Ordering::AcqRel);
-                                    eprintln!("[watcher] auto-refresh failed: {err}");
+                                if change_version.load(Ordering::Acquire) == dirty_snapshot {
+                                    cleared_version.store(dirty_snapshot, Ordering::Release);
+                                }
+                                eprintln!("[watcher] auto-refresh done");
+                                if let Some(handle) = APP_HANDLE.get()
+                                    && let Some(w) = handle.get_webview_window("main")
+                                {
+                                    let _ = w.emit("index-ready", ());
                                 }
                             }
-                            in_progress.store(false, Ordering::Release);
+                            Err(err) => {
+                                change_version.fetch_add(1, Ordering::AcqRel);
+                                eprintln!("[watcher] auto-refresh failed: {err}");
+                            }
                         }
+                        in_progress.store(false, Ordering::Release);
                     }
                 }
             });

--- a/apps/linows/src-tauri/src/state.rs
+++ b/apps/linows/src-tauri/src/state.rs
@@ -33,13 +33,18 @@ impl AppState {
             watcher_control: Mutex::new(None),
         };
 
-        state.start_background_bootstrap();
         state.start_index_watchers();
         state
     }
 
     pub fn init_app_handle(app: &tauri::App) {
         let _ = APP_HANDLE.set(app.handle().clone());
+    }
+
+    /// Must be called after `init_app_handle` so the `index-ready` event
+    /// can be emitted once the bootstrap finishes.
+    pub fn start_bootstrap(&self) {
+        self.start_background_bootstrap();
     }
 
     pub fn with_engine<T>(&self, f: impl FnOnce(&QueryEngine) -> T) -> T {

--- a/apps/linows/src-tauri/src/state.rs
+++ b/apps/linows/src-tauri/src/state.rs
@@ -64,10 +64,6 @@ impl AppState {
     }
 
     pub fn request_index_refresh(&self) -> bool {
-        let config = RuntimeConfig::load();
-        if config.lazy_indexing_enabled && !self.is_index_dirty() {
-            return false;
-        }
         if !self.try_acquire_refresh_slot() {
             return false;
         }
@@ -216,10 +212,16 @@ impl AppState {
         }
 
         let change_version = &self.index_change_version as *const AtomicU64;
+        let cleared_version = &self.index_cleared_version as *const AtomicU64;
+        let in_progress = &self.index_refresh_in_progress as *const AtomicBool;
+        let engine_lock = &self.engine as *const RwLock<QueryEngine>;
 
         // SAFETY: AppState lives for the app's lifetime.
         unsafe {
             let change_version = &*change_version;
+            let cleared_version = &*cleared_version;
+            let in_progress = &*in_progress;
+            let engine_lock = &*engine_lock;
 
             thread::spawn(move || {
                 let (event_tx, event_rx) = mpsc::channel::<notify::Result<Event>>();
@@ -234,23 +236,75 @@ impl AppState {
                 };
 
                 for root in &active_roots {
-                    let _ = watcher.watch(Path::new(root), RecursiveMode::Recursive);
+                    match watcher.watch(Path::new(root), RecursiveMode::Recursive) {
+                        Ok(()) => eprintln!("[watcher] watching: {root}"),
+                        Err(e) => eprintln!("[watcher] failed to watch {root}: {e}"),
+                    }
                 }
+
+                let debounce = std::time::Duration::from_secs(2);
+                let mut last_dirty_at: Option<Instant> = None;
 
                 loop {
                     if stop_rx.try_recv().is_ok() {
                         break;
                     }
 
-                    match event_rx.recv_timeout(std::time::Duration::from_secs(1)) {
+                    match event_rx.recv_timeout(std::time::Duration::from_millis(500)) {
                         Ok(Ok(event)) => {
                             if should_mark_dirty(&event) {
-                                change_version.fetch_add(1, Ordering::AcqRel);
+                                let v = change_version.fetch_add(1, Ordering::AcqRel);
+                                eprintln!(
+                                    "[watcher] dirty! v={} {:?} {:?}",
+                                    v + 1,
+                                    event.kind,
+                                    event.paths
+                                );
+                                last_dirty_at = Some(Instant::now());
                             }
                         }
                         Ok(Err(_)) => {}
                         Err(mpsc::RecvTimeoutError::Timeout) => {}
                         Err(mpsc::RecvTimeoutError::Disconnected) => break,
+                    }
+
+                    // Auto-refresh after debounce period
+                    if let Some(t) = last_dirty_at {
+                        if t.elapsed() >= debounce
+                            && in_progress
+                                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                                .is_ok()
+                        {
+                            last_dirty_at = None;
+                            let dirty_snapshot = change_version.load(Ordering::Acquire);
+                            let db_path = default_db_path();
+                            eprintln!("[watcher] auto-refreshing index...");
+
+                            match QueryEngine::bootstrap_sqlite(&db_path) {
+                                Ok(()) => {
+                                    if let Ok(new_engine) = QueryEngine::from_sqlite(&db_path) {
+                                        let mut guard = engine_lock
+                                            .write()
+                                            .unwrap_or_else(|poisoned| poisoned.into_inner());
+                                        *guard = new_engine;
+                                    }
+                                    if change_version.load(Ordering::Acquire) == dirty_snapshot {
+                                        cleared_version.store(dirty_snapshot, Ordering::Release);
+                                    }
+                                    eprintln!("[watcher] auto-refresh done");
+                                    if let Some(handle) = APP_HANDLE.get()
+                                        && let Some(w) = handle.get_webview_window("main")
+                                    {
+                                        let _ = w.emit("index-ready", ());
+                                    }
+                                }
+                                Err(err) => {
+                                    change_version.fetch_add(1, Ordering::AcqRel);
+                                    eprintln!("[watcher] auto-refresh failed: {err}");
+                                }
+                            }
+                            in_progress.store(false, Ordering::Release);
+                        }
                     }
                 }
             });
@@ -261,11 +315,6 @@ impl AppState {
         // Mark dirty so lazy indexing check passes
         self.index_change_version.fetch_add(1, Ordering::AcqRel);
         self.request_index_refresh()
-    }
-
-    fn is_index_dirty(&self) -> bool {
-        self.index_change_version.load(Ordering::Acquire)
-            != self.index_cleared_version.load(Ordering::Acquire)
     }
 
     fn try_acquire_refresh_slot(&self) -> bool {

--- a/apps/linows/src-tauri/tauri.conf.json
+++ b/apps/linows/src-tauri/tauri.conf.json
@@ -57,8 +57,7 @@
           "libharfbuzz0b",
           "libdbus-1-3",
           "libasound2",
-          "xdg-desktop-portal",
-          "xclip"
+          "xdg-desktop-portal"
         ],
         "section": "utils",
         "priority": "optional"

--- a/apps/linows/src/js/ipc.js
+++ b/apps/linows/src/js/ipc.js
@@ -33,6 +33,10 @@ export async function hideWindow() {
   return invoke('hide_window');
 }
 
+export async function quitApp() {
+  return invoke('quit_app');
+}
+
 export async function getIcon(kind, path, id) {
   return invoke('get_icon', { kind, path, id });
 }

--- a/apps/linows/src/js/keyboard.js
+++ b/apps/linows/src/js/keyboard.js
@@ -49,6 +49,13 @@ export function setSettingsMode(mod, contentArea, searchBar) {
 }
 
 function handleKeyDown(e) {
+  // Alt+Shift+Q quits the app
+  if (e.altKey && (e.shiftKey || shiftHeld) && (e.key === 'Q' || e.key === 'q')) {
+    e.preventDefault();
+    import('./ipc.js').then(m => m.quitApp());
+    return;
+  }
+
   // Ctrl+Shift+, toggles settings
   if (e.ctrlKey && (e.shiftKey || shiftHeld) && (e.key === ',' || e.key === '<')) {
     e.preventDefault();

--- a/core/engine/src/index/settings.rs
+++ b/core/engine/src/index/settings.rs
@@ -5,6 +5,11 @@ use look_indexing::{Candidate, CandidateKind};
 use std::sync::mpsc;
 
 pub fn discover_system_settings_entries(tx: mpsc::SyncSender<Candidate>) {
+    // Only emit settings if the settings app is available on this system.
+    // e.g. gnome-control-center on GNOME, skip on i3/sway/minimal distros.
+    if !platform::has_settings_app() {
+        return;
+    }
     for entry in platform::settings_catalog() {
         let mut candidate = Candidate::new(
             &candidate_id(entry),
@@ -123,7 +128,11 @@ mod tests {
         let discovered: Vec<Candidate> = rx.into_iter().collect();
         producer.join().expect("settings discovery thread panicked");
 
-        assert_eq!(discovered.len(), platform::settings_catalog().len());
+        if platform::has_settings_app() {
+            assert_eq!(discovered.len(), platform::settings_catalog().len());
+        } else {
+            assert_eq!(discovered.len(), 0);
+        }
 
         for candidate in discovered {
             assert_eq!(candidate.kind, CandidateKind::App);

--- a/core/engine/src/platform/linux/settings_catalog.rs
+++ b/core/engine/src/platform/linux/settings_catalog.rs
@@ -59,16 +59,10 @@ pub(crate) static SETTINGS_CATALOG: &[SettingsCatalogEntry] = &[
     },
     // Personalization
     SettingsCatalogEntry {
-        title: "Background",
-        target: "background",
-        candidate_id_suffix: "background",
-        aliases: "wallpaper background desktop picture settings",
-    },
-    SettingsCatalogEntry {
         title: "Appearance",
-        target: "appearance",
+        target: "background",
         candidate_id_suffix: "appearance",
-        aliases: "appearance theme dark light style color settings",
+        aliases: "appearance theme dark light style color accent wallpaper background desktop picture settings",
     },
     SettingsCatalogEntry {
         title: "Notifications",
@@ -151,5 +145,25 @@ pub(crate) static SETTINGS_CATALOG: &[SettingsCatalogEntry] = &[
         target: "wellbeing",
         candidate_id_suffix: "wellbeing",
         aliases: "wellbeing screen time break reminder digital health settings",
+    },
+    // Ubuntu-specific
+    SettingsCatalogEntry {
+        title: "Ubuntu Desktop",
+        target: "ubuntu",
+        candidate_id_suffix: "ubuntu",
+        aliases: "ubuntu desktop dock appearance theme dark light style icons settings",
+    },
+    // Devices (optional)
+    SettingsCatalogEntry {
+        title: "Wacom",
+        target: "wacom",
+        candidate_id_suffix: "wacom",
+        aliases: "wacom tablet pen stylus drawing pressure settings",
+    },
+    SettingsCatalogEntry {
+        title: "Mobile Broadband",
+        target: "wwan",
+        candidate_id_suffix: "wwan",
+        aliases: "mobile broadband cellular data sim card wwan settings",
     },
 ];

--- a/core/engine/src/platform/mod.rs
+++ b/core/engine/src/platform/mod.rs
@@ -64,3 +64,27 @@ pub(crate) fn settings_subtitle_prefix() -> &'static str {
 pub(crate) fn settings_catalog() -> &'static [SettingsCatalogEntry] {
     platform_impl::SETTINGS_CATALOG
 }
+
+/// Check if the system has a settings app (e.g. gnome-control-center).
+/// Returns false on i3, sway, or minimal distros without a DE settings app.
+pub(crate) fn has_settings_app() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        true // macOS always has System Settings
+    }
+    #[cfg(target_os = "windows")]
+    {
+        true // Windows always has Settings
+    }
+    #[cfg(target_os = "linux")]
+    {
+        use std::process::Command;
+        Command::new("which")
+            .arg("gnome-control-center")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+}


### PR DESCRIPTION
## Summary

- xclip dep leads to crash while installing if User OS doesn't have xclip
- fix issue with app open
- add alt + shift + q to force quit

## Why

- #117 

## Changes

-

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
