### PR TITLE
fix: hover issue and dev mode

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -27,11 +27,6 @@ jobs:
 
       - uses: DeterminateSystems/nix-installer-action@main
 
-      - uses: cachix/cachix-action@v15
-        with:
-          name: look
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-
       - name: Build
         run: nix build ./apps/linows#default
 

--- a/apps/linows/src-tauri/src/files.rs
+++ b/apps/linows/src-tauri/src/files.rs
@@ -59,6 +59,11 @@ pub fn get_app_version(path: String) -> Option<String> {
 }
 
 #[tauri::command]
+pub fn is_dev_build() -> bool {
+    cfg!(debug_assertions)
+}
+
+#[tauri::command]
 pub fn copy_files_to_clipboard(paths: Vec<String>) -> Result<(), String> {
     if paths.is_empty() {
         return Ok(());

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -125,6 +125,44 @@ fn main() {
         return;
     }
 
+    // Dev mode: use separate config and database so dev doesn't pollute production.
+    // SAFETY: Called at startup before any threads are spawned.
+    #[cfg(debug_assertions)]
+    {
+        let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+        if std::env::var("LOOK_CONFIG_PATH")
+            .unwrap_or_default()
+            .trim()
+            .is_empty()
+        {
+            unsafe {
+                std::env::set_var(
+                    "LOOK_CONFIG_PATH",
+                    std::path::PathBuf::from(&home).join(".look.dev.config"),
+                );
+            }
+        }
+        if std::env::var("LOOK_DB_PATH")
+            .unwrap_or_default()
+            .trim()
+            .is_empty()
+        {
+            let db_dir = std::env::var("XDG_DATA_HOME")
+                .map(|d| std::path::PathBuf::from(d))
+                .unwrap_or_else(|_| std::path::PathBuf::from(&home).join(".local").join("share"))
+                .join("look");
+            let _ = std::fs::create_dir_all(&db_dir);
+            unsafe {
+                std::env::set_var("LOOK_DB_PATH", db_dir.join("look.dev.db"));
+            }
+        }
+        eprintln!(
+            "[dev] config={} db={}",
+            std::env::var("LOOK_CONFIG_PATH").unwrap_or_default(),
+            std::env::var("LOOK_DB_PATH").unwrap_or_default(),
+        );
+    }
+
     // Disable WebKitGTK GPU rendering in environments without GPU (VMs, containers).
     // Without this, WebKitGTK segfaults when no DRI device is available.
     // SAFETY: Called at startup before any threads are spawned.
@@ -292,6 +330,7 @@ fn main() {
             // Files: meta, version, clipboard, music, folder
             files::get_file_meta,
             files::get_app_version,
+            files::is_dev_build,
             files::copy_files_to_clipboard,
             files::get_home_dir,
             files::list_fonts,

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -148,7 +148,7 @@ fn main() {
             .is_empty()
         {
             let db_dir = std::env::var("XDG_DATA_HOME")
-                .map(|d| std::path::PathBuf::from(d))
+                .map(std::path::PathBuf::from)
                 .unwrap_or_else(|_| std::path::PathBuf::from(&home).join(".local").join("share"))
                 .join("look");
             let _ = std::fs::create_dir_all(&db_dir);

--- a/apps/linows/src/css/components/results.css
+++ b/apps/linows/src/css/components/results.css
@@ -15,10 +15,6 @@
   border-top: var(--border-thickness) solid var(--divider-color);
 }
 
-.result-row:hover {
-  background: var(--selection-fill);
-}
-
 .result-row.selected {
   background: var(--selection-fill);
 }

--- a/apps/linows/src/css/layout.css
+++ b/apps/linows/src/css/layout.css
@@ -46,6 +46,7 @@
 
 /* Search bar */
 .search-bar {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 10px;
@@ -126,4 +127,18 @@
 .hint-bar-link:hover {
   color: var(--accent-color);
   text-decoration: underline;
+}
+
+.dev-badge {
+  position: absolute;
+  top: 50%;
+  right: var(--content-padding);
+  transform: translateY(-50%);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  color: #fff;
+  background: #e05252;
+  padding: 1px 5px;
+  border-radius: 3px;
 }

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -13,7 +13,7 @@ import {
   onWindowShown, onIndexReady, requestIndexRefresh, getHomeDir, copyFilesToClipboard,
   evalCalc, runShellCommand, getSystemInfo,
   listProcesses, listProcessesOnPort, killProcess, getIcon,
-  copyToClipboard, deleteClipboardEntry,
+  copyToClipboard, deleteClipboardEntry, isDevBuild,
 } from './ipc.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
@@ -79,6 +79,16 @@ document.addEventListener('DOMContentLoaded', async () => {
       'Enter open \u2022 Ctrl+Enter search web \u2022 Ctrl+P pick \u2022 Ctrl+C copy \u2022 Ctrl+F reveal \u2022 Esc hide';
   });
   settings.restoreOnStartup();
+
+  // Show DEV badge when running in dev mode (cargo tauri dev)
+  isDevBuild().then((isDev) => {
+    if (isDev) {
+      const badge = document.createElement('span');
+      badge.className = 'dev-badge';
+      badge.textContent = 'DEV';
+      document.getElementById('search-bar').appendChild(badge);
+    }
+  });
 
   // Expose command mode toggle for keyboard.js
   keyboard.setCommandMode(commands);

--- a/apps/linows/src/js/components/results.js
+++ b/apps/linows/src/js/components/results.js
@@ -9,6 +9,7 @@ let selectedIndex = -1;
 let container = null;
 let onSelectionChange = null;
 let onPickChange = null;
+let mouseSelectEnabled = true;
 
 export function init(containerEl) {
   container = containerEl;
@@ -61,7 +62,9 @@ export function selectPrev() {
   select((selectedIndex - 1 + currentResults.length) % currentResults.length);
 }
 
-export function select(index) {
+export function select(index, { fromMouse = false } = {}) {
+  if (index === selectedIndex && fromMouse) return;
+
   const prev = container.querySelector('.result-row.selected');
   if (prev) prev.classList.remove('selected');
 
@@ -70,7 +73,12 @@ export function select(index) {
   const rows = container.querySelectorAll('.result-row');
   if (rows[index]) {
     rows[index].classList.add('selected');
-    rows[index].scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    if (!fromMouse) {
+      // Keyboard-driven: scroll into view but suppress mouseenter during scroll
+      mouseSelectEnabled = false;
+      rows[index].scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+      requestAnimationFrame(() => { mouseSelectEnabled = true; });
+    }
   }
 
   if (onSelectionChange) {
@@ -192,6 +200,10 @@ function createRow(result, index) {
     el.innerHTML = checkIcon;
     row.appendChild(el);
   }
+
+  row.addEventListener('mouseenter', () => {
+    if (mouseSelectEnabled) select(index, { fromMouse: true });
+  });
 
   row.addEventListener('click', () => {
     select(index);

--- a/apps/linows/src/js/ipc.js
+++ b/apps/linows/src/js/ipc.js
@@ -49,6 +49,10 @@ export async function getAppVersion(path) {
   return invoke('get_app_version', { path });
 }
 
+export async function isDevBuild() {
+  return invoke('is_dev_build');
+}
+
 export async function copyFilesToClipboard(paths) {
   return invoke('copy_files_to_clipboard', { paths });
 }


### PR DESCRIPTION
## Summary

- The hover and keyboard selection aren't separated -> when user navigates app by tab / up down with a cursor points to an app then hit enter -> Look might accidentally open 2 apps

## Why

- #134 

## Changes

- Keyboard-driven: scroll into view but suppress mouseenter during scroll
- Also add a dev mode (pin a dev water mark for developers), dev mode app uses diff db, diff config file
- Addition:
  - remove cachix push from main push event

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
