### PR TITLE
Feat: Macos file preview

### DIFF
--- a/apps/macos/LauncherApp/look-app/Support/HighlightedTextCache.swift
+++ b/apps/macos/LauncherApp/look-app/Support/HighlightedTextCache.swift
@@ -13,7 +13,9 @@ nonisolated enum HighlightedTextCache {
     }()
 
     static func key(path: String, mtime: Date, size: Int64) -> String {
-        "\(path)|\(Int(mtime.timeIntervalSince1970))|\(size)"
+        // Use full sub-second precision; truncating to Int seconds
+        // collides on rapid save/resave + same byte size.
+        "\(path)|\(mtime.timeIntervalSince1970)|\(size)"
     }
 
     static func get(_ key: String) -> NSAttributedString? {

--- a/apps/macos/LauncherApp/look-app/Support/HighlightedTextCache.swift
+++ b/apps/macos/LauncherApp/look-app/Support/HighlightedTextCache.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// LRU cache for highlighted file previews, keyed by
+/// `(path, mtime, size)` so a file is re-tokenized only when it
+/// actually changes on disk.
+nonisolated enum HighlightedTextCache {
+    // NSCache is documented thread-safe; mark nonisolated(unsafe) to
+    // satisfy Swift 6 strict-concurrency without an actor wrapper.
+    nonisolated(unsafe) private static let cache: NSCache<NSString, NSAttributedString> = {
+        let c = NSCache<NSString, NSAttributedString>()
+        c.countLimit = 32
+        return c
+    }()
+
+    static func key(path: String, mtime: Date, size: Int64) -> String {
+        "\(path)|\(Int(mtime.timeIntervalSince1970))|\(size)"
+    }
+
+    static func get(_ key: String) -> NSAttributedString? {
+        cache.object(forKey: key as NSString)
+    }
+
+    static func set(_ key: String, _ value: NSAttributedString) {
+        cache.setObject(value, forKey: key as NSString)
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/QuickLookPreviewService.swift
+++ b/apps/macos/LauncherApp/look-app/Support/QuickLookPreviewService.swift
@@ -1,0 +1,75 @@
+import AppKit
+import Foundation
+import QuickLookThumbnailing
+
+/// Generates Quick Look thumbnails for file results, with a size gate
+/// (so we don't ask the OS to syntax-highlight a 20 MB log file just to
+/// render a tile) and an LRU cache keyed by (path, mtime, size).
+///
+/// See specs/quicklook-file-preview.md for the full behavior contract.
+actor QuickLookPreviewService {
+    static let shared = QuickLookPreviewService()
+
+    private let cache: NSCache<NSString, NSImage> = {
+        let c = NSCache<NSString, NSImage>()
+        c.countLimit = 64
+        return c
+    }()
+
+    // Text/code files: QuickLook renders the *whole* file to produce a
+    // thumbnail. Cap aggressively so 5 MB JSON dumps don't stall.
+    private static let textExtensions: Set<String> = [
+        "txt", "md", "markdown", "rst", "log", "csv", "tsv",
+        "json", "yaml", "yml", "toml", "ini", "conf", "cfg", "env",
+        "xml", "html", "htm", "css", "scss", "sass", "less",
+        "js", "mjs", "cjs", "ts", "tsx", "jsx",
+        "py", "rb", "go", "rs", "swift",
+        "c", "cc", "cpp", "cxx", "h", "hh", "hpp", "hxx", "m", "mm",
+        "java", "kt", "kts", "scala", "groovy",
+        "sh", "bash", "zsh", "fish",
+        "sql", "lua", "php", "pl", "r", "clj", "ex", "exs", "erl",
+        "hs", "ml", "fs", "fsx", "dart", "vue", "svelte"
+    ]
+
+    private static let textFileSizeCap: Int64 = 512 * 1024            // 512 KB
+    private static let defaultSizeCap: Int64 = 20 * 1024 * 1024       // 20 MB
+
+    static func sizeCap(forPath path: String) -> Int64 {
+        return isTextFile(path: path) ? textFileSizeCap : defaultSizeCap
+    }
+
+    static func isTextFile(path: String) -> Bool {
+        let ext = (path as NSString).pathExtension.lowercased()
+        return textExtensions.contains(ext)
+    }
+
+    /// Returns nil if the file is missing, exceeds the size cap for its
+    /// type, or QuickLook produced no representation.
+    func thumbnail(forPath path: String, size: CGSize, scale: CGFloat) async -> NSImage? {
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+              let fileSize = attrs[.size] as? Int64,
+              let mtime = attrs[.modificationDate] as? Date else {
+            return nil
+        }
+        guard fileSize <= Self.sizeCap(forPath: path) else { return nil }
+
+        let key = "\(path)|\(Int(mtime.timeIntervalSince1970))|\(fileSize)|\(Int(size.width))x\(Int(size.height))@\(scale)" as NSString
+        if let cached = cache.object(forKey: key) { return cached }
+
+        let request = QLThumbnailGenerator.Request(
+            fileAt: URL(fileURLWithPath: path),
+            size: size,
+            scale: scale,
+            representationTypes: .thumbnail
+        )
+
+        let image: NSImage? = await withCheckedContinuation { continuation in
+            QLThumbnailGenerator.shared.generateBestRepresentation(for: request) { rep, _ in
+                continuation.resume(returning: rep?.nsImage)
+            }
+        }
+
+        if let image { cache.setObject(image, forKey: key) }
+        return image
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/QuickLookPreviewService.swift
+++ b/apps/macos/LauncherApp/look-app/Support/QuickLookPreviewService.swift
@@ -53,7 +53,9 @@ actor QuickLookPreviewService {
         }
         guard fileSize <= Self.sizeCap(forPath: path) else { return nil }
 
-        let key = "\(path)|\(Int(mtime.timeIntervalSince1970))|\(fileSize)|\(Int(size.width))x\(Int(size.height))@\(scale)" as NSString
+        // Full sub-second mtime precision: truncating to Int seconds
+        // collides on rapid save/resave + same byte size.
+        let key = "\(path)|\(mtime.timeIntervalSince1970)|\(fileSize)|\(Int(size.width))x\(Int(size.height))@\(scale)" as NSString
         if let cached = cache.object(forKey: key) { return cached }
 
         let request = QLThumbnailGenerator.Request(

--- a/apps/macos/LauncherApp/look-app/Support/SyntaxHighlighter.swift
+++ b/apps/macos/LauncherApp/look-app/Support/SyntaxHighlighter.swift
@@ -1,0 +1,149 @@
+import AppKit
+import SwiftUI
+
+/// Lightweight syntax highlighter for the file preview pane.
+/// Tokenizes by language and applies foreground colors via
+/// AttributedString. Not as accurate as a real parser — designed for
+/// "readable at a glance," not editor-quality fidelity.
+nonisolated enum SyntaxHighlighter {
+    enum Language {
+        case c, cpp, css, go, html, java, javascript, json, markdown,
+             python, ruby, rust, shell, swift, typescript, yaml, plain
+
+        static func from(path: String) -> Language {
+            switch (path as NSString).pathExtension.lowercased() {
+            case "go": return .go
+            case "swift": return .swift
+            case "rs": return .rust
+            case "py": return .python
+            case "rb": return .ruby
+            case "js", "mjs", "cjs", "jsx": return .javascript
+            case "ts", "tsx": return .typescript
+            case "c", "h", "m": return .c
+            case "cpp", "cc", "cxx", "hpp", "hh", "hxx", "mm": return .cpp
+            case "java", "kt", "kts", "scala", "groovy": return .java
+            case "sh", "bash", "zsh", "fish": return .shell
+            case "html", "htm", "xml", "svg", "vue", "svelte": return .html
+            case "css", "scss", "sass", "less": return .css
+            case "json": return .json
+            case "yaml", "yml", "toml": return .yaml
+            case "md", "markdown", "rst": return .markdown
+            default: return .plain
+            }
+        }
+    }
+
+    static func highlight(_ source: String, path: String) -> NSAttributedString {
+        let lang = Language.from(path: path)
+        if lang == .plain { return NSAttributedString(string: source) }
+
+        // Build with NSMutableAttributedString + NSRange so each token's
+        // attribute set is O(1). Using AttributedString.Index per token
+        // would walk the String from startIndex each time — O(n²) on a
+        // 64 KB file with thousands of tokens.
+        let keywordC = NSColor(srgbRed: 0.82, green: 0.49, blue: 0.79, alpha: 1)
+        let stringC  = NSColor(srgbRed: 0.91, green: 0.66, blue: 0.42, alpha: 1)
+        let commentC = NSColor(srgbRed: 0.45, green: 0.47, blue: 0.45, alpha: 1)
+        let numberC  = NSColor(srgbRed: 0.55, green: 0.78, blue: 0.84, alpha: 1)
+
+        let mut = NSMutableAttributedString(string: source)
+        let keywords = keywords(for: lang)
+        let (lineCmt, blockCmt) = commentDelimiters(for: lang)
+        let ns = source as NSString
+        let len = ns.length
+
+        func paint(_ start: Int, _ end: Int, _ color: NSColor) {
+            mut.addAttribute(.foregroundColor, value: color,
+                             range: NSRange(location: start, length: end - start))
+        }
+
+        var i = 0
+        while i < len {
+            // Line comment
+            if let pfx = lineCmt, i + pfx.count <= len,
+               ns.substring(with: NSRange(location: i, length: pfx.count)) == pfx {
+                let nl = ns.range(of: "\n", options: [],
+                                  range: NSRange(location: i, length: len - i))
+                let end = nl.location == NSNotFound ? len : nl.location
+                paint(i, end, commentC)
+                i = end; continue
+            }
+            // Block comment
+            if let bc = blockCmt, i + bc.0.count <= len,
+               ns.substring(with: NSRange(location: i, length: bc.0.count)) == bc.0 {
+                let after = i + bc.0.count
+                let r = ns.range(of: bc.1, options: [],
+                                 range: NSRange(location: after, length: len - after))
+                let end = r.location == NSNotFound ? len : r.location + r.length
+                paint(i, end, commentC)
+                i = end; continue
+            }
+            let c = ns.character(at: i)
+            // String: " ' `
+            if c == 34 || c == 39 || c == 96 {
+                var j = i + 1
+                while j < len {
+                    let k = ns.character(at: j)
+                    if k == 92, j + 1 < len { j += 2; continue }  // backslash escape
+                    if k == c { j += 1; break }
+                    if k == 10 { break }  // newline → unterminated
+                    j += 1
+                }
+                paint(i, j, stringC); i = j; continue
+            }
+            // Number
+            if c >= 48 && c <= 57 {
+                var j = i
+                while j < len {
+                    let k = ns.character(at: j)
+                    if (k >= 48 && k <= 57) || k == 46 || k == 95 || k == 120
+                        || (k >= 97 && k <= 102) || (k >= 65 && k <= 70) { j += 1 }
+                    else { break }
+                }
+                paint(i, j, numberC); i = j; continue
+            }
+            // Identifier / keyword
+            if (c >= 65 && c <= 90) || (c >= 97 && c <= 122) || c == 95 {
+                var j = i
+                while j < len {
+                    let k = ns.character(at: j)
+                    if (k >= 48 && k <= 57) || (k >= 65 && k <= 90)
+                        || (k >= 97 && k <= 122) || k == 95 { j += 1 }
+                    else { break }
+                }
+                let word = ns.substring(with: NSRange(location: i, length: j - i))
+                if keywords.contains(word) { paint(i, j, keywordC) }
+                i = j; continue
+            }
+            i += 1
+        }
+        return mut
+    }
+
+    private static func keywords(for lang: Language) -> Set<String> {
+        switch lang {
+        case .go: return ["break","case","chan","const","continue","default","defer","else","fallthrough","for","func","go","goto","if","import","interface","map","package","range","return","select","struct","switch","type","var","nil","true","false","iota"]
+        case .swift: return ["associatedtype","class","deinit","enum","extension","fileprivate","func","import","init","inout","internal","let","open","operator","private","protocol","public","static","struct","subscript","typealias","var","break","case","continue","default","defer","do","else","fallthrough","for","guard","if","in","repeat","return","switch","where","while","as","Any","catch","false","is","nil","rethrows","self","Self","super","throw","throws","true","try","async","await","actor"]
+        case .rust: return ["as","async","await","break","const","continue","crate","dyn","else","enum","extern","false","fn","for","if","impl","in","let","loop","match","mod","move","mut","pub","ref","return","self","Self","static","struct","super","trait","true","type","unsafe","use","where","while"]
+        case .python: return ["False","None","True","and","as","assert","async","await","break","class","continue","def","del","elif","else","except","finally","for","from","global","if","import","in","is","lambda","nonlocal","not","or","pass","raise","return","try","while","with","yield"]
+        case .javascript, .typescript: return ["var","let","const","function","return","if","else","for","while","do","switch","case","default","break","continue","new","this","super","class","extends","import","export","from","async","await","yield","typeof","instanceof","in","of","try","catch","finally","throw","true","false","null","undefined","void","delete","interface","type","enum","public","private","protected","readonly"]
+        case .c: return ["auto","break","case","char","const","continue","default","do","double","else","enum","extern","float","for","goto","if","inline","int","long","register","restrict","return","short","signed","sizeof","static","struct","switch","typedef","union","unsigned","void","volatile","while"]
+        case .cpp: return ["alignas","alignof","auto","bool","break","case","catch","char","class","const","constexpr","continue","decltype","default","delete","do","double","else","enum","explicit","export","extern","false","float","for","friend","goto","if","inline","int","long","mutable","namespace","new","noexcept","nullptr","operator","private","protected","public","return","short","signed","sizeof","static","static_cast","struct","switch","template","this","throw","true","try","typedef","typeid","typename","union","unsigned","using","virtual","void","volatile","while"]
+        case .java: return ["abstract","assert","boolean","break","byte","case","catch","char","class","const","continue","default","do","double","else","enum","extends","false","final","finally","float","for","goto","if","implements","import","instanceof","int","interface","long","native","new","null","package","private","protected","public","return","short","static","strictfp","super","switch","synchronized","this","throw","throws","transient","true","try","void","volatile","while","fun","val","var"]
+        case .ruby: return ["alias","and","begin","break","case","class","def","do","else","elsif","end","ensure","false","for","if","in","module","next","nil","not","or","redo","rescue","retry","return","self","super","then","true","undef","unless","until","when","while","yield"]
+        case .shell: return ["if","then","else","elif","fi","case","esac","for","while","do","done","in","function","return","local","export","unset","readonly","declare","let","alias","source"]
+        case .json, .yaml: return ["true","false","null"]
+        default: return []
+        }
+    }
+
+    private static func commentDelimiters(for lang: Language) -> (String?, (String, String)?) {
+        switch lang {
+        case .python, .ruby, .shell, .yaml: return ("#", nil)
+        case .html: return (nil, ("<!--", "-->"))
+        case .css: return (nil, ("/*", "*/"))
+        case .json, .markdown, .plain: return (nil, nil)
+        default: return ("//", ("/*", "*/"))
+        }
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/HighlightedTextView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/HighlightedTextView.swift
@@ -1,0 +1,57 @@
+import AppKit
+import SwiftUI
+
+/// AppKit-backed display of large attributed strings. SwiftUI's `Text`
+/// inside a ScrollView lays out the entire AttributedString
+/// synchronously and slows badly with hundreds of color spans;
+/// NSTextView uses TextKit's incremental layout and stays fast.
+struct HighlightedTextView: NSViewRepresentable {
+    let attributed: NSAttributedString
+    let font: NSFont
+    let defaultColor: NSColor
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scroll = NSScrollView()
+        scroll.hasVerticalScroller = false
+        scroll.hasHorizontalScroller = false
+        scroll.autohidesScrollers = true
+        scroll.drawsBackground = false
+        scroll.borderType = .noBorder
+
+        let text = NSTextView()
+        text.isEditable = false
+        text.isSelectable = true
+        text.drawsBackground = false
+        text.textContainerInset = NSSize(width: 10, height: 10)
+        text.textContainer?.lineFragmentPadding = 0
+        text.isHorizontallyResizable = false
+        text.isVerticallyResizable = true
+        text.autoresizingMask = [.width]
+        text.textContainer?.widthTracksTextView = true
+        text.allowsUndo = false
+
+        scroll.documentView = text
+        return scroll
+    }
+
+    func updateNSView(_ nsView: NSScrollView, context: Context) {
+        guard let text = nsView.documentView as? NSTextView,
+              let storage = text.textStorage else { return }
+        // Setting via textStorage avoids the perf cost of NSTextView's
+        // `string` setter (which throws away typing attributes / undo).
+        storage.setAttributedString(attributed)
+        let fullRange = NSRange(location: 0, length: storage.length)
+        // Apply default font over the whole range.
+        storage.addAttribute(.font, value: font, range: fullRange)
+        // Paint the theme's default text color on ranges the highlighter
+        // didn't already color (identifiers, punctuation, whitespace).
+        // NSTextView's default is labelColor — too bright for our pane.
+        storage.enumerateAttribute(.foregroundColor, in: fullRange) { value, range, _ in
+            if value == nil {
+                storage.addAttribute(.foregroundColor, value: defaultColor, range: range)
+            }
+        }
+        // Reset scroll to top when content changes.
+        text.scroll(NSPoint(x: 0, y: 0))
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
@@ -178,7 +178,7 @@ struct ResultsListView: View {
 
     var body: some View {
         ScrollViewReader { proxy in
-            ScrollView {
+            ScrollView(.vertical, showsIndicators: false) {
                 LazyVStack(spacing: 4) {
                     ForEach(results) { result in
                         LauncherRowView(

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/QuickLookPreviewImage.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/QuickLookPreviewImage.swift
@@ -1,0 +1,54 @@
+import AppKit
+import SwiftUI
+
+/// SwiftUI view that renders a Quick Look thumbnail of a file path,
+/// with a 150 ms dwell debounce and automatic cancellation when the
+/// path changes (so rapid arrow-key navigation never spends time
+/// rendering intermediate selections).
+///
+/// Falls back to nothing if QuickLook produces no representation
+/// (file too large, unsupported type, unreadable). The caller's
+/// existing icon + metadata layout remains visible.
+struct QuickLookPreviewImage: View {
+    let path: String
+    let maxHeight: CGFloat
+
+    @State private var image: NSImage?
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(nsImage: image)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(maxWidth: .infinity, maxHeight: maxHeight)
+                    .shadow(color: .black.opacity(0.2), radius: 8, x: 0, y: 4)
+            } else {
+                Color.clear.frame(maxWidth: .infinity, maxHeight: maxHeight)
+            }
+        }
+        .task(id: path) {
+            image = nil
+            // Dwell: don't render until selection has been stable for
+            // 150 ms. `.task(id:)` cancels the prior task on path change,
+            // so the sleep just returns early on rapid navigation.
+            try? await Task.sleep(nanoseconds: 150_000_000)
+            if Task.isCancelled { return }
+
+            let scale = NSScreen.main?.backingScaleFactor ?? 2.0
+            // Request size is generous; SwiftUI's .scaledToFit handles
+            // final display sizing within the pane. Cap the height to
+            // avoid an infinite-size request when the caller passes
+            // maxHeight = .infinity (flex layout).
+            let requestHeight = maxHeight.isFinite ? maxHeight : 600
+            let requestSize = CGSize(width: 800, height: requestHeight)
+            let img = await QuickLookPreviewService.shared.thumbnail(
+                forPath: path,
+                size: requestSize,
+                scale: scale
+            )
+            if Task.isCancelled { return }
+            image = img
+        }
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
@@ -7,7 +7,6 @@ struct ResultPreviewView: View {
     let result: LauncherResult
     var onDeleteClipboard: (() -> Void)? = nil
 
-    private let imageExtensions = ["jpg", "jpeg", "png", "gif", "bmp", "tiff", "heic", "webp", "svg", "ico", "pdf"]
     private static let modifiedDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
@@ -20,16 +19,6 @@ struct ResultPreviewView: View {
         formatter.timeStyle = .medium
         return formatter
     }()
-
-    private var isImageFile: Bool {
-        let ext = (result.path as NSString).pathExtension.lowercased()
-        return imageExtensions.contains(ext)
-    }
-
-    private var previewImage: NSImage? {
-        guard isImageFile else { return nil }
-        return NSImage(contentsOfFile: result.path)
-    }
 
     private var clipboardIcon: NSImage {
         NSImage(systemSymbolName: "doc.on.clipboard", accessibilityDescription: nil)
@@ -122,15 +111,11 @@ struct ResultPreviewView: View {
                     Spacer()
                 }
 
-                if isImageFile, let image = previewImage {
-                    HStack {
-                        Spacer()
-                        Image(nsImage: image)
-                            .resizable()
-                            .scaledToFit()
-                            .frame(maxHeight: 180)
-                            .shadow(color: .black.opacity(0.2), radius: 8, x: 0, y: 4)
-                        Spacer()
+                if result.kind == .file {
+                    if QuickLookPreviewService.isTextFile(path: result.path) {
+                        TextFilePreview(path: result.path, maxHeight: .infinity)
+                    } else {
+                        QuickLookPreviewImage(path: result.path, maxHeight: .infinity)
                     }
                 }
 
@@ -154,7 +139,9 @@ struct ResultPreviewView: View {
                     InfoRow(label: "Modified", value: modified)
                 }
 
-                Spacer()
+                if result.kind != .file {
+                    Spacer()
+                }
             }
             .padding(12)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/TextFilePreview.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/TextFilePreview.swift
@@ -1,0 +1,96 @@
+import AppKit
+import SwiftUI
+
+/// In-process text-file preview: reads the first chunk of a text/code
+/// file off the main thread, syntax-highlights it, and displays it in
+/// an AppKit NSTextView (much faster than SwiftUI Text for large
+/// attributed strings).
+///
+/// The file is already size-capped upstream (see
+/// `QuickLookPreviewService.sizeCap`); this view additionally caps the
+/// displayed content at 16 KB.
+struct TextFilePreview: View {
+    @EnvironmentObject private var themeStore: ThemeStore
+    let path: String
+    let maxHeight: CGFloat
+
+    // NSTextView (used by HighlightedTextView) virtualizes layout via
+    // TextKit, so we can comfortably show larger files than SwiftUI
+    // Text allowed. 64 KB is ≈2000 lines — well over preview needs.
+    nonisolated private static let displayByteCap: Int = 64 * 1024
+    // NSAttributedString isn't Sendable but is documented thread-safe
+    // for read access; mark the static empty constant nonisolated(unsafe).
+    nonisolated(unsafe) private static let empty = NSAttributedString(string: "")
+
+    nonisolated private final class HighlightResult: @unchecked Sendable {
+        let attr: NSAttributedString
+        let key: String?
+        init(_ attr: NSAttributedString, _ key: String?) {
+            self.attr = attr
+            self.key = key
+        }
+    }
+
+    @State private var content: NSAttributedString = TextFilePreview.empty
+
+    private var displayFont: NSFont {
+        NSFont.monospacedSystemFont(
+            ofSize: CGFloat(themeStore.settings.fontSize - 1),
+            weight: .regular
+        )
+    }
+
+    var body: some View {
+        HighlightedTextView(
+            attributed: content,
+            font: displayFont,
+            defaultColor: NSColor(themeStore.secondaryTextColor())
+        )
+            .frame(maxWidth: .infinity, maxHeight: maxHeight)
+            .background(themeStore.controlFillColor(),
+                        in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .task(id: path) {
+                let p = path
+                // Cache hit → paint immediately, no debounce / no I/O.
+                if let attrs = try? FileManager.default.attributesOfItem(atPath: p),
+                   let mtime = attrs[.modificationDate] as? Date,
+                   let size = attrs[.size] as? Int64,
+                   let cached = HighlightedTextCache.get(
+                       HighlightedTextCache.key(path: p, mtime: mtime, size: size)
+                   ) {
+                    content = cached
+                    return
+                }
+
+                content = Self.empty
+                try? await Task.sleep(nanoseconds: 150_000_000)
+                if Task.isCancelled { return }
+
+                let result = await Task.detached { () -> HighlightResult in
+                    guard let data = try? Data(
+                        contentsOf: URL(fileURLWithPath: p),
+                        options: [.mappedIfSafe]
+                    ) else { return HighlightResult(Self.empty, nil) }
+                    let slice = data.prefix(Self.displayByteCap)
+                    // Lossy UTF-8 decode: never fails on partial codepoints
+                    // or invalid bytes (becomes U+FFFD). The Latin-1
+                    // fallback was wrong for UTF-8 files truncated
+                    // mid-codepoint and produced mojibake for non-ASCII.
+                    let text = String(decoding: slice, as: UTF8.self)
+                    let highlighted = SyntaxHighlighter.highlight(text, path: p)
+                    let attrs = try? FileManager.default.attributesOfItem(atPath: p)
+                    let mtime = attrs?[.modificationDate] as? Date
+                    let size = attrs?[.size] as? Int64
+                    let keyStr: String? = (mtime != nil && size != nil)
+                        ? HighlightedTextCache.key(path: p, mtime: mtime!, size: size!)
+                        : nil
+                    return HighlightResult(highlighted, keyStr)
+                }.value
+                if Task.isCancelled { return }
+                content = result.attr
+                if let keyStr = result.key {
+                    HighlightedTextCache.set(keyStr, result.attr)
+                }
+            }
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Window/WindowAutoScale.swift
+++ b/apps/macos/LauncherApp/look-app/Window/WindowAutoScale.swift
@@ -1,0 +1,115 @@
+import AppKit
+import Foundation
+
+/// Screen-based auto-scale for the launcher window.
+///
+/// Mirrors the Linux/Windows formula in
+/// apps/linows/src-tauri/src/main.rs (`scaled_window_size`):
+/// 1.0× at ≤1080-point screen height, linear to 1.2× at 1440p,
+/// capped at 1.3× on taller displays.
+///
+/// SwiftUI/AppKit work in points, so unlike the Tauri version we do
+/// not multiply by backingScaleFactor — the OS handles that.
+/// NSScreen height on a 2× Retina 4K is already 1080 points, matching
+/// the Tauri `logical_h = physical_h / scale` derivation.
+///
+/// Recentering on every show is intentionally omitted: the macOS
+/// launcher is draggable (isMovableByWindowBackground), so users
+/// place it where they want. We size and center once, on first
+/// window attach.
+enum WindowAutoScale {
+    // Base size matches the Linux/Windows build (apps/linows/src-tauri):
+    // 860×580 logical, landscape — list pane + preview pane side by side.
+    static let baseWidth: CGFloat = 860
+    static let baseHeight: CGFloat = 580
+
+    static func ratio(forScreenHeightPoints h: CGFloat) -> CGFloat {
+        guard h > 1080 else { return 1.0 }
+        let r = 1.0 + (h - 1080) / (1440 - 1080) * 0.2
+        return min(r, 1.3)
+    }
+
+    static func size(for screen: NSScreen) -> CGSize {
+        let r = ratio(forScreenHeightPoints: screen.frame.height)
+        return CGSize(
+            width: (baseWidth * r).rounded(),
+            height: (baseHeight * r).rounded()
+        )
+    }
+
+    /// Frame that centers the scaled launcher within the screen's
+    /// visibleFrame (so it doesn't overlap the menu bar or Dock).
+    static func centeredFrame(on screen: NSScreen) -> NSRect {
+        let size = size(for: screen)
+        let visible = screen.visibleFrame
+        let x = visible.origin.x + (visible.width - size.width) / 2
+        let y = visible.origin.y + (visible.height - size.height) / 2
+        return NSRect(x: x.rounded(), y: y.rounded(), width: size.width, height: size.height)
+    }
+
+    /// Resize the window to match the current screen's scale, keeping the
+    /// existing position anchor (top-left). Used when the user drags the
+    /// window to a different display — we adjust the scale but never the
+    /// position, since the macOS launcher is user-draggable.
+    ///
+    /// Clamps the result inside the screen's visibleFrame so we never
+    /// leave the window partially off-screen (e.g. tucked behind a notch
+    /// or menu bar after a screen with different geometry).
+    static func resizeKeepingTopLeft(_ window: NSWindow) {
+        guard let screen = window.screen else { return }
+        let newSize = size(for: screen)
+        let currentFrame = window.frame
+        if currentFrame.size == newSize { return }
+
+        // AppKit's frame origin is bottom-left; preserve the visual top by
+        // shifting origin.y when height changes.
+        var newOrigin = NSPoint(
+            x: currentFrame.origin.x,
+            y: currentFrame.origin.y + currentFrame.height - newSize.height
+        )
+
+        let visible = screen.visibleFrame
+        let maxX = visible.maxX - newSize.width
+        let minX = visible.minX
+        let maxY = visible.maxY - newSize.height
+        let minY = visible.minY
+        newOrigin.x = min(max(newOrigin.x, minX), maxX)
+        newOrigin.y = min(max(newOrigin.y, minY), maxY)
+
+        let newFrame = NSRect(origin: newOrigin, size: newSize)
+        if newFrame != currentFrame {
+            window.setFrame(newFrame, display: true, animate: false)
+        }
+    }
+
+    /// Defer a resize until the user is no longer holding the mouse
+    /// (i.e. the drag has ended). Calling `setFrame` mid-drag fights
+    /// AppKit's mouse tracking and leaves the window in a broken state.
+    /// Each call supersedes any pending resize for the same window so
+    /// rapid screen crossings collapse to a single resize when the
+    /// drag finishes.
+    @MainActor private static var pendingResizeTokens: [ObjectIdentifier: UUID] = [:]
+
+    @MainActor
+    static func scheduleResize(for window: NSWindow) {
+        let id = ObjectIdentifier(window)
+        let token = UUID()
+        pendingResizeTokens[id] = token
+
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 50_000_000)
+            while pendingResizeTokens[id] == token {
+                // Mouse button still down → user is still dragging.
+                // Resize only after the button is released so we don't
+                // fight AppKit's mouse tracking mid-drag.
+                if NSEvent.pressedMouseButtons & 1 != 0 {
+                    try? await Task.sleep(nanoseconds: 80_000_000)
+                    continue
+                }
+                pendingResizeTokens[id] = nil
+                resizeKeepingTopLeft(window)
+                return
+            }
+        }
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Window/WindowConfigurator.swift
+++ b/apps/macos/LauncherApp/look-app/Window/WindowConfigurator.swift
@@ -45,6 +45,10 @@ struct WindowConfigurator: NSViewRepresentable {
         window.setContentBorderThickness(0, for: .maxY)
         window.collectionBehavior.insert(.moveToActiveSpace)
         window.collectionBehavior.insert(.fullScreenAuxiliary)
+        // Float above other apps so dragging the launcher onto a screen
+        // where another app has a window in front does not bury it.
+        // Matches the Linux/Windows build's set_always_on_top(true).
+        window.level = .floating
         window.standardWindowButton(.closeButton)?.isHidden = true
         window.standardWindowButton(.miniaturizeButton)?.isHidden = true
         window.standardWindowButton(.zoomButton)?.isHidden = true
@@ -60,6 +64,22 @@ struct WindowConfigurator: NSViewRepresentable {
             contentView.wantsLayer = true
             contentView.layer?.cornerRadius = cornerRadius
             contentView.layer?.masksToBounds = true
+        }
+
+        if let screen = window.screen ?? NSScreen.main {
+            window.setFrame(WindowAutoScale.centeredFrame(on: screen), display: true)
+        }
+
+        // Re-apply scaling when the window crosses to a different display.
+        // Position is preserved (top-left anchor) — only size changes,
+        // since the macOS launcher is user-draggable.
+        NotificationCenter.default.addObserver(
+            forName: NSWindow.didChangeScreenNotification,
+            object: window,
+            queue: .main
+        ) { note in
+            guard let w = note.object as? NSWindow else { return }
+            WindowAutoScale.scheduleResize(for: w)
         }
     }
 }

--- a/apps/macos/LauncherApp/look-app/look_appApp.swift
+++ b/apps/macos/LauncherApp/look-app/look_appApp.swift
@@ -126,7 +126,7 @@ struct look_appApp: App {
     var body: some Scene {
         WindowGroup(id: "main") {
             ContentView()
-                .frame(minWidth: 620, minHeight: 600)
+                .frame(minWidth: 860, minHeight: 580)
                 .background(WindowConfigurator())
                 .environmentObject(appUIState)
                 .environmentObject(themeStore)

--- a/bridge/ffi/Cargo.lock
+++ b/bridge/ffi/Cargo.lock
@@ -284,6 +284,7 @@ dependencies = [
  "serde",
  "serde_json",
  "unicode-normalization",
+ "windows",
 ]
 
 [[package]]
@@ -738,10 +739,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core",
+ "windows-link 0.1.3",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-sys"
@@ -758,7 +861,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -767,7 +870,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -776,6 +879,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Files preview feature for macos first
- With text files, limit previewed content is 64KB (~ 2K lines: not a small number for a preview feature)
- Screen based auto scale for Look

## Why

-

## Changes

-

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
