### PR TITLE
Fix: Translation issue, startup issue

### DIFF
--- a/apps/linows/src-tauri/src/commands.rs
+++ b/apps/linows/src-tauri/src/commands.rs
@@ -25,9 +25,16 @@ pub struct UsageResult {
     pub error: Option<String>,
 }
 
+const DEFAULT_SEARCH_LIMIT: u32 = 40;
+const MAX_SEARCH_LIMIT: u32 = 100;
+
 #[tauri::command]
 pub fn search(state: State<'_, AppState>, query: String, limit: u32) -> SearchPayload {
-    let max = if limit == 0 { 40 } else { limit.min(100) } as usize;
+    let max = if limit == 0 {
+        DEFAULT_SEARCH_LIMIT
+    } else {
+        limit.min(MAX_SEARCH_LIMIT)
+    } as usize;
 
     let scored = state.with_engine(|engine| engine.search_scored(&query, max));
 

--- a/apps/linows/src-tauri/src/config.rs
+++ b/apps/linows/src-tauri/src/config.rs
@@ -81,8 +81,11 @@ pub fn reset_config() -> Result<(), String> {
     std::fs::write(&path, default).map_err(|e| format!("Failed to reset config: {e}"))
 }
 
+pub const ENV_CONFIG_PATH: &str = "LOOK_CONFIG_PATH";
+const CONFIG_FILE: &str = ".look.config";
+
 pub fn config_file_path() -> std::path::PathBuf {
-    if let Ok(custom) = std::env::var("LOOK_CONFIG_PATH") {
+    if let Ok(custom) = std::env::var(ENV_CONFIG_PATH) {
         let trimmed = custom.trim();
         if !trimmed.is_empty() {
             return std::path::PathBuf::from(trimmed);
@@ -91,5 +94,5 @@ pub fn config_file_path() -> std::path::PathBuf {
     let home = std::env::var("HOME")
         .or_else(|_| std::env::var("USERPROFILE"))
         .unwrap_or_else(|_| ".".to_string());
-    std::path::PathBuf::from(home).join(".look.config")
+    std::path::PathBuf::from(home).join(CONFIG_FILE)
 }

--- a/apps/linows/src-tauri/src/consts.rs
+++ b/apps/linows/src-tauri/src/consts.rs
@@ -1,0 +1,8 @@
+// Shared constants used across multiple modules.
+
+pub const MAIN_WINDOW: &str = "main";
+pub const EVENT_INDEX_READY: &str = "index-ready";
+
+/// Windows process creation flag to suppress console windows.
+#[cfg(target_os = "windows")]
+pub const CREATE_NO_WINDOW: u32 = 0x0800_0000;

--- a/apps/linows/src-tauri/src/files.rs
+++ b/apps/linows/src-tauri/src/files.rs
@@ -254,11 +254,15 @@ pub async fn pick_image(app: tauri::AppHandle) -> Option<String> {
     rx.recv().ok().flatten()
 }
 
+const SECS_PER_DAY: u64 = 86400;
+const SECS_PER_HOUR: u64 = 3600;
+const SECS_PER_MINUTE: u64 = 60;
+
 fn time_from_unix(secs: u64) -> String {
-    let days = secs / 86400;
-    let time_secs = secs % 86400;
-    let hours = time_secs / 3600;
-    let minutes = (time_secs % 3600) / 60;
+    let days = secs / SECS_PER_DAY;
+    let time_secs = secs % SECS_PER_DAY;
+    let hours = time_secs / SECS_PER_HOUR;
+    let minutes = (time_secs % SECS_PER_HOUR) / SECS_PER_MINUTE;
 
     let (year, month, day) = civil_from_days(days as i64);
     format!("{year:04}-{month:02}-{day:02} {hours:02}:{minutes:02}")

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -341,13 +341,29 @@ fn disable_gpu_acceleration(app: &tauri::App) {
     }
 }
 
-/// Enable autostart on first launch (only if user hasn't explicitly configured it).
-fn enable_autostart_on_first_launch() {
+/// Sync autostart registration with config on every launch.
+///
+/// On first launch (no `launch_at_login` key yet) — enable autostart and persist.
+/// On subsequent launches — re-sync the registry/desktop-entry with the current
+/// exe path so it stays valid after updates or reinstalls (matches WinUI3 behavior).
+fn sync_autostart() {
     let config_path = config::config_file_path();
     let config_content = std::fs::read_to_string(&config_path).unwrap_or_default();
-    if !config_content.contains("launch_at_login") {
-        let _ = autostart::set_autostart(true);
-    }
+
+    let enabled = if config_content.contains("launch_at_login") {
+        config_content
+            .lines()
+            .any(|l| l.trim().starts_with("launch_at_login") && l.contains("true"))
+    } else {
+        // First launch — enable by default and persist.
+        let _ = config::set_config(vec![config::ConfigUpdate {
+            key: "launch_at_login".into(),
+            value: "true".into(),
+        }]);
+        true
+    };
+
+    let _ = autostart::set_autostart(enabled);
 }
 
 /// Register global shortcuts (Alt+Space to toggle, Alt+Shift+Q to quit).
@@ -463,7 +479,7 @@ fn main() {
     #[cfg(target_os = "linux")]
     let disable_gpu = detect_and_disable_virtual_gpu() || arch_disable_gpu_from_config();
 
-    enable_autostart_on_first_launch();
+    sync_autostart();
 
     let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -6,6 +6,7 @@ mod calc;
 mod clipboard;
 mod commands;
 mod config;
+mod consts;
 mod files;
 mod music;
 mod platform;
@@ -52,6 +53,11 @@ fn supports_transparency() -> bool {
 
 const BASE_W: f64 = 860.0;
 const BASE_H: f64 = 580.0;
+/// Grace period (ms) after show — ignore focus-loss within this window.
+const AUTO_HIDE_GRACE_MS: u64 = 300;
+/// Guard (ms) to prevent re-showing after auto-hide (GNOME X11 race).
+const AUTO_HIDE_RESHOW_GUARD_MS: u64 = 200;
+const EVENT_WINDOW_SHOWN: &str = "window-shown";
 
 /// Scale window size for larger monitors. Base at 1080p (1.0x), up to 1.3x max.
 /// 1440p → 1.2x, 4K → 1.3x (capped).
@@ -72,14 +78,14 @@ fn scaled_window_size(screen_w: u32, screen_h: u32, scale: f64) -> (u32, u32) {
 
 /// Toggle the main window: hide if visible, show (centered) if hidden.
 fn toggle_window(app_handle: &tauri::AppHandle) {
-    let Some(window) = app_handle.get_webview_window("main") else {
+    let Some(window) = app_handle.get_webview_window(consts::MAIN_WINDOW) else {
         return;
     };
     if window.is_visible().unwrap_or(false) {
         #[cfg(target_os = "linux")]
         platform::linux::window_focus::notify_hidden();
         let _ = window.hide();
-    } else if now_ms() - LAST_AUTO_HIDDEN_AT.load(Ordering::Relaxed) > 200 {
+    } else if now_ms() - LAST_AUTO_HIDDEN_AT.load(Ordering::Relaxed) > AUTO_HIDE_RESHOW_GUARD_MS {
         // Only show if auto-hide didn't JUST fire.
         // On GNOME X11, Focused(false) races with this handler —
         // auto-hide hides the window before we run, so is_visible
@@ -103,7 +109,7 @@ fn toggle_window(app_handle: &tauri::AppHandle) {
         if tiling {
             recenter_window(&window);
         }
-        let _ = window.emit("window-shown", ());
+        let _ = window.emit(EVENT_WINDOW_SHOWN, ());
 
         // On Linux/X11, bypass Mutter's focus-stealing prevention
         // by bumping _NET_WM_USER_TIME before activation.
@@ -206,19 +212,19 @@ fn setup_dev_env() {
         .filter(|s| !s.trim().is_empty())
         .unwrap_or_else(|| ".".to_string());
 
-    if std::env::var("LOOK_CONFIG_PATH")
+    if std::env::var(config::ENV_CONFIG_PATH)
         .unwrap_or_default()
         .trim()
         .is_empty()
     {
         unsafe {
             std::env::set_var(
-                "LOOK_CONFIG_PATH",
+                config::ENV_CONFIG_PATH,
                 std::path::PathBuf::from(&home).join(".look.dev.config"),
             );
         }
     }
-    if std::env::var("LOOK_DB_PATH")
+    if std::env::var(state::ENV_DB_PATH)
         .unwrap_or_default()
         .trim()
         .is_empty()
@@ -243,13 +249,13 @@ fn setup_dev_env() {
 
         let _ = std::fs::create_dir_all(&db_dir);
         unsafe {
-            std::env::set_var("LOOK_DB_PATH", db_dir.join("look.dev.db"));
+            std::env::set_var(state::ENV_DB_PATH, db_dir.join("look.dev.db"));
         }
     }
     eprintln!(
         "[dev] config={} db={}",
-        std::env::var("LOOK_CONFIG_PATH").unwrap_or_default(),
-        std::env::var("LOOK_DB_PATH").unwrap_or_default(),
+        std::env::var(config::ENV_CONFIG_PATH).unwrap_or_default(),
+        std::env::var(state::ENV_DB_PATH).unwrap_or_default(),
     );
 }
 
@@ -328,7 +334,7 @@ fn arch_disable_gpu_from_config() -> bool {
 /// so we set the policy at the API level before the first render.
 #[cfg(target_os = "linux")]
 fn disable_gpu_acceleration(app: &tauri::App) {
-    if let Some(webview) = app.get_webview_window("main") {
+    if let Some(webview) = app.get_webview_window(consts::MAIN_WINDOW) {
         let _ = webview.with_webview(|wv| {
             use webkit2gtk::SettingsExt;
             let inner = wv.inner();
@@ -347,17 +353,28 @@ fn disable_gpu_acceleration(app: &tauri::App) {
 /// On subsequent launches — re-sync the registry/desktop-entry with the current
 /// exe path so it stays valid after updates or reinstalls (matches WinUI3 behavior).
 fn sync_autostart() {
+    const KEY: &str = "launch_at_login";
+
     let config_path = config::config_file_path();
     let config_content = std::fs::read_to_string(&config_path).unwrap_or_default();
 
-    let enabled = if config_content.contains("launch_at_login") {
-        config_content
-            .lines()
-            .any(|l| l.trim().starts_with("launch_at_login") && l.contains("true"))
+    let config_value = config_content.lines().find_map(|l| {
+        let l = l.trim();
+        if !l.starts_with('#') {
+            l.split_once('=')
+                .filter(|(k, _)| k.trim() == KEY)
+                .map(|(_, v)| v.trim() == "true")
+        } else {
+            None
+        }
+    });
+
+    let enabled = if let Some(val) = config_value {
+        val
     } else {
         // First launch — enable by default and persist.
         let _ = config::set_config(vec![config::ConfigUpdate {
-            key: "launch_at_login".into(),
+            key: KEY.into(),
             value: "true".into(),
         }]);
         true
@@ -418,12 +435,14 @@ fn register_shortcuts(
 #[cfg(target_os = "linux")]
 fn setup_x11_focus_monitor(app: &tauri::App) {
     platform::linux::window_focus::cache_self_window();
-    let window = app.get_webview_window("main").expect("main window missing");
+    let window = app
+        .get_webview_window(consts::MAIN_WINDOW)
+        .expect("main window missing");
     platform::linux::window_focus::start_active_window_monitor(move || {
         if PICKING_FILE.load(Ordering::Relaxed) {
             return;
         }
-        if now_ms() - LAST_SHOWN_AT.load(Ordering::Relaxed) > 300 {
+        if now_ms() - LAST_SHOWN_AT.load(Ordering::Relaxed) > AUTO_HIDE_GRACE_MS {
             LAST_AUTO_HIDDEN_AT.store(now_ms(), Ordering::Relaxed);
             let _ = window.hide();
         }
@@ -457,7 +476,7 @@ fn setup_window_events(window: &tauri::WebviewWindow) {
             #[cfg(not(target_os = "linux"))]
             tauri::WindowEvent::Focused(false)
                 if !PICKING_FILE.load(Ordering::Relaxed)
-                    && now_ms() - LAST_SHOWN_AT.load(Ordering::Relaxed) > 300 =>
+                    && now_ms() - LAST_SHOWN_AT.load(Ordering::Relaxed) > AUTO_HIDE_GRACE_MS =>
             {
                 LAST_AUTO_HIDDEN_AT.store(now_ms(), Ordering::Relaxed);
                 let _ = w.hide();
@@ -483,7 +502,7 @@ fn main() {
 
     let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
-            if let Some(window) = app.get_webview_window("main") {
+            if let Some(window) = app.get_webview_window(consts::MAIN_WINDOW) {
                 let _ = window.show();
                 let _ = window.set_focus();
             }
@@ -521,7 +540,9 @@ fn main() {
                 setup_x11_focus_monitor(app);
             }
 
-            let window = app.get_webview_window("main").expect("main window missing");
+            let window = app
+                .get_webview_window(consts::MAIN_WINDOW)
+                .expect("main window missing");
             // On transparency-capable Linux compositors, force the GTK window
             // background to transparent. Without this, GTK paints its theme
             // background (opaque, square corners) on the surface before WebKit

--- a/apps/linows/src-tauri/src/shell.rs
+++ b/apps/linows/src-tauri/src/shell.rs
@@ -3,12 +3,16 @@ pub fn run_shell_command(cmd: String) -> Result<String, String> {
     // sh on Unix, cmd /C on Windows. The frontend doesn't know which it's on
     // and lets the user type whatever fits their muscle memory.
     #[cfg(target_os = "windows")]
-    let spawned = std::process::Command::new("cmd")
-        .args(["/C", &cmd])
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn();
+    let spawned = {
+        use std::os::windows::process::CommandExt;
+        std::process::Command::new("cmd")
+            .args(["/C", &cmd])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .creation_flags(0x08000000) // CREATE_NO_WINDOW
+            .spawn()
+    };
     #[cfg(not(target_os = "windows"))]
     let spawned = std::process::Command::new("sh")
         .args(["-c", &cmd])

--- a/apps/linows/src-tauri/src/shell.rs
+++ b/apps/linows/src-tauri/src/shell.rs
@@ -1,3 +1,7 @@
+const TIMEOUT_SECS: u64 = 10;
+const MAX_OUTPUT_BYTES: usize = 800;
+const POLL_INTERVAL_MS: u64 = 50;
+
 #[tauri::command]
 pub fn run_shell_command(cmd: String) -> Result<String, String> {
     // sh on Unix, cmd /C on Windows. The frontend doesn't know which it's on
@@ -10,7 +14,7 @@ pub fn run_shell_command(cmd: String) -> Result<String, String> {
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
-            .creation_flags(0x08000000) // CREATE_NO_WINDOW
+            .creation_flags(crate::consts::CREATE_NO_WINDOW)
             .spawn()
     };
     #[cfg(not(target_os = "windows"))]
@@ -22,7 +26,7 @@ pub fn run_shell_command(cmd: String) -> Result<String, String> {
         .spawn();
     let mut child = spawned.map_err(|e| format!("Failed to run: {e}"))?;
 
-    let timeout = std::time::Duration::from_secs(10);
+    let timeout = std::time::Duration::from_secs(TIMEOUT_SECS);
     let start = std::time::Instant::now();
     loop {
         match child.try_wait() {
@@ -31,9 +35,9 @@ pub fn run_shell_command(cmd: String) -> Result<String, String> {
                 if start.elapsed() > timeout {
                     let _ = child.kill();
                     let _ = child.wait();
-                    return Ok("(timed out after 10s)".to_string());
+                    return Ok(format!("(timed out after {TIMEOUT_SECS}s)"));
                 }
-                std::thread::sleep(std::time::Duration::from_millis(50));
+                std::thread::sleep(std::time::Duration::from_millis(POLL_INTERVAL_MS));
             }
             Err(e) => return Err(format!("Wait error: {e}")),
         }
@@ -56,8 +60,8 @@ pub fn run_shell_command(cmd: String) -> Result<String, String> {
         result.push_str(&stderr);
     }
 
-    if result.len() > 800 {
-        result.truncate(800);
+    if result.len() > MAX_OUTPUT_BYTES {
+        result.truncate(MAX_OUTPUT_BYTES);
         result.push_str("\n... (truncated)");
     }
 

--- a/apps/linows/src-tauri/src/state.rs
+++ b/apps/linows/src-tauri/src/state.rs
@@ -10,6 +10,9 @@ use std::thread;
 use std::time::Instant;
 use tauri::{Emitter, Manager};
 
+const WATCHER_DEBOUNCE_SECS: u64 = 2;
+const WATCHER_POLL_MS: u64 = 500;
+
 static APP_HANDLE: OnceLock<tauri::AppHandle> = OnceLock::new();
 
 pub struct AppState {
@@ -147,9 +150,9 @@ impl AppState {
                             started_at.elapsed().as_millis()
                         );
                         if let Some(handle) = APP_HANDLE.get()
-                            && let Some(w) = handle.get_webview_window("main")
+                            && let Some(w) = handle.get_webview_window(crate::consts::MAIN_WINDOW)
                         {
-                            let _ = w.emit("index-ready", ());
+                            let _ = w.emit(crate::consts::EVENT_INDEX_READY, ());
                         }
                     }
                     Err(err) => {
@@ -242,7 +245,7 @@ impl AppState {
                     }
                 }
 
-                let debounce = std::time::Duration::from_secs(2);
+                let debounce = std::time::Duration::from_secs(WATCHER_DEBOUNCE_SECS);
                 let mut last_dirty_at: Option<Instant> = None;
 
                 loop {
@@ -250,7 +253,7 @@ impl AppState {
                         break;
                     }
 
-                    match event_rx.recv_timeout(std::time::Duration::from_millis(500)) {
+                    match event_rx.recv_timeout(std::time::Duration::from_millis(WATCHER_POLL_MS)) {
                         Ok(Ok(event)) => {
                             if should_mark_dirty(&event) {
                                 let v = change_version.fetch_add(1, Ordering::AcqRel);
@@ -293,9 +296,10 @@ impl AppState {
                                 }
                                 eprintln!("[watcher] auto-refresh done");
                                 if let Some(handle) = APP_HANDLE.get()
-                                    && let Some(w) = handle.get_webview_window("main")
+                                    && let Some(w) =
+                                        handle.get_webview_window(crate::consts::MAIN_WINDOW)
                                 {
-                                    let _ = w.emit("index-ready", ());
+                                    let _ = w.emit(crate::consts::EVENT_INDEX_READY, ());
                                 }
                             }
                             Err(err) => {
@@ -323,8 +327,12 @@ impl AppState {
     }
 }
 
+pub const ENV_DB_PATH: &str = "LOOK_DB_PATH";
+const APP_DIR: &str = "look";
+const DB_FILE: &str = "look.db";
+
 pub fn default_db_path() -> PathBuf {
-    if let Ok(custom) = env::var("LOOK_DB_PATH") {
+    if let Ok(custom) = env::var(ENV_DB_PATH) {
         let trimmed = custom.trim();
         if !trimmed.is_empty() {
             return PathBuf::from(trimmed);
@@ -336,7 +344,7 @@ pub fn default_db_path() -> PathBuf {
         if let Ok(base) = env::var("LOCALAPPDATA") {
             let trimmed = base.trim();
             if !trimmed.is_empty() {
-                return PathBuf::from(trimmed).join("look").join("look.db");
+                return PathBuf::from(trimmed).join(APP_DIR).join(DB_FILE);
             }
         }
     }
@@ -346,15 +354,15 @@ pub fn default_db_path() -> PathBuf {
         if let Ok(data_home) = env::var("XDG_DATA_HOME") {
             let trimmed = data_home.trim();
             if !trimmed.is_empty() {
-                return PathBuf::from(trimmed).join("look").join("look.db");
+                return PathBuf::from(trimmed).join(APP_DIR).join(DB_FILE);
             }
         }
         if let Ok(home) = env::var("HOME") {
             return PathBuf::from(home)
                 .join(".local")
                 .join("share")
-                .join("look")
-                .join("look.db");
+                .join(APP_DIR)
+                .join(DB_FILE);
         }
     }
 
@@ -362,7 +370,7 @@ pub fn default_db_path() -> PathBuf {
     let home = env::var("HOME")
         .or_else(|_| env::var("USERPROFILE"))
         .unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(home).join(".look").join("look.db")
+    PathBuf::from(home).join(".look").join(DB_FILE)
 }
 
 fn should_mark_dirty(event: &Event) -> bool {

--- a/apps/linows/src-tauri/src/translate.rs
+++ b/apps/linows/src-tauri/src/translate.rs
@@ -52,11 +52,10 @@ pub fn translate(text: String, target_lang: String) -> TranslateResult {
     ])
     .arg(&url);
 
-    // Hide the console window that Windows creates for child processes.
     #[cfg(target_os = "windows")]
     {
         use std::os::windows::process::CommandExt;
-        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+        cmd.creation_flags(crate::consts::CREATE_NO_WINDOW);
     }
 
     let output = cmd.output();

--- a/apps/linows/src-tauri/src/translate.rs
+++ b/apps/linows/src-tauri/src/translate.rs
@@ -39,19 +39,27 @@ pub fn translate(text: String, target_lang: String) -> TranslateResult {
     let encoded = percent_encode(&text);
     let url = format!("{TRANSLATE_URL_PREFIX}{target_lang}{TRANSLATE_URL_MIDDLE}{encoded}");
 
-    let output = std::process::Command::new("curl")
-        .args([
-            "-s",
-            "-m",
-            "3",
-            "--user-agent",
-            CURL_USER_AGENT,
-            "--tlsv1.2",
-            "-H",
-            "Accept-Language: en-US,en;q=0.9",
-        ])
-        .arg(&url)
-        .output();
+    let mut cmd = std::process::Command::new("curl");
+    cmd.args([
+        "-s",
+        "-m",
+        "3",
+        "--user-agent",
+        CURL_USER_AGENT,
+        "--tlsv1.2",
+        "-H",
+        "Accept-Language: en-US,en;q=0.9",
+    ])
+    .arg(&url);
+
+    // Hide the console window that Windows creates for child processes.
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    }
+
+    let output = cmd.output();
 
     let body = match output {
         Ok(out) if out.status.success() => match String::from_utf8(out.stdout) {

--- a/apps/linows/src-tauri/tauri.conf.json
+++ b/apps/linows/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicoverbruggen/tauri-v2-schema/main/schema.json",
   "productName": "Look",
-  "version": "0.5.2",
+  "version": "0.5.4",
   "identifier": "com.look.desktop",
   "build": {
     "frontendDist": "../src",

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -16,6 +16,14 @@ import {
   copyToClipboard, deleteClipboardEntry, isDevBuild,
 } from './ipc.js';
 
+const HINT_MAIN = 'Enter open \u2022 Ctrl+Enter search web \u2022 Ctrl+P pick \u2022 Ctrl+C copy \u2022 Ctrl+F reveal \u2022 Esc hide';
+const HINT_TRANSLATE = 'Enter translate \u2022 Esc clear';
+const HINT_CLIPBOARD = 'Enter copy \u2022 Delete remove \u2022 Esc clear';
+const BANNER_DURATION_SHORT = 1.0;
+const BANNER_DURATION_MEDIUM = 1.2;
+const BANNER_DURATION_LONG = 1.5;
+const KILL_FEEDBACK_DELAY_MS = 300;
+
 document.addEventListener('DOMContentLoaded', async () => {
   const app = document.getElementById('app');
 
@@ -30,7 +38,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // Hint bar — always at bottom, shared by all screens
   app.insertAdjacentHTML('beforeend',
-    '<div class="hint-bar" id="hint-bar"><span>Enter open \u2022 Ctrl+Enter search web \u2022 Ctrl+P pick \u2022 Ctrl+C copy \u2022 Ctrl+F reveal \u2022 Esc hide</span><span class="hint-bar-copy">\u00A9 2026 by <a class="hint-bar-link" href="#">Kunkka</a></span></div>');
+    `<div class="hint-bar" id="hint-bar"><span>${HINT_MAIN}</span><span class="hint-bar-copy">\u00A9 2026 by <a class="hint-bar-link" href="#">Kunkka</a></span></div>`);
 
   // Load command panels into cmd-main
   const cmdMain = document.getElementById('cmd-main');
@@ -75,8 +83,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     queryInput.value = '';
     search.handleQueryInput('');
     queryInput.focus();
-    hintBar.querySelector('span').textContent =
-      'Enter open \u2022 Ctrl+Enter search web \u2022 Ctrl+P pick \u2022 Ctrl+C copy \u2022 Ctrl+F reveal \u2022 Esc hide';
+    hintBar.querySelector('span').textContent = HINT_MAIN;
   });
   settings.restoreOnStartup();
 
@@ -116,10 +123,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         .map((i) => i.path);
       if (paths.length > 0) {
         copyFilesToClipboard(paths)
-          .then(() => banner.show(`Picked ${pickedItems.length} item(s)`, 'success', 1.0))
-          .catch(() => banner.show('Pick failed', 'error', 1.2));
+          .then(() => banner.show(`Picked ${pickedItems.length} item(s)`, 'success', BANNER_DURATION_SHORT))
+          .catch(() => banner.show('Pick failed', 'error', BANNER_DURATION_MEDIUM));
       } else {
-        banner.show(`Picked ${pickedItems.length} item(s)`, 'success', 1.0);
+        banner.show(`Picked ${pickedItems.length} item(s)`, 'success', BANNER_DURATION_SHORT);
       }
     } else {
       picked.update([]);
@@ -163,16 +170,16 @@ document.addEventListener('DOMContentLoaded', async () => {
     search.handleQueryInput(value);
     const h = hintBar.querySelector('span');
     if (search.isTranslateMode()) {
-      h.textContent = 'Enter translate \u2022 Esc clear';
+      h.textContent = HINT_TRANSLATE;
       resultsList.hidden = true;
       previewPanel.hidden = true;
       if (!translatePanel.isActive()) translatePanel.showPlaceholder();
     } else if (search.isClipboardMode()) {
-      h.textContent = 'Enter copy \u2022 Delete remove \u2022 Esc clear';
+      h.textContent = HINT_CLIPBOARD;
       resultsList.hidden = false;
       translatePanel.hide();
     } else {
-      h.textContent = 'Enter open \u2022 Ctrl+Enter search web \u2022 Ctrl+P pick \u2022 Ctrl+C copy \u2022 Ctrl+F reveal \u2022 Esc hide';
+      h.textContent = HINT_MAIN;
       resultsList.hidden = false;
       translatePanel.hide();
     }
@@ -259,8 +266,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     queryInput.parentElement.style.display = '';
     resultsList.hidden = false;
     previewPanel.hidden = false;
-    hintBar.querySelector('span').textContent =
-      'Enter open \u2022 Ctrl+Enter search web \u2022 Ctrl+P pick \u2022 Ctrl+C copy \u2022 Ctrl+F reveal \u2022 Esc hide';
+    hintBar.querySelector('span').textContent = HINT_MAIN;
     queryInput.value = '';
     search.handleQueryInput('');
     queryInput.focus();
@@ -304,12 +310,12 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (!pid) return;
       try {
         const msg = await killProcess(pid);
-        banner.show(msg, 'success', 1.2);
-        await new Promise((r) => setTimeout(r, 300));
+        banner.show(msg, 'success', BANNER_DURATION_MEDIUM);
+        await new Promise((r) => setTimeout(r, KILL_FEEDBACK_DELAY_MS));
         const procs = await listProcesses();
         commands.setProcessList(procs);
       } catch (err) {
-        banner.show(err || 'Kill failed', 'error', 1.5);
+        banner.show(err || 'Kill failed', 'error', BANNER_DURATION_LONG);
       }
       return;
     }
@@ -331,7 +337,7 @@ document.addEventListener('DOMContentLoaded', async () => {
           const result = await evalCalc(input);
           commands.showFeedback(result);
           await navigator.clipboard.writeText(result);
-          banner.show('Result copied', 'success', 1.0);
+          banner.show('Result copied', 'success', BANNER_DURATION_SHORT);
         } catch (err) {
           commands.showFeedback(err || 'Invalid expression', true);
         }

--- a/apps/linows/src/js/components/results.js
+++ b/apps/linows/src/js/components/results.js
@@ -10,6 +10,7 @@ let selectedIndex = -1;
 let container = null;
 let onSelectionChange = null;
 let onPickChange = null;
+
 export function init(containerEl) {
   container = containerEl;
 }

--- a/apps/linows/src/js/screens/commands/kill.js
+++ b/apps/linows/src/js/screens/commands/kill.js
@@ -1,3 +1,6 @@
+const MAX_PORT = 65535;
+const PORT_DEBOUNCE_MS = 200;
+
 let panel = null;
 let input = null;
 let feedback = null;
@@ -132,11 +135,11 @@ function filterProcesses(query) {
     filteredProcesses = [];
     selectedIndex = 0;
     const port = parseInt(query.slice(1));
-    if (port > 0 && port <= 65535) {
+    if (port > 0 && port <= MAX_PORT) {
       clearTimeout(portDebounce);
       portDebounce = setTimeout(() => {
         if (onExecute) onExecute('kill-port', String(port));
-      }, 200);
+      }, PORT_DEBOUNCE_MS);
     }
     return;
   } else {

--- a/apps/linows/src/js/screens/commands/pomo.js
+++ b/apps/linows/src/js/screens/commands/pomo.js
@@ -17,6 +17,7 @@ const DEFAULT_SESSIONS = [
 
 const ENDING_SOON_SECS = 10;
 const IDLE_FADE_SECS = 5;
+const TICK_INTERVAL_MS = 500;
 
 // --- Persistence ---
 const STORAGE_KEY_SESSIONS = 'pomo_sessions';
@@ -247,7 +248,7 @@ function advanceSession() {
 
 function startTick() {
   stopTick();
-  tickTimer = setInterval(tick, 500);
+  tickTimer = setInterval(tick, TICK_INTERVAL_MS);
 }
 
 function stopTick() {

--- a/apps/linows/src/js/search.js
+++ b/apps/linows/src/js/search.js
@@ -2,6 +2,8 @@ import { search as ipcSearch, getClipboardHistory } from './ipc.js';
 
 const DEBOUNCE_MS = 70;
 const MIN_QUICK_FOLDER_PREFIX = 2;
+const SEARCH_LIMIT = 40;
+const CLIPBOARD_TITLE_MAX_CHARS = 80;
 let debounceTimer = null;
 let onResultsCallback = null;
 let homeDir = null;
@@ -72,7 +74,7 @@ export function handleQueryInput(query) {
 
 async function performSearch(query) {
   try {
-    const payload = await ipcSearch(query, 40);
+    const payload = await ipcSearch(query, SEARCH_LIMIT);
     const results = prependQuickFolders(payload.results, query);
     if (onResultsCallback) {
       onResultsCallback(results, query);
@@ -113,7 +115,7 @@ async function performClipboardSearch(filter) {
     const entries = await getClipboardHistory(filter);
     const results = entries.map((e, i) => {
       // Title: first 80 chars, newlines → spaces
-      const title = e.text.replace(/\n/g, '  ').slice(0, 80) || '(empty)';
+      const title = e.text.replace(/\n/g, '  ').slice(0, CLIPBOARD_TITLE_MAX_CHARS) || '(empty)';
       const shortDate = formatShortDate(e.timestamp);
       const subtitle = `Clipboard  \u2022  ${e.char_count} chars  \u2022  ${e.line_count} lines  \u2022  ${shortDate}`;
       return {


### PR DESCRIPTION
## Summary

- Fix translation issue
- Fix windows auto startup issue
- Clean magic string and number

## Why

- 

## Changes

- Add CREATE_NO_WINDOW flag to curl (translate) and cmd /C (shell command) process spawns so no terminal window appears on Windows when users do translation.
- Replace enable_autostart_on_first_launch() with sync_autostart(), re-syncs the registry entry (Windows) or .desktop file (Linux) with the current exe path on every launch, matching WinUI3 behavior. Fixes autostart breaking after updates/reinstalls and keeps config file in sync with system state


## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
