### PR TITLE
fix: Issue with scale on multi monitors

### DIFF
--- a/apps/linows/src-tauri/src/gnome-shell-extension/extension.js
+++ b/apps/linows/src-tauri/src/gnome-shell-extension/extension.js
@@ -9,6 +9,10 @@ const IFACE = `
       <arg type="s" direction="in" name="desktop_id"/>
       <arg type="b" direction="out" name="success"/>
     </method>
+    <method name="GetPointer">
+      <arg type="i" direction="out" name="x"/>
+      <arg type="i" direction="out" name="y"/>
+    </method>
   </interface>
 </node>`;
 
@@ -33,6 +37,11 @@ export default class LookIntegration extends Extension {
             Gio.bus_unown_name(this._owner);
             this._owner = null;
         }
+    }
+
+    GetPointer() {
+        const [x, y] = global.get_pointer();
+        return [x, y];
     }
 
     FocusApp(desktop_id) {

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -110,7 +110,10 @@ fn toggle_window(app_handle: &tauri::AppHandle) {
         let monitors = window.available_monitors().unwrap_or_default();
         let monitor_key = (
             monitors.len(),
-            monitors.first().map(|m| m.scale_factor().to_bits()).unwrap_or(0),
+            monitors
+                .first()
+                .map(|m| m.scale_factor().to_bits())
+                .unwrap_or(0),
         );
         let setup_changed = {
             let mut last = LAST_MONITOR_KEY.lock().unwrap();
@@ -149,7 +152,10 @@ fn center_and_scale_window(window: &tauri::WebviewWindow) {
     if let Ok(monitors) = window.available_monitors() {
         let key = (
             monitors.len(),
-            monitors.first().map(|m| m.scale_factor().to_bits()).unwrap_or(0),
+            monitors
+                .first()
+                .map(|m| m.scale_factor().to_bits())
+                .unwrap_or(0),
         );
         *LAST_MONITOR_KEY.lock().unwrap() = key;
     }
@@ -164,9 +170,7 @@ fn center_and_scale_window(window: &tauri::WebviewWindow) {
     let logical_screen_h = screen.height as f64 / scale;
     eprintln!(
         "[look:scale] monitor={}x{} scale={} logical_screen={}x{} → window={}x{}",
-        screen.width, screen.height, scale,
-        logical_screen_w, logical_screen_h,
-        win_w, win_h,
+        screen.width, screen.height, scale, logical_screen_w, logical_screen_h, win_w, win_h,
     );
     let size = tauri::LogicalSize::new(win_w as f64, win_h as f64);
     let _ = window.set_size(size);

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -20,7 +20,7 @@ mod translate;
 use state::AppState;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
-use tauri::{Emitter, Manager, PhysicalPosition};
+use tauri::{Emitter, Manager};
 
 /// Timestamp (ms) of last window show, used to debounce focus-loss auto-hide.
 static LAST_SHOWN_AT: AtomicU64 = AtomicU64::new(0);
@@ -32,6 +32,8 @@ static LAST_AUTO_HIDDEN_AT: AtomicU64 = AtomicU64::new(0);
 /// focus, and without this guard Focused(false) auto-hide would dismiss Look
 /// while the user is still picking.
 pub static PICKING_FILE: AtomicBool = AtomicBool::new(false);
+/// Tracks monitor count + primary scale so we re-scale when monitors change.
+static LAST_MONITOR_KEY: std::sync::Mutex<(usize, u64)> = std::sync::Mutex::new((0, 0));
 
 fn now_ms() -> u64 {
     SystemTime::now()
@@ -60,8 +62,9 @@ const AUTO_HIDE_GRACE_MS: u64 = 300;
 const AUTO_HIDE_RESHOW_GUARD_MS: u64 = 200;
 const EVENT_WINDOW_SHOWN: &str = "window-shown";
 
-/// Scale window size for larger monitors. Base at 1080p (1.0x), up to 1.3x max.
-/// 1440p → 1.2x, 4K → 1.3x (capped).
+/// Scale window size (logical pixels) to fit the current monitor.
+/// Base size targets 1080p (1.0×). Scales up for larger logical screens
+/// (1440p → 1.2×, 4K → 1.3× cap).
 fn scaled_window_size(screen_w: u32, screen_h: u32, scale: f64) -> (u32, u32) {
     let logical_h = screen_h as f64 / scale;
     let ratio = if logical_h <= 1080.0 {
@@ -72,8 +75,8 @@ fn scaled_window_size(screen_w: u32, screen_h: u32, scale: f64) -> (u32, u32) {
         r.min(1.3)
     };
     let _ = screen_w; // used only for centering
-    let w = (BASE_W * ratio * scale).round() as u32;
-    let h = (BASE_H * ratio * scale).round() as u32;
+    let w = (BASE_W * ratio).round() as u32;
+    let h = (BASE_H * ratio).round() as u32;
     (w, h)
 }
 
@@ -102,12 +105,27 @@ fn toggle_window(app_handle: &tauri::AppHandle) {
         #[cfg(not(target_os = "linux"))]
         let tiling = false;
 
-        if !tiling {
+        // Recenter when multiple monitors (cursor may have moved to a
+        // different screen) or when the monitor setup changed (plug/unplug).
+        let monitors = window.available_monitors().unwrap_or_default();
+        let monitor_key = (
+            monitors.len(),
+            monitors.first().map(|m| m.scale_factor().to_bits()).unwrap_or(0),
+        );
+        let setup_changed = {
+            let mut last = LAST_MONITOR_KEY.lock().unwrap();
+            let changed = *last != monitor_key;
+            *last = monitor_key;
+            changed
+        };
+        let need_recenter = monitors.len() > 1 || setup_changed;
+
+        if need_recenter && !tiling {
             recenter_window(&window);
         }
         let _ = window.set_always_on_top(true);
         let _ = window.show();
-        if tiling {
+        if need_recenter && tiling {
             recenter_window(&window);
         }
         let _ = window.emit(EVENT_WINDOW_SHOWN, ());
@@ -127,6 +145,14 @@ fn toggle_window(app_handle: &tauri::AppHandle) {
 /// Center and scale a window to fit the current monitor.
 /// Called once at startup. Avoid calling on toggle — see toggle_window.
 fn center_and_scale_window(window: &tauri::WebviewWindow) {
+    // Seed the monitor key so the first toggle doesn't needlessly recenter.
+    if let Ok(monitors) = window.available_monitors() {
+        let key = (
+            monitors.len(),
+            monitors.first().map(|m| m.scale_factor().to_bits()).unwrap_or(0),
+        );
+        *LAST_MONITOR_KEY.lock().unwrap() = key;
+    }
     let Some(monitor) = monitor_at_cursor(window) else {
         return;
     };
@@ -134,33 +160,86 @@ fn center_and_scale_window(window: &tauri::WebviewWindow) {
     let screen = monitor.size();
     let scale = monitor.scale_factor();
     let (win_w, win_h) = scaled_window_size(screen.width, screen.height, scale);
-    let size = tauri::PhysicalSize::new(win_w, win_h);
+    let logical_screen_w = screen.width as f64 / scale;
+    let logical_screen_h = screen.height as f64 / scale;
+    eprintln!(
+        "[look:scale] monitor={}x{} scale={} logical_screen={}x{} → window={}x{}",
+        screen.width, screen.height, scale,
+        logical_screen_w, logical_screen_h,
+        win_w, win_h,
+    );
+    let size = tauri::LogicalSize::new(win_w as f64, win_h as f64);
     let _ = window.set_size(size);
     // Lock min/max to the scaled size: on Wayland, hide()/show() can
     // otherwise revert to tauri.conf's default (860×580) on remap,
     // producing a visible "big rectangle then snap" on toggle.
-    let _ = window.set_min_size(Some(tauri::Size::Physical(size)));
-    let _ = window.set_max_size(Some(tauri::Size::Physical(size)));
-    let x = pos.x + ((screen.width as f64 - win_w as f64) / 2.0) as i32;
-    let y = pos.y + ((screen.height as f64 - win_h as f64) / 2.0) as i32;
-    let _ = window.set_position(PhysicalPosition::new(x, y));
+    let _ = window.set_min_size(Some(tauri::Size::Logical(size)));
+    let _ = window.set_max_size(Some(tauri::Size::Logical(size)));
+    let lx = pos.x as f64 / scale + (logical_screen_w - win_w as f64) / 2.0;
+    let ly = pos.y as f64 / scale + (logical_screen_h - win_h as f64) / 2.0;
+    let _ = window.set_position(tauri::LogicalPosition::new(lx, ly));
 }
 
 /// Find the monitor that contains the cursor. Falls back to the window's
 /// current monitor, then the first available monitor.
 fn monitor_at_cursor(window: &tauri::WebviewWindow) -> Option<tauri::Monitor> {
-    if let Ok(cursor) = window.cursor_position()
+    // Try Tauri's cursor_position first (works on X11).
+    // On Wayland, cursor_position() fails — fall back to GNOME Shell D-Bus.
+    // GNOME Shell's global.get_pointer() returns *logical* coordinates,
+    // while Tauri's monitor positions/sizes are *physical* pixels.
+    // We track which space the cursor is in so the hit-test works correctly.
+    // On Wayland, Tauri's cursor_position() returns Ok((0,0)) instead of
+    // failing — it never reflects the real pointer location. Use the GNOME
+    // Shell extension (which calls global.get_pointer()) on Wayland instead.
+    #[cfg(target_os = "linux")]
+    let wayland = is_wayland();
+    #[cfg(not(target_os = "linux"))]
+    let wayland = false;
+
+    let (cursor, cursor_is_logical) = if !wayland {
+        match window.cursor_position() {
+            Ok(pos) => (Some(pos), false),
+            Err(_) => (None, false),
+        }
+    } else {
+        #[cfg(target_os = "linux")]
+        {
+            let pos = platform::linux::gnome_ext::get_pointer()
+                .map(|(x, y)| tauri::PhysicalPosition::new(x as f64, y as f64));
+            (pos, true) // GNOME Shell returns logical coords
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            (None, false)
+        }
+    };
+
+    if let Some(cursor) = cursor
         && let Ok(monitors) = window.available_monitors()
     {
-        let cx = cursor.x as i32;
-        let cy = cursor.y as i32;
+        let cx = cursor.x;
+        let cy = cursor.y;
         for m in &monitors {
             let pos = m.position();
             let size = m.size();
-            let mx = pos.x;
-            let my = pos.y;
-            let mw = size.width as i32;
-            let mh = size.height as i32;
+            let scale = m.scale_factor();
+            // When cursor is in logical coords (GNOME Shell on Wayland),
+            // convert each monitor's physical bounds to logical for comparison.
+            let (mx, my, mw, mh) = if cursor_is_logical {
+                (
+                    pos.x as f64 / scale,
+                    pos.y as f64 / scale,
+                    size.width as f64 / scale,
+                    size.height as f64 / scale,
+                )
+            } else {
+                (
+                    pos.x as f64,
+                    pos.y as f64,
+                    size.width as f64,
+                    size.height as f64,
+                )
+            };
             if cx >= mx && cx < mx + mw && cy >= my && cy < my + mh {
                 return Some(m.clone());
             }
@@ -185,19 +264,26 @@ fn recenter_window(window: &tauri::WebviewWindow) {
     let screen = monitor.size();
     let scale = monitor.scale_factor();
     let (win_w, win_h) = scaled_window_size(screen.width, screen.height, scale);
-    // Update size constraints if scale changed (different DPI monitors)
-    let size = tauri::PhysicalSize::new(win_w, win_h);
+    let logical_screen_w = screen.width as f64 / scale;
+    let logical_screen_h = screen.height as f64 / scale;
+    // Relax min/max constraints FIRST so the new size isn't clamped to the
+    // old monitor's dimensions, then resize, then lock constraints again.
+    let size = tauri::LogicalSize::new(win_w as f64, win_h as f64);
+    let _ = window.set_min_size(None::<tauri::Size>);
+    let _ = window.set_max_size(None::<tauri::Size>);
     let _ = window.set_size(size);
-    let _ = window.set_min_size(Some(tauri::Size::Physical(size)));
-    let _ = window.set_max_size(Some(tauri::Size::Physical(size)));
-    let x = pos.x + ((screen.width as f64 - win_w as f64) / 2.0) as i32;
-    let y = pos.y + ((screen.height as f64 - win_h as f64) / 2.0) as i32;
-    let _ = window.set_position(PhysicalPosition::new(x, y));
+    let _ = window.set_min_size(Some(tauri::Size::Logical(size)));
+    let _ = window.set_max_size(Some(tauri::Size::Logical(size)));
+    let lx = pos.x as f64 / scale + (logical_screen_w - win_w as f64) / 2.0;
+    let ly = pos.y as f64 / scale + (logical_screen_h - win_h as f64) / 2.0;
+    let _ = window.set_position(tauri::LogicalPosition::new(lx, ly));
 }
 
 #[cfg(target_os = "linux")]
 fn is_wayland() -> bool {
-    platform::linux::transparency::is_wayland()
+    use std::sync::OnceLock;
+    static CACHED: OnceLock<bool> = OnceLock::new();
+    *CACHED.get_or_init(platform::linux::transparency::is_wayland)
 }
 
 /// Set dev-mode config and database paths so dev doesn't pollute production.

--- a/apps/linows/src-tauri/src/platform/linux/gnome_ext.rs
+++ b/apps/linows/src-tauri/src/platform/linux/gnome_ext.rs
@@ -26,10 +26,8 @@ fn dbus_runtime() -> &'static tokio::runtime::Runtime {
 /// Cached D-Bus session connection.
 fn dbus_conn() -> Option<&'static zbus::Connection> {
     static CONN: OnceLock<Option<zbus::Connection>> = OnceLock::new();
-    CONN.get_or_init(|| {
-        dbus_runtime().block_on(async { zbus::Connection::session().await.ok() })
-    })
-    .as_ref()
+    CONN.get_or_init(|| dbus_runtime().block_on(async { zbus::Connection::session().await.ok() }))
+        .as_ref()
 }
 
 const METADATA_JSON: &str = include_str!("../../gnome-shell-extension/metadata.json");
@@ -149,7 +147,9 @@ pub fn get_pointer() -> Option<(i32, i32)> {
 /// Uses zbus to call directly from Look's process (which has focus),
 /// so GNOME trusts the activation request without showing a "ready" popup.
 pub fn try_focus_app(desktop_id: &str) -> bool {
-    let Some(conn) = dbus_conn() else { return false };
+    let Some(conn) = dbus_conn() else {
+        return false;
+    };
     let id = desktop_id.to_string();
     dbus_runtime()
         .block_on(async {

--- a/apps/linows/src-tauri/src/platform/linux/gnome_ext.rs
+++ b/apps/linows/src-tauri/src/platform/linux/gnome_ext.rs
@@ -5,11 +5,32 @@
 //! windows — the same mechanism GNOME's own Activities search uses.
 
 use std::path::PathBuf;
+use std::sync::OnceLock;
 
 const EXT_UUID: &str = "look-integration@lookapp";
 const DBUS_NAME: &str = "com.look.ShellIntegration";
 const DBUS_PATH: &str = "/com/look/ShellIntegration";
 const DBUS_IFACE: &str = "com.look.ShellIntegration";
+
+/// Shared tokio runtime for D-Bus calls — avoids creating a new one each call.
+fn dbus_runtime() -> &'static tokio::runtime::Runtime {
+    static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+    RT.get_or_init(|| {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("failed to create D-Bus tokio runtime")
+    })
+}
+
+/// Cached D-Bus session connection.
+fn dbus_conn() -> Option<&'static zbus::Connection> {
+    static CONN: OnceLock<Option<zbus::Connection>> = OnceLock::new();
+    CONN.get_or_init(|| {
+        dbus_runtime().block_on(async { zbus::Connection::session().await.ok() })
+    })
+    .as_ref()
+}
 
 const METADATA_JSON: &str = include_str!("../../gnome-shell-extension/metadata.json");
 const EXTENSION_JS: &str = include_str!("../../gnome-shell-extension/extension.js");
@@ -100,38 +121,54 @@ fn build_extension_zip(path: &std::path::Path) -> std::io::Result<()> {
     Ok(())
 }
 
-/// Try to focus an app by its desktop file ID using the GNOME Shell extension.
-/// Returns true if the app was focused (had existing windows).
-///
-/// Uses zbus to call directly from Look's process (which has focus),
-/// so GNOME trusts the activation request without showing a "ready" popup.
-pub fn try_focus_app(desktop_id: &str) -> bool {
-    // Build the tokio runtime inline — this is called from a sync context
-    // and needs to complete quickly.
-    let id = desktop_id.to_string();
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build();
-    let Ok(rt) = rt else { return false };
-
-    rt.block_on(async {
-        let conn = zbus::Connection::session().await.ok()?;
-        let reply: (bool,) = conn
+/// Get the cursor position via the GNOME Shell extension's GetPointer D-Bus method.
+/// Works on Wayland where Tauri's cursor_position() is unavailable.
+pub fn get_pointer() -> Option<(i32, i32)> {
+    let conn = dbus_conn()?;
+    dbus_runtime().block_on(async {
+        let reply: (i32, i32) = conn
             .call_method(
                 Some(DBUS_NAME),
                 DBUS_PATH,
                 Some(DBUS_IFACE),
-                "FocusApp",
-                &id,
+                "GetPointer",
+                &(),
             )
             .await
             .ok()?
             .body()
             .deserialize()
             .ok()?;
-        Some(reply.0)
+        Some(reply)
     })
-    .unwrap_or(false)
+}
+
+/// Try to focus an app by its desktop file ID using the GNOME Shell extension.
+/// Returns true if the app was focused (had existing windows).
+///
+/// Uses zbus to call directly from Look's process (which has focus),
+/// so GNOME trusts the activation request without showing a "ready" popup.
+pub fn try_focus_app(desktop_id: &str) -> bool {
+    let Some(conn) = dbus_conn() else { return false };
+    let id = desktop_id.to_string();
+    dbus_runtime()
+        .block_on(async {
+            let reply: (bool,) = conn
+                .call_method(
+                    Some(DBUS_NAME),
+                    DBUS_PATH,
+                    Some(DBUS_IFACE),
+                    "FocusApp",
+                    &id,
+                )
+                .await
+                .ok()?
+                .body()
+                .deserialize()
+                .ok()?;
+            Some(reply.0)
+        })
+        .unwrap_or(false)
 }
 
 fn extension_dir() -> PathBuf {

--- a/apps/linows/src-tauri/tauri.conf.json
+++ b/apps/linows/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicoverbruggen/tauri-v2-schema/main/schema.json",
   "productName": "Look",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "identifier": "com.look.desktop",
   "build": {
     "frontendDist": "../src",

--- a/apps/linows/src/css/components/commands.css
+++ b/apps/linows/src/css/components/commands.css
@@ -19,10 +19,6 @@
   border-radius: 6px;
 }
 
-.cmd-row:hover {
-  background: var(--selection-fill);
-}
-
 .cmd-row-active {
   background: var(--selection-fill);
 }
@@ -198,10 +194,6 @@
   border-radius: 6px;
   cursor: pointer;
   font-size: var(--font-size);
-}
-
-.cmd-proc-row:hover {
-  background: var(--selection-fill);
 }
 
 .cmd-proc-row-active {


### PR DESCRIPTION
## Summary

- Last approach with multi screens has issue if a screen has scale != 1. 
- remove hover on commands creen

## Why

-

## Changes

- calc the logic size, then re-scale look based on screen size. 
- this is only need with gnome at the moment, with windows; i have no idea, but I think this will be ok. If you find problems, please log an issue. that will help a lot! 

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
