### PR TITLE
Feat: folder preview macos

### DIFF
--- a/apps/linows/src-tauri/tauri.conf.json
+++ b/apps/linows/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicoverbruggen/tauri-v2-schema/main/schema.json",
   "productName": "Look",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "identifier": "com.look.desktop",
   "build": {
     "frontendDist": "../src",

--- a/apps/macos/LauncherApp/look-app/Support/FolderListingService.swift
+++ b/apps/macos/LauncherApp/look-app/Support/FolderListingService.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+struct FolderEntry: Equatable {
+    let name: String
+    let isDir: Bool
+    let size: Int64?
+}
+
+struct FolderListing: Equatable {
+    let items: [FolderEntry]
+    let folderCount: Int
+    let fileCount: Int
+    let truncated: Bool
+}
+
+enum FolderListingService {
+    nonisolated static let listCap = 30
+
+    static func list(path: String) async -> FolderListing? {
+        await Task.detached(priority: .userInitiated) {
+            listSync(path: path)
+        }.value
+    }
+
+    nonisolated private static func listSync(path: String) -> FolderListing? {
+        let url = URL(fileURLWithPath: path)
+        let keys: [URLResourceKey] = [.isDirectoryKey, .fileSizeKey]
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: keys,
+            options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants]
+        ) else {
+            return nil
+        }
+
+        var folderNames: [String] = []
+        var files: [(name: String, url: URL)] = []
+
+        for child in entries {
+            let name = child.lastPathComponent
+            if name.hasPrefix(".") { continue }
+            let isDir = (try? child.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+            if isDir {
+                folderNames.append(name)
+            } else {
+                files.append((name, child))
+            }
+        }
+
+        folderNames.sort { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+        files.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+
+        let folderCount = folderNames.count
+        let fileCount = files.count
+        let total = folderCount + fileCount
+
+        var items: [FolderEntry] = []
+        items.reserveCapacity(min(total, listCap))
+
+        for name in folderNames {
+            if items.count >= listCap { break }
+            items.append(FolderEntry(name: name, isDir: true, size: nil))
+        }
+        for file in files {
+            if items.count >= listCap { break }
+            let size = (try? file.url.resourceValues(forKeys: [.fileSizeKey]).fileSize).flatMap(Int64.init)
+            items.append(FolderEntry(name: file.name, isDir: false, size: size))
+        }
+
+        return FolderListing(
+            items: items,
+            folderCount: folderCount,
+            fileCount: fileCount,
+            truncated: total > listCap
+        )
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/FolderPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/FolderPreviewView.swift
@@ -1,0 +1,100 @@
+import AppKit
+import SwiftUI
+
+struct FolderPreviewView: View {
+    @EnvironmentObject private var themeStore: ThemeStore
+    let path: String
+    let listing: FolderListing?
+
+    private var rowFont: Font {
+        themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular)
+    }
+
+    private var sizeFont: Font {
+        themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular)
+    }
+
+    private func formatSize(_ bytes: Int64) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        return formatter.string(fromByteCount: bytes)
+    }
+
+    private func icon(for entry: FolderEntry) -> NSImage {
+        let childPath = (path as NSString).appendingPathComponent(entry.name)
+        return NSWorkspace.shared.icon(forFile: childPath)
+    }
+
+    private func open(_ entry: FolderEntry) {
+        let childPath = (path as NSString).appendingPathComponent(entry.name)
+        NSWorkspace.shared.open(URL(fileURLWithPath: childPath))
+    }
+
+    var body: some View {
+        if let listing {
+            if listing.items.isEmpty {
+                Text("Empty folder")
+                    .font(rowFont)
+                    .foregroundStyle(themeStore.mutedTextColor())
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 16)
+            } else {
+                list(listing)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func list(_ listing: FolderListing) -> some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                ForEach(Array(listing.items.enumerated()), id: \.offset) { index, entry in
+                    if index > 0,
+                       entry.isDir == false,
+                       listing.items[index - 1].isDir == true {
+                        Divider()
+                            .padding(.vertical, 4)
+                    }
+                    row(entry)
+                }
+
+                if listing.truncated {
+                    Text("Showing \(listing.items.count) of \(listing.folderCount + listing.fileCount)")
+                        .font(sizeFont)
+                        .foregroundStyle(themeStore.mutedTextColor())
+                        .padding(.vertical, 6)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                }
+            }
+        }
+        .background(themeStore.controlFillColor(), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .frame(maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private func row(_ entry: FolderEntry) -> some View {
+        HStack(spacing: 8) {
+            Image(nsImage: icon(for: entry))
+                .resizable()
+                .frame(width: 16, height: 16)
+
+            Text(entry.name)
+                .font(rowFont)
+                .foregroundStyle(themeStore.fontColor())
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            Spacer(minLength: 8)
+
+            if !entry.isDir, let size = entry.size {
+                Text(formatSize(size))
+                    .font(sizeFont)
+                    .foregroundStyle(themeStore.secondaryTextColor())
+            }
+        }
+        .contentShape(Rectangle())
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .onTapGesture { open(entry) }
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
@@ -177,7 +177,13 @@ struct ResultPreviewView: View {
                     return
                 }
                 folderListing = nil
-                folderListing = await FolderListingService.list(path: result.path)
+                let path = result.path
+                let listing = await FolderListingService.list(path: path)
+                // .task(id:) cancels this closure when the result changes,
+                // but the detached worker keeps running — guard against
+                // stale assignment when the user moved on to another folder.
+                if Task.isCancelled { return }
+                folderListing = listing
             }
         }
     }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
@@ -7,6 +7,19 @@ struct ResultPreviewView: View {
     let result: LauncherResult
     var onDeleteClipboard: (() -> Void)? = nil
 
+    @State private var folderListing: FolderListing?
+
+    private func folderCountText(_ listing: FolderListing) -> String? {
+        var parts: [String] = []
+        if listing.folderCount > 0 {
+            parts.append("\(listing.folderCount) folder\(listing.folderCount == 1 ? "" : "s")")
+        }
+        if listing.fileCount > 0 {
+            parts.append("\(listing.fileCount) file\(listing.fileCount == 1 ? "" : "s")")
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: ", ")
+    }
+
     private static let modifiedDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
@@ -103,9 +116,18 @@ struct ResultPreviewView: View {
 
                         HStack(spacing: 6) {
                             KindBadge(kind: result.kind.rawValue)
-                            Text(info.size)
-                                .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular))
-                                .foregroundStyle(themeStore.secondaryTextColor())
+                            if result.kind == .folder {
+                                if let listing = folderListing,
+                                   let counts = folderCountText(listing) {
+                                    Text(counts)
+                                        .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular))
+                                        .foregroundStyle(themeStore.secondaryTextColor())
+                                }
+                            } else {
+                                Text(info.size)
+                                    .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular))
+                                    .foregroundStyle(themeStore.secondaryTextColor())
+                            }
                         }
                     }
                     Spacer()
@@ -117,6 +139,10 @@ struct ResultPreviewView: View {
                     } else {
                         QuickLookPreviewImage(path: result.path, maxHeight: .infinity)
                     }
+                }
+
+                if result.kind == .folder {
+                    FolderPreviewView(path: result.path, listing: folderListing)
                 }
 
                 if let version = info.version {
@@ -139,12 +165,20 @@ struct ResultPreviewView: View {
                     InfoRow(label: "Modified", value: modified)
                 }
 
-                if result.kind != .file {
+                if result.kind != .file && result.kind != .folder {
                     Spacer()
                 }
             }
             .padding(12)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .task(id: result.kind == .folder ? result.path : "") {
+                guard result.kind == .folder else {
+                    folderListing = nil
+                    return
+                }
+                folderListing = nil
+                folderListing = await FolderListingService.list(path: result.path)
+            }
         }
     }
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -20,6 +20,7 @@ This document tracks what `look` supports today and what is planned next.
 - open with `Enter`, reveal in Finder with `Cmd+F`
 - copy selected file/folder path/content handle with `Cmd+C`
 - multi-pick files/folders with `Cmd+P` (toggle); picked set is mirrored to the system pasteboard for paste anywhere. `Cmd+Shift+P` clears the set
+- preview pane: text/image file previews, plus folder previews listing the immediate children (folders first, capped at 30, click to open)
 
 ### Clipboard and translation
 


### PR DESCRIPTION
## Summary

- Folder preview for Look MacOS

## Why

- none

## Changes

<img width="857" height="610" alt="image" src="https://github.com/user-attachments/assets/6161f83c-7ebc-4536-957b-d085ac038052" />


## Testing

- [x] `cargo check --workspace --manifest-path core/Cargo.toml`
- [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [x] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [x] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered
