### PR TITLE
fix issue in setting - ** blue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ docs/tmp-issue-tracker.md
 
 # internal feature specs — maintainer-only design notes; user docs live in docs/
 specs/
+# blogs
+blogs/
 
 # .NET / Visual Studio
 ## User-specific files

--- a/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Appearance.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Appearance.swift
@@ -121,7 +121,7 @@ extension ThemeSettingsView {
                 LabeledSlider(title: "Border Thick", value: $settings.borderThickness, range: 0...6)
                 LabeledSlider(title: "Border Red", value: $settings.borderRed, range: 0...1)
                 LabeledSlider(title: "Border Green", value: $settings.borderGreen, range: 0...1)
-                LabeledSlider(title: "Border Blue", value: $settings.fontBlue, range: 0...1)
+                LabeledSlider(title: "Border Blue", value: $settings.borderBlue, range: 0...1)
                 LabeledSlider(title: "Border Opacity", value: $settings.borderOpacity, range: 0...1)
             }
             .onAppear {


### PR DESCRIPTION
## Summary

- Text blue and Border blue are one, due to a typo

## Why

-

## Changes

-

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
