### PR TITLE
Feat: Smart app switching with Look

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,28 +3,8 @@ name: CI
 on:
   push:
     branches: [main, dev]
-    # Skip the whole workflow for pushes that touch ONLY these files —
-    # nothing in the build/test matrix can be affected by them. Per-job
-    # path filters below still gate the platform-specific builds for
-    # the remaining cases.
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'blogs/**'
-      - 'assets/**'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.editorconfig'
   pull_request:
     branches: [main, dev]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'blogs/**'
-      - 'assets/**'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.editorconfig'
 
 # Cancel any prior in-progress run for the same branch / PR when a new
 # push comes in. Stops the slow linows build from keeping a stale

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,11 +108,10 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
-      - name: Install cargo-binstall
-        run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-
       - name: Install cargo-audit
-        run: cargo binstall cargo-audit --no-confirm
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
 
       - name: Audit dependencies (core workspace)
         run: cargo audit --file core/Cargo.lock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,35 @@ name: CI
 on:
   push:
     branches: [main, dev]
+    # Skip the whole workflow for pushes that touch ONLY these files —
+    # nothing in the build/test matrix can be affected by them. Per-job
+    # path filters below still gate the platform-specific builds for
+    # the remaining cases.
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'blogs/**'
+      - 'assets/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.editorconfig'
   pull_request:
     branches: [main, dev]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'blogs/**'
+      - 'assets/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.editorconfig'
+
+# Cancel any prior in-progress run for the same branch / PR when a new
+# push comes in. Stops the slow linows build from keeping a stale
+# commit's lane busy after you've already force-pushed an update.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always

--- a/apps/macos/LauncherApp/look-app/Models/RunningAppsService.swift
+++ b/apps/macos/LauncherApp/look-app/Models/RunningAppsService.swift
@@ -19,26 +19,12 @@ final class RunningAppsService: ObservableObject {
     @Published private(set) var activePID: pid_t?
 
     private let ownPID = ProcessInfo.processInfo.processIdentifier
-    private var timer: Timer?
-    private var observers: [NSObjectProtocol] = []
     // Most-recently-active first. Bundle ID preferred; falls back to pid for apps without one.
     private var recencyOrder: [String] = []
 
     init() {
         attachNotifications()
         refresh()
-    }
-
-    func startPolling(interval: TimeInterval = 2.5) {
-        timer?.invalidate()
-        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
-            Task { @MainActor in self?.refresh() }
-        }
-    }
-
-    func stopPolling() {
-        timer?.invalidate()
-        timer = nil
     }
 
     func refresh() {
@@ -76,7 +62,7 @@ final class RunningAppsService: ObservableObject {
     private func attachNotifications() {
         let nc = NSWorkspace.shared.notificationCenter
 
-        let activated = nc.addObserver(
+        nc.addObserver(
             forName: NSWorkspace.didActivateApplicationNotification,
             object: nil,
             queue: .main
@@ -92,7 +78,7 @@ final class RunningAppsService: ObservableObject {
             }
         }
 
-        let launched = nc.addObserver(
+        nc.addObserver(
             forName: NSWorkspace.didLaunchApplicationNotification,
             object: nil,
             queue: .main
@@ -100,15 +86,13 @@ final class RunningAppsService: ObservableObject {
             Task { @MainActor in self?.refresh() }
         }
 
-        let terminated = nc.addObserver(
+        nc.addObserver(
             forName: NSWorkspace.didTerminateApplicationNotification,
             object: nil,
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor in self?.refresh() }
         }
-
-        observers = [activated, launched, terminated]
     }
 
     private func recencyKey(for item: RunningAppItem) -> String {

--- a/apps/macos/LauncherApp/look-app/Models/RunningAppsService.swift
+++ b/apps/macos/LauncherApp/look-app/Models/RunningAppsService.swift
@@ -56,23 +56,62 @@ final class RunningAppsService: ObservableObject {
         }
     }
 
-    func activate(index: Int) {
+    @discardableResult
+    func activate(index: Int) -> Bool {
         let log = RunningAppsLog.logger
         guard index >= 0, index < items.count else {
             log.debug("activate(index: \(index, privacy: .public)) — out of range (count=\(self.items.count, privacy: .public))")
-            return
+            return false
         }
         let item = items[index]
         guard let app = NSRunningApplication(processIdentifier: item.id) else {
             log.debug("activate \(item.name, privacy: .public) pid=\(item.id, privacy: .public) — NSRunningApplication lookup returned nil (process gone?)")
-            return
+            return false
         }
         guard !app.isTerminated else {
             log.debug("activate \(item.name, privacy: .public) pid=\(item.id, privacy: .public) — already terminated")
-            return
+            return false
         }
-        let result = app.activate()
-        log.debug("activate \(item.name, privacy: .public) pid=\(item.id, privacy: .public) — NSRunningApplication.activate() returned \(result, privacy: .public)")
+        let wasHidden = app.isHidden
+        if wasHidden {
+            app.unhide()
+        }
+        // Detect Finder-style apps that show up in the running list but
+        // have no visible window. Activating them alone would flash the
+        // launcher closed with nothing visibly happening. Track this so
+        // we can follow up with a `NSWorkspace.openApplication(...)`
+        // which fires the same "reopen" event a Dock click sends —
+        // those apps respond by spawning a fresh window.
+        let hadVisibleWindow = Self.hasOnScreenWindow(pid: app.processIdentifier)
+        let result = app.activate(options: [.activateAllWindows])
+        log.debug("activate \(item.name, privacy: .public) pid=\(item.id, privacy: .public) wasHidden=\(wasHidden, privacy: .public) hadVisibleWindow=\(hadVisibleWindow, privacy: .public) — activate returned \(result, privacy: .public)")
+        if result, !hadVisibleWindow, let bundleURL = app.bundleURL {
+            let configuration = NSWorkspace.OpenConfiguration()
+            configuration.activates = true
+            configuration.addsToRecentItems = false
+            NSWorkspace.shared.openApplication(at: bundleURL, configuration: configuration) { _, error in
+                if let error {
+                    log.debug("openApplication(at:) follow-up failed for \(item.name, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                }
+            }
+        }
+        return result
+    }
+
+    /// Returns true if the given pid owns at least one on-screen,
+    /// non-desktop-element window. Used to detect apps that are in the
+    /// "running but no window" state (Finder is the canonical example)
+    /// so we can follow `activate()` with a reopen request.
+    private static func hasOnScreenWindow(pid: pid_t) -> Bool {
+        let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+        guard let infos = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] else {
+            return false
+        }
+        let key = kCGWindowOwnerPID as String
+        return infos.contains { info in
+            guard let ownerPID = info[key] as? pid_t else { return false }
+            return ownerPID == pid
+        }
     }
 
     private func attachNotifications() {

--- a/apps/macos/LauncherApp/look-app/Models/RunningAppsService.swift
+++ b/apps/macos/LauncherApp/look-app/Models/RunningAppsService.swift
@@ -1,0 +1,136 @@
+import AppKit
+import Combine
+import Foundation
+
+struct RunningAppItem: Identifiable, Equatable {
+    let id: pid_t
+    let bundleIdentifier: String?
+    let name: String
+    let icon: NSImage?
+
+    static func == (lhs: RunningAppItem, rhs: RunningAppItem) -> Bool {
+        lhs.id == rhs.id && lhs.name == rhs.name && lhs.bundleIdentifier == rhs.bundleIdentifier
+    }
+}
+
+@MainActor
+final class RunningAppsService: ObservableObject {
+    @Published private(set) var items: [RunningAppItem] = []
+    @Published private(set) var activePID: pid_t?
+
+    private let ownPID = ProcessInfo.processInfo.processIdentifier
+    private var timer: Timer?
+    private var observers: [NSObjectProtocol] = []
+    // Most-recently-active first. Bundle ID preferred; falls back to pid for apps without one.
+    private var recencyOrder: [String] = []
+
+    init() {
+        attachNotifications()
+        refresh()
+    }
+
+    func startPolling(interval: TimeInterval = 2.5) {
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.refresh() }
+        }
+    }
+
+    func stopPolling() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    func refresh() {
+        let frontmost = NSWorkspace.shared.frontmostApplication?.processIdentifier
+        let running = NSWorkspace.shared.runningApplications
+            .filter { $0.activationPolicy == .regular }
+            .filter { $0.processIdentifier != ownPID }
+
+        let snapshot: [RunningAppItem] = running.map { app in
+            RunningAppItem(
+                id: app.processIdentifier,
+                bundleIdentifier: app.bundleIdentifier,
+                name: app.localizedName ?? app.bundleIdentifier ?? "App",
+                icon: app.icon
+            )
+        }
+
+        let sorted = sortByRecency(snapshot)
+        items = Array(sorted.prefix(AppConstants.Launcher.RunningAppsStrip.maxItems))
+
+        if let frontmost, frontmost != ownPID {
+            activePID = frontmost
+            promote(pid: frontmost)
+        }
+    }
+
+    func activate(index: Int) {
+        guard index >= 0, index < items.count else { return }
+        let item = items[index]
+        guard let app = NSRunningApplication(processIdentifier: item.id) else { return }
+        guard !app.isTerminated else { return }
+        _ = app.activate()
+    }
+
+    private func attachNotifications() {
+        let nc = NSWorkspace.shared.notificationCenter
+
+        let activated = nc.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            let activatedPID = (note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication)?.processIdentifier
+            Task { @MainActor in
+                guard let self else { return }
+                if let pid = activatedPID {
+                    self.promote(pid: pid)
+                    self.activePID = pid
+                }
+                self.refresh()
+            }
+        }
+
+        let launched = nc.addObserver(
+            forName: NSWorkspace.didLaunchApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.refresh() }
+        }
+
+        let terminated = nc.addObserver(
+            forName: NSWorkspace.didTerminateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.refresh() }
+        }
+
+        observers = [activated, launched, terminated]
+    }
+
+    private func recencyKey(for item: RunningAppItem) -> String {
+        item.bundleIdentifier ?? "pid:\(item.id)"
+    }
+
+    private func promote(pid: pid_t) {
+        guard let app = NSRunningApplication(processIdentifier: pid) else { return }
+        let key = app.bundleIdentifier ?? "pid:\(pid)"
+        recencyOrder.removeAll { $0 == key }
+        recencyOrder.insert(key, at: 0)
+    }
+
+    private func sortByRecency(_ items: [RunningAppItem]) -> [RunningAppItem] {
+        let order = recencyOrder
+        return items.sorted { lhs, rhs in
+            let lk = recencyKey(for: lhs)
+            let rk = recencyKey(for: rhs)
+            let li = order.firstIndex(of: lk) ?? Int.max
+            let ri = order.firstIndex(of: rk) ?? Int.max
+            if li != ri { return li < ri }
+            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Models/RunningAppsService.swift
+++ b/apps/macos/LauncherApp/look-app/Models/RunningAppsService.swift
@@ -1,6 +1,11 @@
 import AppKit
 import Combine
 import Foundation
+import OSLog
+
+enum RunningAppsLog {
+    static let logger = Logger(subsystem: "noah-code.Look", category: "running-apps")
+}
 
 struct RunningAppItem: Identifiable, Equatable {
     let id: pid_t
@@ -52,11 +57,22 @@ final class RunningAppsService: ObservableObject {
     }
 
     func activate(index: Int) {
-        guard index >= 0, index < items.count else { return }
+        let log = RunningAppsLog.logger
+        guard index >= 0, index < items.count else {
+            log.debug("activate(index: \(index, privacy: .public)) — out of range (count=\(self.items.count, privacy: .public))")
+            return
+        }
         let item = items[index]
-        guard let app = NSRunningApplication(processIdentifier: item.id) else { return }
-        guard !app.isTerminated else { return }
-        _ = app.activate()
+        guard let app = NSRunningApplication(processIdentifier: item.id) else {
+            log.debug("activate \(item.name, privacy: .public) pid=\(item.id, privacy: .public) — NSRunningApplication lookup returned nil (process gone?)")
+            return
+        }
+        guard !app.isTerminated else {
+            log.debug("activate \(item.name, privacy: .public) pid=\(item.id, privacy: .public) — already terminated")
+            return
+        }
+        let result = app.activate()
+        log.debug("activate \(item.name, privacy: .public) pid=\(item.id, privacy: .public) — NSRunningApplication.activate() returned \(result, privacy: .public)")
     }
 
     private func attachNotifications() {

--- a/apps/macos/LauncherApp/look-app/Models/RunningAppsService.swift
+++ b/apps/macos/LauncherApp/look-app/Models/RunningAppsService.swift
@@ -24,8 +24,6 @@ final class RunningAppsService: ObservableObject {
     @Published private(set) var activePID: pid_t?
 
     private let ownPID = ProcessInfo.processInfo.processIdentifier
-    // Most-recently-active first. Bundle ID preferred; falls back to pid for apps without one.
-    private var recencyOrder: [String] = []
 
     init() {
         attachNotifications()
@@ -47,12 +45,16 @@ final class RunningAppsService: ObservableObject {
             )
         }
 
-        let sorted = sortByRecency(snapshot)
+        // Alphabetical, stable. Reordering on activation was forcing the
+        // user to re-scan the strip after every switch — keep positions
+        // fixed so the Cmd+N key for "Discord" stays the same.
+        let sorted = snapshot.sorted { lhs, rhs in
+            lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }
         items = Array(sorted.prefix(AppConstants.Launcher.RunningAppsStrip.maxItems))
 
         if let frontmost, frontmost != ownPID {
             activePID = frontmost
-            promote(pid: frontmost)
         }
     }
 
@@ -125,51 +127,20 @@ final class RunningAppsService: ObservableObject {
             let activatedPID = (note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication)?.processIdentifier
             Task { @MainActor in
                 guard let self else { return }
-                if let pid = activatedPID {
-                    self.promote(pid: pid)
-                    self.activePID = pid
-                }
+                // Track which app is frontmost (for the accent ring) but
+                // do NOT reorder items — positions are kept stable.
+                if let pid = activatedPID { self.activePID = pid }
                 self.refresh()
             }
         }
 
-        nc.addObserver(
-            forName: NSWorkspace.didLaunchApplicationNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in self?.refresh() }
-        }
-
-        nc.addObserver(
-            forName: NSWorkspace.didTerminateApplicationNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in self?.refresh() }
-        }
-    }
-
-    private func recencyKey(for item: RunningAppItem) -> String {
-        item.bundleIdentifier ?? "pid:\(item.id)"
-    }
-
-    private func promote(pid: pid_t) {
-        guard let app = NSRunningApplication(processIdentifier: pid) else { return }
-        let key = app.bundleIdentifier ?? "pid:\(pid)"
-        recencyOrder.removeAll { $0 == key }
-        recencyOrder.insert(key, at: 0)
-    }
-
-    private func sortByRecency(_ items: [RunningAppItem]) -> [RunningAppItem] {
-        let order = recencyOrder
-        return items.sorted { lhs, rhs in
-            let lk = recencyKey(for: lhs)
-            let rk = recencyKey(for: rhs)
-            let li = order.firstIndex(of: lk) ?? Int.max
-            let ri = order.firstIndex(of: rk) ?? Int.max
-            if li != ri { return li < ri }
-            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        for name in [
+            NSWorkspace.didLaunchApplicationNotification,
+            NSWorkspace.didTerminateApplicationNotification,
+        ] {
+            nc.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
+                Task { @MainActor in self?.refresh() }
+            }
         }
     }
 }

--- a/apps/macos/LauncherApp/look-app/Models/ThemeSettings.swift
+++ b/apps/macos/LauncherApp/look-app/Models/ThemeSettings.swift
@@ -82,6 +82,33 @@ enum BackgroundImageMode: String, CaseIterable, Codable, Identifiable {
     }
 }
 
+enum RunningAppsPlacement: String, CaseIterable, Codable, Identifiable {
+    case none
+    case top
+    case right
+    case bottom
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .none: return "None"
+        case .top: return "Top"
+        case .right: return "Right"
+        case .bottom: return "Bottom"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .none: return "Hide the strip and disable ⌘+number switching"
+        case .top: return "Horizontal row above the launcher"
+        case .right: return "Vertical column to the right"
+        case .bottom: return "Horizontal row below the launcher"
+        }
+    }
+}
+
 enum BackendLogLevel: String, CaseIterable, Codable, Identifiable {
     case error
     case info
@@ -135,6 +162,8 @@ struct ThemeSettings: Codable, Equatable {
     var lazyIndexingEnabled: Bool = true
     var backendLogLevel: BackendLogLevel = .error
     var launchAtLogin: Bool = true
+
+    var runningAppsPlacement: RunningAppsPlacement = .right
 
     static let `default` = ThemeSettings()
 }

--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -104,6 +104,21 @@ enum AppConstants {
         static let commandResultFontSize: CGFloat = 18
         static let calcMaxMagnitude = 1_000_000_000_000.0
 
+        enum Panel {
+            static let width: CGFloat = 860
+            static let height: CGFloat = 580
+        }
+
+        enum RunningAppsStrip {
+            static let iconSize: CGFloat = 34
+            static let horizontalPadding: CGFloat = 6
+            static let verticalPadding: CGFloat = 10
+            static let panelGap: CGFloat = 8
+            static let maxItems = 9
+
+            static var width: CGFloat { iconSize + horizontalPadding * 2 + 8 }
+        }
+
         static let commandCatalog: [AppCommand] = [
             AppCommand(id: Command.calc, title: "calc (⌘1)", detail: "Evaluate math expression", placeholder: "Type math expression"),
             AppCommand(id: Command.pomo, title: "pomo (⌘2)", detail: "Pomodoro focus timer", placeholder: "Manage focus sessions"),

--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -120,6 +120,45 @@ enum AppConstants {
             static let maxItems = 9
 
             static var width: CGFloat { iconSize + horizontalPadding * 2 + edgeSlack }
+
+            /// Cmd-number keys in order of physical ease to press from
+            /// the typical Cmd-Space launcher posture: left index/middle
+            /// fingers first (1, 2, 3), then right-hand edge (9, 8),
+            /// then 4 and 7, and finally the painful centre keys
+            /// (6, 5). Used as a *resource* — when the strip has fewer
+            /// than 9 icons we only consume the easy keys from the
+            /// front of this list, so 5/6/7 only appear in 7+ app
+            /// configurations.
+            private static let easinessOrder: [Int] = [1, 2, 3, 9, 8, 4, 7, 6, 5]
+
+            /// Returns the Cmd-number keys to assign to a strip of
+            /// `total` icons, in left-to-right visual order. We pick the
+            /// `total` easiest keys from `easinessOrder` and sort them
+            /// ascending so the strip still reads naturally (e.g. for
+            /// total=5 → `[1, 2, 3, 8, 9]` instead of `[1, 2, 3, 9, 8]`).
+            static func badgeKeys(total: Int) -> [Int] {
+                guard total > 0 else { return [] }
+                return Array(easinessOrder.prefix(min(total, maxItems))).sorted()
+            }
+
+            /// The Cmd-number key shown on the badge of the icon at
+            /// `position` (left-to-right, 0-indexed) in a strip of size
+            /// `total`. Returns `position + 1` as a fallback for any
+            /// out-of-range query.
+            static func ergonomicKey(forVisualPosition position: Int, total: Int) -> Int {
+                let keys = badgeKeys(total: total)
+                guard position >= 0, position < keys.count else { return position + 1 }
+                return keys[position]
+            }
+
+            /// Inverse of `ergonomicKey`: maps the Cmd-number key the
+            /// user pressed (1..9) to the visual position of the icon
+            /// they targeted. Returns nil when that key isn't currently
+            /// assigned to any icon (e.g. user pressed Cmd+5 with only
+            /// 4 running apps).
+            static func visualPosition(forKey key: Int, total: Int) -> Int? {
+                badgeKeys(total: total).firstIndex(of: key)
+            }
         }
 
         static let commandCatalog: [AppCommand] = [

--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -113,10 +113,13 @@ enum AppConstants {
             static let iconSize: CGFloat = 34
             static let horizontalPadding: CGFloat = 6
             static let verticalPadding: CGFloat = 10
+            static let itemGap: CGFloat = 8
             static let panelGap: CGFloat = 8
+            // Slack on each end of the strip to keep the active ring from being clipped.
+            static let edgeSlack: CGFloat = 8
             static let maxItems = 9
 
-            static var width: CGFloat { iconSize + horizontalPadding * 2 + 8 }
+            static var width: CGFloat { iconSize + horizontalPadding * 2 + edgeSlack }
         }
 
         static let commandCatalog: [AppCommand] = [

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
@@ -35,6 +35,7 @@ final class KeyboardSelectionMonitor {
         onToggleHelp: @escaping @MainActor () -> Void,
         onDismissHelpIfVisible: @escaping @MainActor () -> Bool,
         onSelectCommandByIndex: @escaping @MainActor (Int) -> Void,
+        onActivateRunningApp: @escaping @MainActor (Int) -> Bool = { _ in false },
         onConfirmKill: (@MainActor () -> Void)? = nil,
         onCancelKill: (@MainActor () -> Void)? = nil,
         killConfirmationActive: @escaping @MainActor () -> Bool = { false }
@@ -115,7 +116,7 @@ final class KeyboardSelectionMonitor {
             }
 
             if event.modifierFlags.contains(.command) && !event.modifierFlags.contains(.control) && !event.modifierFlags.contains(.option) {
-                // macOS digit keyCodes are not contiguous: 1=18, 2=19, 3=20, 4=21, 5=23.
+                // macOS digit keyCodes are not contiguous: 1=18, 2=19, 3=20, 4=21, 5=23, 6=22, 7=26, 8=28, 9=25.
                 let mappedIndex: Int?
                 switch event.keyCode {
                 case 18: mappedIndex = 1
@@ -123,13 +124,25 @@ final class KeyboardSelectionMonitor {
                 case 20: mappedIndex = 3
                 case 21: mappedIndex = 4
                 case 23: mappedIndex = 5
+                case 22: mappedIndex = 6
+                case 26: mappedIndex = 7
+                case 28: mappedIndex = 8
+                case 25: mappedIndex = 9
                 default: mappedIndex = nil
                 }
                 if let index = mappedIndex {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
-                        onSelectCommandByIndex(index)
+                    if inCommandMode() {
+                        if index <= 5 {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+                                onSelectCommandByIndex(index)
+                            }
+                            return nil
+                        }
+                    } else {
+                        if onActivateRunningApp(index - 1) {
+                            return nil
+                        }
                     }
-                    return nil
                 }
             }
 

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
@@ -133,15 +133,19 @@ final class KeyboardSelectionMonitor {
                 if let index = mappedIndex {
                     if inCommandMode() {
                         if index <= 5 {
+                            Self.logger.debug("⌘+\(index, privacy: .public) -> command catalog (index \(index, privacy: .public))")
                             DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
                                 onSelectCommandByIndex(index)
                             }
                             return nil
                         }
+                        Self.logger.debug("⌘+\(index, privacy: .public) ignored (in command mode, only 1-5 mapped)")
                     } else {
+                        Self.logger.debug("⌘+\(index, privacy: .public) -> running-apps switcher (slot \(index - 1, privacy: .public))")
                         if onActivateRunningApp(index - 1) {
                             return nil
                         }
+                        Self.logger.debug("⌘+\(index, privacy: .public) running-apps activation declined (no slot or placement=.none), falling through")
                     }
                 }
             }

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
@@ -117,35 +117,35 @@ final class KeyboardSelectionMonitor {
 
             if event.modifierFlags.contains(.command) && !event.modifierFlags.contains(.control) && !event.modifierFlags.contains(.option) {
                 // macOS digit keyCodes are not contiguous: 1=18, 2=19, 3=20, 4=21, 5=23, 6=22, 7=26, 8=28, 9=25.
-                let mappedIndex: Int?
+                let cmdNumberKey: Int?
                 switch event.keyCode {
-                case 18: mappedIndex = 1
-                case 19: mappedIndex = 2
-                case 20: mappedIndex = 3
-                case 21: mappedIndex = 4
-                case 23: mappedIndex = 5
-                case 22: mappedIndex = 6
-                case 26: mappedIndex = 7
-                case 28: mappedIndex = 8
-                case 25: mappedIndex = 9
-                default: mappedIndex = nil
+                case 18: cmdNumberKey = 1
+                case 19: cmdNumberKey = 2
+                case 20: cmdNumberKey = 3
+                case 21: cmdNumberKey = 4
+                case 23: cmdNumberKey = 5
+                case 22: cmdNumberKey = 6
+                case 26: cmdNumberKey = 7
+                case 28: cmdNumberKey = 8
+                case 25: cmdNumberKey = 9
+                default: cmdNumberKey = nil
                 }
-                if let index = mappedIndex {
+                if let key = cmdNumberKey {
                     if inCommandMode() {
-                        if index <= 5 {
-                            Self.logger.debug("⌘+\(index, privacy: .public) -> command catalog (index \(index, privacy: .public))")
+                        if key <= 5 {
+                            Self.logger.debug("⌘+\(key, privacy: .public) -> command catalog")
                             DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
-                                onSelectCommandByIndex(index)
+                                onSelectCommandByIndex(key)
                             }
                             return nil
                         }
-                        Self.logger.debug("⌘+\(index, privacy: .public) ignored (in command mode, only 1-5 mapped)")
+                        Self.logger.debug("⌘+\(key, privacy: .public) ignored (command mode only maps 1-5)")
                     } else {
-                        Self.logger.debug("⌘+\(index, privacy: .public) -> running-apps switcher (slot \(index - 1, privacy: .public))")
-                        if onActivateRunningApp(index - 1) {
+                        Self.logger.debug("⌘+\(key, privacy: .public) -> running-apps switcher")
+                        if onActivateRunningApp(key) {
                             return nil
                         }
-                        Self.logger.debug("⌘+\(index, privacy: .public) running-apps activation declined (no slot or placement=.none), falling through")
+                        Self.logger.debug("⌘+\(key, privacy: .public) running-apps activation declined, falling through")
                     }
                 }
             }

--- a/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
@@ -848,14 +848,22 @@ alias_brow=Safari|Arc|Google Chrome|Chrome|Firefox|Brave
             return decoded
         }
 
+        // Backfill keys added after the first release so existing UserDefaults blobs
+        // (which won't contain new non-optional Codable properties) still decode
+        // instead of falling back to .default and wiping the user's customizations.
         guard
-            var object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
-            object["lazyIndexingEnabled"] == nil
+            var object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
         else {
             return .default
         }
 
-        object["lazyIndexingEnabled"] = true
+        if object["lazyIndexingEnabled"] == nil {
+            object["lazyIndexingEnabled"] = true
+        }
+        if object["runningAppsPlacement"] == nil {
+            object["runningAppsPlacement"] = ThemeSettings.default.runningAppsPlacement.rawValue
+        }
+
         guard
             let migratedData = try? JSONSerialization.data(withJSONObject: object),
             let migrated = try? decoder.decode(ThemeSettings.self, from: migratedData)

--- a/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
@@ -233,6 +233,9 @@ final class ThemeStore: ObservableObject {
         // Settings blur multiplier
         upsertConfigLine(&lines, key: "settings_blur_multiplier", value: String(format: "%.2f", settings.settingsBlurMultiplier))
 
+        // Running apps switcher
+        upsertConfigLine(&lines, key: "running_apps_placement", value: settings.runningAppsPlacement.rawValue)
+
         let payload = lines.joined(separator: "\n") + "\n"
         do {
             try payload.write(to: path, atomically: true, encoding: .utf8)
@@ -523,6 +526,10 @@ final class ThemeStore: ObservableObject {
             case "settings_blur_multiplier":
                 if let parsed = parseUnitDouble(value) {
                     settings.settingsBlurMultiplier = parsed
+                }
+            case "running_apps_placement":
+                if let placement = RunningAppsPlacement(rawValue: value.lowercased()) {
+                    settings.runningAppsPlacement = placement
                 }
             default:
                 continue
@@ -818,6 +825,9 @@ ui_border_red=1.0
 ui_border_green=1.0
 ui_border_blue=1.0
 ui_border_opacity=0.12
+
+# Running apps switcher: none, top, right, bottom
+running_apps_placement=right
 
 # Search aliases (apps + System Settings). Format: alias_<keyword>=Term1|Term2|Term3
 alias_note=Notion|Obsidian|Notes|Apple Notes|Bear|Logseq

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
@@ -193,6 +193,9 @@ extension LauncherView {
                 commandFeedback = "Selected /\(command.id)"
                 requestCommandInputFocusIfNeeded()
             },
+            onActivateRunningApp: { [self] index in
+                activateRunningApp(at: index)
+            },
             onConfirmKill: { [self] in
                 if let pendingKillCandidate {
                     runKillCommand(candidate: pendingKillCandidate)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
@@ -193,8 +193,8 @@ extension LauncherView {
                 commandFeedback = "Selected /\(command.id)"
                 requestCommandInputFocusIfNeeded()
             },
-            onActivateRunningApp: { [self] index in
-                activateRunningApp(at: index)
+            onActivateRunningApp: { [self] key in
+                activateRunningApp(forKey: key)
             },
             onConfirmKill: { [self] in
                 if let pendingKillCandidate {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -104,9 +104,18 @@ struct LauncherView: View {
 
         let target = runningAppsService.items[index]
         log.debug("  -> activating slot \(index, privacy: .public): \(target.name, privacy: .public) (pid=\(target.id, privacy: .public), bundle=\(target.bundleIdentifier ?? "nil", privacy: .public))")
-        runningAppsService.activate(index: index)
-        hideLauncherWindow(restorePreviousApp: false)
-        return true
+        let activated = runningAppsService.activate(index: index)
+        // Only hide the launcher if the target actually came forward.
+        // If activate failed (process gone, denied, etc.), leave the
+        // launcher visible so the user can see something went wrong
+        // and pick a different slot instead of getting a confusing
+        // "flash" with no app switch.
+        if activated {
+            hideLauncherWindow(restorePreviousApp: false)
+        } else {
+            log.debug("  -> activation returned false, keeping launcher visible")
+        }
+        return activated
     }
 
     static let postHideActivationDelay: TimeInterval = 0.01

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -67,8 +67,13 @@ struct LauncherView: View {
     @State var pidToRestoreOnHide: pid_t?
     @StateObject var runningAppsService = RunningAppsService()
 
+    var runningAppsPlacement: RunningAppsPlacement {
+        themeStore.settings.runningAppsPlacement
+    }
+
     var shouldShowRunningAppsStrip: Bool {
-        !isCommandMode
+        runningAppsPlacement != .none
+            && !isCommandMode
             && !appUIState.showsThemeSettings
             && !showsHelpScreen
             && !runningAppsService.items.isEmpty
@@ -76,7 +81,8 @@ struct LauncherView: View {
 
     @discardableResult
     func activateRunningApp(at index: Int) -> Bool {
-        guard !isCommandMode,
+        guard runningAppsPlacement != .none,
+              !isCommandMode,
               !appUIState.showsThemeSettings,
               index >= 0,
               index < runningAppsService.items.count
@@ -402,194 +408,29 @@ struct LauncherView: View {
         let contentSpacing: CGFloat = isCommandMode ? 8 : 12
         let contentPadding: CGFloat = isCommandMode ? 10 : 14
 
-        HStack(alignment: .center, spacing: AppConstants.Launcher.RunningAppsStrip.panelGap) {
-        ZStack {
-            themedBackground
+        let placement = runningAppsPlacement
+        let gap = AppConstants.Launcher.RunningAppsStrip.panelGap
 
-            VStack(alignment: .leading, spacing: contentSpacing) {
-                if appUIState.showsThemeSettings {
-                    ThemeSettingsView(settings: $themeStore.settings)
-                } else {
-                    if !isCommandMode {
-                        SearchInputBar(
-                            text: $query,
-                            isCommandMode: $isCommandMode,
-                            isQueryFocused: $isQueryFocused,
-                            activeCommand: activeCommand,
-                            themeStore: themeStore,
-                            onSubmit: handleSubmit,
-                            onExitCommandMode: exitCommandMode
-                        )
-                    }
-
-                    if let bannerMessage {
-                        HStack(spacing: 8) {
-                            Text(bannerMessage)
-                                .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .semibold))
-                                .foregroundStyle(themeStore.fontColor())
-                            if let copyText = bannerCopyText {
-                                Button("Copy") {
-                                    NSPasteboard.general.clearContents()
-                                    NSPasteboard.general.setString(copyText, forType: .string)
-                                    showBanner("Copied", style: .info, duration: 1.0)
-                                }
-                                .buttonStyle(.plain)
-                                .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .semibold))
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 3)
-                                .background(.white.opacity(0.18), in: Capsule())
-                            }
-                        }
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 6)
-                            .background(bannerStyle.background, in: Capsule())
-                            .transition(.move(edge: .top).combined(with: .opacity))
-                    }
-
-                    if isCommandMode {
-                        commandModeView
-                    } else if isTranslationQuery {
-                        LookupDefinitionPanelView(
-                            definition: lookupDefinition,
-                            emptyHint: translationEmptyHint,
-                            isWebMode: isWebTranslationQuery,
-                            themeStore: themeStore
-                        )
-                    } else {
-                        if showsHelpScreen {
-                            LauncherHelpScreenView(themeStore: themeStore)
-                        } else if isClipboardQuery && displayedResults.isEmpty {
-                            ClipboardEmptyStateView(themeStore: themeStore)
-                        } else {
-                            HStack(spacing: 0) {
-                                ResultsListView(
-                                    results: displayedResults,
-                                    selectedID: selectedResultID,
-                                    pickedKeys: Set(pickedKeys),
-                                    themeStore: themeStore,
-                                    onSelect: { selectedResultID = $0 },
-                                    onOpen: { _ in openSelectedApp() }
-                                )
-
-                                if !pickedKeys.isEmpty {
-                                    Rectangle()
-                                        .fill(.white.opacity(0.08))
-                                        .frame(width: 1)
-                                        .padding(.vertical, 4)
-
-                                    PickedItemsPanel(
-                                        pickedKeys: pickedKeys,
-                                        pickedByKey: pickedResultsByKey,
-                                        themeStore: themeStore,
-                                        onRemove: { removePicked(key: $0) },
-                                        onClearAll: { clearAllPicked() }
-                                    )
-                                } else if let selectedID = selectedResultID,
-                                   let selectedResult = displayedResults.first(where: { $0.id == selectedID }) {
-                                    Rectangle()
-                                        .fill(.white.opacity(0.08))
-                                        .frame(width: 1)
-                                        .padding(.vertical, 4)
-
-                                    ResultPreviewView(
-                                        result: selectedResult,
-                                        onDeleteClipboard: selectedResult.kind == .clipboard
-                                            ? { deleteClipboardResult(resultID: selectedResult.id) }
-                                            : nil
-                                    )
-                                }
-                            }
-                        }
-                    }
-
-                    if isCommandMode {
-                        Spacer(minLength: 0)
-                    }
-
-                    if !isKillConfirmationVisible {
-                        HintBar(hint: currentHint, themeStore: themeStore)
-                    }
+        Group {
+            switch placement {
+            case .none:
+                borderedPanel(windowCornerRadius: windowCornerRadius, contentSpacing: contentSpacing, contentPadding: contentPadding)
+            case .right:
+                HStack(alignment: .center, spacing: gap) {
+                    borderedPanel(windowCornerRadius: windowCornerRadius, contentSpacing: contentSpacing, contentPadding: contentPadding)
+                    reservedStrip(axis: .vertical)
+                }
+            case .top:
+                VStack(alignment: .center, spacing: gap) {
+                    reservedStrip(axis: .horizontal)
+                    borderedPanel(windowCornerRadius: windowCornerRadius, contentSpacing: contentSpacing, contentPadding: contentPadding)
+                }
+            case .bottom:
+                VStack(alignment: .center, spacing: gap) {
+                    borderedPanel(windowCornerRadius: windowCornerRadius, contentSpacing: contentSpacing, contentPadding: contentPadding)
+                    reservedStrip(axis: .horizontal)
                 }
             }
-            .padding(contentPadding)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-            .font(themeStore.uiFont())
-            .foregroundStyle(themeStore.fontColor())
-            .background(.black.opacity(0.16), in: RoundedRectangle(cornerRadius: windowCornerRadius, style: .continuous))
-            .contentShape(Rectangle())
-            .onTapGesture {
-                focusActiveInput()
-            }
-        }
-        .background(Color.clear)
-        .clipShape(RoundedRectangle(cornerRadius: windowCornerRadius, style: .continuous))
-        .overlay {
-            let borderWidth = themeStore.borderLineWidth()
-            if borderWidth > 0 {
-                RoundedRectangle(cornerRadius: windowCornerRadius, style: .continuous)
-                    .strokeBorder(
-                        hasSudoWarning ? Color.orange.opacity(0.95) : themeStore.borderColor(),
-                        lineWidth: borderWidth
-                    )
-            }
-        }
-        .overlay(alignment: .topTrailing) {
-            if shouldShowTestHint {
-                Text("TEST APP")
-                    .font(themeStore.uiFont(size: CGFloat(max(10, themeStore.settings.fontSize - 3)), weight: .bold))
-                    .foregroundStyle(Color.red.opacity(0.95))
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 5)
-                    .background(.black.opacity(0.35), in: Capsule())
-                    .padding(.top, 8)
-                    .padding(.trailing, 10)
-            }
-        }
-        .overlay(alignment: .bottomTrailing) {
-            Link("© 2026 by Kunkka", destination: URL(string: "https://github.com/kunkka19xx")!)
-                .font(themeStore.uiFont(size: CGFloat(max(9, themeStore.settings.fontSize - 4)), weight: .regular))
-                .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.50))
-                .padding(.trailing, 10)
-                .padding(.bottom, 8)
-        }
-        .overlay(alignment: .bottom) {
-            if isCommandMode,
-               activeCommandID == AppConstants.Launcher.Command.kill,
-               let pendingKillCandidate
-            {
-                KillConfirmationBar(
-                    candidate: pendingKillCandidate,
-                    themeStore: themeStore,
-                    onConfirm: {
-                        runKillCommand(candidate: pendingKillCandidate)
-                        self.pendingKillCandidate = nil
-                    },
-                    onCancel: {
-                        self.pendingKillCandidate = nil
-                    }
-                )
-                .padding(.horizontal, 14)
-                .padding(.bottom, 24)
-            }
-        }
-        .frame(maxWidth: AppConstants.Launcher.Panel.width, maxHeight: AppConstants.Launcher.Panel.height)
-        .layoutPriority(1)
-
-            Color.clear
-                .frame(width: AppConstants.Launcher.RunningAppsStrip.width)
-                .overlay {
-                    if shouldShowRunningAppsStrip {
-                        RunningAppsStripView(
-                            service: runningAppsService,
-                            themeStore: themeStore,
-                            onActivate: { index in
-                                _ = activateRunningApp(at: index)
-                            }
-                        )
-                        .transition(.opacity)
-                    }
-                }
-                .allowsHitTesting(shouldShowRunningAppsStrip)
         }
         .ignoresSafeArea()
         .onAppear {
@@ -598,7 +439,6 @@ struct LauncherView: View {
             focusActiveInput()
             refreshClipboardMonitoringMode()
             runningAppsService.refresh()
-            runningAppsService.startPolling()
         }
         .onDisappear {
             invalidateSearchRequests()
@@ -606,7 +446,6 @@ struct LauncherView: View {
             lookupPreviewTask?.cancel()
             keyboardMonitor.stop()
             clipboardStore.setMonitoringMode(.background)
-            runningAppsService.stopPolling()
         }
         .onChange(of: query) { _, _ in
             if !isCommandMode, let cmd = extractInlineCommand(from: query), cmd.hasSpace {
@@ -644,8 +483,6 @@ struct LauncherView: View {
             }
         }
         .onChange(of: activeCommandID) { _, newID in
-            // Remember which command was last open so re-entering
-            // command mode resumes there instead of always /calc.
             if let newID { appUIState.lastCommandID = newID }
         }
         .onChange(of: appUIState.showsThemeSettings) { _, showsSettings in
@@ -666,15 +503,10 @@ struct LauncherView: View {
         ) { _ in
             focusActiveInput()
             refreshClipboardMonitoringMode()
-            runningAppsService.refresh()
         }
         .onReceive(
             NotificationCenter.default.publisher(for: NSApplication.didResignActiveNotification)
         ) { _ in
-            // User clicked into another app — dismiss the launcher so it
-            // doesn't linger floating above whatever they switched to.
-            // Pass restorePreviousApp: false because the user already
-            // chose the new frontmost app themselves.
             if launcherWindow()?.isVisible == true {
                 hideLauncherWindow(restorePreviousApp: false)
             }
@@ -700,7 +532,6 @@ struct LauncherView: View {
             refreshClipboardMonitoringMode()
         }
         .onReceive(NotificationCenter.default.publisher(for: .lookOpenPomoRequested)) { _ in
-            // Menu-bar mini-timer click → land directly inside /pomo command panel.
             DispatchQueue.main.async {
                 if !isCommandMode {
                     enterCommandMode(commandID: AppConstants.Launcher.Command.pomo, prefilledInput: "")
@@ -710,5 +541,247 @@ struct LauncherView: View {
                 }
             }
         }
+    }
+
+    @ViewBuilder
+    private func borderedPanel(windowCornerRadius: CGFloat, contentSpacing: CGFloat, contentPadding: CGFloat) -> some View {
+        ZStack {
+            themedBackground
+
+            VStack(alignment: .leading, spacing: contentSpacing) {
+                panelContent
+            }
+            .padding(contentPadding)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .font(themeStore.uiFont())
+            .foregroundStyle(themeStore.fontColor())
+            .background(.black.opacity(0.16), in: RoundedRectangle(cornerRadius: windowCornerRadius, style: .continuous))
+            .contentShape(Rectangle())
+            .onTapGesture { focusActiveInput() }
+        }
+        .background(Color.clear)
+        .clipShape(RoundedRectangle(cornerRadius: windowCornerRadius, style: .continuous))
+        .overlay { borderOverlay(cornerRadius: windowCornerRadius) }
+        .modifier(PanelDecorationsModifier(
+            testHint: { testHintOverlay },
+            copyright: { copyrightOverlay },
+            killBar: { killConfirmationOverlay }
+        ))
+        .frame(maxWidth: AppConstants.Launcher.Panel.width, maxHeight: AppConstants.Launcher.Panel.height)
+        .layoutPriority(1)
+    }
+
+    @ViewBuilder
+    private var panelContent: some View {
+        if appUIState.showsThemeSettings {
+            ThemeSettingsView(settings: $themeStore.settings)
+        } else {
+            if !isCommandMode {
+                SearchInputBar(
+                    text: $query,
+                    isCommandMode: $isCommandMode,
+                    isQueryFocused: $isQueryFocused,
+                    activeCommand: activeCommand,
+                    themeStore: themeStore,
+                    onSubmit: handleSubmit,
+                    onExitCommandMode: exitCommandMode
+                )
+            }
+
+            if let bannerMessage {
+                bannerView(message: bannerMessage)
+            }
+
+            if isCommandMode {
+                commandModeView
+            } else if isTranslationQuery {
+                LookupDefinitionPanelView(
+                    definition: lookupDefinition,
+                    emptyHint: translationEmptyHint,
+                    isWebMode: isWebTranslationQuery,
+                    themeStore: themeStore
+                )
+            } else if showsHelpScreen {
+                LauncherHelpScreenView(themeStore: themeStore)
+            } else if isClipboardQuery && displayedResults.isEmpty {
+                ClipboardEmptyStateView(themeStore: themeStore)
+            } else {
+                resultsRow
+            }
+
+            if isCommandMode {
+                Spacer(minLength: 0)
+            }
+
+            if !isKillConfirmationVisible {
+                HintBar(hint: currentHint, themeStore: themeStore)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func bannerView(message: String) -> some View {
+        HStack(spacing: 8) {
+            Text(message)
+                .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .semibold))
+                .foregroundStyle(themeStore.fontColor())
+            if let copyText = bannerCopyText {
+                Button("Copy") {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(copyText, forType: .string)
+                    showBanner("Copied", style: .info, duration: 1.0)
+                }
+                .buttonStyle(.plain)
+                .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .semibold))
+                .padding(.horizontal, 8)
+                .padding(.vertical, 3)
+                .background(.white.opacity(0.18), in: Capsule())
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(bannerStyle.background, in: Capsule())
+        .transition(.move(edge: .top).combined(with: .opacity))
+    }
+
+    @ViewBuilder
+    private var resultsRow: some View {
+        HStack(spacing: 0) {
+            ResultsListView(
+                results: displayedResults,
+                selectedID: selectedResultID,
+                pickedKeys: Set(pickedKeys),
+                themeStore: themeStore,
+                onSelect: { selectedResultID = $0 },
+                onOpen: { _ in openSelectedApp() }
+            )
+
+            if !pickedKeys.isEmpty {
+                resultsDivider
+                PickedItemsPanel(
+                    pickedKeys: pickedKeys,
+                    pickedByKey: pickedResultsByKey,
+                    themeStore: themeStore,
+                    onRemove: { removePicked(key: $0) },
+                    onClearAll: { clearAllPicked() }
+                )
+            } else if let selectedID = selectedResultID,
+                      let selectedResult = displayedResults.first(where: { $0.id == selectedID }) {
+                resultsDivider
+                ResultPreviewView(
+                    result: selectedResult,
+                    onDeleteClipboard: selectedResult.kind == .clipboard
+                        ? { deleteClipboardResult(resultID: selectedResult.id) }
+                        : nil
+                )
+            }
+        }
+    }
+
+    private var resultsDivider: some View {
+        Rectangle()
+            .fill(.white.opacity(0.08))
+            .frame(width: 1)
+            .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private func borderOverlay(cornerRadius: CGFloat) -> some View {
+        let borderWidth = themeStore.borderLineWidth()
+        if borderWidth > 0 {
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .strokeBorder(
+                    hasSudoWarning ? Color.orange.opacity(0.95) : themeStore.borderColor(),
+                    lineWidth: borderWidth
+                )
+        }
+    }
+
+    @ViewBuilder
+    private var testHintOverlay: some View {
+        if shouldShowTestHint {
+            Text("TEST APP")
+                .font(themeStore.uiFont(size: CGFloat(max(10, themeStore.settings.fontSize - 3)), weight: .bold))
+                .foregroundStyle(Color.red.opacity(0.95))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .background(.black.opacity(0.35), in: Capsule())
+                .padding(.top, 8)
+                .padding(.trailing, 10)
+        }
+    }
+
+    private var copyrightOverlay: some View {
+        Link("© 2026 by Kunkka", destination: URL(string: "https://github.com/kunkka19xx")!)
+            .font(themeStore.uiFont(size: CGFloat(max(9, themeStore.settings.fontSize - 4)), weight: .regular))
+            .foregroundStyle(themeStore.fontColor(opacityMultiplier: 0.50))
+            .padding(.trailing, 10)
+            .padding(.bottom, 8)
+    }
+
+    @ViewBuilder
+    private var killConfirmationOverlay: some View {
+        if isCommandMode,
+           activeCommandID == AppConstants.Launcher.Command.kill,
+           let pendingKillCandidate
+        {
+            KillConfirmationBar(
+                candidate: pendingKillCandidate,
+                themeStore: themeStore,
+                onConfirm: {
+                    runKillCommand(candidate: pendingKillCandidate)
+                    self.pendingKillCandidate = nil
+                },
+                onCancel: {
+                    self.pendingKillCandidate = nil
+                }
+            )
+            .padding(.horizontal, 14)
+            .padding(.bottom, 24)
+        }
+    }
+
+    @ViewBuilder
+    private func reservedStrip(axis: Axis) -> some View {
+        if axis == .vertical {
+            Color.clear
+                .frame(width: AppConstants.Launcher.RunningAppsStrip.width)
+                .overlay { stripOverlay(axis: axis) }
+                .allowsHitTesting(shouldShowRunningAppsStrip)
+        } else {
+            Color.clear
+                .frame(height: AppConstants.Launcher.RunningAppsStrip.width)
+                .overlay { stripOverlay(axis: axis) }
+                .allowsHitTesting(shouldShowRunningAppsStrip)
+        }
+    }
+
+    @ViewBuilder
+    private func stripOverlay(axis: Axis) -> some View {
+        if shouldShowRunningAppsStrip {
+            RunningAppsStripView(
+                service: runningAppsService,
+                themeStore: themeStore,
+                axis: axis,
+                onActivate: { index in
+                    _ = activateRunningApp(at: index)
+                }
+            )
+            .transition(.opacity)
+        }
+    }
+
+}
+
+private struct PanelDecorationsModifier<TestHint: View, Copyright: View, KillBar: View>: ViewModifier {
+    @ViewBuilder let testHint: () -> TestHint
+    @ViewBuilder let copyright: () -> Copyright
+    @ViewBuilder let killBar: () -> KillBar
+
+    func body(content: Content) -> some View {
+        content
+            .overlay(alignment: .topTrailing, content: testHint)
+            .overlay(alignment: .bottomTrailing, content: copyright)
+            .overlay(alignment: .bottom, content: killBar)
     }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -79,41 +79,31 @@ struct LauncherView: View {
             && !runningAppsService.items.isEmpty
     }
 
+    /// Activates the strip icon assigned to Cmd+`key`. The key is mapped
+    /// to a visual position via the ergonomic layout in
+    /// `AppConstants.Launcher.RunningAppsStrip.visualPosition(forKey:total:)`.
+    /// Returns true when the target app actually came forward; the
+    /// launcher only auto-hides on success so a silent failure (process
+    /// gone, denied) leaves the strip visible for another attempt.
     @discardableResult
-    func activateRunningApp(at index: Int) -> Bool {
+    func activateRunningApp(forKey key: Int) -> Bool {
         let log = RunningAppsLog.logger
-        let itemNames = runningAppsService.items.map(\.name).joined(separator: ", ")
-        log.debug("activateRunningApp(at: \(index, privacy: .public)) — placement=\(runningAppsPlacement.rawValue, privacy: .public) isCommandMode=\(isCommandMode, privacy: .public) showsSettings=\(appUIState.showsThemeSettings, privacy: .public) items=[\(itemNames, privacy: .public)]")
+        let total = runningAppsService.items.count
 
-        guard runningAppsPlacement != .none else {
-            log.debug("  -> declined: placement is .none")
+        if runningAppsPlacement == .none || isCommandMode || appUIState.showsThemeSettings {
+            log.debug("⌘+\(key, privacy: .public) declined (placement=\(self.runningAppsPlacement.rawValue, privacy: .public) cmd=\(self.isCommandMode, privacy: .public) settings=\(self.appUIState.showsThemeSettings, privacy: .public))")
             return false
         }
-        guard !isCommandMode else {
-            log.debug("  -> declined: in command mode")
-            return false
-        }
-        guard !appUIState.showsThemeSettings else {
-            log.debug("  -> declined: settings open")
-            return false
-        }
-        guard index >= 0, index < runningAppsService.items.count else {
-            log.debug("  -> declined: index \(index, privacy: .public) out of range (count=\(runningAppsService.items.count, privacy: .public))")
+        guard let position = AppConstants.Launcher.RunningAppsStrip.visualPosition(forKey: key, total: total) else {
+            log.debug("⌘+\(key, privacy: .public) declined (no slot for this key, items=\(total, privacy: .public))")
             return false
         }
 
-        let target = runningAppsService.items[index]
-        log.debug("  -> activating slot \(index, privacy: .public): \(target.name, privacy: .public) (pid=\(target.id, privacy: .public), bundle=\(target.bundleIdentifier ?? "nil", privacy: .public))")
-        let activated = runningAppsService.activate(index: index)
-        // Only hide the launcher if the target actually came forward.
-        // If activate failed (process gone, denied, etc.), leave the
-        // launcher visible so the user can see something went wrong
-        // and pick a different slot instead of getting a confusing
-        // "flash" with no app switch.
+        let target = runningAppsService.items[position]
+        let activated = runningAppsService.activate(index: position)
+        log.debug("⌘+\(key, privacy: .public) -> position \(position, privacy: .public) \(target.name, privacy: .public) (activated=\(activated, privacy: .public))")
         if activated {
             hideLauncherWindow(restorePreviousApp: false)
-        } else {
-            log.debug("  -> activation returned false, keeping launcher visible")
         }
         return activated
     }
@@ -801,8 +791,8 @@ struct LauncherView: View {
                 service: runningAppsService,
                 themeStore: themeStore,
                 axis: axis,
-                onActivate: { index in
-                    _ = activateRunningApp(at: index)
+                onActivate: { key in
+                    _ = activateRunningApp(forKey: key)
                 }
             )
             .transition(.opacity)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -65,6 +65,26 @@ struct LauncherView: View {
     @State var focusRequestToken: UInt64 = 0
     @State var lookupDefinition: LookupDefinition?
     @State var pidToRestoreOnHide: pid_t?
+    @StateObject var runningAppsService = RunningAppsService()
+
+    var shouldShowRunningAppsStrip: Bool {
+        !isCommandMode
+            && !appUIState.showsThemeSettings
+            && !showsHelpScreen
+            && !runningAppsService.items.isEmpty
+    }
+
+    @discardableResult
+    func activateRunningApp(at index: Int) -> Bool {
+        guard !isCommandMode,
+              !appUIState.showsThemeSettings,
+              index >= 0,
+              index < runningAppsService.items.count
+        else { return false }
+        runningAppsService.activate(index: index)
+        hideLauncherWindow(restorePreviousApp: false)
+        return true
+    }
 
     static let postHideActivationDelay: TimeInterval = 0.01
     static let postOpenActivationDelay: TimeInterval = 0.05
@@ -382,6 +402,7 @@ struct LauncherView: View {
         let contentSpacing: CGFloat = isCommandMode ? 8 : 12
         let contentPadding: CGFloat = isCommandMode ? 10 : 14
 
+        HStack(alignment: .center, spacing: AppConstants.Launcher.RunningAppsStrip.panelGap) {
         ZStack {
             themedBackground
 
@@ -551,12 +572,33 @@ struct LauncherView: View {
                 .padding(.bottom, 24)
             }
         }
+        .frame(maxWidth: AppConstants.Launcher.Panel.width, maxHeight: AppConstants.Launcher.Panel.height)
+        .layoutPriority(1)
+
+            Color.clear
+                .frame(width: AppConstants.Launcher.RunningAppsStrip.width)
+                .overlay {
+                    if shouldShowRunningAppsStrip {
+                        RunningAppsStripView(
+                            service: runningAppsService,
+                            themeStore: themeStore,
+                            onActivate: { index in
+                                _ = activateRunningApp(at: index)
+                            }
+                        )
+                        .transition(.opacity)
+                    }
+                }
+                .allowsHitTesting(shouldShowRunningAppsStrip)
+        }
         .ignoresSafeArea()
         .onAppear {
             refreshSearchResults()
             startKeyboardNavigationIfNeeded()
             focusActiveInput()
             refreshClipboardMonitoringMode()
+            runningAppsService.refresh()
+            runningAppsService.startPolling()
         }
         .onDisappear {
             invalidateSearchRequests()
@@ -564,6 +606,7 @@ struct LauncherView: View {
             lookupPreviewTask?.cancel()
             keyboardMonitor.stop()
             clipboardStore.setMonitoringMode(.background)
+            runningAppsService.stopPolling()
         }
         .onChange(of: query) { _, _ in
             if !isCommandMode, let cmd = extractInlineCommand(from: query), cmd.hasSpace {
@@ -623,6 +666,7 @@ struct LauncherView: View {
         ) { _ in
             focusActiveInput()
             refreshClipboardMonitoringMode()
+            runningAppsService.refresh()
         }
         .onReceive(
             NotificationCenter.default.publisher(for: NSApplication.didResignActiveNotification)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -81,12 +81,29 @@ struct LauncherView: View {
 
     @discardableResult
     func activateRunningApp(at index: Int) -> Bool {
-        guard runningAppsPlacement != .none,
-              !isCommandMode,
-              !appUIState.showsThemeSettings,
-              index >= 0,
-              index < runningAppsService.items.count
-        else { return false }
+        let log = RunningAppsLog.logger
+        let itemNames = runningAppsService.items.map(\.name).joined(separator: ", ")
+        log.debug("activateRunningApp(at: \(index, privacy: .public)) — placement=\(runningAppsPlacement.rawValue, privacy: .public) isCommandMode=\(isCommandMode, privacy: .public) showsSettings=\(appUIState.showsThemeSettings, privacy: .public) items=[\(itemNames, privacy: .public)]")
+
+        guard runningAppsPlacement != .none else {
+            log.debug("  -> declined: placement is .none")
+            return false
+        }
+        guard !isCommandMode else {
+            log.debug("  -> declined: in command mode")
+            return false
+        }
+        guard !appUIState.showsThemeSettings else {
+            log.debug("  -> declined: settings open")
+            return false
+        }
+        guard index >= 0, index < runningAppsService.items.count else {
+            log.debug("  -> declined: index \(index, privacy: .public) out of range (count=\(runningAppsService.items.count, privacy: .public))")
+            return false
+        }
+
+        let target = runningAppsService.items[index]
+        log.debug("  -> activating slot \(index, privacy: .public): \(target.name, privacy: .public) (pid=\(target.id, privacy: .public), bundle=\(target.bundleIdentifier ?? "nil", privacy: .public))")
         runningAppsService.activate(index: index)
         hideLauncherWindow(restorePreviousApp: false)
         return true
@@ -508,7 +525,18 @@ struct LauncherView: View {
             NotificationCenter.default.publisher(for: NSApplication.didResignActiveNotification)
         ) { _ in
             if launcherWindow()?.isVisible == true {
-                hideLauncherWindow(restorePreviousApp: false)
+                let log = Logger(subsystem: "noah-code.Look", category: "window-resize")
+                // Dragging the launcher across screens triggers a
+                // programmatic resize, which briefly drops Look's frontmost
+                // status and fires this notification. Ignore the auto-hide
+                // when that just happened — the user is still interacting
+                // with the launcher, not switching to another app.
+                if WindowAutoScale.didProgrammaticallyResizeRecently() {
+                    log.debug("didResignActiveNotification ignored (within \(WindowAutoScale.resizeSettleWindow, privacy: .public)s of a programmatic resize)")
+                } else {
+                    log.debug("didResignActiveNotification -> hideLauncherWindow(restorePreviousApp: false)")
+                    hideLauncherWindow(restorePreviousApp: false)
+                }
             }
             refreshClipboardMonitoringMode()
         }
@@ -567,7 +595,6 @@ struct LauncherView: View {
             copyright: { copyrightOverlay },
             killBar: { killConfirmationOverlay }
         ))
-        .frame(maxWidth: AppConstants.Launcher.Panel.width, maxHeight: AppConstants.Launcher.Panel.height)
         .layoutPriority(1)
     }
 
@@ -743,17 +770,19 @@ struct LauncherView: View {
 
     @ViewBuilder
     private func reservedStrip(axis: Axis) -> some View {
-        if axis == .vertical {
-            Color.clear
-                .frame(width: AppConstants.Launcher.RunningAppsStrip.width)
-                .overlay { stripOverlay(axis: axis) }
-                .allowsHitTesting(shouldShowRunningAppsStrip)
-        } else {
-            Color.clear
-                .frame(height: AppConstants.Launcher.RunningAppsStrip.width)
-                .overlay { stripOverlay(axis: axis) }
-                .allowsHitTesting(shouldShowRunningAppsStrip)
+        ZStack {
+            // Back layer: an empty NSView that returns
+            // mouseDownCanMoveWindow=true so the strip's spacing/padding
+            // becomes a window drag handle. Strip icons sit on top and
+            // keep their tap/hover behavior.
+            WindowDragArea()
+            stripOverlay(axis: axis)
         }
+        .frame(
+            width: axis == .vertical ? AppConstants.Launcher.RunningAppsStrip.width : nil,
+            height: axis == .horizontal ? AppConstants.Launcher.RunningAppsStrip.width : nil
+        )
+        .allowsHitTesting(shouldShowRunningAppsStrip)
     }
 
     @ViewBuilder

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -82,9 +82,11 @@ struct LauncherView: View {
     /// Activates the strip icon assigned to Cmd+`key`. The key is mapped
     /// to a visual position via the ergonomic layout in
     /// `AppConstants.Launcher.RunningAppsStrip.visualPosition(forKey:total:)`.
-    /// Returns true when the target app actually came forward; the
-    /// launcher only auto-hides on success so a silent failure (process
-    /// gone, denied) leaves the strip visible for another attempt.
+    /// On success the launcher is *not* hidden here — instead we let
+    /// `didResignActiveNotification` close it, which only fires after
+    /// macOS has handed key-window status to the target app. Hiding
+    /// synchronously raced that handoff and left the keyboard focused
+    /// nowhere visible.
     @discardableResult
     func activateRunningApp(forKey key: Int) -> Bool {
         let log = RunningAppsLog.logger
@@ -102,9 +104,8 @@ struct LauncherView: View {
         let target = runningAppsService.items[position]
         let activated = runningAppsService.activate(index: position)
         log.debug("⌘+\(key, privacy: .public) -> position \(position, privacy: .public) \(target.name, privacy: .public) (activated=\(activated, privacy: .public))")
-        if activated {
-            hideLauncherWindow(restorePreviousApp: false)
-        }
+        // If activate failed (process gone, denied, etc.) didResignActive
+        // won't fire and the launcher stays visible for another attempt.
         return activated
     }
 

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/RunningAppsStripView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/RunningAppsStripView.swift
@@ -29,15 +29,17 @@ struct RunningAppsStripView: View {
 
     @ViewBuilder
     private var iconStack: some View {
-        ForEach(0..<service.items.count, id: \.self) { index in
+        let total = service.items.count
+        ForEach(0..<total, id: \.self) { index in
             let item = service.items[index]
+            let shortcutNumber = Layout.ergonomicKey(forVisualPosition: index, total: total)
             RunningAppIconItem(
                 item: item,
-                shortcutNumber: index + 1,
+                shortcutNumber: shortcutNumber,
                 isActive: service.activePID == item.id,
                 isHovered: hoveredIndex == index,
                 themeStore: themeStore,
-                onTap: { onActivate(index) },
+                onTap: { onActivate(shortcutNumber) },
                 onHoverChange: { hovering in
                     hoveredIndex = hovering ? index : (hoveredIndex == index ? nil : hoveredIndex)
                 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/RunningAppsStripView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/RunningAppsStripView.swift
@@ -6,35 +6,43 @@ struct RunningAppsStripView: View {
 
     @ObservedObject var service: RunningAppsService
     let themeStore: ThemeStore
+    let axis: Axis
     let onActivate: (Int) -> Void
 
     @State private var hoveredIndex: Int?
 
     var body: some View {
-        VStack(spacing: gap) {
-            ForEach(0..<service.items.count, id: \.self) { index in
-                let item = service.items[index]
-                RunningAppIconItem(
-                    item: item,
-                    shortcutNumber: index + 1,
-                    isActive: service.activePID == item.id,
-                    isHovered: hoveredIndex == index,
-                    themeStore: themeStore,
-                    onTap: { onActivate(index) },
-                    onHoverChange: { hovering in
-                        hoveredIndex = hovering ? index : (hoveredIndex == index ? nil : hoveredIndex)
-                    }
-                )
-            }
+        if axis == .vertical {
+            VStack(spacing: Layout.itemGap) { iconStack }
+                .padding(.vertical, Layout.verticalPadding)
+                .padding(.horizontal, Layout.horizontalPadding)
+                .frame(width: Layout.width)
+                .frame(maxHeight: .infinity)
+        } else {
+            HStack(spacing: Layout.itemGap) { iconStack }
+                .padding(.horizontal, Layout.verticalPadding)
+                .padding(.vertical, Layout.horizontalPadding)
+                .frame(height: Layout.width)
+                .frame(maxWidth: .infinity)
         }
-        .padding(.vertical, Layout.verticalPadding)
-        .padding(.horizontal, Layout.horizontalPadding)
-        .frame(width: Layout.width)
-        .frame(maxHeight: .infinity)
     }
 
-    private var gap: CGFloat {
-        Layout.iconSize < 26 ? 6 : 8
+    @ViewBuilder
+    private var iconStack: some View {
+        ForEach(0..<service.items.count, id: \.self) { index in
+            let item = service.items[index]
+            RunningAppIconItem(
+                item: item,
+                shortcutNumber: index + 1,
+                isActive: service.activePID == item.id,
+                isHovered: hoveredIndex == index,
+                themeStore: themeStore,
+                onTap: { onActivate(index) },
+                onHoverChange: { hovering in
+                    hoveredIndex = hovering ? index : (hoveredIndex == index ? nil : hoveredIndex)
+                }
+            )
+        }
     }
 }
 

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/RunningAppsStripView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/RunningAppsStripView.swift
@@ -1,0 +1,119 @@
+import AppKit
+import SwiftUI
+
+struct RunningAppsStripView: View {
+    typealias Layout = AppConstants.Launcher.RunningAppsStrip
+
+    @ObservedObject var service: RunningAppsService
+    let themeStore: ThemeStore
+    let onActivate: (Int) -> Void
+
+    @State private var hoveredIndex: Int?
+
+    var body: some View {
+        VStack(spacing: gap) {
+            ForEach(0..<service.items.count, id: \.self) { index in
+                let item = service.items[index]
+                RunningAppIconItem(
+                    item: item,
+                    shortcutNumber: index + 1,
+                    isActive: service.activePID == item.id,
+                    isHovered: hoveredIndex == index,
+                    themeStore: themeStore,
+                    onTap: { onActivate(index) },
+                    onHoverChange: { hovering in
+                        hoveredIndex = hovering ? index : (hoveredIndex == index ? nil : hoveredIndex)
+                    }
+                )
+            }
+        }
+        .padding(.vertical, Layout.verticalPadding)
+        .padding(.horizontal, Layout.horizontalPadding)
+        .frame(width: Layout.width)
+        .frame(maxHeight: .infinity)
+    }
+
+    private var gap: CGFloat {
+        Layout.iconSize < 26 ? 6 : 8
+    }
+}
+
+private struct RunningAppIconItem: View {
+    let item: RunningAppItem
+    let shortcutNumber: Int
+    let isActive: Bool
+    let isHovered: Bool
+    let themeStore: ThemeStore
+    let onTap: () -> Void
+    let onHoverChange: (Bool) -> Void
+
+    private let iconSize: CGFloat = AppConstants.Launcher.RunningAppsStrip.iconSize
+    private var iconCornerRadius: CGFloat { iconSize * 0.22 }
+
+    var body: some View {
+        ZStack {
+            iconView
+                .overlay(alignment: .topTrailing) { badge }
+                .overlay { activeRing }
+                .scaleEffect(isHovered ? 1.12 : 1.0)
+                .opacity(isActive ? 1.0 : (isHovered ? 0.95 : 0.75))
+                .animation(.easeOut(duration: 0.15), value: isHovered)
+                .animation(.easeOut(duration: 0.15), value: isActive)
+                .contentShape(Rectangle())
+                .onTapGesture { onTap() }
+                .onHover { hovering in onHoverChange(hovering) }
+                .help(tooltipText)
+        }
+        .frame(width: iconSize, height: iconSize)
+    }
+
+    @ViewBuilder
+    private var iconView: some View {
+        if let icon = item.icon {
+            Image(nsImage: icon)
+                .resizable()
+                .interpolation(.high)
+                .frame(width: iconSize, height: iconSize)
+                .clipShape(RoundedRectangle(cornerRadius: iconCornerRadius, style: .continuous))
+        } else {
+            RoundedRectangle(cornerRadius: iconCornerRadius, style: .continuous)
+                .fill(themeStore.fontColor(opacityMultiplier: 0.14))
+                .frame(width: iconSize, height: iconSize)
+                .overlay {
+                    Text(String(item.name.prefix(1)).uppercased())
+                        .font(themeStore.uiFont(size: 12, weight: .semibold))
+                        .foregroundStyle(themeStore.fontColor())
+                }
+        }
+    }
+
+    @ViewBuilder
+    private var badge: some View {
+        Text("\(shortcutNumber)")
+            .font(.system(size: 9, weight: .bold, design: .monospaced))
+            .foregroundStyle(themeStore.fontColor())
+            .frame(width: 14, height: 14)
+            .background(
+                RoundedRectangle(cornerRadius: 7)
+                    .fill(Color.black.opacity(0.72))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 7)
+                    .strokeBorder(themeStore.fontColor(opacityMultiplier: 0.45), lineWidth: 1)
+            )
+            .offset(x: 5, y: -3)
+    }
+
+    @ViewBuilder
+    private var activeRing: some View {
+        if isActive {
+            RoundedRectangle(cornerRadius: iconCornerRadius + 3, style: .continuous)
+                .strokeBorder(themeStore.accentColor().opacity(0.5), lineWidth: 1.5)
+                .padding(-3)
+        }
+    }
+
+    private var tooltipText: String {
+        "\(item.name) ⌘\(shortcutNumber)"
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Appearance.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Appearance.swift
@@ -5,7 +5,8 @@ extension ThemeSettingsView {
     var appearanceTab: some View {
         ScrollView(.vertical, showsIndicators: false) {
             VStack(alignment: .leading, spacing: 10) {
-                sectionHeaderWithPicker("Theme") {
+                HStack(spacing: 14) {
+                    inlinePickerLabel("Theme")
                     Picker("Theme", selection: $settings.uiTheme) {
                         ForEach(BuiltinThemePreset.allCases) { preset in
                             Text(preset.title).tag(preset)
@@ -17,6 +18,20 @@ extension ThemeSettingsView {
                     .onChange(of: settings.uiTheme) { _, newValue in
                         themeStore.applyBuiltinTheme(newValue)
                     }
+
+                    Spacer().frame(width: 40)
+
+                    inlinePickerLabel("Running Apps")
+                    Picker("Running Apps", selection: $settings.runningAppsPlacement) {
+                        ForEach(RunningAppsPlacement.allCases) { placement in
+                            Text(placement.title).tag(placement)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .labelsHidden()
+                    .frame(width: AppConstants.ThemeUI.pickerWidth)
+
+                    Spacer(minLength: 0)
                 }
 
                 Divider()
@@ -175,6 +190,18 @@ extension ThemeSettingsView {
                 .stroke(.white.opacity(0.12), lineWidth: 1)
         )
         .shadow(color: .black.opacity(0.25), radius: 8, y: 4)
+    }
+
+    @ViewBuilder
+    func inlinePickerLabel(_ title: String) -> some View {
+        HStack(spacing: 6) {
+            Text("▶")
+                .font(.system(size: CGFloat(settings.fontSize - 2)))
+                .foregroundStyle(themeStore.secondaryTextColor())
+            Text(title)
+                .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .semibold))
+                .foregroundStyle(themeStore.secondaryTextColor())
+        }
     }
 
     func placeCaretAtEndOfFontField() {

--- a/apps/macos/LauncherApp/look-app/Window/WindowAutoScale.swift
+++ b/apps/macos/LauncherApp/look-app/Window/WindowAutoScale.swift
@@ -1,5 +1,8 @@
 import AppKit
 import Foundation
+import OSLog
+
+private let windowAutoScaleLog = Logger(subsystem: "noah-code.Look", category: "window-resize")
 
 /// Screen-based auto-scale for the launcher window.
 ///
@@ -29,18 +32,57 @@ enum WindowAutoScale {
         return min(r, 1.3)
     }
 
-    static func size(for screen: NSScreen) -> CGSize {
+    /// Base content size for the bordered launcher panel plus the running-apps
+    /// strip area for a given placement. The strip is purely additive — `.none`
+    /// matches the original 860×580; `.right` grows width; `.top`/`.bottom`
+    /// grow height. Everything is later multiplied by the screen ratio.
+    static func baseSize(for placement: RunningAppsPlacement) -> CGSize {
+        let stripExtent = AppConstants.Launcher.RunningAppsStrip.width
+            + AppConstants.Launcher.RunningAppsStrip.panelGap
+        switch placement {
+        case .none:
+            return CGSize(width: baseWidth, height: baseHeight)
+        case .right:
+            return CGSize(width: baseWidth + stripExtent, height: baseHeight)
+        case .top, .bottom:
+            return CGSize(width: baseWidth, height: baseHeight + stripExtent)
+        }
+    }
+
+    static func size(for screen: NSScreen, placement: RunningAppsPlacement = .none) -> CGSize {
+        // The screen ratio scales the bordered panel only. The running-apps
+        // strip is composed of fixed-size icons (per AppConstants), so adding
+        // its extent *after* scaling keeps the panel at its natural ratio
+        // and adds a consistent strip area regardless of display size.
         let r = ratio(forScreenHeightPoints: screen.frame.height)
-        return CGSize(
+        let scaledPanel = CGSize(
             width: (baseWidth * r).rounded(),
             height: (baseHeight * r).rounded()
         )
+        let stripExtent = AppConstants.Launcher.RunningAppsStrip.width
+            + AppConstants.Launcher.RunningAppsStrip.panelGap
+        // The bordered launcher panel is consistently sized as
+        // (baseWidth × (baseHeight + stripExtent)) regardless of placement —
+        // this is what makes every placement *feel* the same. The window
+        // size on top adds only the strip's own footprint.
+        let consistentPanel = CGSize(
+            width: scaledPanel.width,
+            height: scaledPanel.height + stripExtent
+        )
+        switch placement {
+        case .none:
+            return consistentPanel
+        case .right:
+            return CGSize(width: consistentPanel.width + stripExtent, height: consistentPanel.height)
+        case .top, .bottom:
+            return CGSize(width: consistentPanel.width, height: consistentPanel.height + stripExtent)
+        }
     }
 
     /// Frame that centers the scaled launcher within the screen's
     /// visibleFrame (so it doesn't overlap the menu bar or Dock).
-    static func centeredFrame(on screen: NSScreen) -> NSRect {
-        let size = size(for: screen)
+    static func centeredFrame(on screen: NSScreen, placement: RunningAppsPlacement = .none) -> NSRect {
+        let size = size(for: screen, placement: placement)
         let visible = screen.visibleFrame
         let x = visible.origin.x + (visible.width - size.width) / 2
         let y = visible.origin.y + (visible.height - size.height) / 2
@@ -55,11 +97,21 @@ enum WindowAutoScale {
     /// Clamps the result inside the screen's visibleFrame so we never
     /// leave the window partially off-screen (e.g. tucked behind a notch
     /// or menu bar after a screen with different geometry).
-    static func resizeKeepingTopLeft(_ window: NSWindow) {
-        guard let screen = window.screen else { return }
-        let newSize = size(for: screen)
+    @MainActor
+    static func resizeKeepingTopLeft(_ window: NSWindow, placement: RunningAppsPlacement = .none) {
+        guard let screen = window.screen else {
+            windowAutoScaleLog.debug("resize: window.screen is nil, skipping")
+            return
+        }
+        let newSize = size(for: screen, placement: placement)
         let currentFrame = window.frame
-        if currentFrame.size == newSize { return }
+        let visible = screen.visibleFrame
+        windowAutoScaleLog.debug("resize start: placement=\(placement.rawValue, privacy: .public) screen=\(screen.frame.debugDescription, privacy: .public) visible=\(visible.debugDescription, privacy: .public) current=\(currentFrame.debugDescription, privacy: .public) newSize=\(newSize.debugDescription, privacy: .public) isVisible=\(window.isVisible, privacy: .public)")
+
+        if currentFrame.size == newSize {
+            windowAutoScaleLog.debug("resize: size unchanged, skipping")
+            return
+        }
 
         // AppKit's frame origin is bottom-left; preserve the visual top by
         // shifting origin.y when height changes.
@@ -68,7 +120,6 @@ enum WindowAutoScale {
             y: currentFrame.origin.y + currentFrame.height - newSize.height
         )
 
-        let visible = screen.visibleFrame
         let maxX = visible.maxX - newSize.width
         let minX = visible.minX
         let maxY = visible.maxY - newSize.height
@@ -77,8 +128,11 @@ enum WindowAutoScale {
         newOrigin.y = min(max(newOrigin.y, minY), maxY)
 
         let newFrame = NSRect(origin: newOrigin, size: newSize)
+        windowAutoScaleLog.debug("resize -> newFrame=\(newFrame.debugDescription, privacy: .public) (clamp bounds x=\(minX, privacy: .public)..\(maxX, privacy: .public), y=\(minY, privacy: .public)..\(maxY, privacy: .public))")
         if newFrame != currentFrame {
+            Self.lastProgrammaticResizeAt = Date()
             window.setFrame(newFrame, display: true, animate: false)
+            windowAutoScaleLog.debug("resize done: applied=\(window.frame.debugDescription, privacy: .public) isVisible=\(window.isVisible, privacy: .public)")
         }
     }
 
@@ -90,11 +144,31 @@ enum WindowAutoScale {
     /// drag finishes.
     @MainActor private static var pendingResizeTokens: [ObjectIdentifier: UUID] = [:]
 
+    /// Timestamp of the most recent programmatic `setFrame` from this module.
+    /// `didResignActiveNotification` can fire shortly after a screen-drag
+    /// resize because the size change briefly knocks the launcher off
+    /// "frontmost" status. Surface a "did we just resize?" check so the
+    /// launcher's auto-hide-on-resign handler can ignore those events.
+    @MainActor private static var lastProgrammaticResizeAt: Date?
+
+    static let resizeSettleWindow: TimeInterval = 1.0
+
     @MainActor
-    static func scheduleResize(for window: NSWindow) {
+    static func didProgrammaticallyResizeRecently() -> Bool {
+        guard let t = lastProgrammaticResizeAt else { return false }
+        return Date().timeIntervalSince(t) < resizeSettleWindow
+    }
+
+    @MainActor
+    static func scheduleResize(for window: NSWindow, placement: RunningAppsPlacement = .none) {
         let id = ObjectIdentifier(window)
         let token = UUID()
         pendingResizeTokens[id] = token
+        // Start the suppression window NOW (at notification time) — even
+        // if the resize turns out to be a no-op (e.g., same scale across
+        // screens), the screen change itself can briefly drop the
+        // launcher's frontmost status and trigger the auto-hide.
+        Self.lastProgrammaticResizeAt = Date()
 
         Task { @MainActor in
             try? await Task.sleep(nanoseconds: 50_000_000)
@@ -107,7 +181,7 @@ enum WindowAutoScale {
                     continue
                 }
                 pendingResizeTokens[id] = nil
-                resizeKeepingTopLeft(window)
+                resizeKeepingTopLeft(window, placement: placement)
                 return
             }
         }

--- a/apps/macos/LauncherApp/look-app/Window/WindowConfigurator.swift
+++ b/apps/macos/LauncherApp/look-app/Window/WindowConfigurator.swift
@@ -1,7 +1,14 @@
 import AppKit
+import OSLog
 import SwiftUI
 
 struct WindowConfigurator: NSViewRepresentable {
+    let placement: RunningAppsPlacement
+
+    init(placement: RunningAppsPlacement = .none) {
+        self.placement = placement
+    }
+
     func makeNSView(context: Context) -> NSView {
         let view = NSView()
         DispatchQueue.main.async {
@@ -15,12 +22,33 @@ struct WindowConfigurator: NSViewRepresentable {
     // update was causing visible flicker during drag: setting styleMask,
     // isOpaque, layer.cornerRadius, masksToBounds, etc. on a moving window
     // forces CALayer recomposition mid-drag. Window properties here are
-    // all constant, so we only configure once (when the window first
-    // attaches) — subsequent updates are a no-op.
+    // all constant, so we only run that block once. The running-apps
+    // placement is the one thing that needs to react — resize the window
+    // when the user picks a new placement.
     func updateNSView(_ nsView: NSView, context: Context) {
+        let placement = self.placement
         DispatchQueue.main.async {
             configureWindow(from: nsView, force: false)
+            guard let window = nsView.window else { return }
+            // AppKit re-shows the standard window buttons whenever the
+            // window is resized / restyled, so re-hide them on every
+            // update. Cheap (sets three NSView.isHidden flags) and
+            // prevents the title-bar buttons from flashing back when the
+            // user changes running-apps placement in Settings.
+            hideStandardButtons(in: window)
+            let last = lastAppliedPlacement[ObjectIdentifier(window)]
+            if last != placement {
+                lastAppliedPlacement[ObjectIdentifier(window)] = placement
+                WindowAutoScale.resizeKeepingTopLeft(window, placement: placement)
+                hideStandardButtons(in: window)
+            }
         }
+    }
+
+    private func hideStandardButtons(in window: NSWindow) {
+        window.standardWindowButton(.closeButton)?.isHidden = true
+        window.standardWindowButton(.miniaturizeButton)?.isHidden = true
+        window.standardWindowButton(.zoomButton)?.isHidden = true
     }
 
     private func configureWindow(from view: NSView, force: Bool) {
@@ -67,22 +95,29 @@ struct WindowConfigurator: NSViewRepresentable {
         }
 
         if let screen = window.screen ?? NSScreen.main {
-            window.setFrame(WindowAutoScale.centeredFrame(on: screen), display: true)
+            window.setFrame(WindowAutoScale.centeredFrame(on: screen, placement: placement), display: true)
         }
+        lastAppliedPlacement[ObjectIdentifier(window)] = placement
 
         // Re-apply scaling when the window crosses to a different display.
         // Position is preserved (top-left anchor) — only size changes,
         // since the macOS launcher is user-draggable.
+        let currentPlacement = placement
         NotificationCenter.default.addObserver(
             forName: NSWindow.didChangeScreenNotification,
             object: window,
             queue: .main
         ) { note in
             guard let w = note.object as? NSWindow else { return }
-            WindowAutoScale.scheduleResize(for: w)
+            let p = lastAppliedPlacement[ObjectIdentifier(w)] ?? currentPlacement
+            Logger(subsystem: "noah-code.Look", category: "window-resize")
+                .debug("didChangeScreenNotification fired — placement=\(p.rawValue, privacy: .public), scheduling resize")
+            WindowAutoScale.scheduleResize(for: w, placement: p)
         }
     }
 }
+
+@MainActor private var lastAppliedPlacement: [ObjectIdentifier: RunningAppsPlacement] = [:]
 
 // One-shot guard so configureWindow runs exactly once per NSWindow.
 // Only ever read/written on the main actor (configureWindow is invoked

--- a/apps/macos/LauncherApp/look-app/Window/WindowDragArea.swift
+++ b/apps/macos/LauncherApp/look-app/Window/WindowDragArea.swift
@@ -1,0 +1,24 @@
+import AppKit
+import SwiftUI
+
+/// Invisible NSView whose only job is to return
+/// `mouseDownCanMoveWindow = true` so AppKit drags the launcher window
+/// when a mouseDown lands on the view directly (i.e. no SwiftUI gesture
+/// upstream claimed the event). Used as the background of the
+/// running-apps strip area; without it the strip's spacing/padding is
+/// unreachable as a window-drag handle because SwiftUI's tap/hover
+/// gestures on each icon consume mouseDown.
+///
+/// NOTE: This is the *limited* drag fix — it only works where SwiftUI
+/// doesn't claim the event (strip padding + bordered-panel padding).
+/// The deeper "drag from anywhere, including across vertically-stacked
+/// monitors" problem is parked — see docs/tasks.md "macOS launcher
+/// drag" entry for the open work.
+struct WindowDragArea: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView { MouseDownDraggableView() }
+    func updateNSView(_ nsView: NSView, context: Context) {}
+}
+
+private final class MouseDownDraggableView: NSView {
+    override var mouseDownCanMoveWindow: Bool { true }
+}

--- a/apps/macos/LauncherApp/look-app/look_appApp.swift
+++ b/apps/macos/LauncherApp/look-app/look_appApp.swift
@@ -124,9 +124,19 @@ struct look_appApp: App {
     }
 
     var body: some Scene {
-        WindowGroup(id: "main") {
+        let windowWidth: CGFloat = AppConstants.Launcher.Panel.width
+            + AppConstants.Launcher.RunningAppsStrip.width
+            + AppConstants.Launcher.RunningAppsStrip.panelGap
+        let windowHeight: CGFloat = AppConstants.Launcher.Panel.height
+
+        return WindowGroup(id: "main") {
             ContentView()
-                .frame(minWidth: 860, minHeight: 580)
+                .frame(
+                    minWidth: windowWidth,
+                    maxWidth: windowWidth,
+                    minHeight: windowHeight,
+                    maxHeight: windowHeight
+                )
                 .background(WindowConfigurator())
                 .environmentObject(appUIState)
                 .environmentObject(themeStore)

--- a/apps/macos/LauncherApp/look-app/look_appApp.swift
+++ b/apps/macos/LauncherApp/look-app/look_appApp.swift
@@ -109,6 +109,14 @@ struct look_appApp: App {
             .resolvingSymlinksInPath()
     }
 
+    /// Minimum SwiftUI content size. The actual window size is set by
+    /// WindowAutoScale (screen-ratio aware) via WindowConfigurator; this is
+    /// just a floor so SwiftUI never asks for a smaller window.
+    private func baseMinSize(for placement: RunningAppsPlacement) -> (CGFloat, CGFloat) {
+        let size = WindowAutoScale.baseSize(for: placement)
+        return (size.width, size.height)
+    }
+
     private func readInfoPlist(at url: URL) -> [String: Any]? {
         guard let data = try? Data(contentsOf: url) else { return nil }
         guard
@@ -124,20 +132,12 @@ struct look_appApp: App {
     }
 
     var body: some Scene {
-        let windowWidth: CGFloat = AppConstants.Launcher.Panel.width
-            + AppConstants.Launcher.RunningAppsStrip.width
-            + AppConstants.Launcher.RunningAppsStrip.panelGap
-        let windowHeight: CGFloat = AppConstants.Launcher.Panel.height
-
-        return WindowGroup(id: "main") {
+        WindowGroup(id: "main") {
+            let placement = themeStore.settings.runningAppsPlacement
+            let (minW, minH) = baseMinSize(for: placement)
             ContentView()
-                .frame(
-                    minWidth: windowWidth,
-                    maxWidth: windowWidth,
-                    minHeight: windowHeight,
-                    maxHeight: windowHeight
-                )
-                .background(WindowConfigurator())
+                .frame(minWidth: minW, minHeight: minH)
+                .background(WindowConfigurator(placement: placement))
                 .environmentObject(appUIState)
                 .environmentObject(themeStore)
         }


### PR DESCRIPTION
## Summary

- Smart apps switching.
- List running apps, tag apps with digits
- User can press cmd + digit to switch app

## Why

- #78 

## Changes

-

## Testing

- [x] `cargo check --workspace --manifest-path core/Cargo.toml`
- [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [ ] Backward compatibility considered
