### PR TITLE
Fix typo in README regarding Electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you want a launcher that stays out of your way and does exactly what you aske
 | Platform        | macOS · Windows · Linux | macOS only | macOS · Win (beta) | macOS only   | Linux only | Linux only |
 | Open source     | ✅ GPLv3                | ❌         | ❌                 | ❌           | ✅         | ✅         |
 | Local-first     | ✅                      | ✅         | ❌ cloud sync      | ✅           | ✅         | ✅         |
-| No Electron)    | ✅                      | ✅         | ❌                 | ✅           | ✅         | ✅         |
+| No Electron     | ✅                      | ✅         | ❌                 | ✅           | ✅         | ✅         |
 | No plugin store | ✅                      | ✅         | ❌                 | ❌ Powerpack | ✅         | ✅         |
 
 > If this is useful, ⭐ star the repo — it's the single biggest signal that helps the project keep shipping.


### PR DESCRIPTION
## Summary

- Type in readme.

## Why

- Type in readme.

## Changes

- Fix extra ) typo in readme.

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
