### PR TITLE
Chore: Work around with minimized electron apps on windows

### DIFF
--- a/apps/linows/src-tauri/Cargo.toml
+++ b/apps/linows/src-tauri/Cargo.toml
@@ -45,6 +45,7 @@ windows = { version = "0.61", features = [
     "Win32_System_Registry",
     "Win32_System_SystemInformation",
     "Win32_System_Threading",
+    "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_Shell",
     "Win32_UI_Shell_Common",
     "Win32_UI_WindowsAndMessaging",

--- a/apps/linows/src-tauri/src/platform/windows/window_focus.rs
+++ b/apps/linows/src-tauri/src/platform/windows/window_focus.rs
@@ -365,10 +365,10 @@ fn find_main_window_for_pids(pids: &[u32]) -> Option<HWND> {
 
         // Owned windows are dialogs/popups, not the app's main frame.
         let owner = unsafe { GetWindow(hwnd, GW_OWNER) };
-        if let Ok(o) = owner {
-            if !o.0.is_null() {
-                return TRUE;
-            }
+        if let Ok(o) = owner
+            && !o.0.is_null()
+        {
+            return TRUE;
         }
         // WS_EX_TOOLWINDOW = floating palette, not the main frame.
         let exstyle = unsafe { GetWindowLongW(hwnd, GWL_EXSTYLE) } as u32;

--- a/apps/linows/src-tauri/src/platform/windows/window_focus.rs
+++ b/apps/linows/src-tauri/src/platform/windows/window_focus.rs
@@ -14,10 +14,10 @@
 //!   exe-path comparison against `QueryFullProcessImageNameW`, pre-filtered
 //!   by basename to skip the kernel call on most processes.
 //!
-//! Once a PID matches, `EnumWindows` finds the first visible top-level
-//! window for it; `SetForegroundWindow` (with `SW_RESTORE` for minimized
-//! windows) raises it. Call this **before** hiding Look's own window —
-//! `SetForegroundWindow` only succeeds while we still hold foreground.
+//! Once a PID matches, `EnumWindows` picks the best top-level frame and
+//! `activate_window` raises it (AttachThreadInput + sync ShowWindow if
+//! iconic + SetForegroundWindow). Call sites must run this **before**
+//! hiding Look's own window — see commands.rs for ordering.
 
 use windows::Win32::Foundation::{CloseHandle, FALSE, HANDLE, HWND, LPARAM, MAX_PATH, TRUE};
 use windows::Win32::System::Com::{
@@ -28,12 +28,15 @@ use windows::Win32::System::Diagnostics::ToolHelp::{
     CreateToolhelp32Snapshot, PROCESSENTRY32W, Process32FirstW, Process32NextW, TH32CS_SNAPPROCESS,
 };
 use windows::Win32::System::Threading::{
-    OpenProcess, PROCESS_NAME_WIN32, PROCESS_QUERY_LIMITED_INFORMATION, QueryFullProcessImageNameW,
+    AttachThreadInput, GetCurrentThreadId, OpenProcess, PROCESS_NAME_WIN32,
+    PROCESS_QUERY_LIMITED_INFORMATION, QueryFullProcessImageNameW,
 };
+use windows::Win32::UI::Input::KeyboardAndMouse::SetFocus;
 use windows::Win32::UI::Shell::{IShellLinkW, ShellLink};
 use windows::Win32::UI::WindowsAndMessaging::{
-    EnumWindows, GetWindowThreadProcessId, IsIconic, IsWindowVisible, SW_RESTORE,
-    SetForegroundWindow, ShowWindowAsync,
+    BringWindowToTop, EnumWindows, GW_OWNER, GWL_EXSTYLE, GetWindow, GetWindowLongW,
+    GetWindowTextLengthW, GetWindowThreadProcessId, IsIconic, IsWindowVisible, SW_RESTORE,
+    SetForegroundWindow, ShowWindow, WS_EX_TOOLWINDOW,
 };
 use windows::core::BOOL;
 use windows::core::{HSTRING, Interface, PWSTR};
@@ -64,9 +67,8 @@ pub(crate) fn try_focus_existing(path: &str) -> bool {
         return false;
     }
 
-    let target = match resolve_target(trimmed) {
-        Some(t) => t,
-        None => return false,
+    let Some(target) = resolve_target(trimmed) else {
+        return false;
     };
 
     // Collect every PID that matches, not just the first. Modern apps spawn
@@ -86,7 +88,6 @@ pub(crate) fn try_focus_existing(path: &str) -> bool {
     let Some(hwnd) = find_main_window_for_pids(&pids) else {
         return false;
     };
-
     activate_window(hwnd);
     true
 }
@@ -188,7 +189,7 @@ fn find_pids_by_exe(target_exe_path: &str) -> Vec<u32> {
         .unwrap_or("")
         .to_string();
 
-    enumerate_processes(|pid, basename| {
+    let exact = enumerate_processes(|pid, basename| {
         // szExeFile only gives basename, but that's enough to skip the
         // OpenProcess + QueryFullProcessImageName syscalls for non-candidates.
         if !target_basename.is_empty() && !basename.eq_ignore_ascii_case(&target_basename) {
@@ -203,6 +204,43 @@ fn find_pids_by_exe(target_exe_path: &str) -> Vec<u32> {
         }
         match path {
             Some(p) => normalize_path(&p).to_lowercase() == target_norm,
+            None => false,
+        }
+    });
+    if !exact.is_empty() {
+        return exact;
+    }
+
+    // Squirrel/Electron shim fallback: Discord, GitHub Desktop, Slack, Atom and
+    // friends ship a Start-Menu shortcut that points at <Root>\Update.exe with
+    // `--processStart App.exe`. Update.exe pivots to the newest <Root>\app-X.Y.Z\App.exe
+    // and exits, so it's never running when the app is. When the exact match
+    // misses on Update.exe, scan for any non-Update.exe process whose image
+    // lives under the same install root. find_main_window_for_pids then picks
+    // the one with the real top-level window (Electron spawns several helpers).
+    if !target_basename.eq_ignore_ascii_case("Update.exe") {
+        return exact;
+    }
+    let root = std::path::Path::new(&target_norm)
+        .parent()
+        // Refuse to scan a whole drive if the path was just `C:\Update.exe`.
+        .filter(|p| p.parent().is_some());
+    let Some(root) = root else { return exact };
+    let root_prefix = format!("{}\\", root.to_string_lossy());
+
+    enumerate_processes(|pid, basename| {
+        if basename.eq_ignore_ascii_case("Update.exe") {
+            return false;
+        }
+        let Some(handle) = open_process(pid) else {
+            return false;
+        };
+        let path = query_full_image_name(handle);
+        unsafe {
+            let _ = CloseHandle(handle);
+        }
+        match path {
+            Some(p) => normalize_path(&p).to_lowercase().starts_with(&root_prefix),
             None => false,
         }
     })
@@ -292,13 +330,19 @@ fn get_process_aumid(handle: HANDLE) -> Option<String> {
 }
 
 fn find_main_window_for_pids(pids: &[u32]) -> Option<HWND> {
+    // Two-pass: ideal main window first (top-level, visible, non-tool, titled),
+    // then fall back to any visible window belonging to the PID. Apps like
+    // A5:SQL Mk-2 spawn multiple owned dialogs/tool windows; picking the first
+    // visible one means we activate a hidden helper instead of the real frame.
     struct Search<'a> {
         pids: &'a [u32],
-        hwnd: HWND,
+        best: HWND,
+        fallback: HWND,
     }
     let mut search = Search {
         pids,
-        hwnd: HWND::default(),
+        best: HWND::default(),
+        fallback: HWND::default(),
     };
 
     unsafe extern "system" fn cb(hwnd: HWND, lparam: LPARAM) -> BOOL {
@@ -308,31 +352,81 @@ fn find_main_window_for_pids(pids: &[u32]) -> Option<HWND> {
         if !s.pids.contains(&wnd_pid) {
             return TRUE;
         }
+        // Minimized windows still report IsWindowVisible == true (WS_VISIBLE
+        // is retained while iconic) so this filter is safe for the "minimize
+        // to taskbar" case we're trying to fix.
         if !unsafe { IsWindowVisible(hwnd).as_bool() } {
             return TRUE;
         }
-        s.hwnd = hwnd;
+
+        if s.fallback.0.is_null() {
+            s.fallback = hwnd;
+        }
+
+        // Owned windows are dialogs/popups, not the app's main frame.
+        let owner = unsafe { GetWindow(hwnd, GW_OWNER) };
+        if let Ok(o) = owner {
+            if !o.0.is_null() {
+                return TRUE;
+            }
+        }
+        // WS_EX_TOOLWINDOW = floating palette, not the main frame.
+        let exstyle = unsafe { GetWindowLongW(hwnd, GWL_EXSTYLE) } as u32;
+        if exstyle & WS_EX_TOOLWINDOW.0 != 0 {
+            return TRUE;
+        }
+        // Empty title = hidden helper (drag-drop sink, IME composition, etc.).
+        if unsafe { GetWindowTextLengthW(hwnd) } == 0 {
+            return TRUE;
+        }
+
+        s.best = hwnd;
         FALSE
     }
 
     unsafe {
         let _ = EnumWindows(Some(cb), LPARAM(&mut search as *mut _ as isize));
     }
-    if search.hwnd.0.is_null() {
+    let chosen = if !search.best.0.is_null() {
+        search.best
+    } else {
+        search.fallback
+    };
+    if chosen.0.is_null() {
         None
     } else {
-        Some(search.hwnd)
+        Some(chosen)
     }
 }
 
 fn activate_window(hwnd: HWND) {
+    // SetForegroundWindow rejects threads that haven't received the last user
+    // input. Tauri commands run on a tokio worker that never sees raw input,
+    // so the rule trips even though Look's UI thread is foreground. Attach
+    // our input queue to the target's for the duration to lend us its rights.
+    //
+    // SW_RESTORE only when iconic — calling it on a maximized window
+    // un-maximizes it (Edge loses F11/fullscreen). Synchronous `ShowWindow`
+    // (not `ShowWindowAsync`): cross-thread it blocks until the target
+    // processes the restore, so SetForegroundWindow next runs against a
+    // non-iconic window. Async would race and reduce SFW to a taskbar flash.
     unsafe {
-        // SW_RESTORE on a non-minimized window can un-maximize it (Edge losing
-        // F11/fullscreen). Only restore when actually minimized; otherwise
-        // SetForegroundWindow alone is enough to raise the window.
+        let cur_thread = GetCurrentThreadId();
+        let target_thread = GetWindowThreadProcessId(hwnd, None);
+
+        let attached = target_thread != 0
+            && target_thread != cur_thread
+            && AttachThreadInput(cur_thread, target_thread, true).as_bool();
+
         if IsIconic(hwnd).as_bool() {
-            let _ = ShowWindowAsync(hwnd, SW_RESTORE);
+            let _ = ShowWindow(hwnd, SW_RESTORE);
         }
         let _ = SetForegroundWindow(hwnd);
+        let _ = BringWindowToTop(hwnd);
+        let _ = SetFocus(Some(hwnd));
+
+        if attached {
+            let _ = AttachThreadInput(cur_thread, target_thread, false);
+        }
     }
 }

--- a/apps/linows/src/css/layout.css
+++ b/apps/linows/src/css/layout.css
@@ -144,6 +144,15 @@ html[data-os="windows"] .launcher-window {
   color: var(--font-muted);
 }
 
+.hint-bar .hint-sep {
+  color: var(--accent-color);
+  font-weight: 700;
+  font-size: 1.25em;
+  line-height: 1;
+  vertical-align: middle;
+  margin: 0 3px;
+}
+
 .hint-bar-copy {
   font-size: calc(var(--font-size) - 3px);
   color: var(--font-muted);

--- a/apps/linows/src/html/screens/help.html
+++ b/apps/linows/src/html/screens/help.html
@@ -20,6 +20,9 @@
       <div class="help-item"><kbd>Ctrl+Shift+,</kbd><span>Open/close settings panel</span></div>
       <div class="help-item"><kbd>Ctrl+Shift+;</kbd><span>Reload .look.config</span></div>
       <div class="help-item"><kbd>Ctrl+H</kbd><span>Toggle this help screen</span></div>
+      <div class="help-item"><kbd>Ctrl+=</kbd><span>Zoom in UI scale</span></div>
+      <div class="help-item"><kbd>Ctrl+-</kbd><span>Zoom out UI scale</span></div>
+      <div class="help-item"><kbd>Ctrl+0</kbd><span>Reset UI scale</span></div>
       <div class="help-item"><kbd>Esc</kbd><span>Close help / back / hide launcher</span></div>
 
       <!-- Query prefixes -->

--- a/apps/linows/src/html/screens/settings.html
+++ b/apps/linows/src/html/screens/settings.html
@@ -188,6 +188,9 @@
           <div class="settings-shortcut"><kbd>Ctrl+Shift+P</kbd><span>Clear all picks</span></div>
           <div class="settings-shortcut"><kbd>Ctrl+Shift+,</kbd><span>Open/close settings panel</span></div>
           <div class="settings-shortcut"><kbd>Ctrl+Shift+;</kbd><span>Reload .look.config</span></div>
+          <div class="settings-shortcut"><kbd>Ctrl+=</kbd><span>Zoom in UI scale</span></div>
+          <div class="settings-shortcut"><kbd>Ctrl+-</kbd><span>Zoom out UI scale</span></div>
+          <div class="settings-shortcut"><kbd>Ctrl+0</kbd><span>Reset UI scale</span></div>
           <div class="settings-shortcut"><kbd>Esc</kbd><span>Back to app list (in command mode)</span></div>
           <div class="settings-shortcut"><kbd>Alt+Space</kbd><span>Toggle launcher</span></div>
 

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -16,9 +16,20 @@ import {
   copyToClipboard, deleteClipboardEntry, isDevBuild,
 } from './ipc.js';
 
-const HINT_MAIN = 'Enter open \u2022 Ctrl+Enter search web \u2022 Ctrl+P pick \u2022 Ctrl+C copy \u2022 Ctrl+F reveal \u2022 Esc hide';
-const HINT_TRANSLATE = 'Enter translate \u2022 Esc clear';
-const HINT_CLIPBOARD = 'Enter copy \u2022 Delete remove \u2022 Esc clear';
+// Item count and structure mirror the macOS app's `LauncherView.hintItems`
+// (apps/macos/.../LauncherView.swift:302) so both platforms surface the same
+// shortcuts in the same modes. Style stays per-platform: linows uses the
+// colon + bold-bullet format, macOS keeps its space-separated form.
+const HINT_MAIN = 'Enter: Open \u2022 Ctrl+F: Reveal \u2022 Ctrl+H: Help \u2022 Ctrl+/: Command mode';
+const HINT_TRANSLATE = 'Enter: Translate \u2022 Copy per result \u2022 Ctrl+H: Help \u2022 Ctrl+/: Command mode';
+const HINT_CLIPBOARD = 'Enter: Copy clip \u2022 Delete: Remove clip \u2022 Ctrl+H: Help \u2022 Ctrl+/: Command mode';
+
+// Hint constants are static, authored in code \u2014 safe to set as innerHTML so
+// each bullet renders through `.hint-sep` (accent color, bold) for clearer
+// visual separation between key/action pairs.
+function setHint(el, text) {
+  el.innerHTML = text.split(' \u2022 ').join(' <span class="hint-sep">\u2022</span> ');
+}
 const BANNER_DURATION_SHORT = 1.0;
 const BANNER_DURATION_MEDIUM = 1.2;
 const BANNER_DURATION_LONG = 1.5;
@@ -38,7 +49,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // Hint bar — always at bottom, shared by all screens
   app.insertAdjacentHTML('beforeend',
-    `<div class="hint-bar" id="hint-bar"><span>${HINT_MAIN}</span><span class="hint-bar-copy">\u00A9 2026 by <a class="hint-bar-link" href="#">Kunkka</a></span></div>`);
+    `<div class="hint-bar" id="hint-bar"><span></span><span class="hint-bar-copy">\u00A9 2026 by <a class="hint-bar-link" href="#">Kunkka</a></span></div>`);
 
   // Load command panels into cmd-main
   const cmdMain = document.getElementById('cmd-main');
@@ -55,7 +66,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   const resultsList = document.getElementById('results-list');
   const previewPanel = document.getElementById('preview-panel');
   const hintBar = document.getElementById('hint-bar');
+  const hintMessage = hintBar.querySelector('span');
   const contentArea = document.getElementById('search-content');
+  setHint(hintMessage, HINT_MAIN);
 
   hintBar.querySelector('.hint-bar-link').addEventListener('click', (e) => {
     e.preventDefault();
@@ -83,7 +96,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     queryInput.value = '';
     search.handleQueryInput('');
     queryInput.focus();
-    hintBar.querySelector('span').textContent = HINT_MAIN;
+    setHint(hintMessage, HINT_MAIN);
   });
   settings.restoreOnStartup();
 
@@ -168,18 +181,17 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (tryCommandPrefix(value)) return;
 
     search.handleQueryInput(value);
-    const h = hintBar.querySelector('span');
     if (search.isTranslateMode()) {
-      h.textContent = HINT_TRANSLATE;
+      setHint(hintMessage, HINT_TRANSLATE);
       resultsList.hidden = true;
       previewPanel.hidden = true;
       if (!translatePanel.isActive()) translatePanel.showPlaceholder();
     } else if (search.isClipboardMode()) {
-      h.textContent = HINT_CLIPBOARD;
+      setHint(hintMessage, HINT_CLIPBOARD);
       resultsList.hidden = false;
       translatePanel.hide();
     } else {
-      h.textContent = HINT_MAIN;
+      setHint(hintMessage, HINT_MAIN);
       resultsList.hidden = false;
       translatePanel.hide();
     }
@@ -240,25 +252,24 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   function updateCommandHintBar() {
     const cmd = commands.getActiveCommand();
-    const h = hintBar.querySelector('span');
     if (cmd === 'pomo') {
-      h.textContent =
-        'Space start/pause \u2022 R reset \u2022 P music \u2022 Esc back \u2022 Tab/Ctrl+1-5 switch';
+      setHint(hintMessage,
+        'Space: Start/pause \u2022 R: Reset \u2022 P: Music \u2022 Esc: Back \u2022 Tab/Ctrl+1-5: Switch');
     } else if (cmd === 'kill') {
-      h.textContent =
-        'Y confirm \u2022 N cancel \u2022 Tab/Ctrl+1-5 switch \u2022 Esc back';
+      setHint(hintMessage,
+        'Y: Confirm \u2022 N: Cancel \u2022 Tab/Ctrl+1-5: Switch \u2022 Esc: Back');
     } else if (cmd === 'sys') {
-      h.textContent =
-        'Esc back \u2022 Tab/Ctrl+1-5 switch';
+      setHint(hintMessage,
+        'Esc: Back \u2022 Tab/Ctrl+1-5: Switch \u2022 Ctrl+/: Command mode \u2022 Ctrl+Shift+,: Settings');
     } else if (cmd === 'calc') {
-      h.textContent =
-        'Enter evaluate \u2022 Tab/Ctrl+1-5 switch \u2022 Esc back';
+      setHint(hintMessage,
+        'Enter: Evaluate \u2022 Tab: Select \u2022 Ctrl+1-5: Switch \u2022 Esc: Back');
     } else if (cmd === 'shell') {
-      h.textContent =
-        'Enter run \u2022 Tab/Ctrl+1-5 switch \u2022 Esc back';
+      setHint(hintMessage,
+        'Enter: Run \u2022 Tab: Select \u2022 Ctrl+1-5: Switch \u2022 Esc: Back');
     } else {
-      h.textContent =
-        'Tab/Ctrl+1-5 switch \u2022 Esc back';
+      setHint(hintMessage,
+        'Enter: Run \u2022 Tab: Select \u2022 Ctrl+1-5: Switch \u2022 Esc: Back');
     }
   }
 
@@ -267,7 +278,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     resultsList.hidden = false;
     previewPanel.hidden = false;
     translatePanel.hide();
-    hintBar.querySelector('span').textContent = HINT_MAIN;
+    setHint(hintMessage, HINT_MAIN);
     queryInput.value = '';
     search.handleQueryInput('');
     queryInput.focus();

--- a/apps/linows/src/js/keyboard.js
+++ b/apps/linows/src/js/keyboard.js
@@ -85,6 +85,27 @@ function handleKeyDown(e) {
     }
   }
 
+  // Ctrl+= / Ctrl+- / Ctrl+0 — UI zoom in/out/reset. Mirrors macOS
+  // Cmd+= / Cmd+- / Cmd+0 (apps/macos/.../look_appApp.swift:177). Global:
+  // works in search, command, settings, and help screens.
+  if (e.ctrlKey && !e.shiftKey && !e.altKey && settingsModule) {
+    if (e.key === '=') {
+      e.preventDefault();
+      settingsModule.zoomIn();
+      return;
+    }
+    if (e.key === '-') {
+      e.preventDefault();
+      settingsModule.zoomOut();
+      return;
+    }
+    if (e.key === '0') {
+      e.preventDefault();
+      settingsModule.resetZoom();
+      return;
+    }
+  }
+
   // Delegate to settings if active
   if (settingsModule?.isActive()) {
     if (settingsModule.handleKey(e)) return;

--- a/apps/linows/src/js/screens/settings.js
+++ b/apps/linows/src/js/screens/settings.js
@@ -17,6 +17,47 @@ const BLUR_PRESETS = {
   soft: { ui_blur_opacity: 0.60 },
 };
 
+// UI zoom — mirrors macOS ThemeStore.zoomIn/zoomOut/resetZoom
+// (apps/macos/.../Support/ThemeStore.swift:270). The effective `--font-size`
+// is `baseFontSize * uiScale`; baseFontSize tracks the slider value, uiScale
+// is the user's Ctrl+= / Ctrl+- / Ctrl+0 multiplier. Persisted in localStorage
+// (not .look.config) so the config file stays scoped to declarative settings.
+const UI_SCALE_MIN = 0.7;
+const UI_SCALE_MAX = 1.8;
+const UI_SCALE_STEP = 0.1;
+const UI_SCALE_KEY = 'look.uiScale';
+let baseFontSizePx = 14;
+let uiScale = clampUiScale(parseFloat(localStorage.getItem(UI_SCALE_KEY)) || 1);
+
+function clampUiScale(v) {
+  return Math.min(UI_SCALE_MAX, Math.max(UI_SCALE_MIN, Math.round(v * 10) / 10));
+}
+
+function applyFontSize() {
+  const px = Math.round(baseFontSizePx * uiScale);
+  document.documentElement.style.setProperty('--font-size', px + 'px');
+}
+
+applyFontSize();
+
+export function zoomIn() {
+  uiScale = clampUiScale(uiScale + UI_SCALE_STEP);
+  localStorage.setItem(UI_SCALE_KEY, String(uiScale));
+  applyFontSize();
+}
+
+export function zoomOut() {
+  uiScale = clampUiScale(uiScale - UI_SCALE_STEP);
+  localStorage.setItem(UI_SCALE_KEY, String(uiScale));
+  applyFontSize();
+}
+
+export function resetZoom() {
+  uiScale = 1;
+  localStorage.setItem(UI_SCALE_KEY, String(uiScale));
+  applyFontSize();
+}
+
 const CSS_MAP = {
   ui_tint_red: applytint,
   ui_tint_green: applytint,
@@ -31,7 +72,8 @@ const CSS_MAP = {
   ui_blur_opacity: applyBlurOpacity,
   settings_blur_multiplier: applyBlurOpacity,
   ui_font_size: (v) => {
-    document.documentElement.style.setProperty('--font-size', Math.round(parseFloat(v)) + 'px');
+    baseFontSizePx = Math.round(parseFloat(v));
+    applyFontSize();
   },
   ui_font_red: applyFontColor,
   ui_font_green: applyFontColor,
@@ -628,7 +670,7 @@ function updateSettingsHint() {
   } else if (activeTab === 'shortcuts') {
     hint.textContent = 'Tips: t"word for web EN/VI/JA translation \u2022 /kill to force quit apps';
   } else {
-    hint.textContent = 'Tab switch tabs \u2022 Esc back';
+    hint.innerHTML = 'Tab: Switch tabs <span class="hint-sep">\u2022</span> Esc: Back';
   }
 }
 


### PR DESCRIPTION
## Summary

- Look's index had Discord path as C:\Users\…\AppData\Local\Discord\Update.exe. 
That's the Squirrel updater shim — it's only used to pivot to the latest installed vers and then immediately exits. 
- The actually-running process is Discord.exe buried inside
  …\Discord\app-1.0.x\Discord.exe. So Look's exact-path match found zero PIDs, gave up, and launched a new instance instead. Same trap catches Slack, GitHub Desktop, Atom, and other Squirrel/Electron apps.

- A5:SQL Mk-2 (and many other apps) have multiple visible windows under one PID: dialogs, tool palettes, hidden helpers. The original code picked whichever EnumWindows reported firstr.
We now prefer a window that's top-level (no owner), not a tool window, and has a title;  only if none qualifies do we fall back to "any visible window for the PID."

## Why

-

## Changes
- Squirrel-aware fallback: whenthe exact match misses and the target basename is Update.exe, scan for any non-Update.exe process whose image lives  underr the same install root (e.g. anything under C:\Users\…\AppData\Local\Discord\). The window-picker then sorts out which of those is the real main frame versus Electron's helper processes.


  Same flow works for A5 once the window-picker stops grabbing helper HWNDs.

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
