### PR TITLE
fix: Summon issue after restarting MacOS

### DIFF
--- a/apps/macos/LauncherApp/look-app/Support/AppDelegate.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppDelegate.swift
@@ -1,11 +1,21 @@
 import AppKit
 import Darwin
+import SwiftUI
 import UserNotifications
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private let hotKeyManager = GlobalHotKeyManager()
     private let pomoMenuBarItem = PomoMenuBarItem()
+
+    // The launcher window is owned by AppKit (created here), NOT by a SwiftUI
+    // WindowGroup. SwiftUI refuses to create a WindowGroup window on a
+    // background login launch, which left LauncherView (and its Cmd+Space
+    // toggle observer) unmounted → the hotkey fired into the void. An AppKit
+    // NSWindow is not subject to that suppression: we create it at launch
+    // (hidden) so LauncherView is always mounted and the existing
+    // .lookToggleWindowRequested → toggleWindowVisibility() path just works.
+    private var launcherWindow: NSWindow?
 
     // Grace period allows macOS "Quit & Reopen" handoff to release the previous process lock.
     private static let relaunchGracePeriodSeconds: TimeInterval = 0.8
@@ -28,12 +38,46 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.setActivationPolicy(.accessory)
         pomoMenuBarItem.install()
 
+        // Create the launcher window ourselves (hidden) so LauncherView mounts
+        // at launch — even on a cold background-login launch, where SwiftUI
+        // would never create a WindowGroup window. With the view mounted, its
+        // .lookToggleWindowRequested observer is live and Cmd+Space toggles it.
+        makeLauncherWindow()
+
         // Notifications: ask for permission early (so the prompt isn't
         // tied to the user being mid-pomodoro) and forward foreground
         // deliveries through a delegate so banners aren't suppressed
         // when the launcher window is the active app.
         UNUserNotificationCenter.current().delegate = PomoNotifications.foregroundDelegate
         PomoNotifications.requestPermissionEarly()
+    }
+
+    /// Build the launcher window in AppKit, host ContentView in it, and leave
+    /// it hidden. WindowConfigurator (embedded in ContentView) restyles this
+    /// window on first appearance — corner radius, floating level, titlebar
+    /// hairline fix, multi-display autoscale — exactly as it did for the old
+    /// WindowGroup window, so nothing about the launcher's look changes.
+    private func makeLauncherWindow() {
+        let baseSize = WindowAutoScale.baseSize()
+        let (minW, minH) = (baseSize.width, baseSize.height)
+        let content = ContentView()
+            .frame(minWidth: minW, minHeight: minH)
+            .background(WindowConfigurator())
+            .environmentObject(AppUIState.shared)
+            .environmentObject(ThemeStore.shared)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: minW, height: minH),
+            styleMask: [.titled, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = NSHostingView(rootView: content)
+        window.isReleasedWhenClosed = false
+        // Start hidden — this matches the launcher's normal resting state
+        // (it is summoned with Cmd+Space, not shown at launch).
+        window.orderOut(nil)
+        launcherWindow = window
     }
 
     private func shouldTerminateDuplicateInstance() -> Bool {

--- a/apps/macos/LauncherApp/look-app/Support/AppUIState.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppUIState.swift
@@ -2,6 +2,11 @@ import Foundation
 import Combine
 
 final class AppUIState: ObservableObject {
+    // Shared instance so AppDelegate (which now owns the launcher NSWindow and
+    // hosts ContentView) and the App scene's `.commands` operate on the same
+    // state. See AppDelegate.makeLauncherWindow().
+    static let shared = AppUIState()
+
     @Published var showsThemeSettings = false
     @Published var settingsBlurMultiplier: Double {
         didSet {

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/GlobalHotKeyManager.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/GlobalHotKeyManager.swift
@@ -18,6 +18,22 @@ final class GlobalHotKeyManager {
     // NSEvent monitor so the toggle works regardless of focus state.
     nonisolated(unsafe) private var localMonitor: Any?
 
+    // Defense-in-depth for one specific, rare failure: another app already
+    // owns Cmd+Space when Look launches, so RegisterEventHotKey returns -9878
+    // ("hotkey already in use") and the global toggle silently never works.
+    // Retry with backoff so a transient login-time conflict resolves on its own.
+    //
+    // NOTE: this is NOT what fixed "the launcher is invisible after a macOS
+    // restart." That bug was the WindowGroup window never being created at a
+    // background login launch (so LauncherView and its hotkey observer never
+    // mounted); registration actually succeeds (status=0) in that case. The
+    // real fix lives in AppDelegate (`handleToggleHotKey` materializes the
+    // launcher window when the hotkey fires and no window exists yet).
+    // This retry only matters if registration genuinely fails, which is uncommon.
+    private var retryAttempts = 0
+    private static let maxRetryAttempts = 5
+    private var retryWorkItem: DispatchWorkItem?
+
     // deinit is nonisolated; unregister is MainActor. Inline the cleanup
     // here using nonisolated-safe API only.
     deinit {
@@ -33,6 +49,8 @@ final class GlobalHotKeyManager {
     }
 
     func registerToggleHotKey() {
+        retryWorkItem?.cancel()
+        retryWorkItem = nil
         unregister()
 
         let hotKeyId = EventHotKeyID(signature: fourCharCode("LOOK"), id: 1)
@@ -79,6 +97,9 @@ final class GlobalHotKeyManager {
                 nil,
                 &eventHandler
             )
+            retryAttempts = 0
+        } else {
+            scheduleRetry()
         }
 
         // Local monitor: foreground-focused complement to the global
@@ -93,6 +114,23 @@ final class GlobalHotKeyManager {
             }
             return event
         }
+    }
+
+    private func scheduleRetry() {
+        guard retryAttempts < Self.maxRetryAttempts else {
+            hotkeyLog.error("RegisterEventHotKey still failing after \(Self.maxRetryAttempts) attempts; giving up on global hotkey")
+            return
+        }
+        retryAttempts += 1
+        // Ramp the delay so we react quickly to a brief login-time conflict
+        // but back off if it persists: 0.5s, 1.0s, ... capped at 3s.
+        let delay = min(3.0, 0.5 * Double(retryAttempts))
+        hotkeyLog.notice("scheduling hotkey re-registration attempt \(self.retryAttempts) in \(delay)s")
+        let work = DispatchWorkItem { [weak self] in
+            self?.registerToggleHotKey()
+        }
+        retryWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
     }
 
     func unregister() {

--- a/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
@@ -5,6 +5,11 @@ import AppKit
 import ServiceManagement
 
 final class ThemeStore: ObservableObject {
+    // Shared instance so AppDelegate (which hosts ContentView in an
+    // AppKit-owned window) and the App scene's `.commands` (zoom, theme)
+    // operate on the same store. See AppDelegate.makeLauncherWindow().
+    static let shared = ThemeStore()
+
     @Published private(set) var backgroundImageURL: URL?
     @Published private(set) var backgroundImage: NSImage?
     @Published var uiScale: CGFloat = 1.0

--- a/apps/macos/LauncherApp/look-app/look_appApp.swift
+++ b/apps/macos/LauncherApp/look-app/look_appApp.swift
@@ -12,8 +12,11 @@ import SwiftUI
 @main
 struct look_appApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
-    @StateObject private var appUIState = AppUIState()
-    @StateObject private var themeStore = ThemeStore()
+    // The launcher window is owned by AppDelegate (an AppKit NSWindow), not a
+    // SwiftUI WindowGroup — see AppDelegate.makeLauncherWindow() for why. These
+    // stores are shared with that window's hosted ContentView.
+    private let appUIState = AppUIState.shared
+    private let themeStore = ThemeStore.shared
 
     init() {
         if let exitCode = handleCLIFlags() {
@@ -109,14 +112,6 @@ struct look_appApp: App {
             .resolvingSymlinksInPath()
     }
 
-    /// Minimum SwiftUI content size. The actual window size is set by
-    /// WindowAutoScale (screen-ratio aware) via WindowConfigurator; this is
-    /// just a floor so SwiftUI never asks for a smaller window.
-    private func baseMinSize() -> (CGFloat, CGFloat) {
-        let size = WindowAutoScale.baseSize()
-        return (size.width, size.height)
-    }
-
     private func readInfoPlist(at url: URL) -> [String: Any]? {
         guard let data = try? Data(contentsOf: url) else { return nil }
         guard
@@ -132,15 +127,14 @@ struct look_appApp: App {
     }
 
     var body: some Scene {
-        WindowGroup(id: "main") {
-            let (minW, minH) = baseMinSize()
-            ContentView()
-                .frame(minWidth: minW, minHeight: minH)
-                .background(WindowConfigurator())
-                .environmentObject(appUIState)
-                .environmentObject(themeStore)
+        // The launcher window is an AppKit NSWindow owned by AppDelegate (see
+        // AppDelegate.makeLauncherWindow) — SwiftUI won't create a WindowGroup
+        // window on a background login launch, which was the root cause of the
+        // dead Cmd+Space. A Settings scene gives the app a valid Scene to carry
+        // the command menu below without auto-creating any window.
+        Settings {
+            EmptyView()
         }
-        .windowStyle(.hiddenTitleBar)
         .commands {
             CommandGroup(replacing: .newItem) {}
 


### PR DESCRIPTION
## Summary

- Stopped relying on SwiftUI's WindowGroup for the launcher; 
- AppDelegate now owns a real AppKit NSWindow + NSHostingView created at launch, and WindowGroup was demoted to Settings {}.

## Why

- #178 

## Changes

-

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
