### PR TITLE
Feat: Update checker

### DIFF
--- a/Makefile.mac
+++ b/Makefile.mac
@@ -87,6 +87,10 @@ app-install-dev: app-build app-ensure-bundle
 	@plutil -replace CFBundleDisplayName -string "$(DEV_APP_NAME)" "$(DEV_APP_INSTALL_BUNDLE)/Contents/Info.plist"
 	@plutil -replace CFBundleName -string "$(DEV_APP_NAME)" "$(DEV_APP_INSTALL_BUNDLE)/Contents/Info.plist"
 	@plutil -replace CFBundleIdentifier -string "$(DEV_APP_ID)" "$(DEV_APP_INSTALL_BUNDLE)/Contents/Info.plist"
+	@# Pin dev to 0.0 so it is always "behind" the latest release — lets the
+	@# update-available notice be exercised in dev builds.
+	@plutil -replace CFBundleShortVersionString -string "0.0" "$(DEV_APP_INSTALL_BUNDLE)/Contents/Info.plist"
+	@plutil -replace CFBundleVersion -string "0" "$(DEV_APP_INSTALL_BUNDLE)/Contents/Info.plist"
 	@codesign --force --sign - --deep "$(DEV_APP_INSTALL_BUNDLE)" >/dev/null
 	@"$(LSREGISTER)" -f "$(DEV_APP_INSTALL_BUNDLE)" >/dev/null
 	@echo "Installed $(DEV_APP_NAME) with bundle id $(DEV_APP_ID)"

--- a/apps/linows/src-tauri/src/files.rs
+++ b/apps/linows/src-tauri/src/files.rs
@@ -76,6 +76,17 @@ pub fn is_dev_build() -> bool {
     cfg!(debug_assertions)
 }
 
+/// Source of truth is `tauri.conf.json` (exposed via `PackageInfo`).
+/// Debug builds report a fixed `0.1.0` so the update check can be exercised
+/// end-to-end against the latest GitHub release.
+#[tauri::command]
+pub fn get_lookapp_version(app: tauri::AppHandle) -> String {
+    if cfg!(debug_assertions) {
+        return "0.1.0".to_string();
+    }
+    app.package_info().version.to_string()
+}
+
 #[tauri::command]
 pub fn copy_files_to_clipboard(paths: Vec<String>) -> Result<(), String> {
     if paths.is_empty() {

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -710,6 +710,9 @@ fn main() {
             autostart::get_autostart,
             // Highlight
             highlight::highlight_file_cmd,
+            // About widget: version only. The update check itself runs in
+            // the webview via fetch() — no Rust HTTP/TLS dep needed.
+            files::get_lookapp_version,
         ])
         .build(tauri::generate_context!())
         .expect("error while building look desktop")

--- a/apps/linows/src-tauri/tauri.conf.json
+++ b/apps/linows/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicoverbruggen/tauri-v2-schema/main/schema.json",
   "productName": "Look",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "identifier": "com.look.desktop",
   "build": {
     "frontendDist": "../src",

--- a/apps/linows/src/css/components/update.css
+++ b/apps/linows/src/css/components/update.css
@@ -1,0 +1,116 @@
+/* Notify-only update widget. Shared between Settings (About) and Help. */
+
+.update-widget {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.update-section-label {
+  font-size: calc(var(--font-size) - 1px);
+  font-weight: 600;
+  color: var(--font-color);
+  margin-bottom: 2px;
+}
+
+/* Both mounts live inside their parent's scroll area, so horizontal padding
+   is inherited; only vertical spacing + a divider are set here. */
+.settings-about {
+  padding: 12px 0 4px;
+  margin-top: 8px;
+  border-top: 1px solid var(--divider-color);
+}
+
+.help-update {
+  padding: 4px 0 10px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid var(--divider-color);
+}
+
+.update-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.update-version {
+  font-size: calc(var(--font-size) - 1px);
+  font-weight: 600;
+  color: var(--font-color);
+  user-select: text;
+}
+
+.update-status {
+  font-size: calc(var(--font-size) - 2px);
+  color: var(--font-secondary);
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.update-pill {
+  font-size: calc(var(--font-size) - 2px);
+  font-weight: 600;
+  padding: 4px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--divider-color);
+  background: var(--control-fill);
+  color: var(--font-color);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.update-pill:hover:not(:disabled) {
+  background: var(--selection-fill);
+}
+
+.update-pill:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.update-pill-muted {
+  background: transparent;
+}
+
+.update-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: var(--control-fill);
+  border: 1px solid var(--accent-color, var(--divider-color));
+}
+
+.update-banner-text {
+  flex: 1 1 auto;
+  font-size: calc(var(--font-size) - 1px);
+  font-weight: 600;
+  color: var(--font-color);
+}
+
+.update-hint {
+  font-size: calc(var(--font-size) - 2px);
+  color: var(--font-secondary);
+}
+
+.update-hint-link {
+  color: var(--accent-color, var(--font-color));
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.update-hint-link:hover {
+  opacity: 0.8;
+}
+
+/* Push the version-row pill to flush-right when no status text is present. */
+.update-row > .update-pill {
+  margin-left: auto;
+}
+.update-row > .update-status + .update-pill {
+  margin-left: 0;
+}

--- a/apps/linows/src/html/screens/help.html
+++ b/apps/linows/src/html/screens/help.html
@@ -1,11 +1,14 @@
 <div class="help-overlay" id="help-screen" hidden>
   <div class="help-panel">
     <div class="help-header">
-      <span class="help-title">Keyboard Help</span>
+      <span class="help-title">Help</span>
       <span class="help-close-hint">Ctrl+H to close</span>
     </div>
-    <div class="help-subtitle">Quick guide for app list, app switching, clipboard search, and command flow.</div>
     <div class="help-body">
+      <!-- About / update status sits inside the scroll area, so scrolling
+           the shortcut list moves it off-screen — matches macOS layout. -->
+      <div class="help-update" id="help-update"></div>
+
       <!-- Main -->
       <div class="help-section-title">Main</div>
       <div class="help-item"><kbd>Enter</kbd><span>Open selected app/file/folder or copy selected clipboard item</span></div>

--- a/apps/linows/src/html/screens/settings.html
+++ b/apps/linows/src/html/screens/settings.html
@@ -393,6 +393,11 @@
         </div>
 
       </div>
+
+      <!-- About / update status. Lives inside the scroll area so it sits
+           at the bottom of the settings panel and scrolls with the rest of
+           the content — matches the macOS layout. -->
+      <div class="settings-about" id="settings-about"></div>
     </div>
   </div>
 </div>

--- a/apps/linows/src/index.html
+++ b/apps/linows/src/index.html
@@ -16,6 +16,7 @@
   <link rel="stylesheet" href="css/components/translate.css" />
   <link rel="stylesheet" href="css/components/settings.css" />
   <link rel="stylesheet" href="css/components/help.css" />
+  <link rel="stylesheet" href="css/components/update.css" />
 </head>
 <body>
   <div id="app" class="launcher-window"></div>

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -6,6 +6,7 @@ import * as picked from './components/picked.js';
 import * as banner from './components/banner.js';
 import * as commands from './screens/commands/index.js';
 import * as settings from './screens/settings.js';
+import { mountUpdateWidget } from './screens/update_widget.js';
 import * as translatePanel from './components/translate.js';
 import * as runningApps from './components/running-apps.js';
 import * as platform from './platform.js';
@@ -48,6 +49,12 @@ document.addEventListener('DOMContentLoaded', async () => {
   await load('html/screens/commands/index.html', app);
   await load('html/screens/settings.html', app);
   await load('html/screens/help.html', app);
+
+  // About / version + update-status widget, shared between Settings and Help.
+  // Settings gets an "About" header label; Help mounts the widget bare so the
+  // screen title above already serves as its heading (mirrors macOS layout).
+  mountUpdateWidget(document.getElementById('settings-about'), { label: 'About' });
+  mountUpdateWidget(document.getElementById('help-update'));
 
   // Hint bar — always at bottom, shared by all screens
   app.insertAdjacentHTML('beforeend',

--- a/apps/linows/src/js/ipc.js
+++ b/apps/linows/src/js/ipc.js
@@ -196,3 +196,7 @@ export async function highlightFile(path) {
 export async function listFolder(path) {
   return invoke('list_folder', { path });
 }
+
+export async function getLookappVersion() {
+  return invoke('get_lookapp_version');
+}

--- a/apps/linows/src/js/screens/update_widget.js
+++ b/apps/linows/src/js/screens/update_widget.js
@@ -1,0 +1,237 @@
+// Notify-only update widget mounted in Settings ("About" footer) and Help.
+// We never download or replace the binary — Linux/Windows distros vary too
+// much to bundle a single upgrade command, so the banner links to the
+// release notes and the README install section instead.
+//
+// The check itself runs in the webview via `fetch()` (no Rust HTTP/TLS
+// dep); cross-origin works because `tauri.conf.json` has `csp: null`.
+// Dismissed versions persist in `localStorage`.
+import { getLookappVersion, openPath, isDevBuild } from '../ipc.js';
+import * as platform from '../platform.js';
+
+const RELEASES_API_URL = 'https://api.github.com/repos/kunkka19xx/look/releases/latest';
+const FALLBACK_RELEASES_URL = 'https://github.com/kunkka19xx/look/releases/latest';
+const DISMISSED_VERSION_KEY = 'look.update.dismissedVersion';
+const HTTP_TIMEOUT_MS = 15_000;
+
+// Linux/Windows each have several install paths (deb / AppImage / NixOS /
+// Nix profile / NSIS / install scripts); sending the user to the README
+// section lets them copy the command that matches their setup.
+const INSTALL_HINT_URLS = {
+  linux: 'https://github.com/kunkka19xx/look#linux',
+  windows: 'https://github.com/kunkka19xx/look#windows',
+};
+
+// `container -> label`: Settings mounts with "About", Help mounts bare.
+const widgets = new Map();
+const state = {
+  currentVersion: '',
+  isDev: false,
+  available: null,
+  status: '',
+  isChecking: false,
+};
+
+export async function mountUpdateWidget(container, { label = '' } = {}) {
+  if (!container) return;
+  container.classList.add('update-widget');
+  widgets.set(container, label);
+  render(container);
+  if (!state.currentVersion) {
+    try {
+      [state.currentVersion, state.isDev] = await Promise.all([
+        getLookappVersion(),
+        isDevBuild(),
+      ]);
+    } catch {
+      state.currentVersion = '';
+      state.isDev = false;
+    }
+    renderAll();
+  }
+}
+
+async function handleCheck() {
+  if (state.isChecking) return;
+  state.isChecking = true;
+  state.status = 'Checking…';
+  renderAll();
+  try {
+    const result = await performCheck(state.currentVersion, true);
+    state.available = result.available;
+    state.status = result.status;
+  } catch {
+    state.status = "Couldn't check for updates";
+    state.available = null;
+  } finally {
+    state.isChecking = false;
+    renderAll();
+  }
+}
+
+function handleDismiss() {
+  if (!state.available) return;
+  try {
+    localStorage.setItem(DISMISSED_VERSION_KEY, state.available.version);
+  } catch {
+    // Private mode or quota errors — in-memory dismissal still works.
+  }
+  state.available = null;
+  state.status = '';
+  renderAll();
+}
+
+function handleNotes() {
+  if (!state.available) return;
+  openPath(state.available.release_url, 'browser', '');
+}
+
+function handleInstallHint() {
+  const url = INSTALL_HINT_URLS[platform.os()];
+  if (!url) return;
+  openPath(url, 'browser', '');
+}
+
+async function performCheck(currentVersion, force) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), HTTP_TIMEOUT_MS);
+  let response;
+  try {
+    response = await fetch(RELEASES_API_URL, {
+      headers: { Accept: 'application/vnd.github+json' },
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+  if (!response.ok) {
+    return { available: null, status: "Couldn't check for updates" };
+  }
+  const json = await response.json();
+  const tag = typeof json?.tag_name === 'string' ? json.tag_name : null;
+  if (!tag) {
+    return { available: null, status: "Couldn't check for updates" };
+  }
+  if (json.draft === true || json.prerelease === true) {
+    return latestStatus(currentVersion);
+  }
+  const latest = normalizeVersion(tag);
+  if (!isVersionNewer(latest, normalizeVersion(currentVersion))) {
+    return latestStatus(currentVersion);
+  }
+  // Allow-list GitHub URLs — a compromised response shouldn't hand
+  // `xdg-open` an arbitrary scheme.
+  const rawUrl = typeof json.html_url === 'string' ? json.html_url : '';
+  const releaseUrl = rawUrl.startsWith('https://github.com/') ? rawUrl : FALLBACK_RELEASES_URL;
+  // A manual check ("force") overrides a prior dismissal of the same version.
+  if (!force && safeGetItem(DISMISSED_VERSION_KEY) === latest) {
+    return { available: null, status: '' };
+  }
+  return {
+    available: { version: latest, release_url: releaseUrl },
+    status: `Update available: Look ${latest}`,
+  };
+}
+
+function latestStatus(currentVersion) {
+  const label = currentVersion || 'unknown';
+  return { available: null, status: `You're on the latest version (${label})` };
+}
+
+function safeGetItem(key) {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeVersion(raw) {
+  const trimmed = String(raw).trim();
+  return trimmed.startsWith('v') || trimmed.startsWith('V') ? trimmed.slice(1) : trimmed;
+}
+
+// Numeric dotted compare: "1.10.0" > "1.9.0". Non-numeric segments → 0.
+function isVersionNewer(lhs, rhs) {
+  const a = components(lhs);
+  const b = components(rhs);
+  const count = Math.max(a.length, b.length);
+  for (let i = 0; i < count; i++) {
+    const x = a[i] ?? 0;
+    const y = b[i] ?? 0;
+    if (x !== y) return x > y;
+  }
+  return false;
+}
+
+function components(version) {
+  return String(version).split('.').map((part) => parseInt(part, 10) || 0);
+}
+
+function renderAll() {
+  widgets.forEach((_label, container) => render(container));
+}
+
+function render(container) {
+  const label = widgets.get(container) || '';
+  const { currentVersion, isDev, available, status, isChecking } = state;
+  const devSuffix = isDev ? ' — dev' : '';
+  const versionLabel = currentVersion
+    ? `Look ${escapeHtml(currentVersion)}${devSuffix}`
+    : 'Look …';
+  // Suppress the status text once a real update has surfaced — the banner below
+  // says the same thing more loudly.
+  const showStatus = status && !available;
+
+  let html = '';
+  if (label) {
+    html += `<div class="update-section-label">${escapeHtml(label)}</div>`;
+  }
+  html += `
+    <div class="update-row">
+      <span class="update-version">${versionLabel}</span>
+      ${showStatus ? `<span class="update-status">${escapeHtml(status)}</span>` : ''}
+      <button class="update-pill" type="button" data-action="check"${isChecking ? ' disabled' : ''}>
+        ${isChecking ? 'Checking…' : 'Check for Updates'}
+      </button>
+    </div>
+  `;
+
+  if (available) {
+    html += `
+      <div class="update-banner">
+        <span class="update-banner-text">Update available: Look ${escapeHtml(available.version)}</span>
+        <button class="update-pill" type="button" data-action="notes">Release Notes</button>
+        <button class="update-pill update-pill-muted" type="button" data-action="dismiss">Dismiss</button>
+      </div>
+    `;
+    const os = platform.os();
+    if (INSTALL_HINT_URLS[os]) {
+      const osLabel = os === 'windows' ? 'Windows' : 'Linux';
+      html += `
+        <div class="update-hint">
+          Update on ${osLabel}: <a class="update-hint-link" href="#" data-action="install-hint">see install instructions</a>
+        </div>
+      `;
+    }
+  }
+
+  container.innerHTML = html;
+  container.querySelector('[data-action="check"]')?.addEventListener('click', handleCheck);
+  container.querySelector('[data-action="notes"]')?.addEventListener('click', handleNotes);
+  container.querySelector('[data-action="dismiss"]')?.addEventListener('click', handleDismiss);
+  container.querySelector('[data-action="install-hint"]')?.addEventListener('click', (e) => {
+    e.preventDefault();
+    handleInstallHint();
+  });
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (c) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  }[c]));
+}

--- a/apps/macos/LauncherApp/look-app/Support/AppDelegate.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppDelegate.swift
@@ -34,6 +34,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // when the launcher window is the active app.
         UNUserNotificationCenter.current().delegate = PomoNotifications.foregroundDelegate
         PomoNotifications.requestPermissionEarly()
+
+        // Notify-only update check against GitHub Releases (throttled to once
+        // per 12h). Look ships via Homebrew, so this never self-installs — it
+        // just surfaces a notice linking to the release page.
+        UpdateChecker.shared.checkForUpdates()
     }
 
     private func shouldTerminateDuplicateInstance() -> Bool {

--- a/apps/macos/LauncherApp/look-app/Support/AppVersion.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppVersion.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Single source of truth for the running app's version, read from the bundle
+/// Info.plist. The CLI `-v` path in look_appApp has its own resilient reader for
+/// the case where the binary is invoked outside the .app; inside the GUI we are
+/// always running from the bundle, so Bundle.main is enough here.
+enum AppVersion {
+    /// Marketing version, e.g. "1.0.0". nil if missing from the plist.
+    static var short: String? {
+        (Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String)?
+            .trimmingCharacters(in: .whitespaces)
+            .nonEmpty
+    }
+
+    /// Build number, e.g. "42". nil if missing from the plist.
+    static var build: String? {
+        (Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String)?
+            .trimmingCharacters(in: .whitespaces)
+            .nonEmpty
+    }
+
+    /// True for side-by-side dev installs (`make app-run-dev` rewrites the
+    /// bundle id to `noah-code.Look.Dev`). Dev builds carry a fixed 1.0 version,
+    /// so comparing them against published releases is meaningless.
+    static var isDevBuild: Bool {
+        Bundle.main.bundleIdentifier?.hasSuffix(".Dev") ?? false
+    }
+
+    /// Human-readable label for display, e.g. "Look 1.0.0 (42)" or "Look 1.0.0".
+    /// Dev builds are tagged so the version isn't mistaken for a real release.
+    static var displayString: String {
+        let suffix = isDevBuild ? " — dev" : ""
+        guard let short else { return "Look (unknown version)\(suffix)" }
+        if let build, build != short {
+            return "Look \(short) (\(build))\(suffix)"
+        }
+        return "Look \(short)\(suffix)"
+    }
+}
+
+private extension String {
+    var nonEmpty: String? { isEmpty ? nil : self }
+}

--- a/apps/macos/LauncherApp/look-app/Support/UpdateChecker.swift
+++ b/apps/macos/LauncherApp/look-app/Support/UpdateChecker.swift
@@ -1,0 +1,236 @@
+import AppKit
+import Combine
+import Foundation
+import OSLog
+
+/// Checks GitHub Releases for a newer version of Look and, if one exists,
+/// publishes it so the UI can show a non-intrusive "update available" notice.
+///
+/// This is notify-only: Look is distributed via Homebrew, so we never download
+/// or replace the bundle ourselves. The notice links to the release page and
+/// the user runs `brew upgrade --cask kunkka19xx/tap/look` (or downloads the
+/// asset). Homebrew stays the source of truth for the installed version.
+final class UpdateChecker: ObservableObject {
+    static let shared = UpdateChecker()
+
+    struct AvailableUpdate: Equatable {
+        let version: String
+        let releaseURL: URL
+    }
+
+    /// Non-nil when a newer release exists and the user hasn't dismissed it.
+    /// Mutated only on the main actor so SwiftUI observers stay consistent.
+    @Published private(set) var availableUpdate: AvailableUpdate?
+
+    /// True while a network check is in flight (for "Checking…" UI).
+    @Published private(set) var isChecking = false
+
+    /// Human-readable result of the most recent *manual* check, for feedback
+    /// in Settings. nil during automatic background checks so we never nag.
+    @Published private(set) var statusMessage: String?
+
+    private let latestReleaseURL = URL(string: "https://api.github.com/repos/kunkka19xx/look/releases/latest")!
+    private let session: URLSession
+    private let defaults: UserDefaults
+    private let log = Logger(subsystem: "noah-code.Look", category: "UpdateChecker")
+
+    /// Don't hit the network more than once per this interval across launches.
+    private let minCheckInterval: TimeInterval = 60 * 60 * 12  // 12 hours
+
+    private static let lastCheckKey = "look.update.lastCheckEpoch"
+    private static let dismissedVersionKey = "look.update.dismissedVersion"
+
+    init(session: URLSession = .shared, defaults: UserDefaults = .standard) {
+        self.session = session
+        self.defaults = defaults
+    }
+
+    /// Check for an update, honoring the throttle. Safe to call on every launch.
+    /// Pass `force: true` to bypass the throttle (e.g. a manual "Check now").
+    @MainActor
+    func checkForUpdates(force: Bool = false) {
+        guard !isChecking else { return }
+
+        if !force {
+            let last = defaults.double(forKey: Self.lastCheckKey)
+            if last > 0, Date().timeIntervalSince1970 - last < minCheckInterval {
+                return
+            }
+        }
+
+        guard let current = AppVersion.short else {
+            log.debug("Skipping update check: no current version in bundle")
+            if force { statusMessage = "Couldn't read the current version" }
+            return
+        }
+
+        isChecking = true
+        // Only show inline feedback for user-initiated ("force") checks.
+        statusMessage = force ? "Checking…" : nil
+        Task { @MainActor in
+            defer { self.isChecking = false }
+            await self.performCheck(currentVersion: current, isManual: force)
+        }
+    }
+
+    /// Hide the notice without persisting a dismissal — used once the user has
+    /// kicked off an update. If that upgrade fails, a later check resurfaces it.
+    @MainActor
+    func hideNotice() {
+        availableUpdate = nil
+        statusMessage = nil
+    }
+
+    /// Launch the Homebrew upgrade and hide the notice. Convenience for the
+    /// "Update" buttons so they don't have to coordinate the two calls.
+    @MainActor
+    func startUpdate() {
+        UpdateChecker.runHomebrewUpgrade()
+        hideNotice()
+    }
+
+    /// Hide the current notice and remember the version so we don't nag again
+    /// until an even newer release appears.
+    @MainActor
+    func dismissCurrent() {
+        if let version = availableUpdate?.version {
+            defaults.set(version, forKey: Self.dismissedVersionKey)
+        }
+        availableUpdate = nil
+    }
+
+    @MainActor
+    private func performCheck(currentVersion: String, isManual: Bool) async {
+        var request = URLRequest(url: latestReleaseURL)
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = 15
+
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                log.debug("Update check non-200 response")
+                if isManual { statusMessage = "Couldn't check for updates" }
+                return
+            }
+
+            defaults.set(Date().timeIntervalSince1970, forKey: Self.lastCheckKey)
+
+            guard
+                let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                let tag = json["tag_name"] as? String
+            else {
+                if isManual { statusMessage = "Couldn't check for updates" }
+                return
+            }
+
+            // Ignore drafts/prereleases — only stable updates should nag users.
+            if (json["prerelease"] as? Bool) == true || (json["draft"] as? Bool) == true {
+                if isManual { statusMessage = "You're on the latest version (\(currentVersion))" }
+                return
+            }
+
+            let latest = Self.normalizedVersion(tag)
+            guard Self.isVersion(latest, newerThan: Self.normalizedVersion(currentVersion)) else {
+                availableUpdate = nil
+                if isManual { statusMessage = "You're on the latest version (\(currentVersion))" }
+                return
+            }
+
+            let urlString = (json["html_url"] as? String) ?? "https://github.com/kunkka19xx/look/releases/latest"
+            guard let releaseURL = URL(string: urlString) else { return }
+
+            // A manual check overrides a prior dismissal of this version.
+            if !isManual, defaults.string(forKey: Self.dismissedVersionKey) == latest {
+                availableUpdate = nil
+                return
+            }
+
+            availableUpdate = AvailableUpdate(version: latest, releaseURL: releaseURL)
+            if isManual { statusMessage = "Update available: Look \(latest)" }
+            log.info("Update available: \(latest, privacy: .public) (current \(currentVersion, privacy: .public))")
+        } catch {
+            log.debug("Update check failed: \(error.localizedDescription, privacy: .public)")
+            if isManual { statusMessage = "Couldn't check for updates" }
+        }
+    }
+
+    /// The Homebrew command users run to upgrade Look.
+    static let homebrewUpgradeCommand = "brew upgrade --cask kunkka19xx/tap/look"
+
+    /// Bundle id of the release app the Homebrew cask installs. The dev build
+    /// uses the ".Dev" suffix, but brew always upgrades the release app — so the
+    /// relaunch targets this id, not the running bundle.
+    static let productionBundleID = "noah-code.Look"
+
+    /// Launch Terminal running the Homebrew upgrade. The app isn't sandboxed, so
+    /// we drop a temporary executable `.command` file and open it — Terminal runs
+    /// it without needing Automation (Apple Events) permission. The user sees the
+    /// output and can authenticate if Homebrew asks. Returns false if we couldn't
+    /// stage the script. Note: brew may quit/replace Look while upgrading, which
+    /// is expected for a cask.
+    @discardableResult
+    static func runHomebrewUpgrade() -> Bool {
+        // After a cask upgrade the new bundle is on disk, but the running
+        // process is still the old binary — so on success we quit and relaunch
+        // Look for the user instead of asking them to restart it manually.
+        let script = """
+        #!/bin/bash
+        export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+        echo "Updating Look via Homebrew…"
+        echo ""
+        \(homebrewUpgradeCommand)
+        status=$?
+        echo ""
+        if [ $status -eq 0 ]; then
+          echo "Update complete — relaunching Look…"
+          osascript -e 'tell application id "\(productionBundleID)" to quit' >/dev/null 2>&1
+          sleep 1
+          open -b "\(productionBundleID)" 2>/dev/null || open "/Applications/Look.app"
+          echo "Look has been relaunched. You can close this window."
+        else
+          echo "Update failed (exit $status). See the output above, or run:"
+          echo "  \(homebrewUpgradeCommand)"
+        fi
+        """
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("look-update.command")
+        do {
+            try script.write(to: url, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o755], ofItemAtPath: url.path)
+            NSWorkspace.shared.open(url)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    /// Strip a leading "v" and surrounding whitespace: "v1.2.0" -> "1.2.0".
+    static func normalizedVersion(_ raw: String) -> String {
+        var s = raw.trimmingCharacters(in: .whitespaces)
+        if s.hasPrefix("v") || s.hasPrefix("V") {
+            s.removeFirst()
+        }
+        return s
+    }
+
+    /// Numeric dotted-version comparison. "1.10.0" > "1.9.0". Non-numeric or
+    /// missing components are treated as 0, so it degrades gracefully.
+    static func isVersion(_ lhs: String, newerThan rhs: String) -> Bool {
+        let a = components(lhs)
+        let b = components(rhs)
+        let count = max(a.count, b.count)
+        for i in 0..<count {
+            let x = i < a.count ? a[i] : 0
+            let y = i < b.count ? b[i] : 0
+            if x != y { return x > y }
+        }
+        return false
+    }
+
+    private static func components(_ version: String) -> [Int] {
+        version
+            .split(separator: ".")
+            .map { Int($0.prefix { $0.isNumber }) ?? 0 }
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
@@ -343,6 +343,8 @@ struct LauncherHelpScreenView: View {
                         .foregroundStyle(themeStore.mutedTextColor())
                 }
 
+                AppUpdateStatusView(themeStore: themeStore)
+
                 Text(LauncherHelpContent.subtitle)
                     .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize), weight: .regular))
                     .foregroundStyle(themeStore.secondaryTextColor())
@@ -357,7 +359,7 @@ struct LauncherHelpScreenView: View {
 }
 
 private enum LauncherHelpContent {
-    static let title = "Keyboard Help"
+    static let title = "Help"
     static let closeHint = "Cmd+H to close"
     static let subtitle = "Quick guide for app list, clipboard search, and command flow."
 

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -599,7 +599,7 @@ struct LauncherView: View {
         if appUIState.showsThemeSettings {
             ThemeSettingsView(settings: $themeStore.settings)
         } else {
-            if !isCommandMode {
+            if !isCommandMode && !showsHelpScreen {
                 if shouldShowRunningAppsStrip {
                     // Split the search-bar row in half: search field on the
                     // left, running-apps icons on the right. No floating strip,

--- a/apps/macos/LauncherApp/look-app/Views/Settings/AppUpdateStatusView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Settings/AppUpdateStatusView.swift
@@ -1,0 +1,73 @@
+import AppKit
+import SwiftUI
+
+/// Shared version + update-status UI, used by both Settings → About and the
+/// Help screen header so the two stay in sync (single source of the buttons,
+/// states, and Homebrew hint).
+struct AppUpdateStatusView: View {
+    let themeStore: ThemeStore
+    @ObservedObject private var updateChecker = UpdateChecker.shared
+
+    private var fontSize: CGFloat { CGFloat(themeStore.settings.fontSize) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Text(AppVersion.displayString)
+                    .font(themeStore.uiFont(size: fontSize - 1, weight: .semibold))
+                    .foregroundStyle(themeStore.fontColor())
+                    .textSelection(.enabled)
+
+                if updateChecker.availableUpdate == nil, let status = updateChecker.statusMessage {
+                    Text(status)
+                        .font(themeStore.uiFont(size: fontSize - 2, weight: .regular))
+                        .foregroundStyle(themeStore.mutedTextColor())
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 0)
+
+                pill(updateChecker.isChecking ? "Checking…" : "Check for Updates") {
+                    updateChecker.checkForUpdates(force: true)
+                }
+                .disabled(updateChecker.isChecking)
+            }
+
+            if let update = updateChecker.availableUpdate {
+                HStack(spacing: 8) {
+                    Text("Update available: Look \(update.version)")
+                        .font(themeStore.uiFont(size: fontSize - 1, weight: .semibold))
+                        .foregroundStyle(themeStore.fontColor())
+
+                    pill("Update") { updateChecker.startUpdate() }
+                        .help("Runs '\(UpdateChecker.homebrewUpgradeCommand)' in Terminal")
+                    pill("Notes") { NSWorkspace.shared.open(update.releaseURL) }
+                    pill("Dismiss") { updateChecker.dismissCurrent() }
+
+                    Spacer(minLength: 0)
+                }
+
+                Text("Update with: \(UpdateChecker.homebrewUpgradeCommand)")
+                    .font(themeStore.uiFont(size: fontSize - 2, weight: .regular))
+                    .foregroundStyle(themeStore.mutedTextColor())
+                    .textSelection(.enabled)
+            }
+        }
+    }
+
+    private func pill(_ title: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(themeStore.uiFont(size: fontSize - 2, weight: .semibold))
+                .foregroundStyle(themeStore.fontColor())
+                .padding(.horizontal, 10)
+                .padding(.vertical, 4)
+                .background(.white.opacity(0.16), in: Capsule())
+                .overlay(
+                    Capsule().strokeBorder(.white.opacity(0.22), lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+        .contentShape(Capsule())
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Advanced.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Advanced.swift
@@ -5,6 +5,7 @@ import UniformTypeIdentifiers
 extension ThemeSettingsView {
     var backgroundTab: some View {
         VStack(alignment: .leading, spacing: 10) {
+            ScrollViewReader { proxy in
             ScrollView(.vertical, showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 10) {
                     Text("Background")
@@ -317,6 +318,13 @@ extension ThemeSettingsView {
                         }
                     }
 
+                    Divider()
+                        .overlay(.white.opacity(0.1))
+                        .padding(.vertical, 4)
+
+                    aboutSection
+                        .id(Self.aboutAnchorID)
+
                 }
             }
             .onAppear { syncIndexingInputsFromSettings() }
@@ -326,6 +334,14 @@ extension ThemeSettingsView {
             .onChange(of: settings.fileScanLimit) { _, _ in
                 fileScanLimitInput = String(settings.fileScanLimit)
             }
+            // Reveal the About/update result after a manual "Check for Updates".
+            .onChange(of: updateChecker.statusMessage) { _, message in
+                guard message != nil else { return }
+                withAnimation {
+                    proxy.scrollTo(Self.aboutAnchorID, anchor: .bottom)
+                }
+            }
+            }
 
             Spacer(minLength: 0)
 
@@ -333,6 +349,17 @@ extension ThemeSettingsView {
                 .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 2), weight: .regular))
                 .foregroundStyle(themeStore.mutedTextColor())
         }
+    }
+
+    static let aboutAnchorID = "look-about-section"
+
+    @ViewBuilder
+    var aboutSection: some View {
+        Text("About")
+            .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .semibold))
+            .foregroundStyle(themeStore.secondaryTextColor())
+
+        AppUpdateStatusView(themeStore: themeStore)
     }
 
     func selectBackgroundImage() {

--- a/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView.swift
@@ -9,6 +9,7 @@ struct ThemeSettingsView: View {
 
     @EnvironmentObject var appUIState: AppUIState
     @EnvironmentObject var themeStore: ThemeStore
+    @ObservedObject var updateChecker = UpdateChecker.shared
     @Binding var settings: ThemeSettings
     @State var selectedTab = 0
     @State var saveMessage: String?


### PR DESCRIPTION
## Summary

- Updater for macos and linows
- User can check new version in help screen or advanced / about part!
- We don't add any thing that silently check new version (because it's still an internet connection)

## Why

- #131 

## Changes


## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
