### PR TITLE
Fix package name in README for Ubuntu/Debian unintallation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Uninstall:
 yay -R look-bin
 
 # Ubuntu/Debian
-sudo dpkg -r lookapp
+sudo dpkg -r look
 
 # AppImage — just delete the file
 rm Look_*.AppImage


### PR DESCRIPTION
- Fix mismatch package name to look instead of lookapp

## Summary

- change lookapp to look

## Why

- the mismatch name makes dpkg unable to remove look on ubuntu
```bash
sudo dpkg -r lookapp
[sudo: authenticate] Password:           
dpkg: warning: ignoring request to remove lookapp which is not installed
```

result (successfully removed look):
```
sudo dpkg -r look
(Reading database… 234166 files and directories currently installed.)
Removing look (0.5.7)…
Processing triggers for hicolor-icon-theme (0.18-2build1)…
Processing triggers for gnome-menus (3.38.1-1ubuntu1)…
Processing triggers for desktop-file-utils (0.28-1build1)…
```
## Changes

- Change lookapp to look

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
