### PR TITLE
feat: Remove files, folders with look (MacOS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,17 +54,21 @@ jobs:
               - 'apps/linows/**'
               - 'core/**'
               - '.github/workflows/ci.yml'
+            # NOTE: dorny/paths-filter matches each changed file against the rule
+            # list with OR semantics, and a leading "!" is a picomatch negation
+            # that matches every file *outside* that path - so an excluded-subdir
+            # line like "!.../platform/windows/**" matched virtually any change
+            # (macOS code, docs, README), firing these builds on unrelated PRs.
+            # There's no AND across rules to express "linows changes except subdir
+            # X", so we just trigger on any apps/linows or core change.
             linows_linux:
               - 'apps/linows/**'
               - 'core/**'
               - '.github/workflows/ci.yml'
-              - '!apps/linows/src-tauri/src/platform/windows/**'
             linows_windows:
               - 'apps/linows/**'
               - 'core/**'
               - '.github/workflows/ci.yml'
-              - '!apps/linows/src-tauri/src/platform/linux/**'
-              - '!apps/linows/nix/**'
 
   lint:
     name: lint

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ open "/Applications/Look.app"
 | Open / run                                    | `Enter`          | `Enter`             | `Enter`          |
 | Web search                                    | `Cmd+Enter`      | `Ctrl+Enter`        | `Ctrl+Enter`     |
 | Reveal in file manager                        | `Cmd+F` (Finder) | `Ctrl+F` (Explorer) | `Ctrl+F` (Files) |
+| Move to Trash (or empty the Trash folder)     | `Cmd+D`          | —                   | —                |
 | Command mode (`calc`, `shell`, `kill`, `sys`) | `Cmd+/`          | `Ctrl+/`            | `Ctrl+/`         |
 | Settings                                      | `Cmd+Shift+,`    | `Ctrl+Shift+,`      | `Ctrl+Shift+,`   |
 | Back / hide                                   | `Escape`         | `Escape`            | `Escape`         |

--- a/apps/macos/LauncherApp/LauncherLogicTests/DeleteTargetLogicTests.swift
+++ b/apps/macos/LauncherApp/LauncherLogicTests/DeleteTargetLogicTests.swift
@@ -45,43 +45,38 @@ final class DeleteTargetLogicTests: XCTestCase {
         XCTAssertEqual(eligible.map(\.id), ["here"])
     }
 
-    // MARK: - confirmTitle
-
-    func testConfirmTitleSingularNamesItem() {
-        XCTAssertEqual(
-            DeleteTargetLogic.confirmTitle(displayNames: ["report.pdf"]),
-            "Move \"report.pdf\" to Trash?"
+    func testProtectsHomeRootAndTrash() {
+        let home = "/Users/me"
+        let input = [
+            result("root", .folder, path: "/"),
+            result("home", .folder, path: "/Users/me"),
+            result("homeSlash", .folder, path: "/Users/me/"),
+            result("trash", .folder, path: "/Users/me/.Trash"),
+            result("ok", .folder, path: "/Users/me/Projects"),
+        ]
+        let eligible = DeleteTargetLogic.eligible(
+            from: input,
+            fileExists: { _ in true },
+            homeDirectory: home
         )
+        XCTAssertEqual(eligible.map(\.id), ["ok"])
     }
 
-    func testConfirmTitlePluralShowsCount() {
-        XCTAssertEqual(
-            DeleteTargetLogic.confirmTitle(displayNames: ["a", "b", "c"]),
-            "Move 3 items to Trash?"
-        )
+    // MARK: - isTrashPath
+
+    func testIsTrashPath() {
+        let home = "/Users/me"
+        XCTAssertTrue(DeleteTargetLogic.isTrashPath("/Users/me/.Trash", homeDirectory: home))
+        XCTAssertTrue(DeleteTargetLogic.isTrashPath("/Users/me/.Trash/", homeDirectory: home))
+        XCTAssertFalse(DeleteTargetLogic.isTrashPath("/Users/me/.Trash/file.txt", homeDirectory: home))
+        XCTAssertFalse(DeleteTargetLogic.isTrashPath("/Users/me/Documents", homeDirectory: home))
     }
 
-    // MARK: - confirmDetail
+    // MARK: - empty trash wording
 
-    func testConfirmDetailSingleShowsPath() {
-        XCTAssertEqual(
-            DeleteTargetLogic.confirmDetail(fileCount: 1, folderCount: 0, singlePath: "/tmp/a.txt"),
-            "/tmp/a.txt"
-        )
-    }
-
-    func testConfirmDetailPluralCountsFilesAndFolders() {
-        XCTAssertEqual(
-            DeleteTargetLogic.confirmDetail(fileCount: 2, folderCount: 1, singlePath: nil),
-            "2 files, 1 folder"
-        )
-    }
-
-    func testConfirmDetailOmitsZeroCategory() {
-        XCTAssertEqual(
-            DeleteTargetLogic.confirmDetail(fileCount: 0, folderCount: 3, singlePath: nil),
-            "3 folders"
-        )
+    func testEmptyTrashDetailPluralization() {
+        XCTAssertEqual(DeleteTargetLogic.emptyTrashDetail(itemCount: 1), "1 item — deleted permanently")
+        XCTAssertEqual(DeleteTargetLogic.emptyTrashDetail(itemCount: 7), "7 items — deleted permanently")
     }
 
     // MARK: - resultMessage

--- a/apps/macos/LauncherApp/LauncherLogicTests/DeleteTargetLogicTests.swift
+++ b/apps/macos/LauncherApp/LauncherLogicTests/DeleteTargetLogicTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+@testable import LauncherLogic
+
+final class DeleteTargetLogicTests: XCTestCase {
+    private func result(_ id: String, _ kind: LauncherResultKind, path: String) -> LauncherResult {
+        LauncherResult(id: id, kind: kind, title: id, subtitle: nil, path: path, score: 0)
+    }
+
+    // MARK: - eligible(from:fileExists:)
+
+    func testKeepsFilesAndFoldersThatExist() {
+        let input = [
+            result("a", .file, path: "/tmp/a.txt"),
+            result("b", .folder, path: "/tmp/dir"),
+        ]
+        let eligible = DeleteTargetLogic.eligible(from: input, fileExists: { _ in true })
+        XCTAssertEqual(eligible.map(\.id), ["a", "b"])
+    }
+
+    func testDropsAppsAndClipboard() {
+        let input = [
+            result("app", .app, path: "/Applications/Foo.app"),
+            result("clip", .clipboard, path: "clipboard://1"),
+            result("file", .file, path: "/tmp/keep.txt"),
+        ]
+        let eligible = DeleteTargetLogic.eligible(from: input, fileExists: { _ in true })
+        XCTAssertEqual(eligible.map(\.id), ["file"])
+    }
+
+    func testDropsURLSchemePaths() {
+        let input = [
+            result("settings", .file, path: "x-apple.systempreferences:com.apple.preference"),
+            result("real", .file, path: "/Users/me/doc.pdf"),
+        ]
+        let eligible = DeleteTargetLogic.eligible(from: input, fileExists: { _ in true })
+        XCTAssertEqual(eligible.map(\.id), ["real"])
+    }
+
+    func testDropsNonExistentPaths() {
+        let input = [
+            result("gone", .file, path: "/tmp/gone.txt"),
+            result("here", .file, path: "/tmp/here.txt"),
+        ]
+        let eligible = DeleteTargetLogic.eligible(from: input, fileExists: { $0 == "/tmp/here.txt" })
+        XCTAssertEqual(eligible.map(\.id), ["here"])
+    }
+
+    // MARK: - confirmTitle
+
+    func testConfirmTitleSingularNamesItem() {
+        XCTAssertEqual(
+            DeleteTargetLogic.confirmTitle(displayNames: ["report.pdf"]),
+            "Move \"report.pdf\" to Trash?"
+        )
+    }
+
+    func testConfirmTitlePluralShowsCount() {
+        XCTAssertEqual(
+            DeleteTargetLogic.confirmTitle(displayNames: ["a", "b", "c"]),
+            "Move 3 items to Trash?"
+        )
+    }
+
+    // MARK: - confirmDetail
+
+    func testConfirmDetailSingleShowsPath() {
+        XCTAssertEqual(
+            DeleteTargetLogic.confirmDetail(fileCount: 1, folderCount: 0, singlePath: "/tmp/a.txt"),
+            "/tmp/a.txt"
+        )
+    }
+
+    func testConfirmDetailPluralCountsFilesAndFolders() {
+        XCTAssertEqual(
+            DeleteTargetLogic.confirmDetail(fileCount: 2, folderCount: 1, singlePath: nil),
+            "2 files, 1 folder"
+        )
+    }
+
+    func testConfirmDetailOmitsZeroCategory() {
+        XCTAssertEqual(
+            DeleteTargetLogic.confirmDetail(fileCount: 0, folderCount: 3, singlePath: nil),
+            "3 folders"
+        )
+    }
+
+    // MARK: - resultMessage
+
+    func testResultMessageAllSucceeded() {
+        let (text, isError) = DeleteTargetLogic.resultMessage(trashedCount: 3, failureCount: 0, firstFailure: nil)
+        XCTAssertEqual(text, "Moved 3 to Trash")
+        XCTAssertFalse(isError)
+    }
+
+    func testResultMessageAllFailed() {
+        let (text, isError) = DeleteTargetLogic.resultMessage(
+            trashedCount: 0,
+            failureCount: 1,
+            firstFailure: (name: "locked.txt", reason: "permission denied")
+        )
+        XCTAssertEqual(text, "Failed to trash locked.txt: permission denied")
+        XCTAssertTrue(isError)
+    }
+
+    func testResultMessagePartialFailure() {
+        let (text, isError) = DeleteTargetLogic.resultMessage(
+            trashedCount: 2,
+            failureCount: 1,
+            firstFailure: (name: "x", reason: "y")
+        )
+        XCTAssertEqual(text, "Moved 2, 1 failed")
+        XCTAssertTrue(isError)
+    }
+}

--- a/apps/macos/LauncherApp/Package.swift
+++ b/apps/macos/LauncherApp/Package.swift
@@ -17,10 +17,11 @@ let package = Package(
                 "Support/Launcher/HintText.swift",
                 "Support/AppConstants.swift",
                 "Support/Launcher/LauncherSearchLogic.swift",
+                "Support/Launcher/DeleteTargetLogic.swift",
                 "Support/Launcher/BridgeErrorMapping.swift",
                 "Support/SingleInstanceLock.swift",
                 "Models/LauncherResult.swift",
-                "Views/CalcCommand.swift",
+                "Views/Commands/CalcCommand.swift",
             ]
         ),
         .testTarget(

--- a/apps/macos/LauncherApp/look-app.xcodeproj/project.pbxproj
+++ b/apps/macos/LauncherApp/look-app.xcodeproj/project.pbxproj
@@ -289,6 +289,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = Look;
 				INFOPLIST_KEY_CFBundleIconFile = AppIcon;
 				INFOPLIST_KEY_LSMultipleInstancesProhibited = NO;
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Look uses Finder to empty the Trash and read how many items it contains.";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				OTHER_LDFLAGS = (
@@ -329,6 +330,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = Look;
 				INFOPLIST_KEY_CFBundleIconFile = AppIcon;
 				INFOPLIST_KEY_LSMultipleInstancesProhibited = NO;
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Look uses Finder to empty the Trash and read how many items it contains.";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				OTHER_LDFLAGS = (

--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -28,6 +28,7 @@ struct AppCommand: Identifiable {
 struct QuickFolderDefinition {
     let title: String
     let relativePath: String
+    var subtitle: String? = nil
 }
 
 enum AppConstants {
@@ -74,6 +75,9 @@ enum AppConstants {
                 // the user sees in Finder/Explorer pins it.
                 QuickFolderDefinition(title: "Movies", relativePath: "Movies"),
                 QuickFolderDefinition(title: "Music", relativePath: "Music"),
+                // ~/.Trash is a real directory, so it opens in Finder like any
+                // other quick folder. Typing "trash" pins it; ⌘D empties it.
+                QuickFolderDefinition(title: "Trash", relativePath: ".Trash", subtitle: "Pinned · ⌘D to empty"),
             ]
         }
 

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/DeleteTargetLogic.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/DeleteTargetLogic.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Pure logic for the "delete file/folder to Trash" feature, kept free of
+/// AppKit/SwiftUI so it can be unit-tested in the LauncherLogic package.
+///
+/// The View layer (`DeleteCommand` / `LauncherView`) handles the actual
+/// `NSWorkspace.recycle` call, icons, and state; everything here is data-in /
+/// data-out so it's deterministic under test.
+enum DeleteTargetLogic {
+    /// Filters a set of candidate results down to those that can be trashed:
+    /// only `.file`/`.folder` kinds, excluding URL-scheme "paths" (settings
+    /// panes, custom schemes) and anything no longer present on disk.
+    ///
+    /// `fileExists` is injected so tests don't need a real filesystem.
+    static func eligible(
+        from results: [LauncherResult],
+        fileExists: (String) -> Bool
+    ) -> [LauncherResult] {
+        results.filter { result in
+            guard result.kind == .file || result.kind == .folder else { return false }
+            if isURLScheme(result.path) { return false }
+            return fileExists(result.path)
+        }
+    }
+
+    /// URL-scheme targets contain a ":" and don't start at the filesystem root.
+    static func isURLScheme(_ path: String) -> Bool {
+        path.contains(":") && !path.hasPrefix("/")
+    }
+
+    /// Title for the confirmation banner. Singular names the item; plural shows
+    /// a count so a large basket can't be trashed on a reflexive "Y".
+    static func confirmTitle(displayNames: [String]) -> String {
+        if displayNames.count == 1 {
+            return "Move \"\(displayNames[0])\" to Trash?"
+        }
+        return "Move \(displayNames.count) items to Trash?"
+    }
+
+    /// Detail line: the path for a single item, otherwise a file/folder count.
+    static func confirmDetail(fileCount: Int, folderCount: Int, singlePath: String?) -> String {
+        if let singlePath, fileCount + folderCount == 1 {
+            return singlePath
+        }
+        var parts: [String] = []
+        if fileCount > 0 { parts.append("\(fileCount) file\(fileCount == 1 ? "" : "s")") }
+        if folderCount > 0 { parts.append("\(folderCount) folder\(folderCount == 1 ? "" : "s")") }
+        return parts.joined(separator: ", ")
+    }
+
+    /// Banner text + error flag summarizing a trash outcome.
+    static func resultMessage(trashedCount: Int, failureCount: Int, firstFailure: (name: String, reason: String)?) -> (text: String, isError: Bool) {
+        if failureCount == 0 {
+            return ("Moved \(trashedCount) to Trash", false)
+        }
+        if trashedCount == 0 {
+            let f = firstFailure
+            return ("Failed to trash \(f?.name ?? "item"): \(f?.reason ?? "unknown error")", true)
+        }
+        return ("Moved \(trashedCount), \(failureCount) failed", true)
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/DeleteTargetLogic.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/DeleteTargetLogic.swift
@@ -14,11 +14,13 @@ enum DeleteTargetLogic {
     /// `fileExists` is injected so tests don't need a real filesystem.
     static func eligible(
         from results: [LauncherResult],
-        fileExists: (String) -> Bool
+        fileExists: (String) -> Bool,
+        homeDirectory: String = NSHomeDirectory()
     ) -> [LauncherResult] {
         results.filter { result in
             guard result.kind == .file || result.kind == .folder else { return false }
             if isURLScheme(result.path) { return false }
+            if isProtected(result.path, homeDirectory: homeDirectory) { return false }
             return fileExists(result.path)
         }
     }
@@ -28,24 +30,32 @@ enum DeleteTargetLogic {
         path.contains(":") && !path.hasPrefix("/")
     }
 
-    /// Title for the confirmation banner. Singular names the item; plural shows
-    /// a count so a large basket can't be trashed on a reflexive "Y".
-    static func confirmTitle(displayNames: [String]) -> String {
-        if displayNames.count == 1 {
-            return "Move \"\(displayNames[0])\" to Trash?"
-        }
-        return "Move \(displayNames.count) items to Trash?"
+    /// Refuses to trash catastrophic targets: the filesystem root, the home
+    /// directory itself, and the Trash. (Trash is now a pinned quick folder, so
+    /// Cmd+D on it would otherwise try to recycle ~/.Trash into itself.)
+    static func isProtected(_ path: String, homeDirectory: String) -> Bool {
+        let p = normalize(path)
+        if p.isEmpty || p == "/" { return true }
+        if p == normalize(homeDirectory) { return true }
+        if isTrashPath(path, homeDirectory: homeDirectory) { return true }
+        return false
     }
 
-    /// Detail line: the path for a single item, otherwise a file/folder count.
-    static func confirmDetail(fileCount: Int, folderCount: Int, singlePath: String?) -> String {
-        if let singlePath, fileCount + folderCount == 1 {
-            return singlePath
-        }
-        var parts: [String] = []
-        if fileCount > 0 { parts.append("\(fileCount) file\(fileCount == 1 ? "" : "s")") }
-        if folderCount > 0 { parts.append("\(folderCount) folder\(folderCount == 1 ? "" : "s")") }
-        return parts.joined(separator: ", ")
+    /// True when `path` is the user's Trash (`~/.Trash`). Used both to protect
+    /// it from being trashed and to route Cmd+D on it to "Empty Trash".
+    static func isTrashPath(_ path: String, homeDirectory: String) -> Bool {
+        normalize(path) == normalize(homeDirectory) + "/.Trash"
+    }
+
+    /// Detail line for the Empty Trash confirmation, stressing permanence.
+    static func emptyTrashDetail(itemCount: Int) -> String {
+        "\(itemCount) item\(itemCount == 1 ? "" : "s") — deleted permanently"
+    }
+
+    private static func normalize(_ path: String) -> String {
+        var p = path
+        while p.count > 1 && p.hasSuffix("/") { p.removeLast() }
+        return p
     }
 
     /// Banner text + error flag summarizing a trash outcome.

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
@@ -38,7 +38,11 @@ final class KeyboardSelectionMonitor {
         onActivateRunningApp: @escaping @MainActor (Int) -> Bool = { _ in false },
         onConfirmKill: (@MainActor () -> Void)? = nil,
         onCancelKill: (@MainActor () -> Void)? = nil,
-        killConfirmationActive: @escaping @MainActor () -> Bool = { false }
+        killConfirmationActive: @escaping @MainActor () -> Bool = { false },
+        onRequestDelete: (@MainActor () -> Void)? = nil,
+        onConfirmDelete: (@MainActor () -> Void)? = nil,
+        onCancelDelete: (@MainActor () -> Void)? = nil,
+        deleteConfirmationActive: @escaping @MainActor () -> Bool = { false }
     ) {
         guard monitor == nil else { return }
         self.isKillConfirmationActive = killConfirmationActive
@@ -115,6 +119,17 @@ final class KeyboardSelectionMonitor {
                 return nil
             }
 
+            // Cmd+D (keyCode 2) → trash the selection. Only in result mode; in
+            // command mode it falls through so it keeps any text-editing meaning
+            // in the command input.
+            if (event.keyCode == 2 || event.charactersIgnoringModifiers?.lowercased() == "d")
+                && flags == [.command]
+                && !inCommandMode()
+            {
+                onRequestDelete?()
+                return nil
+            }
+
             if event.modifierFlags.contains(.command) && !event.modifierFlags.contains(.control) && !event.modifierFlags.contains(.option) {
                 // macOS digit keyCodes are not contiguous: 1=18, 2=19, 3=20, 4=21, 5=23, 6=22, 7=26, 8=28, 9=25.
                 let cmdNumberKey: Int?
@@ -168,6 +183,11 @@ final class KeyboardSelectionMonitor {
                     return nil
                 }
 
+                if deleteConfirmationActive() {
+                    onCancelDelete?()
+                    return nil
+                }
+
                 if inCommandMode() {
                     if flags.contains(.shift) {
                         onHideLauncher()
@@ -188,6 +208,24 @@ final class KeyboardSelectionMonitor {
                 }
                 if char == "n" {
                     onCancelKill?()
+                    return nil
+                }
+            }
+
+            if deleteConfirmationActive() {
+                // Enter confirms too — and must be swallowed so it doesn't fall
+                // through to handleSubmit and *open* the file being deleted.
+                if event.keyCode == 36 || event.keyCode == 76 {
+                    onConfirmDelete?()
+                    return nil
+                }
+                let char = event.charactersIgnoringModifiers?.lowercased()
+                if char == "y" {
+                    onConfirmDelete?()
+                    return nil
+                }
+                if char == "n" {
+                    onCancelDelete?()
                     return nil
                 }
             }

--- a/apps/macos/LauncherApp/look-app/Views/Commands/DeleteCommand.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/DeleteCommand.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CoreServices
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -60,27 +61,87 @@ struct DeleteCommand {
     }
 }
 
-struct DeleteConfirmationBar: View {
-    let targets: [DeleteCommand.Target]
+/// Empties the macOS Trash via Finder. `~/.Trash` is TCC-protected, so Look
+/// can't enumerate/remove it directly without Full Disk Access — but Finder
+/// already has the rights, so we drive it through AppleScript (which only needs
+/// a one-time Automation permission). Irreversible, hence the confirm banner.
+struct EmptyTrashCommand {
+    /// Whether Look already has permission to automate Finder — checked WITHOUT
+    /// prompting, so merely previewing the Trash doesn't pop a TCC dialog.
+    @MainActor
+    static func isAutomationAllowed() -> Bool {
+        let target = NSAppleEventDescriptor(bundleIdentifier: "com.apple.finder")
+        guard let desc = target.aeDesc else { return false }
+        return AEDeterminePermissionToAutomateTarget(desc, typeWildCard, typeWildCard, false) == noErr
+    }
+
+    /// Number of items in the Trash, via Finder. Returns nil if Finder
+    /// automation is unavailable/denied. Pass `promptIfNeeded: false` from
+    /// passive contexts (preview) so it never triggers a permission prompt.
+    @MainActor
+    static func itemCount(promptIfNeeded: Bool = true) -> Int? {
+        if !promptIfNeeded && !isAutomationAllowed() { return nil }
+        let (result, error) = runFinder("return count of (items of the trash)")
+        if error != nil { return nil }
+        return result.flatMap { Int(exactly: $0.int32Value) }
+    }
+
+    /// Empties the Trash via Finder, off the main thread (it can take seconds on
+    /// a large Trash). Delivers an error message on failure, nil on success, on
+    /// the main queue. Suppresses Finder's own "are you sure" (we show our own
+    /// confirm) and restores the user's preference afterward — the restore is
+    /// isolated so it can't turn a successful empty into a reported failure.
+    static func empty(completion: @escaping (String?) -> Void) {
+        let body = """
+        set prevWarn to warns before emptying of the trash
+        set warns before emptying of the trash to false
+        set emptyErr to missing value
+        try
+            empty the trash
+        on error errMsg
+            set emptyErr to errMsg
+        end try
+        try
+            set warns before emptying of the trash to prevWarn
+        end try
+        if emptyErr is not missing value then error emptyErr
+        """
+        DispatchQueue.global(qos: .userInitiated).async {
+            let error = runFinder(body).1
+            DispatchQueue.main.async { completion(error) }
+        }
+    }
+
+    nonisolated private static func runFinder(_ body: String) -> (NSAppleEventDescriptor?, String?) {
+        let source = "tell application \"Finder\"\n\(body)\nend tell"
+        guard let script = NSAppleScript(source: source) else {
+            return (nil, "Could not build Finder script")
+        }
+        var errorInfo: NSDictionary?
+        let result = script.executeAndReturnError(&errorInfo)
+        if let errorInfo {
+            let code = (errorInfo[NSAppleScript.errorNumber] as? Int) ?? 0
+            // -1743 = user has not granted (or has denied) Automation permission.
+            if code == -1743 {
+                return (nil, "Allow Look to control Finder in System Settings ▸ Privacy ▸ Automation")
+            }
+            let msg = (errorInfo[NSAppleScript.errorMessage] as? String) ?? "Finder automation failed"
+            return (nil, msg)
+        }
+        return (result, nil)
+    }
+}
+
+/// Shared chrome for the destructive confirm banners (delete-to-Trash and
+/// empty-Trash). Opaque backing so it reads over the results list; danger-tinted
+/// border + shadow mark it as a destructive prompt.
+struct ConfirmActionBar: View {
+    let icon: NSImage
+    let title: String
+    let detail: String
     let themeStore: ThemeStore
     let onConfirm: () -> Void
     let onCancel: () -> Void
-
-    private var title: String {
-        DeleteTargetLogic.confirmTitle(displayNames: targets.map(\.displayName))
-    }
-
-    private var detail: String {
-        DeleteTargetLogic.confirmDetail(
-            fileCount: targets.filter { $0.kind == .file }.count,
-            folderCount: targets.filter { $0.kind == .folder }.count,
-            singlePath: targets.count == 1 ? targets[0].path : nil
-        )
-    }
-
-    private var icon: NSImage {
-        targets.first?.icon ?? NSWorkspace.shared.icon(for: .folder)
-    }
 
     var body: some View {
         HStack(spacing: 12) {
@@ -122,11 +183,6 @@ struct DeleteConfirmationBar: View {
             .buttonStyle(.plain)
         }
         .padding(10)
-        // This bar overlays the results list (unlike the kill bar, which floats
-        // over empty command-mode space), so it needs an opaque backing or the
-        // list bleeds through and the text becomes unreadable. A thick material
-        // obscures content behind; the danger-tinted border + shadow mark it as
-        // a destructive prompt and lift it off the list.
         .background(.ultraThickMaterial, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
         .background(themeStore.controlFillColor(), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
         .overlay(
@@ -134,5 +190,23 @@ struct DeleteConfirmationBar: View {
                 .strokeBorder(themeStore.dangerColor().opacity(0.85), lineWidth: 1)
         )
         .shadow(color: .black.opacity(0.35), radius: 12, y: 4)
+    }
+}
+
+struct EmptyTrashConfirmationBar: View {
+    let itemCount: Int
+    let themeStore: ThemeStore
+    let onConfirm: () -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        ConfirmActionBar(
+            icon: NSImage(named: NSImage.trashFullName) ?? NSWorkspace.shared.icon(for: .folder),
+            title: "Empty Trash?",
+            detail: DeleteTargetLogic.emptyTrashDetail(itemCount: itemCount),
+            themeStore: themeStore,
+            onConfirm: onConfirm,
+            onCancel: onCancel
+        )
     }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Commands/DeleteCommand.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/DeleteCommand.swift
@@ -1,0 +1,138 @@
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// Trash-deletion of file/folder results, mirroring the Kill command's
+/// confirm-then-act UX. Filtering and wording live in `DeleteTargetLogic`
+/// (pure, unit-tested); this file owns the AppKit side: icons, the actual
+/// `NSWorkspace.recycle` call, and the SwiftUI confirmation bar.
+struct DeleteCommand {
+    struct Target: Identifiable {
+        let id: String
+        let displayName: String
+        let path: String
+        let kind: LauncherResultKind
+        let icon: NSImage?
+    }
+
+    struct Outcome {
+        let trashedIDs: [String]
+        let failures: [(id: String, name: String, reason: String)]
+
+        var trashedCount: Int { trashedIDs.count }
+        var firstFailure: (name: String, reason: String)? {
+            failures.first.map { ($0.name, $0.reason) }
+        }
+    }
+
+    /// Moves each target to the macOS Trash via `NSWorkspace.recycle`, reporting
+    /// per-item success/failure so a partial failure is attributable. Recycle's
+    /// completion fires on a background thread, so accumulation is lock-guarded;
+    /// the final `Outcome` is delivered on the main queue.
+    static func trash(_ targets: [Target], completion: @escaping (Outcome) -> Void) {
+        guard !targets.isEmpty else {
+            completion(Outcome(trashedIDs: [], failures: []))
+            return
+        }
+
+        let lock = NSLock()
+        var trashedIDs: [String] = []
+        var failures: [(id: String, name: String, reason: String)] = []
+        let group = DispatchGroup()
+
+        for target in targets {
+            group.enter()
+            NSWorkspace.shared.recycle([URL(fileURLWithPath: target.path)]) { _, error in
+                lock.lock()
+                if let error {
+                    failures.append((target.id, target.displayName, error.localizedDescription))
+                } else {
+                    trashedIDs.append(target.id)
+                }
+                lock.unlock()
+                group.leave()
+            }
+        }
+
+        group.notify(queue: .main) {
+            completion(Outcome(trashedIDs: trashedIDs, failures: failures))
+        }
+    }
+}
+
+struct DeleteConfirmationBar: View {
+    let targets: [DeleteCommand.Target]
+    let themeStore: ThemeStore
+    let onConfirm: () -> Void
+    let onCancel: () -> Void
+
+    private var title: String {
+        DeleteTargetLogic.confirmTitle(displayNames: targets.map(\.displayName))
+    }
+
+    private var detail: String {
+        DeleteTargetLogic.confirmDetail(
+            fileCount: targets.filter { $0.kind == .file }.count,
+            folderCount: targets.filter { $0.kind == .folder }.count,
+            singlePath: targets.count == 1 ? targets[0].path : nil
+        )
+    }
+
+    private var icon: NSImage {
+        targets.first?.icon ?? NSWorkspace.shared.icon(for: .folder)
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(nsImage: icon)
+                .resizable()
+                .frame(width: 24, height: 24)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize), weight: .semibold))
+                    .foregroundStyle(themeStore.fontColor())
+                Text(detail)
+                    .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular))
+                    .foregroundStyle(themeStore.mutedTextColor())
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer()
+            Button {
+                onConfirm()
+            } label: {
+                Text("Y / Yes")
+                    .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .medium))
+                    .foregroundStyle(themeStore.onDangerColor())
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(themeStore.dangerColor(), in: Capsule())
+            }
+            .buttonStyle(.plain)
+            Button {
+                onCancel()
+            } label: {
+                Text("N / No")
+                    .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .medium))
+                    .foregroundStyle(themeStore.fontColor())
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(themeStore.controlFillColor(), in: Capsule())
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(10)
+        // This bar overlays the results list (unlike the kill bar, which floats
+        // over empty command-mode space), so it needs an opaque backing or the
+        // list bleeds through and the text becomes unreadable. A thick material
+        // obscures content behind; the danger-tinted border + shadow mark it as
+        // a destructive prompt and lift it off the list.
+        .background(.ultraThickMaterial, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .background(themeStore.controlFillColor(), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .strokeBorder(themeStore.dangerColor().opacity(0.85), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.35), radius: 12, y: 4)
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/FolderPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/FolderPreviewView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct FolderPreviewView: View {
     @EnvironmentObject private var themeStore: ThemeStore
@@ -96,5 +97,50 @@ struct FolderPreviewView: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
         .onTapGesture { open(entry) }
+    }
+}
+
+/// Finder-backed summary shown in place of a normal folder listing for the
+/// Trash quick folder, which is TCC-protected and can't be enumerated directly.
+/// `itemCount` is nil until Finder automation is granted (we never prompt just
+/// to preview), so the card stays informative without demanding permission.
+struct TrashSummaryView: View {
+    let itemCount: Int?
+    let themeStore: ThemeStore
+
+    private var trashIcon: NSImage {
+        NSImage(named: NSImage.trashFullName)
+            ?? NSWorkspace.shared.icon(for: .folder)
+    }
+
+    private var headline: String {
+        switch itemCount {
+        case .none: return "Open in Finder to view contents"
+        case .some(0): return "Trash is empty"
+        case .some(let count): return "\(count) item\(count == 1 ? "" : "s") in Trash"
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 12) {
+                Image(nsImage: trashIcon)
+                    .resizable()
+                    .frame(width: 28, height: 28)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(headline)
+                        .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .medium))
+                        .foregroundStyle(themeStore.fontColor())
+                    Text("⌘D empties the Trash")
+                        .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular))
+                        .foregroundStyle(themeStore.mutedTextColor())
+                }
+                Spacer()
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(themeStore.controlFillColor().opacity(0.4), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
     }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
@@ -106,7 +106,7 @@ extension LauncherView {
     }
 
     private func isURLScheme(_ target: String) -> Bool {
-        target.contains(":") && !target.hasPrefix("/")
+        DeleteTargetLogic.isURLScheme(target)
     }
 
     private func recordOpen(_ selected: LauncherResult, action: String) {
@@ -314,34 +314,80 @@ extension LauncherView {
             }
     }
 
-    /// Cmd+Delete entry point: builds targets and raises the confirm banner.
+    /// Cmd+D entry point. Files/folders move to Trash immediately (recoverable,
+    /// no confirmation — like Finder's Cmd+Delete). When the single selection is
+    /// the Trash quick folder, routes to Empty Trash, which DOES confirm because
+    /// it's permanent.
     func requestDeleteSelection() {
         guard !isCommandMode, !appUIState.showsThemeSettings, !showsHelpScreen else { return }
-        // Don't stack a second confirmation while one is pending / in flight.
-        guard pendingDeleteTargets.isEmpty else { return }
+        // Don't stack an Empty Trash confirmation, nor start work while a
+        // previous trash/empty is still running (recycle / Finder are async).
+        guard pendingEmptyTrashCount == nil, !isDeleteInFlight else { return }
+
+        // Cmd+D on the pinned Trash folder empties it rather than trashing it.
+        if pickedKeys.isEmpty,
+           let selectedResultID,
+           let selected = displayedResults.first(where: { $0.id == selectedResultID }),
+           selected.kind == .folder,
+           DeleteTargetLogic.isTrashPath(selected.path, homeDirectory: NSHomeDirectory()) {
+            // Count comes from Finder (TCC blocks reading ~/.Trash directly);
+            // this is the right moment to prompt for Automation permission.
+            guard let count = EmptyTrashCommand.itemCount() else {
+                showBanner(
+                    "Allow Look to control Finder in System Settings ▸ Privacy ▸ Automation to empty the Trash",
+                    style: .error,
+                    duration: 2.8
+                )
+                return
+            }
+            guard count > 0 else {
+                showBanner("Trash is already empty", style: .info, duration: 1.2)
+                return
+            }
+            pendingEmptyTrashCount = count
+            return
+        }
 
         let targets = eligibleDeleteTargets()
         guard !targets.isEmpty else {
             showBanner("Select a file or folder to delete", style: .info, duration: 1.2)
             return
         }
-        pendingDeleteTargets = targets
+        // Recoverable — trash straight away, no confirmation.
+        runDeleteCommand(targets: targets)
     }
 
+    /// Confirm/cancel only apply to the permanent Empty Trash prompt now.
     func confirmDeleteSelection() {
-        guard !pendingDeleteTargets.isEmpty else { return }
-        runDeleteCommand(targets: pendingDeleteTargets)
-        pendingDeleteTargets = []
+        guard pendingEmptyTrashCount != nil else { return }
+        pendingEmptyTrashCount = nil
+        runEmptyTrash()
     }
 
     func cancelDeleteSelection() {
-        pendingDeleteTargets = []
+        pendingEmptyTrashCount = nil
+    }
+
+    private func runEmptyTrash() {
+        isDeleteInFlight = true
+        // Finder's "empty the trash" can take seconds on a large Trash; run it
+        // off the main thread so the launcher window stays responsive.
+        EmptyTrashCommand.empty { [self] error in
+            isDeleteInFlight = false
+            if let error {
+                showBanner(error, style: .error, duration: 2.6)
+            } else {
+                showBanner("Emptied Trash", style: .success, duration: 1.6)
+            }
+        }
     }
 
     private func runDeleteCommand(targets: [DeleteCommand.Target]) {
         let targetsByID = Dictionary(targets.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
 
+        isDeleteInFlight = true
         DeleteCommand.trash(targets) { [self] outcome in
+            isDeleteInFlight = false
             let trashed = Set(outcome.trashedIDs)
 
             // Drop trashed items from the picked basket.

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
@@ -405,9 +405,14 @@ extension LauncherView {
                 writePickedToPasteboard()
             }
 
-            // Move selection off any row that was trashed.
-            if let selectedResultID, trashed.contains(selectedResultID) {
-                self.selectedResultID = displayedResults.first(where: { !trashed.contains($0.id) })?.id
+            // Drop the trashed rows from the on-screen results immediately — the
+            // background index refresh below is async and would otherwise leave
+            // the now-gone items visible (and un-previewable) until the next search.
+            backendResults.removeAll { trashed.contains($0.id) }
+
+            // Keep selection valid if it pointed at a now-removed row.
+            if let selectedResultID, !displayedResults.contains(where: { $0.id == selectedResultID }) {
+                self.selectedResultID = displayedResults.first?.id
             }
 
             let message = DeleteTargetLogic.resultMessage(

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
@@ -284,6 +284,97 @@ extension LauncherView {
         )
     }
 
+    // MARK: - Delete to Trash
+
+    /// File/folder targets the delete action should act on: the picked basket
+    /// when non-empty, otherwise the single selected result. Non-deletable
+    /// kinds, URL-scheme paths, and items gone from disk are filtered out by
+    /// `DeleteTargetLogic.eligible`.
+    func eligibleDeleteTargets() -> [DeleteCommand.Target] {
+        let candidates: [LauncherResult]
+        if !pickedKeys.isEmpty {
+            candidates = pickedKeys.compactMap { pickedResultsByKey[$0] }
+        } else if let selectedResultID,
+                  let selected = displayedResults.first(where: { $0.id == selectedResultID }) {
+            candidates = [selected]
+        } else {
+            candidates = []
+        }
+
+        return DeleteTargetLogic
+            .eligible(from: candidates, fileExists: { FileManager.default.fileExists(atPath: $0) })
+            .map { result in
+                DeleteCommand.Target(
+                    id: result.id,
+                    displayName: result.title,
+                    path: result.path,
+                    kind: result.kind,
+                    icon: NSWorkspace.shared.icon(forFile: result.path)
+                )
+            }
+    }
+
+    /// Cmd+Delete entry point: builds targets and raises the confirm banner.
+    func requestDeleteSelection() {
+        guard !isCommandMode, !appUIState.showsThemeSettings, !showsHelpScreen else { return }
+        // Don't stack a second confirmation while one is pending / in flight.
+        guard pendingDeleteTargets.isEmpty else { return }
+
+        let targets = eligibleDeleteTargets()
+        guard !targets.isEmpty else {
+            showBanner("Select a file or folder to delete", style: .info, duration: 1.2)
+            return
+        }
+        pendingDeleteTargets = targets
+    }
+
+    func confirmDeleteSelection() {
+        guard !pendingDeleteTargets.isEmpty else { return }
+        runDeleteCommand(targets: pendingDeleteTargets)
+        pendingDeleteTargets = []
+    }
+
+    func cancelDeleteSelection() {
+        pendingDeleteTargets = []
+    }
+
+    private func runDeleteCommand(targets: [DeleteCommand.Target]) {
+        let targetsByID = Dictionary(targets.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+
+        DeleteCommand.trash(targets) { [self] outcome in
+            let trashed = Set(outcome.trashedIDs)
+
+            // Drop trashed items from the picked basket.
+            for id in outcome.trashedIDs {
+                guard let target = targetsByID[id] else { continue }
+                let key = "\(target.kind.rawValue)|\(target.path)"
+                if let idx = pickedKeys.firstIndex(of: key) {
+                    pickedKeys.remove(at: idx)
+                    pickedResultsByKey.removeValue(forKey: key)
+                }
+            }
+            if pickedKeys.isEmpty {
+                NSPasteboard.general.clearContents()
+            } else {
+                writePickedToPasteboard()
+            }
+
+            // Move selection off any row that was trashed.
+            if let selectedResultID, trashed.contains(selectedResultID) {
+                self.selectedResultID = displayedResults.first(where: { !trashed.contains($0.id) })?.id
+            }
+
+            let message = DeleteTargetLogic.resultMessage(
+                trashedCount: outcome.trashedCount,
+                failureCount: outcome.failures.count,
+                firstFailure: outcome.firstFailure
+            )
+            showBanner(message.text, style: message.isError ? .error : .success, duration: message.isError ? 2.0 : 1.4)
+
+            _ = bridge.requestIndexRefresh()
+        }
+    }
+
     func refreshClipboardSelectionIfNeeded() {
         guard !isCommandMode, isClipboardQuery else { return }
 

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
@@ -207,6 +207,18 @@ extension LauncherView {
             },
             killConfirmationActive: { [self] in
                 pendingKillCandidate != nil
+            },
+            onRequestDelete: { [self] in
+                requestDeleteSelection()
+            },
+            onConfirmDelete: { [self] in
+                confirmDeleteSelection()
+            },
+            onCancelDelete: { [self] in
+                cancelDeleteSelection()
+            },
+            deleteConfirmationActive: { [self] in
+                !pendingDeleteTargets.isEmpty
             }
         )
     }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
@@ -218,7 +218,7 @@ extension LauncherView {
                 cancelDeleteSelection()
             },
             deleteConfirmationActive: { [self] in
-                !pendingDeleteTargets.isEmpty
+                pendingEmptyTrashCount != nil
             }
         )
     }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+WindowControl.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+WindowControl.swift
@@ -155,8 +155,8 @@ extension LauncherView {
         }
         focusRequestToken &+= 1
         isQueryFocused = false
-        // Don't leave a stale delete confirmation to reappear on next show.
-        pendingDeleteTargets = []
+        // Don't leave a stale Empty Trash confirmation to reappear on next show.
+        pendingEmptyTrashCount = nil
         let wasVisible = window.isVisible
         window.orderOut(nil)
         hotkeyLog.notice("hide: orderOut wasVisible=\(wasVisible) restore=\(restorePreviousApp)")

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+WindowControl.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+WindowControl.swift
@@ -155,6 +155,8 @@ extension LauncherView {
         }
         focusRequestToken &+= 1
         isQueryFocused = false
+        // Don't leave a stale delete confirmation to reappear on next show.
+        pendingDeleteTargets = []
         let wasVisible = window.isVisible
         window.orderOut(nil)
         hotkeyLog.notice("hide: orderOut wasVisible=\(wasVisible) restore=\(restorePreviousApp)")

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -59,7 +59,12 @@ struct LauncherView: View {
     @State var lookupPreviewTask: Task<Void, Never>?
     @State var selectedKillSuggestionIndex: Int?
     @State var pendingKillCandidate: KillCommand.Candidate?
-    @State var pendingDeleteTargets: [DeleteCommand.Target] = []
+    // nil == no empty-Trash confirmation pending; otherwise the item count to show.
+    // (Moving files/folders to Trash is recoverable, so it skips confirmation;
+    // only the permanent Empty Trash prompts.)
+    @State var pendingEmptyTrashCount: Int?
+    // True while a trash/empty operation is running, to block re-triggering it.
+    @State var isDeleteInFlight = false
     @State var killListRefreshTick: Int = 0
     @State var recentlyKilledPIDs: Set<Int32> = []
     @State var showsHelpScreen = false
@@ -201,7 +206,7 @@ struct LauncherView: View {
                 id: "\(AppConstants.Launcher.QuickFolder.idPrefix)\(normalizedTitle)",
                 kind: .folder,
                 title: entry.title,
-                subtitle: AppConstants.Launcher.QuickFolder.pinnedSubtitle,
+                subtitle: entry.subtitle ?? AppConstants.Launcher.QuickFolder.pinnedSubtitle,
                 path: folderPath,
                 score: AppConstants.Launcher.Finder.pinnedScore
             )
@@ -378,7 +383,7 @@ struct LauncherView: View {
     }
 
     var isDeleteConfirmationVisible: Bool {
-        !isCommandMode && !pendingDeleteTargets.isEmpty
+        !isCommandMode && pendingEmptyTrashCount != nil
     }
 
     var liveCommandPreview: String? {
@@ -449,10 +454,10 @@ struct LauncherView: View {
             clipboardStore.setMonitoringMode(.background)
         }
         .onChange(of: query) { _, _ in
-            // Editing the query dismisses a pending delete confirmation, mirroring
-            // how the kill command clears its pending candidate on input change.
-            if !pendingDeleteTargets.isEmpty {
-                pendingDeleteTargets = []
+            // Editing the query dismisses a pending Empty Trash confirmation,
+            // mirroring how the kill command clears its pending candidate.
+            if pendingEmptyTrashCount != nil {
+                pendingEmptyTrashCount = nil
             }
             if !isCommandMode, let cmd = extractInlineCommand(from: query), cmd.hasSpace {
                 enterCommandMode(commandID: cmd.id, prefilledInput: cmd.args)
@@ -785,9 +790,9 @@ struct LauncherView: View {
 
     @ViewBuilder
     private var deleteConfirmationOverlay: some View {
-        if !isCommandMode, !pendingDeleteTargets.isEmpty {
-            DeleteConfirmationBar(
-                targets: pendingDeleteTargets,
+        if !isCommandMode, let pendingEmptyTrashCount {
+            EmptyTrashConfirmationBar(
+                itemCount: pendingEmptyTrashCount,
                 themeStore: themeStore,
                 onConfirm: { confirmDeleteSelection() },
                 onCancel: { cancelDeleteSelection() }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -59,6 +59,7 @@ struct LauncherView: View {
     @State var lookupPreviewTask: Task<Void, Never>?
     @State var selectedKillSuggestionIndex: Int?
     @State var pendingKillCandidate: KillCommand.Candidate?
+    @State var pendingDeleteTargets: [DeleteCommand.Target] = []
     @State var killListRefreshTick: Int = 0
     @State var recentlyKilledPIDs: Set<Int32> = []
     @State var showsHelpScreen = false
@@ -338,7 +339,7 @@ struct LauncherView: View {
             return ["Enter copy clip", "Delete remove clip", "Cmd+H help", "Cmd+/ command mode"]
         }
 
-        return ["Enter open", "Cmd+F reveal", "Cmd+H help", "Cmd+/ command mode"]
+        return ["Enter open", "Cmd+F reveal", "Cmd+D trash", "Cmd+H help", "Cmd+/ command mode"]
     }
 
     var commandNamePart: String {
@@ -374,6 +375,10 @@ struct LauncherView: View {
         isCommandMode
             && activeCommandID == AppConstants.Launcher.Command.kill
             && pendingKillCandidate != nil
+    }
+
+    var isDeleteConfirmationVisible: Bool {
+        !isCommandMode && !pendingDeleteTargets.isEmpty
     }
 
     var liveCommandPreview: String? {
@@ -444,6 +449,11 @@ struct LauncherView: View {
             clipboardStore.setMonitoringMode(.background)
         }
         .onChange(of: query) { _, _ in
+            // Editing the query dismisses a pending delete confirmation, mirroring
+            // how the kill command clears its pending candidate on input change.
+            if !pendingDeleteTargets.isEmpty {
+                pendingDeleteTargets = []
+            }
             if !isCommandMode, let cmd = extractInlineCommand(from: query), cmd.hasSpace {
                 enterCommandMode(commandID: cmd.id, prefilledInput: cmd.args)
                 return
@@ -576,7 +586,8 @@ struct LauncherView: View {
         .modifier(PanelDecorationsModifier(
             testHint: { testHintOverlay },
             copyright: { copyrightOverlay },
-            killBar: { killConfirmationOverlay }
+            killBar: { killConfirmationOverlay },
+            deleteBar: { deleteConfirmationOverlay }
         ))
         .layoutPriority(1)
     }
@@ -644,7 +655,7 @@ struct LauncherView: View {
                 Spacer(minLength: 0)
             }
 
-            if !isKillConfirmationVisible {
+            if !isKillConfirmationVisible && !isDeleteConfirmationVisible {
                 HintBar(hint: currentHint, themeStore: themeStore)
             }
         }
@@ -772,18 +783,34 @@ struct LauncherView: View {
         }
     }
 
+    @ViewBuilder
+    private var deleteConfirmationOverlay: some View {
+        if !isCommandMode, !pendingDeleteTargets.isEmpty {
+            DeleteConfirmationBar(
+                targets: pendingDeleteTargets,
+                themeStore: themeStore,
+                onConfirm: { confirmDeleteSelection() },
+                onCancel: { cancelDeleteSelection() }
+            )
+            .padding(.horizontal, 14)
+            .padding(.bottom, 24)
+        }
+    }
+
 
 }
 
-private struct PanelDecorationsModifier<TestHint: View, Copyright: View, KillBar: View>: ViewModifier {
+private struct PanelDecorationsModifier<TestHint: View, Copyright: View, KillBar: View, DeleteBar: View>: ViewModifier {
     @ViewBuilder let testHint: () -> TestHint
     @ViewBuilder let copyright: () -> Copyright
     @ViewBuilder let killBar: () -> KillBar
+    @ViewBuilder let deleteBar: () -> DeleteBar
 
     func body(content: Content) -> some View {
         content
             .overlay(alignment: .topTrailing, content: testHint)
             .overlay(alignment: .bottomTrailing, content: copyright)
             .overlay(alignment: .bottom, content: killBar)
+            .overlay(alignment: .bottom, content: deleteBar)
     }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
@@ -8,6 +8,14 @@ struct ResultPreviewView: View {
     var onDeleteClipboard: (() -> Void)? = nil
 
     @State private var folderListing: FolderListing?
+    @State private var trashItemCount: Int?
+
+    /// The pinned Trash quick folder is TCC-protected, so it can't be listed
+    /// like a normal folder — it gets a Finder-backed summary instead.
+    private var isTrash: Bool {
+        result.kind == .folder
+            && DeleteTargetLogic.isTrashPath(result.path, homeDirectory: NSHomeDirectory())
+    }
 
     private func folderCountText(_ listing: FolderListing) -> String? {
         var parts: [String] = []
@@ -117,7 +125,13 @@ struct ResultPreviewView: View {
                         HStack(spacing: 6) {
                             KindBadge(kind: result.kind.rawValue)
                             if result.kind == .folder {
-                                if let listing = folderListing,
+                                if isTrash {
+                                    if let trashItemCount {
+                                        Text("\(trashItemCount) item\(trashItemCount == 1 ? "" : "s")")
+                                            .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular))
+                                            .foregroundStyle(themeStore.secondaryTextColor())
+                                    }
+                                } else if let listing = folderListing,
                                    let counts = folderCountText(listing) {
                                     Text(counts)
                                         .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular))
@@ -142,7 +156,11 @@ struct ResultPreviewView: View {
                 }
 
                 if result.kind == .folder {
-                    FolderPreviewView(path: result.path, listing: folderListing)
+                    if isTrash {
+                        TrashSummaryView(itemCount: trashItemCount, themeStore: themeStore)
+                    } else {
+                        FolderPreviewView(path: result.path, listing: folderListing)
+                    }
                 }
 
                 if let version = info.version {
@@ -174,6 +192,14 @@ struct ResultPreviewView: View {
             .task(id: result.kind == .folder ? result.path : "") {
                 guard result.kind == .folder else {
                     folderListing = nil
+                    trashItemCount = nil
+                    return
+                }
+                if isTrash {
+                    // Don't list ~/.Trash (TCC) and don't prompt for Automation
+                    // just by previewing — only show a count if already granted.
+                    folderListing = nil
+                    trashItemCount = EmptyTrashCommand.itemCount(promptIfNeeded: false)
                     return
                 }
                 folderListing = nil

--- a/docs/features.md
+++ b/docs/features.md
@@ -20,6 +20,8 @@ This document tracks what `look` supports today and what is planned next.
 - open with `Enter`, reveal in Finder with `Cmd+F`
 - copy selected file/folder path/content handle with `Cmd+C`
 - multi-pick files/folders with `Cmd+P` (toggle); picked set is mirrored to the system pasteboard for paste anywhere. `Cmd+Shift+P` clears the set
+- move selected file/folder (or all picked items) to the Trash with `Cmd+D` — recoverable, no confirmation (macOS only for now)
+- pinned **Trash** quick folder (type `trash`): `Enter` opens it in Finder, its preview shows the item count, and `Cmd+D` empties it via Finder (confirmed, since it's permanent)
 - preview pane: text/image file previews, plus folder previews listing the immediate children (folders first, capped at 30, click to open)
 
 ### Clipboard and translation

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -42,6 +42,7 @@ Look is designed to need as few macOS permissions as possible:
 - **No Full Disk Access** is required. Look indexes standard user directories (`~`, `/Applications`, `~/Documents`, `~/Downloads`, etc.). To index a directory outside those defaults, add it via `file_scan_extra_roots` in `~/.look.config`.
 - **No Screen Recording** is required.
 - **Network access** is used only for explicit actions: `t"` translation, `tw"` dictionary lookup, and `Cmd+Enter` web search. The local search and indexing paths make no network calls.
+- **Finder Automation** is requested only when you empty the Trash (`Cmd+D` on the pinned Trash folder). The Trash is protected by macOS, so Look asks Finder to empty it; macOS prompts once, and you can manage it under `System Settings > Privacy & Security > Automation`. Moving individual files to the Trash needs no permission.
 
 If macOS prompts for permission during an action you didn't trigger, that's a bug — please [file an issue](https://github.com/kunkka19xx/look/issues).
 
@@ -61,9 +62,12 @@ Useful actions:
 - `Cmd+C`: copy selected file/folder
 - `Cmd+P`: toggle pick on the selected file/folder (multi-select); the picked set is written to the system pasteboard so you can paste them anywhere in Finder
 - `Cmd+Shift+P`: clear all picked items
+- `Cmd+D`: move the selected file/folder — or all picked items — to the Trash (macOS only for now). Like Finder's `Cmd+Delete`, this is immediate and unconfirmed because it's recoverable: the items go to the Trash, not permanent deletion. The rows disappear from results right away.
 - `Cmd+Enter`: web search current query (Google)
 
 When at least one item is picked, the right panel switches to the **Picked** list — each row has an `X` to remove a single item, plus a **Clear all** button. File/folder copies (both `Cmd+C` and `Cmd+P`) are excluded from clipboard history.
+
+**Trash.** Type `trash` to pin the Trash quick folder; `Enter` opens it in Finder. With the Trash folder selected, its preview shows the item count and `Cmd+D` **empties** the Trash. Emptying is permanent, so it asks you to confirm (`Y`/`Enter` to empty, `N`/`Esc` to cancel). Look empties the Trash through Finder, so the first time you do this macOS asks for permission to control Finder (see [Permissions](#permissions)).
 
 ## Query prefixes
 
@@ -261,6 +265,7 @@ Note: `Settings Blur` is stored as local app UI state (UserDefaults) and is not 
 - `Cmd+F`: reveal in Finder
 - `Cmd+C`: copy selected file/folder
 - `Cmd+P` / `Cmd+Shift+P`: toggle pick / clear picked set
+- `Cmd+D`: move selected file/folder (or picked items) to Trash; on the pinned Trash folder, empty the Trash (macOS only for now)
 - `Cmd+Shift+,`: toggle settings panel
 - `Cmd+Shift+;`: reload config
 - `Cmd+-`, `Cmd+=`, `Cmd+0`: temporary UI zoom out/in/reset


### PR DESCRIPTION
## Summary

- Cmd+D to delete file and folder in Look
- Add Trash folder as a target folder that you can navigate to from Look 
- You can clean Trash folder by cmd + D (first time requires permission)

## Why

- #187 

## Changes

-

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
