### PR TITLE
Recent places (Macos)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ https://github.com/user-attachments/assets/f8ee0f85-4c0d-4ea5-bb1d-8c8bf014d50d
 - **Search clipboard history** — `c"meeting` finds the snippet you copied an hour ago.
 - **Translate or look up a word** — `t"hello` for quick translation, `tw"word` for a definition panel.
 - **Regex, path, and kind-scoped search** — `r"^Visual.*`, `git/project/readme`, `a"safari`, `f"note`, `d"documents`.
+- **Browse recent files/folders** — `rc"` lists what you most recently opened *and* what recently landed on disk (downloads, screenshots), newest first; `rc"word` filters. macOS for now.
 - **Switch running apps from the launcher** — an icon strip on the right half of the search bar. `Cmd+1`..`Cmd+9` on macOS / `Alt+1`..`Alt+9` on Linux+Windows jumps to a running app. Toggle on/off in `Settings > Appearance > Running Apps`.
 
 All local. No account. No telemetry. No plugin marketplace to manage.

--- a/apps/macos/LauncherApp/LauncherLogicTests/LauncherSearchLogicTests.swift
+++ b/apps/macos/LauncherApp/LauncherLogicTests/LauncherSearchLogicTests.swift
@@ -31,6 +31,9 @@ final class LauncherSearchLogicTests: XCTestCase {
         XCTAssertEqual(LauncherSearchLogic.pinnedLookupScope(for: "d\"doc"), .folders)
         XCTAssertEqual(LauncherSearchLogic.pinnedLookupScope(for: "r\".*"), .disabled)
         XCTAssertEqual(LauncherSearchLogic.pinnedLookupScope(for: "c\"note"), .disabled)
+        // rc" (recent) suppresses pinned quick-folder/Finder injection.
+        XCTAssertEqual(LauncherSearchLogic.pinnedLookupScope(for: "rc\""), .disabled)
+        XCTAssertEqual(LauncherSearchLogic.pinnedLookupScope(for: "rc\"report"), .disabled)
     }
 
     func testNormalizedPinnedQueryRespectsScope() {

--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -47,6 +47,10 @@ enum AppConstants {
             static let folders = "d\""
             static let regex = "r\""
             static let clipboard = "c\""
+            // Recent files/folders, newest-activity first. Handled engine-side
+            // (needs last_used/fs_modified timestamps); the app just sends it
+            // through search and suppresses pinned injection (see LauncherSearchLogic).
+            static let recent = "rc\""
         }
 
         enum Finder {

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/LauncherSearchLogic.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/LauncherSearchLogic.swift
@@ -14,7 +14,10 @@ enum LauncherSearchLogic {
 
         if normalized.hasPrefix(AppConstants.Launcher.QueryPrefix.regex)
             || normalized.hasPrefix(AppConstants.Launcher.QueryPrefix.clipboard)
+            || normalized.hasPrefix(AppConstants.Launcher.QueryPrefix.recent)
         {
+            // Recent (rc") is engine-ranked by recency; suppress quick-folder and
+            // Finder pinned injection so they don't pollute the recent list.
             return .disabled
         }
         if normalized.hasPrefix(AppConstants.Launcher.QueryPrefix.apps) {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
@@ -328,6 +328,34 @@ struct ClipboardEmptyStateView: View {
     }
 }
 
+struct RecentEmptyStateView: View {
+    let themeStore: ThemeStore
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Image(systemName: "clock.arrow.circlepath")
+                    .foregroundStyle(themeStore.accentColor())
+                Text("Recent files & folders")
+                    .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize + 1), weight: .semibold))
+            }
+
+            Text("Nothing recent yet")
+                .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize), weight: .medium))
+                .foregroundStyle(themeStore.secondaryTextColor())
+
+            Text("Open files/folders through Look, or download/create some — newest activity shows here. Type rc\"word to filter.")
+                .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular))
+                .foregroundStyle(themeStore.secondaryTextColor())
+                .lineLimit(3)
+
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+}
+
 struct LauncherHelpScreenView: View {
     let themeStore: ThemeStore
 
@@ -368,6 +396,7 @@ private enum LauncherHelpContent {
         ("Cmd+C", "Copy selected file/folder to pasteboard"),
         ("Cmd+P", "Toggle pick on selected file/folder (multi-select copy)"),
         ("Cmd+Shift+P", "Clear all picked items"),
+        ("Cmd+D", "Move selected file/folder to Trash (on the Trash folder: empty Trash)"),
         ("Tab / Shift+Tab", "Move selection"),
         ("Up / Down", "Move selection"),
         ("Cmd+F", "Reveal selected app/file/folder in Finder"),
@@ -383,6 +412,7 @@ private enum LauncherHelpContent {
         ("a\"word", "Apps only"),
         ("f\"word", "Files only"),
         ("d\"word", "Folders only"),
+        ("rc\"word", "Recent files/folders, newest first (optional filter)"),
         ("r\"pattern", "Regex search"),
         ("c\"word", "Clipboard history search (latest 10 text clips)"),
         ("t\"word", "Web translate (VI/EN/JA)"),

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -253,6 +253,12 @@ struct LauncherView: View {
         LauncherClipboardFeature.isClipboardQuery(query)
     }
 
+    var isRecentQuery: Bool {
+        query.trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .hasPrefix(AppConstants.Launcher.QueryPrefix.recent)
+    }
+
     var clipboardSearchTerm: String? {
         LauncherClipboardFeature.searchTerm(from: query)
     }
@@ -344,7 +350,7 @@ struct LauncherView: View {
             return ["Enter copy clip", "Delete remove clip", "Cmd+H help", "Cmd+/ command mode"]
         }
 
-        return ["Enter open", "Cmd+F reveal", "Cmd+D trash", "Cmd+H help", "Cmd+/ command mode"]
+        return ["Enter open", "Cmd+F reveal", "Cmd+H help", "Cmd+/ command mode"]
     }
 
     var commandNamePart: String {
@@ -652,6 +658,8 @@ struct LauncherView: View {
                 LauncherHelpScreenView(themeStore: themeStore)
             } else if isClipboardQuery && displayedResults.isEmpty {
                 ClipboardEmptyStateView(themeStore: themeStore)
+            } else if isRecentQuery && displayedResults.isEmpty {
+                RecentEmptyStateView(themeStore: themeStore)
             } else {
                 resultsRow
             }

--- a/bridge/ffi/Cargo.lock
+++ b/bridge/ffi/Cargo.lock
@@ -157,12 +157,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashlink"
-version = "0.11.0"
+name = "hashbrown"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "hashbrown",
+ "foldhash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
+dependencies = [
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -188,7 +197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -255,9 +264,9 @@ checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
 dependencies = [
  "cc",
  "pkg-config",
@@ -469,15 +478,15 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.16.1",
  "thiserror",
 ]
 
 [[package]]
 name = "rusqlite"
-version = "0.39.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
 dependencies = [
  "bitflags 2.11.0",
  "fallible-iterator",
@@ -740,47 +749,46 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.61.3"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
  "windows-core",
  "windows-future",
- "windows-link 0.1.3",
  "windows-numerics",
 ]
 
 [[package]]
 name = "windows-collections"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
  "windows-core",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.1.3",
+ "windows-link",
  "windows-result",
  "windows-strings",
 ]
 
 [[package]]
 name = "windows-future"
-version = "0.2.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
  "windows-core",
- "windows-link 0.1.3",
+ "windows-link",
  "windows-threading",
 ]
 
@@ -808,42 +816,36 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core",
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -861,7 +863,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -870,7 +872,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -883,11 +885,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]

--- a/bridge/ffi/src/lib.rs
+++ b/bridge/ffi/src/lib.rs
@@ -285,6 +285,7 @@ mod tests {
             path: "/Applications/Smoke Test App.app".into(),
             use_count: 0,
             last_used_at_unix_s: None,
+            fs_modified_at_unix_s: None,
         }
     }
 

--- a/bridge/ffi/src/lib.rs
+++ b/bridge/ffi/src/lib.rs
@@ -283,9 +283,7 @@ mod tests {
             title: "Smoke Test App".into(),
             subtitle: Some("smoke app".into()),
             path: "/Applications/Smoke Test App.app".into(),
-            use_count: 0,
-            last_used_at_unix_s: None,
-            fs_modified_at_unix_s: None,
+            ..Default::default()
         }
     }
 

--- a/bridge/ffi/src/seed_api.rs
+++ b/bridge/ffi/src/seed_api.rs
@@ -49,19 +49,17 @@ pub(crate) fn look_seed_uwp_apps_json_impl(json: *const c_char) -> bool {
         }
         let id = format!("{}{}", UWP_ID_PREFIX, aumid);
         kept_ids.push(id.clone());
+        // Defaults cover use_count/last_used_at_unix_s (preserved by the ON CONFLICT
+        // clause in upsert_candidates_indexed, so re-seeding on every app start
+        // doesn't reset launch history) and fs_modified_at_unix_s (an app candidate
+        // has no filesystem mtime and isn't part of the recent-files view).
         candidates.push(Candidate {
             id: id.into(),
             kind: CandidateKind::App,
             title: title.into(),
             subtitle: None,
             path: format!("shell:AppsFolder\\{}", aumid).into(),
-            // use_count and last_used_at_unix_s are preserved by the ON CONFLICT
-            // clause in upsert_candidates_indexed, so re-seeding on every app start
-            // doesn't reset the user's launch history.
-            use_count: 0,
-            last_used_at_unix_s: None,
-            // App candidate — no filesystem mtime; not part of the recent-files view.
-            fs_modified_at_unix_s: None,
+            ..Default::default()
         });
     }
 

--- a/bridge/ffi/src/seed_api.rs
+++ b/bridge/ffi/src/seed_api.rs
@@ -60,6 +60,8 @@ pub(crate) fn look_seed_uwp_apps_json_impl(json: *const c_char) -> bool {
             // doesn't reset the user's launch history.
             use_count: 0,
             last_used_at_unix_s: None,
+            // App candidate — no filesystem mtime; not part of the recent-files view.
+            fs_modified_at_unix_s: None,
         });
     }
 

--- a/core/engine/src/index/files.rs
+++ b/core/engine/src/index/files.rs
@@ -4,6 +4,16 @@ use crate::platform::paths::{candidate_id_path_component, path_is_same_or_child}
 use ignore::WalkBuilder;
 use look_indexing::{Candidate, CandidateKind};
 use std::sync::mpsc;
+use std::time::UNIX_EPOCH;
+
+fn modified_unix_s(metadata: Option<&std::fs::Metadata>) -> Option<i64> {
+    metadata?
+        .modified()
+        .ok()?
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_secs() as i64)
+}
 
 pub fn discover_local_files_and_folders(config: &RuntimeConfig, tx: mpsc::SyncSender<Candidate>) {
     let mut roots = config.file_scan_roots.clone();
@@ -79,6 +89,9 @@ fn walk_files(
             break;
         }
 
+        // Read mtime from the walker's entry metadata before consuming `entry`,
+        // so the recent view can rank by when files appeared/changed on disk.
+        let modified_at = modified_unix_s(entry.metadata().ok().as_ref());
         let path_buf = entry.into_path();
         let Some(path_str) = path_buf.to_str() else {
             continue;
@@ -97,6 +110,7 @@ fn walk_files(
             );
             let mut candidate = Candidate::new(&key, CandidateKind::Folder, name, path_str);
             candidate.subtitle = Some(CandidateKind::Folder.as_str().into());
+            candidate.fs_modified_at_unix_s = modified_at;
             let _ = tx.send(candidate);
             continue;
         }
@@ -109,6 +123,7 @@ fn walk_files(
             );
             let mut candidate = Candidate::new(&key, CandidateKind::File, name, path_str);
             candidate.subtitle = Some(CandidateKind::File.as_str().into());
+            candidate.fs_modified_at_unix_s = modified_at;
             let _ = tx.send(candidate);
         }
     }

--- a/core/engine/src/lib.rs
+++ b/core/engine/src/lib.rs
@@ -170,13 +170,22 @@ impl QueryEngine {
         // uninstalled their last app in this root" outcome, and we must still
         // sweep the matching prefixes or the deleted row lingers forever
         // (only an `ALL` refresh would otherwise catch it).
+        // Prune by the `seen` set rather than the old "indexed_at < run_started"
+        // sweep: the change-detecting upsert (see specs/indexing-scale.md) no
+        // longer bumps indexed_at on unchanged rows, so only "not seen this scan"
+        // reliably means "gone". delete_unseen_candidates keeps the indexed_at<run
+        // guard to preserve i64::MAX pinned rows. `seen` is already collected above
+        // for dedup, so this reuses it.
+        // TODO(indexing-scale Direction A): this still required a full walk to
+        // build `seen`. Event-driven incremental indexing (watcher paths) would
+        // delete only the paths the watcher reported removed.
         let prefixes = scope.id_prefixes();
         if scope.is_all() {
             if discovered_count > 0 {
-                let _ = store.delete_stale_candidates(run_started_at)?;
+                let _ = store.delete_unseen_candidates(&seen, run_started_at, &[])?;
             }
         } else if !prefixes.is_empty() {
-            let _ = store.delete_stale_candidates_with_prefixes(run_started_at, &prefixes)?;
+            let _ = store.delete_unseen_candidates(&seen, run_started_at, &prefixes)?;
         }
 
         let usage_cutoff = run_started_at.saturating_sub(USAGE_RETENTION_DAYS * 24 * 3600);

--- a/core/engine/src/query.rs
+++ b/core/engine/src/query.rs
@@ -7,6 +7,10 @@ const PREFIX_FOLDERS: u8 = b'd';
 const PREFIX_REGEX: u8 = b'r';
 const PREFIX_MARKER: u8 = b'"';
 const PREFIX_LENGTH: usize = 2;
+// Two-char prefix `rc"` for the recent-files view. It's engine-side (unlike the
+// Swift-handled `t"`/`tw"`/`c"`) because recency ordering needs the per-candidate
+// `last_used_at` timestamps that only the engine has.
+const RECENT_PREFIX: &[u8] = b"rc\"";
 
 #[derive(Clone, Debug)]
 pub(crate) struct ParsedQuery {
@@ -14,11 +18,24 @@ pub(crate) struct ParsedQuery {
     pub(crate) raw_query: Option<String>,
     pub(crate) kind_filter: Option<CandidateKind>,
     pub(crate) is_regex: bool,
+    pub(crate) is_recent: bool,
 }
 
 impl ParsedQuery {
     pub(crate) fn from_input(input: &str) -> Self {
         let trimmed = input.trim();
+
+        // `rc"` is checked before `r"` (single-char) — they can't collide since
+        // `r"` requires the 2nd byte to be `"`, which is `c` here.
+        if let Some(rest) = strip_recent_prefix(trimmed) {
+            return Self {
+                normalized_query: normalize_for_search(rest),
+                raw_query: None,
+                kind_filter: None,
+                is_regex: false,
+                is_recent: true,
+            };
+        }
 
         if let Some(rest) = strip_prefixed_query(trimmed, PREFIX_FOLDERS) {
             return Self {
@@ -26,6 +43,7 @@ impl ParsedQuery {
                 raw_query: None,
                 kind_filter: Some(CandidateKind::Folder),
                 is_regex: false,
+                is_recent: false,
             };
         }
 
@@ -35,6 +53,7 @@ impl ParsedQuery {
                 raw_query: None,
                 kind_filter: Some(CandidateKind::File),
                 is_regex: false,
+                is_recent: false,
             };
         }
 
@@ -44,6 +63,7 @@ impl ParsedQuery {
                 raw_query: None,
                 kind_filter: Some(CandidateKind::App),
                 is_regex: false,
+                is_recent: false,
             };
         }
 
@@ -53,6 +73,7 @@ impl ParsedQuery {
                 raw_query: Some(rest.to_string()),
                 kind_filter: None,
                 is_regex: true,
+                is_recent: false,
             };
         }
 
@@ -61,8 +82,25 @@ impl ParsedQuery {
             raw_query: None,
             kind_filter: None,
             is_regex: false,
+            is_recent: false,
         }
     }
+}
+
+/// Strips the two-char `rc"` recent prefix (case-insensitive), returning the
+/// optional filter text after it. Returns None when the input isn't `rc"...`.
+fn strip_recent_prefix(input: &str) -> Option<&str> {
+    let bytes = input.as_bytes();
+    if bytes.len() < RECENT_PREFIX.len() {
+        return None;
+    }
+    if !bytes[0].eq_ignore_ascii_case(&RECENT_PREFIX[0])
+        || !bytes[1].eq_ignore_ascii_case(&RECENT_PREFIX[1])
+        || bytes[2] != RECENT_PREFIX[2]
+    {
+        return None;
+    }
+    Some(input[RECENT_PREFIX.len()..].trim())
 }
 
 fn strip_prefixed_query(input: &str, prefix: u8) -> Option<&str> {
@@ -76,4 +114,31 @@ fn strip_prefixed_query(input: &str, prefix: u8) -> Option<&str> {
     }
 
     Some(input[PREFIX_LENGTH..].trim())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ParsedQuery;
+
+    #[test]
+    fn recent_prefix_sets_flag_and_filter() {
+        let parsed = ParsedQuery::from_input("rc\"report");
+        assert!(parsed.is_recent);
+        assert!(!parsed.is_regex);
+        assert_eq!(parsed.normalized_query, "report");
+    }
+
+    #[test]
+    fn recent_prefix_is_case_insensitive_and_allows_empty_filter() {
+        let parsed = ParsedQuery::from_input("RC\"");
+        assert!(parsed.is_recent);
+        assert!(parsed.normalized_query.is_empty());
+    }
+
+    #[test]
+    fn regex_prefix_is_not_treated_as_recent() {
+        let parsed = ParsedQuery::from_input("r\"foo");
+        assert!(parsed.is_regex);
+        assert!(!parsed.is_recent);
+    }
 }

--- a/core/engine/src/query.rs
+++ b/core/engine/src/query.rs
@@ -1,15 +1,14 @@
 use crate::normalize::normalize_for_search;
 use look_indexing::CandidateKind;
 
-const PREFIX_APPS: u8 = b'a';
-const PREFIX_FILES: u8 = b'f';
-const PREFIX_FOLDERS: u8 = b'd';
-const PREFIX_REGEX: u8 = b'r';
-const PREFIX_MARKER: u8 = b'"';
-const PREFIX_LENGTH: usize = 2;
-// Two-char prefix `rc"` for the recent-files view. It's engine-side (unlike the
-// Swift-handled `t"`/`tw"`/`c"`) because recency ordering needs the per-candidate
-// `last_used_at` timestamps that only the engine has.
+// Query prefixes: leading letter(s) matched case-insensitively, trailing `"`
+// exactly (see `strip_query_prefix`). `rc"` must be checked before `r"` — see
+// `from_input`. `rc"` is engine-side (unlike the Swift-handled `t"`/`tw"`/`c"`)
+// because recency ordering needs the per-candidate timestamps only the engine has.
+const PREFIX_APPS: &[u8] = b"a\"";
+const PREFIX_FILES: &[u8] = b"f\"";
+const PREFIX_FOLDERS: &[u8] = b"d\"";
+const PREFIX_REGEX: &[u8] = b"r\"";
 const RECENT_PREFIX: &[u8] = b"rc\"";
 
 #[derive(Clone, Debug)]
@@ -27,7 +26,7 @@ impl ParsedQuery {
 
         // `rc"` is checked before `r"` (single-char) — they can't collide since
         // `r"` requires the 2nd byte to be `"`, which is `c` here.
-        if let Some(rest) = strip_recent_prefix(trimmed) {
+        if let Some(rest) = strip_query_prefix(trimmed, RECENT_PREFIX) {
             return Self {
                 normalized_query: normalize_for_search(rest),
                 raw_query: None,
@@ -37,7 +36,7 @@ impl ParsedQuery {
             };
         }
 
-        if let Some(rest) = strip_prefixed_query(trimmed, PREFIX_FOLDERS) {
+        if let Some(rest) = strip_query_prefix(trimmed, PREFIX_FOLDERS) {
             return Self {
                 normalized_query: normalize_for_search(rest),
                 raw_query: None,
@@ -47,7 +46,7 @@ impl ParsedQuery {
             };
         }
 
-        if let Some(rest) = strip_prefixed_query(trimmed, PREFIX_FILES) {
+        if let Some(rest) = strip_query_prefix(trimmed, PREFIX_FILES) {
             return Self {
                 normalized_query: normalize_for_search(rest),
                 raw_query: None,
@@ -57,7 +56,7 @@ impl ParsedQuery {
             };
         }
 
-        if let Some(rest) = strip_prefixed_query(trimmed, PREFIX_APPS) {
+        if let Some(rest) = strip_query_prefix(trimmed, PREFIX_APPS) {
             return Self {
                 normalized_query: normalize_for_search(rest),
                 raw_query: None,
@@ -67,7 +66,7 @@ impl ParsedQuery {
             };
         }
 
-        if let Some(rest) = strip_prefixed_query(trimmed, PREFIX_REGEX) {
+        if let Some(rest) = strip_query_prefix(trimmed, PREFIX_REGEX) {
             return Self {
                 normalized_query: String::new(),
                 raw_query: Some(rest.to_string()),
@@ -87,33 +86,17 @@ impl ParsedQuery {
     }
 }
 
-/// Strips the two-char `rc"` recent prefix (case-insensitive), returning the
-/// optional filter text after it. Returns None when the input isn't `rc"...`.
-fn strip_recent_prefix(input: &str) -> Option<&str> {
+/// Strips a `…"` query prefix, returning the trimmed text after it (or `None`
+/// when `input` doesn't start with `prefix`). The prefix is matched ASCII
+/// case-insensitively — the trailing `"` has no case, so it matches exactly.
+/// `prefix` is all-ASCII, so its length is always a UTF-8 char boundary in a
+/// matched input.
+fn strip_query_prefix<'a>(input: &'a str, prefix: &[u8]) -> Option<&'a str> {
     let bytes = input.as_bytes();
-    if bytes.len() < RECENT_PREFIX.len() {
+    if bytes.len() < prefix.len() || !bytes[..prefix.len()].eq_ignore_ascii_case(prefix) {
         return None;
     }
-    if !bytes[0].eq_ignore_ascii_case(&RECENT_PREFIX[0])
-        || !bytes[1].eq_ignore_ascii_case(&RECENT_PREFIX[1])
-        || bytes[2] != RECENT_PREFIX[2]
-    {
-        return None;
-    }
-    Some(input[RECENT_PREFIX.len()..].trim())
-}
-
-fn strip_prefixed_query(input: &str, prefix: u8) -> Option<&str> {
-    let bytes = input.as_bytes();
-    if bytes.len() < PREFIX_LENGTH {
-        return None;
-    }
-
-    if !bytes[0].eq_ignore_ascii_case(&prefix) || bytes[1] != PREFIX_MARKER {
-        return None;
-    }
-
-    Some(input[PREFIX_LENGTH..].trim())
+    Some(input[prefix.len()..].trim())
 }
 
 #[cfg(test)]

--- a/core/engine/src/scoring.rs
+++ b/core/engine/src/scoring.rs
@@ -388,9 +388,7 @@ mod tests {
             title: "System Settings".into(),
             subtitle: Some("System Settings".into()),
             path: "/System/Applications/System Settings.app".into(),
-            use_count: 0,
-            last_used_at_unix_s: None,
-            fs_modified_at_unix_s: None,
+            ..Default::default()
         };
         let regular_app = app("Safari", "/Applications/Safari.app");
         let folder = folder("network", "/Users/test/network");
@@ -411,9 +409,7 @@ mod tests {
             title: "Network".into(),
             subtitle: Some("System Settings network".into()),
             path: "x-apple.systempreferences:com.apple.preference.network".into(),
-            use_count: 0,
-            last_used_at_unix_s: None,
-            fs_modified_at_unix_s: None,
+            ..Default::default()
         };
 
         assert!(query_kind_penalty_with_settings_flag(false, &settings_app) < 0);
@@ -427,9 +423,7 @@ mod tests {
             title: "Network".into(),
             subtitle: Some("System Settings network".into()),
             path: "x-apple.systempreferences:com.apple.preference.network".into(),
-            use_count: 0,
-            last_used_at_unix_s: None,
-            fs_modified_at_unix_s: None,
+            ..Default::default()
         };
         let regular_app = app("Safari", "/Applications/Safari.app");
         let regular_file = file("notes.txt", "/Users/test/notes.txt");

--- a/core/engine/src/scoring.rs
+++ b/core/engine/src/scoring.rs
@@ -390,6 +390,7 @@ mod tests {
             path: "/System/Applications/System Settings.app".into(),
             use_count: 0,
             last_used_at_unix_s: None,
+            fs_modified_at_unix_s: None,
         };
         let regular_app = app("Safari", "/Applications/Safari.app");
         let folder = folder("network", "/Users/test/network");
@@ -412,6 +413,7 @@ mod tests {
             path: "x-apple.systempreferences:com.apple.preference.network".into(),
             use_count: 0,
             last_used_at_unix_s: None,
+            fs_modified_at_unix_s: None,
         };
 
         assert!(query_kind_penalty_with_settings_flag(false, &settings_app) < 0);
@@ -427,6 +429,7 @@ mod tests {
             path: "x-apple.systempreferences:com.apple.preference.network".into(),
             use_count: 0,
             last_used_at_unix_s: None,
+            fs_modified_at_unix_s: None,
         };
         let regular_app = app("Safari", "/Applications/Safari.app");
         let regular_file = file("notes.txt", "/Users/test/notes.txt");

--- a/core/engine/src/search.rs
+++ b/core/engine/src/search.rs
@@ -119,6 +119,49 @@ impl QueryEngine {
         finalize_top_k(top)
     }
 
+    fn search_recent_query(&self, normalized_query: &str, limit: usize) -> Vec<(u32, i64)> {
+        // Recent view: files/folders the user has actually opened (last_used_at
+        // set), most-recently-opened first. Apps and never-opened items are
+        // excluded. Optional filter text narrows by title/path substring.
+        let mut matches: Vec<(u32, i64)> = Vec::new();
+        for (idx, candidate) in self.candidates.iter().enumerate() {
+            let kind = &candidate.candidate.kind;
+            if *kind != CandidateKind::File && *kind != CandidateKind::Folder {
+                continue;
+            }
+            // Recency blends "opened through Look" (last_used) with "appeared/
+            // changed on disk" (fs_modified) so freshly downloaded/captured files
+            // surface even before the user opens them. Items with neither are out.
+            let recency = match (
+                candidate.candidate.last_used_at_unix_s,
+                candidate.candidate.fs_modified_at_unix_s,
+            ) {
+                (Some(a), Some(b)) => a.max(b),
+                (Some(a), None) => a,
+                (None, Some(b)) => b,
+                (None, None) => continue,
+            };
+            if !normalized_query.is_empty()
+                && !candidate.title_search.contains(normalized_query)
+                && !candidate.path_search.contains(normalized_query)
+            {
+                continue;
+            }
+            matches.push((idx as u32, recency));
+        }
+
+        // Most recent first; tie-break by title for a stable order.
+        matches.sort_by(|a, b| {
+            b.1.cmp(&a.1).then_with(|| {
+                let title_a = &self.candidates[a.0 as usize].candidate.title;
+                let title_b = &self.candidates[b.0 as usize].candidate.title;
+                title_a.cmp(title_b)
+            })
+        });
+        matches.truncate(limit);
+        matches
+    }
+
     fn search_regex_query(
         &self,
         raw_query: Option<&String>,
@@ -292,7 +335,9 @@ impl QueryEngine {
 
         let parsed_query = ParsedQuery::from_input(query);
         let kind_filter = parsed_query.kind_filter.as_ref();
-        let indices = if parsed_query.normalized_query.is_empty() && !parsed_query.is_regex {
+        let indices = if parsed_query.is_recent {
+            self.search_recent_query(&parsed_query.normalized_query, limit)
+        } else if parsed_query.normalized_query.is_empty() && !parsed_query.is_regex {
             self.search_empty_query(kind_filter, limit)
         } else if parsed_query.is_regex {
             self.search_regex_query(parsed_query.raw_query.as_ref(), kind_filter, limit)
@@ -312,6 +357,82 @@ impl QueryEngine {
 #[cfg(test)]
 mod tests {
     use super::QueryEngine;
+    use look_indexing::{Candidate, CandidateKind};
+
+    fn recent_engine() -> QueryEngine {
+        let mut older = Candidate::new("file:old", CandidateKind::File, "old.txt", "/x/old.txt");
+        older.last_used_at_unix_s = Some(100);
+        let mut newer = Candidate::new("file:new", CandidateKind::File, "new.txt", "/x/new.txt");
+        newer.last_used_at_unix_s = Some(200);
+        let mut folder = Candidate::new(
+            "folder:proj",
+            CandidateKind::Folder,
+            "project",
+            "/x/project",
+        );
+        folder.last_used_at_unix_s = Some(150);
+        // Never opened — must be excluded.
+        let never = Candidate::new(
+            "file:never",
+            CandidateKind::File,
+            "never.txt",
+            "/x/never.txt",
+        );
+        // An app, even if recently used, must be excluded from recent files/folders.
+        let mut app = Candidate::new(
+            "app:safari",
+            CandidateKind::App,
+            "Safari",
+            "/Applications/Safari.app",
+        );
+        app.last_used_at_unix_s = Some(999);
+        QueryEngine::new(vec![older, newer, folder, never, app])
+    }
+
+    #[test]
+    fn recent_orders_by_last_used_descending() {
+        let engine = recent_engine();
+        let results = engine.search_scored("rc\"", 10);
+        let ids: Vec<&str> = results.iter().map(|(c, _)| c.id.as_ref()).collect();
+        assert_eq!(ids, vec!["file:new", "folder:proj", "file:old"]);
+    }
+
+    #[test]
+    fn recent_excludes_apps_and_never_opened() {
+        let engine = recent_engine();
+        let results = engine.search_scored("rc\"", 10);
+        assert!(results.iter().all(|(c, _)| c.kind != CandidateKind::App));
+        assert!(results.iter().all(|(c, _)| c.last_used_at_unix_s.is_some()));
+        assert_eq!(results.len(), 3);
+    }
+
+    #[test]
+    fn recent_includes_newly_modified_files_not_yet_opened() {
+        // A just-downloaded/screenshotted file: fs_modified set, never opened.
+        let mut downloaded =
+            Candidate::new("file:dl", CandidateKind::File, "shot.png", "/x/shot.png");
+        downloaded.fs_modified_at_unix_s = Some(500);
+        // Opened a while ago.
+        let mut opened = Candidate::new("file:old", CandidateKind::File, "old.txt", "/x/old.txt");
+        opened.last_used_at_unix_s = Some(100);
+        // Recently opened but old on disk → ranks by the opened time (the max).
+        let mut both = Candidate::new("file:both", CandidateKind::File, "both.txt", "/x/both.txt");
+        both.last_used_at_unix_s = Some(700);
+        both.fs_modified_at_unix_s = Some(50);
+        let engine = QueryEngine::new(vec![downloaded, opened, both]);
+
+        let results = engine.search_scored("rc\"", 10);
+        let ids: Vec<&str> = results.iter().map(|(c, _)| c.id.as_ref()).collect();
+        assert_eq!(ids, vec!["file:both", "file:dl", "file:old"]);
+    }
+
+    #[test]
+    fn recent_filter_text_narrows_the_set() {
+        let engine = recent_engine();
+        let results = engine.search_scored("rc\"new", 10);
+        let ids: Vec<&str> = results.iter().map(|(c, _)| c.id.as_ref()).collect();
+        assert_eq!(ids, vec!["file:new"]);
+    }
 
     #[test]
     fn term_boundary_match_rejects_inner_substring() {

--- a/core/indexing/src/lib.rs
+++ b/core/indexing/src/lib.rs
@@ -150,6 +150,24 @@ impl Candidate {
             title: title.into(),
             subtitle: Some(path.into()),
             path: path.into(),
+            ..Self::default()
+        }
+    }
+}
+
+impl Default for Candidate {
+    /// Empty candidate used as a base for struct-update construction
+    /// (`Candidate { id, kind, .., ..Default::default() }`). Keeps the
+    /// "all the always-default fields" (`use_count`, the timestamp options) in
+    /// one place so adding another such field doesn't touch every call site.
+    /// `CandidateKind` deliberately has no `Default`, so it's pinned here.
+    fn default() -> Self {
+        Self {
+            id: "".into(),
+            kind: CandidateKind::File,
+            title: "".into(),
+            subtitle: None,
+            path: "".into(),
             use_count: 0,
             last_used_at_unix_s: None,
             fs_modified_at_unix_s: None,

--- a/core/indexing/src/lib.rs
+++ b/core/indexing/src/lib.rs
@@ -136,6 +136,10 @@ pub struct Candidate {
     pub path: Box<str>,
     pub use_count: u64,
     pub last_used_at_unix_s: Option<i64>,
+    /// Filesystem modification time (Unix seconds), captured at index time.
+    /// Lets the "recent" view surface freshly downloaded/created files the user
+    /// hasn't opened through Look yet. `None` for app/settings candidates.
+    pub fs_modified_at_unix_s: Option<i64>,
 }
 
 impl Candidate {
@@ -148,6 +152,7 @@ impl Candidate {
             path: path.into(),
             use_count: 0,
             last_used_at_unix_s: None,
+            fs_modified_at_unix_s: None,
         }
     }
 }

--- a/core/ranking/src/lib.rs
+++ b/core/ranking/src/lib.rs
@@ -40,6 +40,7 @@ mod tests {
             path: "/test".into(),
             use_count,
             last_used_at_unix_s: last_used,
+            fs_modified_at_unix_s: None,
         }
     }
 

--- a/core/ranking/src/lib.rs
+++ b/core/ranking/src/lib.rs
@@ -40,7 +40,7 @@ mod tests {
             path: "/test".into(),
             use_count,
             last_used_at_unix_s: last_used,
-            fs_modified_at_unix_s: None,
+            ..Default::default()
         }
     }
 

--- a/core/storage/src/lib.rs
+++ b/core/storage/src/lib.rs
@@ -258,6 +258,17 @@ impl SqliteStore {
         let tx = self.conn.transaction()?;
         {
             let mut stmt = tx.prepare(
+                // Interim write-reduction (see specs/indexing-scale.md): the `WHERE`
+                // skips the UPDATE entirely when nothing the scan controls changed,
+                // so a reindex after one download/install rewrites ~1 row instead of
+                // all ~8000. Pairs with `delete_unseen_candidates` for pruning — we
+                // can no longer rely on bumping `indexed_at` for every seen row.
+                // List EVERY scan-owned column here; a missing one means stale data
+                // silently lingers. (use_count/last_used_at are intentionally never
+                // overwritten on conflict, so they're not part of change detection.)
+                // TODO(indexing-scale Direction A): the full walk + per-reindex
+                // re-normalize are still O(total). Move to event-driven incremental
+                // indexing (watcher paths) to make reindex cost ∝ changed files.
                 "INSERT INTO candidates (id, kind, title, subtitle, path, use_count, last_used_at_unix_s, indexed_at_unix_s, fs_modified_at_unix_s)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
                  ON CONFLICT(id) DO UPDATE SET
@@ -266,7 +277,12 @@ impl SqliteStore {
                    subtitle = excluded.subtitle,
                      path = excluded.path,
                     indexed_at_unix_s = excluded.indexed_at_unix_s,
-                    fs_modified_at_unix_s = excluded.fs_modified_at_unix_s",
+                    fs_modified_at_unix_s = excluded.fs_modified_at_unix_s
+                 WHERE candidates.kind <> excluded.kind
+                    OR candidates.title <> excluded.title
+                    OR candidates.subtitle IS NOT excluded.subtitle
+                    OR candidates.path <> excluded.path
+                    OR candidates.fs_modified_at_unix_s IS NOT excluded.fs_modified_at_unix_s",
             )?;
 
             for candidate in candidates {
@@ -407,6 +423,76 @@ impl SqliteStore {
         Ok(removed)
     }
 
+    /// Seen-set pruning, the counterpart to the change-detecting upsert
+    /// (see specs/indexing-scale.md). Because the upsert no longer bumps
+    /// `indexed_at` on unchanged rows, "was this seen in the latest scan?" can't
+    /// be inferred from `indexed_at` anymore — we delete rows in scope that are
+    /// NOT in `seen_ids`. The `indexed_at < older_than_unix_s` guard preserves the
+    /// `i64::MAX` pinned/seeded rows (e.g. UWP), exactly like `delete_stale_*`.
+    /// `prefixes` empty = whole table (ALL-scope refresh); otherwise restrict to
+    /// rows whose id starts with one of the prefixes (scoped refresh).
+    ///
+    /// `seen_ids` is staged in an in-memory temp table (PRAGMA temp_store=MEMORY),
+    /// so this adds no persistent writes beyond the rows it actually deletes.
+    pub fn delete_unseen_candidates(
+        &mut self,
+        seen_ids: &HashSet<Box<str>>,
+        older_than_unix_s: i64,
+        prefixes: &[&str],
+    ) -> StorageResult<usize> {
+        let like_clause = if prefixes.is_empty() {
+            String::new()
+        } else {
+            let ors = (0..prefixes.len())
+                .map(|i| format!("id LIKE ?{} ESCAPE '\\'", i + 2))
+                .collect::<Vec<_>>()
+                .join(" OR ");
+            format!(" AND ({ors})")
+        };
+        let escaped: Vec<String> = prefixes
+            .iter()
+            .map(|p| format!("{}%", p.replace('\\', "\\\\").replace('%', "\\%")))
+            .collect();
+
+        let tx = self.conn.transaction()?;
+        tx.execute_batch(
+            "CREATE TEMP TABLE IF NOT EXISTS _seen_ids (id TEXT PRIMARY KEY);
+             DELETE FROM _seen_ids;",
+        )?;
+        {
+            let mut stmt = tx.prepare("INSERT OR IGNORE INTO _seen_ids (id) VALUES (?1)")?;
+            for id in seen_ids {
+                stmt.execute(params![id.as_ref()])?;
+            }
+        }
+
+        let mut bindings: Vec<&dyn rusqlite::ToSql> = Vec::with_capacity(1 + escaped.len());
+        bindings.push(&older_than_unix_s);
+        for s in &escaped {
+            bindings.push(s);
+        }
+
+        let where_unseen = format!(
+            "(indexed_at_unix_s IS NULL OR indexed_at_unix_s < ?1)
+             AND id NOT IN (SELECT id FROM _seen_ids){like_clause}"
+        );
+
+        tx.execute(
+            &format!(
+                "DELETE FROM usage_events WHERE candidate_id IN (
+                   SELECT id FROM candidates WHERE {where_unseen}
+                 )"
+            ),
+            bindings.as_slice(),
+        )?;
+        let removed = tx.execute(
+            &format!("DELETE FROM candidates WHERE {where_unseen}"),
+            bindings.as_slice(),
+        )?;
+        tx.commit()?;
+        Ok(removed)
+    }
+
     /// Scoped variant of `delete_stale_candidates`: prunes only rows whose id begins
     /// with one of `prefixes`. Used by partial reindex paths that re-walk a subset
     /// of sources (e.g. apps-only) and must not prune candidates from sources that
@@ -526,6 +612,8 @@ impl SqliteStore {
         self.conn.execute_batch(
             "PRAGMA foreign_keys = ON;
              PRAGMA journal_mode = WAL;
+             -- Keep the seen-id temp table used by delete_unseen_candidates in RAM.
+             PRAGMA temp_store = MEMORY;
 
              CREATE TABLE IF NOT EXISTS settings (
                  key TEXT PRIMARY KEY,
@@ -822,6 +910,118 @@ mod tests {
 
         let loaded = store.load_candidates(None).expect("load candidates");
         assert!(loaded.is_empty());
+    }
+
+    #[test]
+    fn upsert_skips_write_when_row_unchanged() {
+        let mut store = SqliteStore::open_in_memory().expect("open sqlite in memory");
+        let c = candidate("file:a", "a.txt", "/x/a.txt");
+        store
+            .upsert_candidates_indexed(&[c.clone()], Some(100))
+            .expect("first insert");
+        // Re-upsert identical content on a later run: the WHERE guard should skip
+        // the UPDATE, so indexed_at stays at the original value (no rewrite).
+        store
+            .upsert_candidates_indexed(&[c], Some(200))
+            .expect("no-op upsert");
+        let indexed: i64 = store
+            .conn
+            .query_row(
+                "SELECT indexed_at_unix_s FROM candidates WHERE id = 'file:a'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read indexed_at");
+        assert_eq!(indexed, 100, "unchanged row must not be rewritten");
+    }
+
+    #[test]
+    fn upsert_writes_when_content_changes() {
+        let mut store = SqliteStore::open_in_memory().expect("open sqlite in memory");
+        store
+            .upsert_candidates_indexed(&[candidate("file:a", "a.txt", "/x/a.txt")], Some(100))
+            .expect("first insert");
+        store
+            .upsert_candidates_indexed(&[candidate("file:a", "renamed.txt", "/x/a.txt")], Some(200))
+            .expect("changed upsert");
+        let indexed: i64 = store
+            .conn
+            .query_row(
+                "SELECT indexed_at_unix_s FROM candidates WHERE id = 'file:a'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read indexed_at");
+        assert_eq!(indexed, 200, "changed row must be rewritten");
+        let loaded = store.load_candidates(None).expect("load");
+        assert_eq!(loaded[0].title.as_ref(), "renamed.txt");
+    }
+
+    #[test]
+    fn delete_unseen_removes_unseen_keeps_seen_and_pinned() {
+        let mut store = SqliteStore::open_in_memory().expect("open sqlite in memory");
+        store
+            .upsert_candidates_indexed(
+                &[
+                    candidate("file:a", "a", "/x/a"),
+                    candidate("file:b", "b", "/x/b"),
+                ],
+                Some(100),
+            )
+            .expect("insert files");
+        // Pinned/seeded row uses i64::MAX indexed_at to survive sweeps.
+        store
+            .upsert_candidates_indexed(&[candidate("uwp:pinned", "Pinned", "/p")], Some(i64::MAX))
+            .expect("insert pinned");
+
+        // The latest scan only saw file:a.
+        let mut seen: HashSet<Box<str>> = HashSet::new();
+        seen.insert("file:a".into());
+        let removed = store
+            .delete_unseen_candidates(&seen, 200, &[])
+            .expect("prune unseen");
+        assert_eq!(removed, 1);
+
+        let ids: Vec<String> = store
+            .load_candidates(None)
+            .expect("load")
+            .iter()
+            .map(|c| c.id.to_string())
+            .collect();
+        assert!(ids.contains(&"file:a".to_string()), "seen row kept");
+        assert!(ids.contains(&"uwp:pinned".to_string()), "pinned row kept");
+        assert!(!ids.contains(&"file:b".to_string()), "unseen row removed");
+    }
+
+    #[test]
+    fn delete_unseen_respects_prefixes() {
+        let mut store = SqliteStore::open_in_memory().expect("open sqlite in memory");
+        store
+            .upsert_candidates_indexed(
+                &[
+                    candidate("app:x", "X", "/x"),
+                    candidate("file:y", "Y", "/y"),
+                ],
+                Some(100),
+            )
+            .expect("insert");
+        // Scoped (apps-only) refresh saw nothing: only app:* may be pruned.
+        let seen: HashSet<Box<str>> = HashSet::new();
+        let removed = store
+            .delete_unseen_candidates(&seen, 200, &["app:"])
+            .expect("scoped prune");
+        assert_eq!(removed, 1);
+        let ids: Vec<String> = store
+            .load_candidates(None)
+            .expect("load")
+            .iter()
+            .map(|c| c.id.to_string())
+            .collect();
+        assert!(ids.contains(&"file:y".to_string()), "out-of-scope row kept");
+        assert!(
+            !ids.contains(&"app:x".to_string()),
+            "in-scope unseen removed"
+        );
     }
 
     #[test]

--- a/core/storage/src/lib.rs
+++ b/core/storage/src/lib.rs
@@ -757,9 +757,7 @@ mod tests {
             title: title.into(),
             subtitle: Some("test subtitle".into()),
             path: path.into(),
-            use_count: 0,
-            last_used_at_unix_s: None,
-            fs_modified_at_unix_s: None,
+            ..Default::default()
         }
     }
 
@@ -849,9 +847,7 @@ mod tests {
             title: "Renamed App".into(),
             subtitle: Some("updated subtitle".into()),
             path: "/Applications/Renamed.app".into(),
-            use_count: 0,
-            last_used_at_unix_s: None,
-            fs_modified_at_unix_s: None,
+            ..Default::default()
         };
 
         store

--- a/core/storage/src/lib.rs
+++ b/core/storage/src/lib.rs
@@ -211,10 +211,10 @@ impl SqliteStore {
     pub fn load_candidates(&self, limit: Option<usize>) -> StorageResult<Vec<Candidate>> {
         let sql = match limit {
             Some(_) => {
-                "SELECT id, kind, title, subtitle, path, use_count, last_used_at_unix_s FROM candidates ORDER BY title ASC LIMIT ?1"
+                "SELECT id, kind, title, subtitle, path, use_count, last_used_at_unix_s, fs_modified_at_unix_s FROM candidates ORDER BY title ASC LIMIT ?1"
             }
             None => {
-                "SELECT id, kind, title, subtitle, path, use_count, last_used_at_unix_s FROM candidates ORDER BY title ASC"
+                "SELECT id, kind, title, subtitle, path, use_count, last_used_at_unix_s, fs_modified_at_unix_s FROM candidates ORDER BY title ASC"
             }
         };
 
@@ -239,6 +239,7 @@ impl SqliteStore {
                 path: row.get::<_, String>(4)?.into_boxed_str(),
                 use_count: to_use_count(use_count_raw)?,
                 last_used_at_unix_s: row.get(6)?,
+                fs_modified_at_unix_s: row.get(7)?,
             });
         }
 
@@ -257,14 +258,15 @@ impl SqliteStore {
         let tx = self.conn.transaction()?;
         {
             let mut stmt = tx.prepare(
-                "INSERT INTO candidates (id, kind, title, subtitle, path, use_count, last_used_at_unix_s, indexed_at_unix_s)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+                "INSERT INTO candidates (id, kind, title, subtitle, path, use_count, last_used_at_unix_s, indexed_at_unix_s, fs_modified_at_unix_s)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
                  ON CONFLICT(id) DO UPDATE SET
                    kind = excluded.kind,
                    title = excluded.title,
                    subtitle = excluded.subtitle,
                      path = excluded.path,
-                    indexed_at_unix_s = excluded.indexed_at_unix_s",
+                    indexed_at_unix_s = excluded.indexed_at_unix_s,
+                    fs_modified_at_unix_s = excluded.fs_modified_at_unix_s",
             )?;
 
             for candidate in candidates {
@@ -278,6 +280,7 @@ impl SqliteStore {
                     use_count,
                     candidate.last_used_at_unix_s,
                     indexed_at_unix_s,
+                    candidate.fs_modified_at_unix_s,
                 ])?;
             }
         }
@@ -292,8 +295,8 @@ impl SqliteStore {
 
         {
             let mut stmt = tx.prepare(
-                "INSERT INTO candidates (id, kind, title, subtitle, path, use_count, last_used_at_unix_s, indexed_at_unix_s)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                "INSERT INTO candidates (id, kind, title, subtitle, path, use_count, last_used_at_unix_s, indexed_at_unix_s, fs_modified_at_unix_s)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             )?;
 
             for candidate in candidates {
@@ -307,6 +310,7 @@ impl SqliteStore {
                     use_count,
                     candidate.last_used_at_unix_s,
                     None::<i64>,
+                    candidate.fs_modified_at_unix_s,
                 ])?;
             }
         }
@@ -562,6 +566,10 @@ impl SqliteStore {
             [],
         )?;
 
+        // Filesystem mtime, captured at index time, powers the recent view's
+        // "newly added/changed" signal. Additive column on existing DBs.
+        ensure_column_exists(&self.conn, "candidates", "fs_modified_at_unix_s", "INTEGER")?;
+
         Ok(())
     }
 }
@@ -663,6 +671,7 @@ mod tests {
             path: path.into(),
             use_count: 0,
             last_used_at_unix_s: None,
+            fs_modified_at_unix_s: None,
         }
     }
 
@@ -754,6 +763,7 @@ mod tests {
             path: "/Applications/Renamed.app".into(),
             use_count: 0,
             last_used_at_unix_s: None,
+            fs_modified_at_unix_s: None,
         };
 
         store

--- a/docs/features.md
+++ b/docs/features.md
@@ -15,7 +15,7 @@ This document tracks what `look` supports today and what is planned next.
 ### Core search and launch
 
 - app/file/folder search from one input
-- scoped query prefixes: `a"`, `f"`, `d"`, `r"`
+- scoped query prefixes: `a"`, `f"`, `d"`, `r"`, and `rc"` (recent files/folders, newest first — blends opened-through-Look with recently added/changed on disk; macOS for now)
 - path-fragment friendly matching (slash-biased queries)
 - open with `Enter`, reveal in Finder with `Cmd+F`
 - copy selected file/folder path/content handle with `Cmd+C`

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -74,6 +74,7 @@ When at least one item is picked, the right panel switches to the **Picked** lis
 - `a"term` -> apps only
 - `f"term` -> files only
 - `d"term` -> folders only
+- `rc"term` -> recent files/folders, newest activity first (optional filter; `rc"` alone lists all). Blends what you've opened through Look with what recently appeared/changed on disk (downloads, screenshots). macOS for now.
 - `r"pattern` -> regex search (case-insensitive)
 - `c"term` -> clipboard history search
 - `t"text` -> quick translation panel


### PR DESCRIPTION
## Summary

- Implement built-in recent places for look 
  - search recent files and folder 
  - prefix rc" (thinking another idea but this is good)

## Why

- #199 

## Changes

-

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered