### PR TITLE
Tiny Features (Macos)

### DIFF
--- a/apps/linows/src-tauri/tauri.conf.json
+++ b/apps/linows/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicoverbruggen/tauri-v2-schema/main/schema.json",
   "productName": "Look",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "identifier": "com.look.desktop",
   "build": {
     "frontendDist": "../src",

--- a/apps/macos/LauncherApp/LauncherLogicTests/DeleteTargetLogicTests.swift
+++ b/apps/macos/LauncherApp/LauncherLogicTests/DeleteTargetLogicTests.swift
@@ -62,6 +62,23 @@ final class DeleteTargetLogicTests: XCTestCase {
         XCTAssertEqual(eligible.map(\.id), ["ok"])
     }
 
+    func testDropsQuickFolderPins() {
+        // Quick-folder pins are navigation shortcuts, not delete targets, even
+        // though they're real, existing folders outside the protected set.
+        let prefix = AppConstants.Launcher.QuickFolder.idPrefix
+        let input = [
+            result("\(prefix)applications", .folder, path: "/Applications"),
+            result("\(prefix)documents", .folder, path: "/Users/me/Documents"),
+            result("real", .folder, path: "/Users/me/Projects"),
+        ]
+        let eligible = DeleteTargetLogic.eligible(
+            from: input,
+            fileExists: { _ in true },
+            homeDirectory: "/Users/me"
+        )
+        XCTAssertEqual(eligible.map(\.id), ["real"])
+    }
+
     // MARK: - isTrashPath
 
     func testIsTrashPath() {

--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -72,6 +72,66 @@ enum AppConstants {
             // (needs last_used/fs_modified timestamps); the app just sends it
             // through search and suppresses pinned injection (see LauncherSearchLogic).
             static let recent = "rc\""
+            // Translation prefixes (handled in LauncherView+Translation).
+            static let translate = "t\""
+            static let translateWord = "tw\""
+
+            // Typing a lone `"` opens the prefix-discovery menu (see
+            // PrefixSuggestion.all / LauncherView.isPrefixSuggestionQuery).
+            static let discovery = "\""
+        }
+
+        // Canonical list of query prefixes, with a usage hint and a description.
+        // Single source of truth for the prefix-discovery menu (type `"`), the help
+        // screen's "Query modes" section, and the Settings → Shortcuts panel, so
+        // the three can't drift apart.
+        enum PrefixSuggestion {
+            // Synthetic result id prefix; lets the row view and open handler tell a
+            // discovery suggestion apart from a real candidate.
+            static let resultIDPrefix = "prefixhint:"
+
+            struct Entry: Identifiable {
+                let prefix: String
+                let argHint: String
+                let description: String
+                /// Whether this entry appears in the live `"` discovery menu.
+                /// The `"` entry itself is documented in the static lists but
+                /// hidden from the menu it opens (see `menuEntries`).
+                var listedInMenu: Bool = true
+                var id: String { prefix }
+                /// What the help/shortcuts lists show, e.g. `a"word` (or just `"`).
+                var displayWithArg: String { prefix + argHint }
+            }
+
+            /// Entries shown in the live discovery menu (excludes `"` itself).
+            static var menuEntries: [Entry] { all.filter(\.listedInMenu) }
+
+            static let all: [Entry] = [
+                Entry(
+                    prefix: QueryPrefix.discovery, argHint: "",
+                    description: "Browse all prefixes", listedInMenu: false),
+                Entry(prefix: QueryPrefix.apps, argHint: "word", description: "Apps only"),
+                Entry(prefix: QueryPrefix.files, argHint: "word", description: "Files only"),
+                Entry(prefix: QueryPrefix.folders, argHint: "word", description: "Folders only"),
+                Entry(
+                    prefix: QueryPrefix.recent, argHint: "word",
+                    description: "Recent files/folders, newest first (optional filter)"),
+                Entry(prefix: QueryPrefix.regex, argHint: "pattern", description: "Regex search"),
+                Entry(
+                    prefix: QueryPrefix.clipboard, argHint: "word",
+                    description: "Clipboard history search (latest 10 text clips)"),
+                Entry(prefix: QueryPrefix.translate, argHint: "word", description: "Web translate (VI/EN/JA)"),
+                Entry(
+                    prefix: QueryPrefix.translateWord, argHint: "word",
+                    description: "Lookup panel with definitions"),
+            ]
+
+            /// Recovers the query prefix encoded in a discovery-suggestion result
+            /// id, or nil when `resultID` isn't a discovery suggestion.
+            static func prefix(fromResultID resultID: String) -> String? {
+                guard resultID.hasPrefix(resultIDPrefix) else { return nil }
+                return String(resultID.dropFirst(resultIDPrefix.count))
+            }
         }
 
         enum Finder {

--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -26,9 +26,30 @@ struct AppCommand: Identifiable {
 }
 
 struct QuickFolderDefinition {
+    /// Where a quick folder lives. Most are under the user's home directory
+    /// (`.home("Desktop")`); a few are fixed system locations outside home
+    /// (`.absolute("/Applications")`).
+    enum Location {
+        case home(String)
+        case absolute(String)
+    }
+
     let title: String
-    let relativePath: String
+    let location: Location
     var subtitle: String? = nil
+
+    /// Resolves to a concrete filesystem path. Home-relative entries are joined
+    /// onto `homeDirectory`; absolute entries are used verbatim.
+    func resolvedPath(homeDirectory: String) -> String {
+        switch location {
+        case .home(let relativePath):
+            return URL(fileURLWithPath: homeDirectory)
+                .appendingPathComponent(relativePath)
+                .path
+        case .absolute(let path):
+            return path
+        }
+    }
 }
 
 enum AppConstants {
@@ -69,19 +90,29 @@ enum AppConstants {
             static let idPrefix = "quickfolder:"
             static let pinnedSubtitle = "Pinned home folder"
             static let minPrefixMatchLength = 2
+            static let absoluteFolderSubtitle = "Pinned folder"
             static let entries: [QuickFolderDefinition] = [
-                QuickFolderDefinition(title: "Desktop", relativePath: "Desktop"),
-                QuickFolderDefinition(title: "Documents", relativePath: "Documents"),
-                QuickFolderDefinition(title: "Downloads", relativePath: "Downloads"),
-                QuickFolderDefinition(title: "Pictures", relativePath: "Pictures"),
+                QuickFolderDefinition(title: "Desktop", location: .home("Desktop")),
+                QuickFolderDefinition(title: "Documents", location: .home("Documents")),
+                QuickFolderDefinition(title: "Downloads", location: .home("Downloads")),
+                QuickFolderDefinition(title: "Pictures", location: .home("Pictures")),
                 // macOS names this folder "Movies" (Windows calls the equivalent "Videos");
                 // each platform's QuickFolder uses the OS-native folder name so typing what
                 // the user sees in Finder/Explorer pins it.
-                QuickFolderDefinition(title: "Movies", relativePath: "Movies"),
-                QuickFolderDefinition(title: "Music", relativePath: "Music"),
+                QuickFolderDefinition(title: "Movies", location: .home("Movies")),
+                QuickFolderDefinition(title: "Music", location: .home("Music")),
+                // /Applications is a system folder outside home — the folder indexer
+                // only walks Desktop/Documents/Downloads, so pin it here to make it
+                // reachable. .app bundles inside it stay app candidates, not folders.
+                QuickFolderDefinition(
+                    title: "Applications",
+                    location: .absolute("/Applications"),
+                    subtitle: absoluteFolderSubtitle
+                ),
                 // ~/.Trash is a real directory, so it opens in Finder like any
                 // other quick folder. Typing "trash" pins it; ⌘D empties it.
-                QuickFolderDefinition(title: "Trash", relativePath: ".Trash", subtitle: "Pinned · ⌘D to empty"),
+                QuickFolderDefinition(
+                    title: "Trash", location: .home(".Trash"), subtitle: "Pinned · ⌘D to empty"),
             ]
         }
 

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/DeleteTargetLogic.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/DeleteTargetLogic.swift
@@ -19,10 +19,21 @@ enum DeleteTargetLogic {
     ) -> [LauncherResult] {
         results.filter { result in
             guard result.kind == .file || result.kind == .folder else { return false }
+            if isQuickFolderPin(result.id) { return false }
             if isURLScheme(result.path) { return false }
             if isProtected(result.path, homeDirectory: homeDirectory) { return false }
             return fileExists(result.path)
         }
+    }
+
+    /// Quick-folder results (Desktop, Documents, …, Applications, Trash) are
+    /// navigation pins, not delete targets - Cmd+D must never trash the real
+    /// folder behind one. They aren't covered by `isProtected` (most are ordinary
+    /// home subfolders / `/Applications`), so they're excluded by id here. Cmd+D
+    /// on the Trash pin is routed to Empty Trash before eligibility is checked
+    /// (see `requestDeleteSelection`).
+    static func isQuickFolderPin(_ id: String) -> Bool {
+        id.hasPrefix(AppConstants.Launcher.QuickFolder.idPrefix)
     }
 
     /// URL-scheme targets contain a ":" and don't start at the filesystem root.
@@ -59,7 +70,9 @@ enum DeleteTargetLogic {
     }
 
     /// Banner text + error flag summarizing a trash outcome.
-    static func resultMessage(trashedCount: Int, failureCount: Int, firstFailure: (name: String, reason: String)?) -> (text: String, isError: Bool) {
+    static func resultMessage(
+        trashedCount: Int, failureCount: Int, firstFailure: (name: String, reason: String)?
+    ) -> (text: String, isError: Bool) {
         if failureCount == 0 {
             return ("Moved \(trashedCount) to Trash", false)
         }

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/HintText.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/HintText.swift
@@ -10,6 +10,6 @@ enum HintText {
 
     enum Settings {
         static let advancedApply = "Save Config applies changes immediately. Cmd+Shift+; is only needed after editing .look.config manually."
-        static let shortcutsTips = "Tips: t\"word for web EN/VI/JA translation | tw\"word for dictionary lookup panel | /kill to force quit apps"
+        static let shortcutsTips = "Tips: type \" to browse all prefixes | rc\"word for recent files/folders | t\"word for web EN/VI/JA translation | tw\"word for dictionary lookup panel | /kill to force quit apps"
     }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
@@ -10,7 +10,16 @@ struct LauncherRowView: View {
     let isPicked: Bool
     let onOpen: () -> Void
 
+    private var isPrefixSuggestion: Bool {
+        result.id.hasPrefix(AppConstants.Launcher.PrefixSuggestion.resultIDPrefix)
+    }
+
     private var rowIcon: NSImage {
+        if isPrefixSuggestion {
+            return NSImage(systemSymbolName: "magnifyingglass", accessibilityDescription: nil)
+                ?? NSWorkspace.shared.icon(for: .plainText)
+        }
+
         if result.kind == .clipboard {
             return NSImage(systemSymbolName: "doc.on.clipboard", accessibilityDescription: nil)
                 ?? NSImage(systemSymbolName: "doc.text", accessibilityDescription: nil)
@@ -58,6 +67,9 @@ struct LauncherRowView: View {
     }
 
     private var metaLabel: String {
+        if isPrefixSuggestion {
+            return result.subtitle ?? ""
+        }
         if result.kind == .clipboard {
             return result.subtitle ?? kindLabel
         }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
@@ -408,16 +408,10 @@ private enum LauncherHelpContent {
         ("Esc", "Close help / back / hide launcher"),
     ]
 
-    static let queryModes: [(String, String)] = [
-        ("a\"word", "Apps only"),
-        ("f\"word", "Files only"),
-        ("d\"word", "Folders only"),
-        ("rc\"word", "Recent files/folders, newest first (optional filter)"),
-        ("r\"pattern", "Regex search"),
-        ("c\"word", "Clipboard history search (latest 10 text clips)"),
-        ("t\"word", "Web translate (VI/EN/JA)"),
-        ("tw\"word", "Lookup panel with definitions"),
-    ]
+    // Derived from the canonical prefix list so the help screen and the `"`
+    // discovery menu stay in sync.
+    static let queryModes: [(String, String)] =
+        AppConstants.Launcher.PrefixSuggestion.all.map { ($0.displayWithArg, $0.description) }
 
     static let commandMode: [(String, String)] = [
         ("Tab / Shift+Tab", "Switch command"),

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
@@ -10,6 +10,14 @@ extension LauncherView {
             let selected = displayedResults.first(where: { $0.id == selectedResultID })
         else { return }
 
+        // Prefix-discovery menu: choosing an entry fills its prefix into the
+        // field (cursor ready for the term) rather than opening anything.
+        if let prefix = AppConstants.Launcher.PrefixSuggestion.prefix(fromResultID: selected.id) {
+            query = prefix
+            isQueryFocused = true
+            return
+        }
+
         switch selected.kind {
         case .app:
             guard ensureTargetExists(selected) else { return }
@@ -144,7 +152,7 @@ extension LauncherView {
     }
 
     func revealSelectedInFinder() {
-        guard !isCommandMode,
+        guard !isCommandMode, !isPrefixSuggestionQuery,
               let selectedID = selectedResultID,
               let selected = displayedResults.first(where: { $0.id == selectedID })
         else { return }
@@ -174,7 +182,7 @@ extension LauncherView {
     }
 
     func togglePickForSelectedResult() {
-        guard !isCommandMode,
+        guard !isCommandMode, !isPrefixSuggestionQuery,
               let selectedID = selectedResultID,
               let selected = displayedResults.first(where: { $0.id == selectedID })
         else { return }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Translation.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Translation.swift
@@ -14,13 +14,16 @@ extension LauncherView {
     }
 
     func extractTranslationQuery(from input: String) -> TranslationCommand? {
-        if input.hasPrefix("t\"") {
-            let text = String(input.dropFirst(2)).trimmingCharacters(in: .whitespacesAndNewlines)
+        let translate = AppConstants.Launcher.QueryPrefix.translate
+        let translateWord = AppConstants.Launcher.QueryPrefix.translateWord
+        if input.hasPrefix(translate) {
+            let text = String(input.dropFirst(translate.count)).trimmingCharacters(in: .whitespacesAndNewlines)
             return text.isEmpty ? nil : .network(text)
         }
 
-        if input.count >= 3, input.prefix(3).lowercased() == "tw\"" {
-            let text = String(input.dropFirst(3)).trimmingCharacters(in: .whitespacesAndNewlines)
+        if input.count >= translateWord.count,
+            input.prefix(translateWord.count).lowercased() == translateWord {
+            let text = String(input.dropFirst(translateWord.count)).trimmingCharacters(in: .whitespacesAndNewlines)
             return text.isEmpty ? nil : .lookup(text)
         }
 

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -257,6 +257,31 @@ struct LauncherView: View {
             .hasPrefix(AppConstants.Launcher.QueryPrefix.recent)
     }
 
+    /// A lone `"` opens the prefix-discovery menu: a list of every query prefix
+    /// with a short description. Picking one fills the prefix into the field.
+    var isPrefixSuggestionQuery: Bool {
+        query.trimmingCharacters(in: .whitespacesAndNewlines)
+            == AppConstants.Launcher.QueryPrefix.discovery
+    }
+
+    /// Synthetic results backing the discovery menu. Rendered through the normal
+    /// results list so selection/keyboard nav work as usual; `openSelectedApp`
+    /// recognises the id prefix and inserts the prefix instead of opening.
+    var prefixSuggestionResults: [LauncherResult] {
+        let suggestions = AppConstants.Launcher.PrefixSuggestion.menuEntries
+        return suggestions.enumerated().map { index, entry in
+            LauncherResult(
+                id: "\(AppConstants.Launcher.PrefixSuggestion.resultIDPrefix)\(entry.prefix)",
+                kind: .app,
+                title: entry.displayWithArg,
+                subtitle: entry.description,
+                path: "",
+                // Preserve list order: higher score sorts first, top entry highest.
+                score: suggestions.count - index
+            )
+        }
+    }
+
     var clipboardSearchTerm: String? {
         LauncherClipboardFeature.searchTerm(from: query)
     }
@@ -270,7 +295,8 @@ struct LauncherView: View {
     }
 
     var displayedResults: [LauncherResult] {
-        isClipboardQuery ? clipboardResults : backendFilteredResults
+        if isPrefixSuggestionQuery { return prefixSuggestionResults }
+        return isClipboardQuery ? clipboardResults : backendFilteredResults
     }
 
     var isTranslationQuery: Bool {
@@ -342,6 +368,10 @@ struct LauncherView: View {
 
         if showsHelpScreen {
             return ["Cmd+H close help", "Esc hide launcher", "Cmd+/ command mode", "Enter open"]
+        }
+
+        if isPrefixSuggestionQuery {
+            return ["Enter pick prefix", "Up/Down move", "Esc clear", "Cmd+H help"]
         }
 
         if isClipboardQuery {
@@ -472,7 +502,9 @@ struct LauncherView: View {
                 if showsHelpScreen {
                     showsHelpScreen = false
                 }
-                if isClipboardQuery {
+                if isClipboardQuery || isPrefixSuggestionQuery {
+                    // Both render synthetic results (clip history / prefix menu);
+                    // no backend search, just re-seed the selection.
                     setInitialSelection()
                 } else {
                     refreshSearchResults()
@@ -718,7 +750,8 @@ struct LauncherView: View {
                     onRemove: { removePicked(key: $0) },
                     onClearAll: { clearAllPicked() }
                 )
-            } else if let selectedID = selectedResultID,
+            } else if !isPrefixSuggestionQuery,
+                      let selectedID = selectedResultID,
                       let selectedResult = displayedResults.first(where: { $0.id == selectedID }) {
                 resultsDivider
                 ResultPreviewView(

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -197,9 +197,7 @@ struct LauncherView: View {
                     && normalized.count >= AppConstants.Launcher.QuickFolder.minPrefixMatchLength)
             guard isMatch else { return nil }
 
-            let folderPath = URL(fileURLWithPath: NSHomeDirectory())
-                .appendingPathComponent(entry.relativePath)
-                .path
+            let folderPath = entry.resolvedPath(homeDirectory: NSHomeDirectory())
             guard FileManager.default.fileExists(atPath: folderPath) else { return nil }
 
             return LauncherResult(

--- a/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Shortcuts.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Shortcuts.swift
@@ -56,13 +56,12 @@ enum ShortcutDocs {
         ),
         ShortcutSectionData(
             title: "Search prefixes",
-            items: [
-                ShortcutItem(keys: "a\"", action: "Apps-only query"),
-                ShortcutItem(keys: "f\"", action: "Files-only query"),
-                ShortcutItem(keys: "d\"", action: "Folders-only query"),
-                ShortcutItem(keys: "r\"", action: "Regex query"),
-                ShortcutItem(keys: "c\"", action: "Clipboard history query"),
-            ]
+            // Derived from the canonical prefix list (AppConstants) so this panel,
+            // the in-window help screen, and the `"` discovery menu can't drift.
+            // Type `"` alone to browse these prefixes interactively.
+            items: AppConstants.Launcher.PrefixSuggestion.all.map {
+                ShortcutItem(keys: $0.prefix, action: $0.description)
+            }
         ),
         ShortcutSectionData(
             title: "Clipboard history",

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -71,6 +71,8 @@ When at least one item is picked, the right panel switches to the **Picked** lis
 
 ## Query prefixes
 
+Don't remember the prefixes? Type a single `"` to open a menu listing every prefix with a short description — pick one (click or `↑`/`↓` then `Enter`) to drop it into the search field, ready for your term.
+
 - `a"term` -> apps only
 - `f"term` -> files only
 - `d"term` -> folders only


### PR DESCRIPTION
## Summary

- Add prefixes search, type " -> list all prefixes
- Add Applications folder

## Why

- #191 #208 

## Changes

-

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
