### PR TITLE
chore: tiny improvements for commands and prefixes searching

### DIFF
--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -115,6 +115,21 @@ enum AppConstants {
             /// Entries shown in the live discovery menu (excludes `"` itself).
             static var menuEntries: [Entry] { all.filter(\.listedInMenu) }
 
+            /// Discovery entries narrowed by `filter` - the text typed after the
+            /// leading `"`. Case-insensitive substring match against the prefix,
+            /// its display form, and the description, so `"folder` finds `d"` by
+            /// intent rather than only by the cryptic prefix letter. An empty
+            /// filter returns the full menu.
+            static func menuEntries(matching filter: String) -> [Entry] {
+                let needle = filter.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+                guard !needle.isEmpty else { return menuEntries }
+                return menuEntries.filter {
+                    $0.prefix.lowercased().contains(needle)
+                        || $0.displayWithArg.lowercased().contains(needle)
+                        || $0.description.lowercased().contains(needle)
+                }
+            }
+
             static let all: [Entry] = [
                 Entry(
                     prefix: QueryPrefix.discovery, argHint: "",

--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -304,6 +304,32 @@ enum AppConstants {
             AppCommand(id: Command.sys, title: "sys (⌘5)", detail: "Show system information", placeholder: "View system info"),
         ]
 
+        /// Commands narrowed by `filter` - the text typed after a leading `:`.
+        /// Case-insensitive substring match against the command id and its
+        /// description, so `:end` or `:process` both surface `kill`. An empty
+        /// filter returns the whole catalog.
+        static func commandCatalog(matching filter: String) -> [AppCommand] {
+            let needle = filter.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard !needle.isEmpty else { return commandCatalog }
+            return commandCatalog.filter {
+                $0.id.lowercased().contains(needle)
+                    || $0.detail.lowercased().contains(needle)
+            }
+        }
+
+        // Command-discovery rows (type `:`). Like PrefixSuggestion, these are
+        // Swift-synthesized rows in the main results list, told apart by id;
+        // `openSelectedApp` enters the command instead of opening a file.
+        enum CommandSuggestion {
+            static let resultIDPrefix = "cmdhint:"
+
+            /// Recovers the command id encoded in a discovery-row result id, or nil.
+            static func commandID(fromResultID resultID: String) -> String? {
+                guard resultID.hasPrefix(resultIDPrefix) else { return nil }
+                return String(resultID.dropFirst(resultIDPrefix.count))
+            }
+        }
+
         static let normalHint = HintText.Launcher.normal
         static let commandHint = HintText.Launcher.command
         static let killHint = HintText.Launcher.kill

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
@@ -18,7 +18,16 @@ struct LauncherRowView: View {
         result.id.hasPrefix(AppConstants.Launcher.WebSuggestion.resultIDPrefix)
     }
 
+    private var isCommandSuggestion: Bool {
+        result.id.hasPrefix(AppConstants.Launcher.CommandSuggestion.resultIDPrefix)
+    }
+
     private var rowIcon: NSImage {
+        if isCommandSuggestion {
+            return NSImage(systemSymbolName: "terminal", accessibilityDescription: nil)
+                ?? NSWorkspace.shared.icon(for: .plainText)
+        }
+
         if isPrefixSuggestion || isWebSuggestion {
             return NSImage(systemSymbolName: "magnifyingglass", accessibilityDescription: nil)
                 ?? NSWorkspace.shared.icon(for: .plainText)
@@ -71,7 +80,7 @@ struct LauncherRowView: View {
     }
 
     private var metaLabel: String {
-        if isPrefixSuggestion || isWebSuggestion {
+        if isPrefixSuggestion || isWebSuggestion || isCommandSuggestion {
             return result.subtitle ?? ""
         }
         if result.kind == .clipboard {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
@@ -27,6 +27,12 @@ extension LauncherView {
             return
         }
 
+        // Command-discovery row: enter that command's panel (empty input).
+        if let commandID = AppConstants.Launcher.CommandSuggestion.commandID(fromResultID: selected.id) {
+            enterCommandMode(commandID: commandID, prefilledInput: "")
+            return
+        }
+
         switch selected.kind {
         case .app:
             guard ensureTargetExists(selected) else { return }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Search.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Search.swift
@@ -121,7 +121,7 @@ extension LauncherView {
 
         guard themeStore.settings.aiEnabled,
               !isCommandMode, !isClipboardQuery, !isPrefixSuggestionQuery,
-              !isTranslationQuery, trimmed.count >= 2
+              !isCommandSuggestionQuery, !isTranslationQuery, trimmed.count >= 2
         else {
             if !webSuggestions.isEmpty { webSuggestions = [] }
             return

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -260,18 +260,27 @@ struct LauncherView: View {
             .hasPrefix(AppConstants.Launcher.QueryPrefix.recent)
     }
 
-    /// A lone `"` opens the prefix-discovery menu: a list of every query prefix
-    /// with a short description. Picking one fills the prefix into the field.
+    /// A leading `"` opens the prefix-discovery menu: a list of every query
+    /// prefix with a short description. Typing after the `"` (e.g. `"folder`)
+    /// filters the list by name/description; picking one fills the prefix in.
     var isPrefixSuggestionQuery: Bool {
         query.trimmingCharacters(in: .whitespacesAndNewlines)
-            == AppConstants.Launcher.QueryPrefix.discovery
+            .hasPrefix(AppConstants.Launcher.QueryPrefix.discovery)
+    }
+
+    /// The text typed after the leading `"`, used to filter the discovery menu.
+    var prefixSuggestionFilter: String {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let discovery = AppConstants.Launcher.QueryPrefix.discovery
+        guard trimmed.hasPrefix(discovery) else { return "" }
+        return String(trimmed.dropFirst(discovery.count))
     }
 
     /// Synthetic results backing the discovery menu. Rendered through the normal
     /// results list so selection/keyboard nav work as usual; `openSelectedApp`
     /// recognises the id prefix and inserts the prefix instead of opening.
     var prefixSuggestionResults: [LauncherResult] {
-        let suggestions = AppConstants.Launcher.PrefixSuggestion.menuEntries
+        let suggestions = AppConstants.Launcher.PrefixSuggestion.menuEntries(matching: prefixSuggestionFilter)
         return suggestions.enumerated().map { index, entry in
             LauncherResult(
                 id: "\(AppConstants.Launcher.PrefixSuggestion.resultIDPrefix)\(entry.prefix)",

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -294,6 +294,43 @@ struct LauncherView: View {
         }
     }
 
+    /// A leading `:` opens the command-discovery menu: every command with its
+    /// description. Typing after the `:` (e.g. `:process`) filters by id and
+    /// description; picking one enters that command. A `:<exact-id> <args>`
+    /// live-trigger (e.g. `:calc 2+2`) jumps straight into the command instead
+    /// (handled in `onChange(of: query)`), so it isn't a discovery query.
+    var isCommandSuggestionQuery: Bool {
+        guard !isCommandMode else { return false }
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix(":") else { return false }
+        if let cmd = extractInlineCommand(from: query), cmd.hasSpace { return false }
+        return true
+    }
+
+    /// The text typed after the leading `:`, used to filter the command menu.
+    var commandSuggestionFilter: String {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix(":") else { return "" }
+        return String(trimmed.dropFirst())
+    }
+
+    /// Synthetic results backing the command-discovery menu. Rendered through the
+    /// normal results list; `openSelectedApp` recognises the id prefix and enters
+    /// the command instead of opening a file.
+    var commandSuggestionResults: [LauncherResult] {
+        let matches = AppConstants.Launcher.commandCatalog(matching: commandSuggestionFilter)
+        return matches.enumerated().map { index, command in
+            LauncherResult(
+                id: "\(AppConstants.Launcher.CommandSuggestion.resultIDPrefix)\(command.id)",
+                kind: .app,
+                title: command.title,
+                subtitle: command.detail,
+                path: "",
+                score: matches.count - index
+            )
+        }
+    }
+
     var clipboardSearchTerm: String? {
         LauncherClipboardFeature.searchTerm(from: query)
     }
@@ -310,7 +347,7 @@ struct LauncherView: View {
     /// hand like `prefixSuggestionResults`; `openSelectedApp` recognises the id
     /// prefix and runs a web search instead of opening a file.
     var webSuggestionResults: [LauncherResult] {
-        guard !isCommandMode, !isClipboardQuery, !isPrefixSuggestionQuery else { return [] }
+        guard !isCommandMode, !isClipboardQuery, !isPrefixSuggestionQuery, !isCommandSuggestionQuery else { return [] }
         return webSuggestions.enumerated().map { index, text in
             LauncherResult(
                 id: "\(AppConstants.Launcher.WebSuggestion.resultIDPrefix)\(text)",
@@ -325,6 +362,7 @@ struct LauncherView: View {
 
     var displayedResults: [LauncherResult] {
         if isPrefixSuggestionQuery { return prefixSuggestionResults }
+        if isCommandSuggestionQuery { return commandSuggestionResults }
         if isClipboardQuery { return clipboardResults }
         return backendFilteredResults + webSuggestionResults
     }
@@ -402,6 +440,10 @@ struct LauncherView: View {
 
         if isPrefixSuggestionQuery {
             return ["Enter pick prefix", "Up/Down move", "Esc clear", "Cmd+H help"]
+        }
+
+        if isCommandSuggestionQuery {
+            return ["Enter run command", "Up/Down move", "Esc clear", "Cmd+H help"]
         }
 
         if isClipboardQuery {
@@ -534,9 +576,9 @@ struct LauncherView: View {
                 if showsHelpScreen {
                     showsHelpScreen = false
                 }
-                if isClipboardQuery || isPrefixSuggestionQuery {
-                    // Both render synthetic results (clip history / prefix menu);
-                    // no backend search, just re-seed the selection.
+                if isClipboardQuery || isPrefixSuggestionQuery || isCommandSuggestionQuery {
+                    // These render synthetic results (clip history / prefix menu /
+                    // command menu); no backend search, just re-seed the selection.
                     aiAnswer.cancel()
                     setInitialSelection()
                 } else {
@@ -827,7 +869,7 @@ struct LauncherView: View {
                     onRemove: { removePicked(key: $0) },
                     onClearAll: { clearAllPicked() }
                 )
-            } else if !isPrefixSuggestionQuery,
+            } else if !isPrefixSuggestionQuery, !isCommandSuggestionQuery,
                       let selectedID = selectedResultID,
                       let selectedResult = displayedResults.first(where: { $0.id == selectedID }),
                       // Search suggestions have nothing to preview — let the list


### PR DESCRIPTION
## Summary

- Prefixes search with description -> easier life
- Add auto suggestion for commands as well. 

## Why

- #208 

## Changes

-

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
