### PR TITLE
Linows: Comamnds and prefixes suggestion for Linows

### DIFF
--- a/apps/linows/src/css/layout.css
+++ b/apps/linows/src/css/layout.css
@@ -152,6 +152,14 @@ html[data-os="windows"] .launcher-window {
   scrollbar-width: none;
 }
 
+/* When the preview pane is hidden (discovery menus, etc.), let the results
+ * list span both grid columns so it doesn't get squeezed into column 1 while
+ * the running-apps strip occupies column 2's top row. Matches macOS, which
+ * drops the preview pane entirely in `"` / `:` discovery modes. */
+.main-pane:has(.preview-panel[hidden]) .results-list {
+  grid-column: 1 / -1;
+}
+
 .results-list::-webkit-scrollbar {
   display: none;
 }

--- a/apps/linows/src/html/screens/help.html
+++ b/apps/linows/src/html/screens/help.html
@@ -37,6 +37,7 @@
 
       <!-- Query prefixes -->
       <div class="help-section-title">Query prefixes</div>
+      <div class="help-item"><kbd>"</kbd><span>Browse all prefixes — type a letter to filter, Enter to pick</span></div>
       <div class="help-item"><kbd>a"word</kbd><span>Apps only</span></div>
       <div class="help-item"><kbd>f"word</kbd><span>Files only</span></div>
       <div class="help-item"><kbd>d"word</kbd><span>Folders only</span></div>
@@ -47,6 +48,8 @@
 
       <!-- Command mode -->
       <div class="help-section-title">Command mode</div>
+      <div class="help-item"><kbd>:</kbd><span>Browse all commands — type to filter, Enter to run</span></div>
+      <div class="help-item"><kbd>:cmd&nbsp;args</kbd><span>Jump straight into a command, e.g. <kbd>:calc 2+2</kbd></span></div>
       <div class="help-item"><kbd>Tab / Shift+Tab</kbd><span>Switch command</span></div>
       <div class="help-item"><kbd>Ctrl+1..5</kbd><span>Switch to /calc, /pomo, /kill, /shell, /sys</span></div>
       <div class="help-item"><kbd>:3000</kbd><span>Find process listening on port</span></div>

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -19,6 +19,7 @@ import {
   copyToClipboard, deleteClipboardEntry, isDevBuild,
   getConfig,
 } from './ipc.js';
+import { prefixFromResultId, commandIdFromResultId } from './catalog.js';
 
 // Item count and structure mirror the macOS app's `LauncherView.hintItems`
 // (apps/macos/.../LauncherView.swift:302) so both platforms surface the same
@@ -27,6 +28,10 @@ import {
 const HINT_MAIN = 'Enter: Open \u2022 Ctrl+F: Reveal \u2022 Ctrl+H: Help \u2022 Ctrl+/: Command mode';
 const HINT_TRANSLATE = 'Enter: Translate \u2022 Copy per result \u2022 Ctrl+H: Help \u2022 Ctrl+/: Command mode';
 const HINT_CLIPBOARD = 'Enter: Copy clip \u2022 Delete: Remove clip \u2022 Ctrl+H: Help \u2022 Ctrl+/: Command mode';
+// Discovery-menu hints \u2014 mirror macOS prefixSuggestion / commandSuggestion
+// hint bars (LauncherView.swift hintItems).
+const HINT_PREFIX_DISCOVERY = 'Enter: Pick prefix \u2022 Up/Down: Move \u2022 Esc: Clear \u2022 Ctrl+H: Help';
+const HINT_COMMAND_DISCOVERY = 'Enter: Run command \u2022 Up/Down: Move \u2022 Esc: Clear \u2022 Ctrl+H: Help';
 
 // Hint constants are static, authored in code \u2014 safe to set as innerHTML so
 // each bullet renders through `.hint-sep` (accent color, bold) for clearer
@@ -133,12 +138,17 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Expose command mode toggle for keyboard.js
   keyboard.setCommandMode(commands);
 
-  // Update right panel when selection changes
+  // Update right panel when selection changes. Discovery rows have nothing
+  // to preview (synthetic, empty path) — let the list span full width instead
+  // of showing an empty pane (matches macOS LauncherView.swift:872).
   results.setOnSelectionChange((item) => {
-    if (!results.hasPickedItems()) {
-      previewPanel.hidden = false;
-      preview.update(item);
+    if (results.hasPickedItems()) return;
+    if (item && (prefixFromResultId(item.id) != null || commandIdFromResultId(item.id) != null)) {
+      previewPanel.hidden = true;
+      return;
     }
+    previewPanel.hidden = false;
+    preview.update(item);
   });
 
   // Wire clipboard delete from preview panel
@@ -172,20 +182,25 @@ document.addEventListener('DOMContentLoaded', async () => {
     results.render(items);
   });
 
-  // :cmd prefix → jump into command mode (e.g. :calc 2+2, :kill chrome)
+  // :cmd <args> live trigger — jumps straight into that command's panel with
+  // the rest of the text prefilled (e.g. `:calc 2+2`, `:kill chrome`). Bare
+  // `:calc` without a trailing space stays in the discovery menu (matches
+  // macOS extractInlineCommand semantics); the user can press Enter on the
+  // highlighted row to enter the command with empty input.
   const CMD_PREFIX_MAP = { calc: 'calc', pomo: 'pomo', kill: 'kill', shell: 'shell', sys: 'sys' };
 
   function tryCommandPrefix(value) {
     if (!value.startsWith(':')) return false;
     const rest = value.slice(1);
-    const spaceIdx = rest.indexOf(' ');
-    const cmdName = spaceIdx >= 0 ? rest.slice(0, spaceIdx) : rest;
+    const spaceIdx = rest.search(/\s/);
+    // No whitespace → not a live trigger; let the discovery menu handle it.
+    if (spaceIdx < 0) return false;
+    const cmdName = rest.slice(0, spaceIdx);
     const cmdId = CMD_PREFIX_MAP[cmdName.toLowerCase()];
     if (!cmdId) return false;
-    const input = spaceIdx >= 0 ? rest.slice(spaceIdx + 1) : '';
+    const input = rest.slice(spaceIdx + 1);
     commands.enterById(cmdId);
     enterCommandMode();
-    // Set the command input if there's text after the command name
     const cmdInput = document.getElementById('cmd-input');
     if (cmdInput && input) {
       cmdInput.value = input;
@@ -213,6 +228,20 @@ document.addEventListener('DOMContentLoaded', async () => {
       runningApps.setSuspended(false);
       if (runningApps.isEnabled()) runningApps.refresh();
       translatePanel.hide();
+    } else if (search.isPrefixHintMode()) {
+      setHint(hintMessage, HINT_PREFIX_DISCOVERY);
+      resultsList.hidden = false;
+      previewPanel.hidden = true;
+      runningApps.setSuspended(false);
+      if (runningApps.isEnabled()) runningApps.refresh();
+      translatePanel.hide();
+    } else if (search.isCommandHintMode()) {
+      setHint(hintMessage, HINT_COMMAND_DISCOVERY);
+      resultsList.hidden = false;
+      previewPanel.hidden = true;
+      runningApps.setSuspended(false);
+      if (runningApps.isEnabled()) runningApps.refresh();
+      translatePanel.hide();
     } else {
       setHint(hintMessage, HINT_MAIN);
       resultsList.hidden = false;
@@ -226,13 +255,31 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Click on result row -> open
   resultsList.addEventListener('result-activate', () => {
     const item = results.getSelected();
-    if (item) {
-      import('./ipc.js').then(({ openPath, recordUsage }) => {
-        openPath(item.path, item.kind, item.id);
-        const actionMap = { app: 'open_app', file: 'open_file', folder: 'open_folder' };
-        recordUsage(item.id, actionMap[item.kind] || 'open_file');
-      });
+    if (!item) return;
+
+    // Discovery rows behave the same on click as on Enter: pick a prefix fills
+    // the query, pick a command enters that command's panel.
+    const hintedPrefix = prefixFromResultId(item.id);
+    if (hintedPrefix != null) {
+      queryInput.value = hintedPrefix;
+      queryInput.focus();
+      queryInput.setSelectionRange(hintedPrefix.length, hintedPrefix.length);
+      queryInput.dispatchEvent(new Event('input'));
+      return;
     }
+    const hintedCmd = commandIdFromResultId(item.id);
+    if (hintedCmd != null) {
+      commands.enterById(hintedCmd);
+      enterCommandMode();
+      queryInput.value = '';
+      return;
+    }
+
+    import('./ipc.js').then(({ openPath, recordUsage }) => {
+      openPath(item.path, item.kind, item.id);
+      const actionMap = { app: 'open_app', file: 'open_file', folder: 'open_folder' };
+      recordUsage(item.id, actionMap[item.kind] || 'open_file');
+    });
   });
 
   // When window shown via global hotkey, focus input and select all

--- a/apps/linows/src/js/catalog.js
+++ b/apps/linows/src/js/catalog.js
@@ -1,0 +1,102 @@
+// Single source of truth for query prefixes and slash commands, mirroring
+// macOS AppConstants.swift (PrefixSuggestion + commandCatalog) so the
+// `"` menu, the `:` menu, and the Help screen can't drift. linows omits
+// `tw"` (no dictionary lookup yet).
+
+import { calculator, timer, xCircle, terminal, info } from './icons.js';
+
+// Synthetic-row id namespaces — the renderer and Enter/click handlers tell
+// discovery rows apart from real candidates by id prefix.
+const PREFIX_HINT_ID = 'prefixhint:';
+const COMMAND_HINT_ID = 'cmdhint:';
+const DISCOVERY_CHAR = '"';
+
+const PREFIX_ENTRIES = [
+  { prefix: 'a"',  argHint: 'word',    description: 'Apps only' },
+  { prefix: 'f"',  argHint: 'word',    description: 'Files only' },
+  { prefix: 'd"',  argHint: 'word',    description: 'Folders only' },
+  { prefix: 'rc"', argHint: 'word',    description: 'Recent files/folders, newest first (optional filter)' },
+  { prefix: 'r"',  argHint: 'pattern', description: 'Regex search' },
+  { prefix: 'c"',  argHint: 'word',    description: 'Clipboard history search (latest 10 text clips)' },
+  { prefix: 't"',  argHint: 'word',    description: 'Web translate (VI/EN/JA)' },
+];
+
+// Shortcut numbers must match the Ctrl+1..5 bindings in
+// screens/commands/index.js, otherwise the title hint lies to the user.
+const COMMAND_ENTRIES = [
+  { id: 'calc',  title: 'calc (Ctrl+1)',  detail: 'Evaluate math expression',          icon: calculator },
+  { id: 'pomo',  title: 'pomo (Ctrl+2)',  detail: 'Pomodoro focus timer',              icon: timer },
+  { id: 'kill',  title: 'kill (Ctrl+3)',  detail: 'Force kill app or process by port', icon: xCircle },
+  { id: 'shell', title: 'shell (Ctrl+4)', detail: 'Run a shell command',               icon: terminal },
+  { id: 'sys',   title: 'sys (Ctrl+5)',   detail: 'Show system information',           icon: info },
+];
+
+// True when `:cmd <ws>` should bypass the discovery menu and live-trigger
+// the command panel (matches macOS extractInlineCommand). Bare `:calc` keeps
+// the menu open; only whitespace after a known id flips the trigger.
+function isInlineCommandWithArgs(query) {
+  if (!query.startsWith(':')) return false;
+  const spaceIdx = query.slice(1).search(/\s/);
+  if (spaceIdx < 0) return false;
+  const id = query.slice(1, 1 + spaceIdx).toLowerCase();
+  return COMMAND_ENTRIES.some((c) => c.id === id);
+}
+
+export function isPrefixSuggestionQuery(query) {
+  return query.trimStart().startsWith(DISCOVERY_CHAR);
+}
+
+export function isCommandSuggestionQuery(query) {
+  const trimmed = query.trimStart();
+  return trimmed.startsWith(':') && !isInlineCommandWithArgs(trimmed);
+}
+
+// Synthetic rows backing the `"` menu, narrowed by what the user typed after
+// the leading `"`. Case-insensitive substring match against prefix, display
+// form, and description — so `"folder` finds `d"` by intent rather than only
+// by the cryptic prefix letter.
+export function prefixSuggestionResults(query) {
+  const filter = query.trimStart().slice(DISCOVERY_CHAR.length).trim().toLowerCase();
+  const entries = filter
+    ? PREFIX_ENTRIES.filter((e) =>
+        e.prefix.toLowerCase().includes(filter)
+        || (e.prefix + e.argHint).toLowerCase().includes(filter)
+        || e.description.toLowerCase().includes(filter))
+    : PREFIX_ENTRIES;
+  return entries.map((entry, index) => ({
+    id: `${PREFIX_HINT_ID}${entry.prefix}`,
+    kind: 'app',
+    title: entry.prefix + entry.argHint,
+    subtitle: entry.description,
+    path: '',
+    score: entries.length - index,
+  }));
+}
+
+// Synthetic rows backing the `:` menu. `:end` or `:process` both surface
+// `kill`. Each row carries its command's icon so the list scans visually.
+export function commandSuggestionResults(query) {
+  const filter = query.trimStart().slice(1).trim().toLowerCase();
+  const entries = filter
+    ? COMMAND_ENTRIES.filter((e) =>
+        e.id.toLowerCase().includes(filter)
+        || e.detail.toLowerCase().includes(filter))
+    : COMMAND_ENTRIES;
+  return entries.map((entry, index) => ({
+    id: `${COMMAND_HINT_ID}${entry.id}`,
+    kind: 'app',
+    title: entry.title,
+    subtitle: entry.detail,
+    path: '',
+    score: entries.length - index,
+    iconSvg: entry.icon,
+  }));
+}
+
+export function prefixFromResultId(resultId) {
+  return resultId?.startsWith(PREFIX_HINT_ID) ? resultId.slice(PREFIX_HINT_ID.length) : null;
+}
+
+export function commandIdFromResultId(resultId) {
+  return resultId?.startsWith(COMMAND_HINT_ID) ? resultId.slice(COMMAND_HINT_ID.length) : null;
+}

--- a/apps/linows/src/js/components/results.js
+++ b/apps/linows/src/js/components/results.js
@@ -197,15 +197,20 @@ function createRow(result, index) {
   // list scans visually. Returns null if the path isn't an ms-settings URI.
   const windowsSettingsSvg = getWindowsSettingsIcon(result.path);
   const fallbacks = { file: fileIcon, folder: folderIcon, setting: settingIcon, clipboard: clipboardIcon };
-  icon.innerHTML = windowsSettingsSvg
+  // Synthetic discovery rows (prefix/command menus) ship their own glyph in
+  // result.iconSvg so the list scans visually; everything else falls back to
+  // the kind-based stub until the backend icon fetch resolves.
+  icon.innerHTML = result.iconSvg
+    || windowsSettingsSvg
     || (isLinuxSettings ? settingIcon : (fallbacks[result.kind] || appIcon));
   icon.style.background = 'var(--control-fill)';
   icon.style.color = 'var(--font-secondary)';
   row.appendChild(icon);
 
   // Skip backend icon fetch for ms-settings entries — the Shell PNG would just
-  // be the generic gear and would clobber our category-specific glyph.
-  if (result.kind !== 'clipboard' && !windowsSettingsSvg) {
+  // be the generic gear and would clobber our category-specific glyph. Same
+  // applies to synthetic discovery rows whose `path` is empty.
+  if (result.kind !== 'clipboard' && !windowsSettingsSvg && !result.iconSvg && result.path) {
     loadIcon(icon, result.kind, result.path, result.id);
   }
 

--- a/apps/linows/src/js/keyboard.js
+++ b/apps/linows/src/js/keyboard.js
@@ -6,6 +6,7 @@ import * as banner from './components/banner.js';
 import * as confirm from './components/confirm.js';
 import * as runningApps from './components/running-apps.js';
 import { trash as trashIcon } from './icons.js';
+import { prefixFromResultId, commandIdFromResultId } from './catalog.js';
 
 let queryInput = null;
 let shiftHeld = false;
@@ -216,7 +217,8 @@ function handleKeyDown(e) {
 
     case 'Escape':
       e.preventDefault();
-      if (search.isClipboardMode() || search.isTranslateMode()) {
+      if (search.isClipboardMode() || search.isTranslateMode()
+          || search.isPrefixHintMode() || search.isCommandHintMode()) {
         queryInput.value = '';
         translatePanel.hide();
         queryInput.dispatchEvent(new Event('input'));
@@ -229,6 +231,7 @@ function handleKeyDown(e) {
     case 'f':
       if (e.ctrlKey) {
         e.preventDefault();
+        if (isDiscoveryMode()) break;
         revealSelected();
       }
       break;
@@ -236,6 +239,7 @@ function handleKeyDown(e) {
     case 'c':
       if (e.ctrlKey && !window.getSelection()?.toString()) {
         e.preventDefault();
+        if (isDiscoveryMode()) break;
         copySelectedPath();
       }
       break;
@@ -247,6 +251,7 @@ function handleKeyDown(e) {
         results.clearPicks();
       } else if (e.ctrlKey) {
         e.preventDefault();
+        if (isDiscoveryMode()) break;
         results.togglePick(results.getSelected());
       }
       break;
@@ -255,10 +260,18 @@ function handleKeyDown(e) {
     case 'D':
       if (e.ctrlKey && !e.shiftKey && !e.altKey) {
         e.preventDefault();
+        if (isDiscoveryMode()) break;
         handleTrashShortcut();
       }
       break;
   }
+}
+
+// Side actions (reveal, copy path, pick, trash) don't make sense on synthetic
+// discovery rows — their `path` is empty. Mirrors macOS guards on
+// revealSelectedInFinder / togglePickForSelectedResult.
+function isDiscoveryMode() {
+  return search.isPrefixHintMode() || search.isCommandHintMode();
 }
 
 function trashTargetsFromSelection() {
@@ -329,6 +342,25 @@ async function handleEmptyTrash() {
 async function openSelected() {
   const item = results.getSelected();
   if (!item) return;
+
+  // Discovery rows: `prefixhint:` fills the query with that prefix (cursor
+  // ready for the term); `cmdhint:` enters the command's panel with empty
+  // input. Mirrors macOS openSelectedApp.
+  const hintedPrefix = prefixFromResultId(item.id);
+  if (hintedPrefix != null) {
+    queryInput.value = hintedPrefix;
+    queryInput.focus();
+    queryInput.setSelectionRange(hintedPrefix.length, hintedPrefix.length);
+    queryInput.dispatchEvent(new Event('input'));
+    return;
+  }
+  const hintedCmd = commandIdFromResultId(item.id);
+  if (hintedCmd != null && commandMode && enterCommandModeFn) {
+    commandMode.enterById(hintedCmd);
+    enterCommandModeFn();
+    queryInput.value = '';
+    return;
+  }
 
   try {
     await openPath(item.path, item.kind, item.id);

--- a/apps/linows/src/js/search.js
+++ b/apps/linows/src/js/search.js
@@ -1,4 +1,8 @@
 import { search as ipcSearch, getClipboardHistory } from './ipc.js';
+import {
+  isPrefixSuggestionQuery, isCommandSuggestionQuery,
+  prefixSuggestionResults, commandSuggestionResults,
+} from './catalog.js';
 
 const DEBOUNCE_MS = 70;
 const MIN_QUICK_FOLDER_PREFIX = 2;
@@ -10,6 +14,8 @@ let homeDir = null;
 let clipboardMode = false;
 let translateMode = false;
 let recentMode = false;
+let prefixHintMode = false;
+let commandHintMode = false;
 
 /** Resolved by the backend (Windows: SHGetKnownFolderPath; *nix: $HOME/<name>).
  *  Empty until setQuickFolders is called at boot. */
@@ -39,6 +45,14 @@ export function isRecentMode() {
   return recentMode;
 }
 
+export function isPrefixHintMode() {
+  return prefixHintMode;
+}
+
+export function isCommandHintMode() {
+  return commandHintMode;
+}
+
 export function getTranslateText() {
   return translateMode ? _translateText : '';
 }
@@ -47,6 +61,25 @@ let _translateText = '';
 
 export function handleQueryInput(query) {
   clearTimeout(debounceTimer);
+
+  // Discovery menus — `"` lists every query prefix, `:` lists every slash
+  // command, both filterable by what follows the leading character. Must
+  // run before the t"/c"/rc" branches because the leading chars overlap.
+  if (isPrefixSuggestionQuery(query)) {
+    prefixHintMode = true;
+    commandHintMode = translateMode = clipboardMode = recentMode = false;
+    if (onResultsCallback) onResultsCallback(prefixSuggestionResults(query), query);
+    return;
+  }
+  if (isCommandSuggestionQuery(query)) {
+    commandHintMode = true;
+    prefixHintMode = translateMode = clipboardMode = recentMode = false;
+    if (onResultsCallback) onResultsCallback(commandSuggestionResults(query), query);
+    return;
+  }
+
+  prefixHintMode = false;
+  commandHintMode = false;
 
   if (query.startsWith('t"')) {
     translateMode = true;


### PR DESCRIPTION
## Summary

- comamnds and prefixes suggestion for Linows

## Why

- #208 

## Changes

-

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
