### PR TITLE
Linows: Web enable for linows

### DIFF
--- a/apps/linows/src-tauri/src/answers.rs
+++ b/apps/linows/src-tauri/src/answers.rs
@@ -1,0 +1,64 @@
+//! Tauri commands over `look_answers`. The look-answers crate ships blocking
+//! HTTP (via curl subprocess) and no async runtime, so anything that touches
+//! the network runs on the Tauri blocking pool to keep the UI thread free.
+//!
+//! Mirrors `bridge/ffi/src/answers_api.rs` on macOS — the wire shape is the
+//! same `Answer` struct from look-answers, serialised straight to JSON.
+
+use look_answers::Answer;
+use tauri::async_runtime;
+
+/// Network-free pattern gate. Used to decide whether `instant_answer` is even
+/// worth firing (matches currency/weather/crypto grammar without hitting the
+/// network), and as part of the AI-answer trigger heuristic on the JS side.
+#[tauri::command]
+pub fn instant_has_match(query: String) -> bool {
+    look_answers::has_match(&query)
+}
+
+/// Definitional entity extractor — e.g. `"what is vim"` → `Some("vim")`. Used
+/// by the JS controller to pick the Wikipedia search term. Cheap (regex only),
+/// so it stays on the calling thread.
+#[tauri::command]
+pub fn definitional_entity(query: String) -> Option<String> {
+    look_answers::definitional_entity(&query)
+}
+
+/// Instant answer for currency / weather / crypto grammar. Returns `None` when
+/// the query doesn't match a provider or the network call fails.
+#[tauri::command]
+pub async fn instant_answer(query: String) -> Option<Answer> {
+    async_runtime::spawn_blocking(move || look_answers::instant_answer(&query))
+        .await
+        .ok()
+        .flatten()
+}
+
+/// DuckDuckGo Instant Answer API. Used for "what is X" lookups that aren't
+/// covered by Wikipedia, and for short factoids.
+#[tauri::command]
+pub async fn duckduckgo_answer(query: String) -> Option<Answer> {
+    async_runtime::spawn_blocking(move || look_answers::duckduckgo_answer(&query))
+        .await
+        .ok()
+        .flatten()
+}
+
+/// Wikipedia REST API summary. `term` should be the extracted entity, not the
+/// raw query — the JS controller calls `definitional_entity` first.
+#[tauri::command]
+pub async fn wikipedia_answer(term: String) -> Option<Answer> {
+    async_runtime::spawn_blocking(move || look_answers::wikipedia_answer(&term))
+        .await
+        .ok()
+        .flatten()
+}
+
+/// Google autocomplete (via DuckDuckGo's `/ac/` endpoint). Returns up to
+/// `limit` suggestions; empty vec on failure or short queries.
+#[tauri::command]
+pub async fn web_suggestions(query: String, limit: usize) -> Vec<String> {
+    async_runtime::spawn_blocking(move || look_answers::web_suggestions(&query, limit))
+        .await
+        .unwrap_or_default()
+}

--- a/apps/linows/src-tauri/src/commands.rs
+++ b/apps/linows/src-tauri/src/commands.rs
@@ -508,6 +508,7 @@ fn focus_default_browser() -> bool {
     false
 }
 
+#[cfg(target_os = "linux")]
 fn try_focus_window(wm_class: &str) -> bool {
     // Sway (Wayland): SWAYSOCK is set, swaymsg shares i3's IPC and CLI but
     // Wayland-native clients identify by `app_id`, not WM_CLASS. XWayland

--- a/apps/linows/src-tauri/src/commands.rs
+++ b/apps/linows/src-tauri/src/commands.rs
@@ -194,11 +194,13 @@ pub fn open_path(
         let _ = window.hide();
         std::thread::spawn(move || {
             let _ = open::that(&path);
+            // Give the browser a beat to receive the URL and surface its new
+            // tab — otherwise the focus attempt below races the spawn and
+            // sees no matching window yet.
             #[cfg(target_os = "linux")]
-            for class in &["Brave-browser", "firefox", "chromium", "Google-chrome"] {
-                if try_focus_window(class) {
-                    break;
-                }
+            {
+                std::thread::sleep(std::time::Duration::from_millis(150));
+                focus_default_browser();
             }
         });
         Ok(())
@@ -454,7 +456,80 @@ fn launch_app(exec: &str, id: Option<&str>) -> Result<(), String> {
 }
 
 #[cfg(target_os = "linux")]
+/// Bring the user's default browser window to the foreground. Resolves the
+/// browser via `xdg-mime query default x-scheme-handler/https` so we focus
+/// the exact browser xdg-open just sent the URL to — not whichever browser
+/// happened to come first in a hard-coded candidate list (which would
+/// route the focus to the wrong window when the user has multiple browsers
+/// open, e.g. Brave default but Firefox also running).
+///
+/// Tries the GNOME Shell extension first (FocusApp by .desktop id, works on
+/// GNOME Wayland), then falls back to WM_CLASS / app_id matching via
+/// try_focus_window which knows about Sway, i3, and X11.
+#[cfg(target_os = "linux")]
+fn focus_default_browser() -> bool {
+    let Ok(output) = std::process::Command::new("xdg-mime")
+        .args(["query", "default", "x-scheme-handler/https"])
+        .output()
+    else {
+        return false;
+    };
+    let desktop_id = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if desktop_id.is_empty() {
+        return false;
+    }
+
+    // GNOME Shell extension — exact desktop id.
+    if crate::platform::linux::gnome_ext::try_focus_app(&desktop_id) {
+        return true;
+    }
+
+    // Strip ".desktop" suffix to get the base id (e.g. "brave-browser").
+    // That's typically the WM_CLASS / app_id the browser advertises — Sway
+    // and i3 match it case-insensitively via the (?i) flag inside
+    // try_focus_window, so "brave-browser" matches "Brave-browser" too.
+    let base = desktop_id.strip_suffix(".desktop").unwrap_or(&desktop_id);
+    if try_focus_window(base) {
+        return true;
+    }
+    // Some browsers use the last path segment of a reverse-DNS id as their
+    // class (e.g. "org.mozilla.firefox.desktop" → "firefox"). Try that too.
+    if let Some(tail) = base.rsplit('.').next()
+        && tail != base
+        && try_focus_window(tail)
+    {
+        return true;
+    }
+    false
+}
+
 fn try_focus_window(wm_class: &str) -> bool {
+    // Sway (Wayland): SWAYSOCK is set, swaymsg shares i3's IPC and CLI but
+    // Wayland-native clients identify by `app_id`, not WM_CLASS. XWayland
+    // clients still fall back to class/instance. The x11rb path below can't
+    // see Wayland windows at all, so this branch is the only thing that
+    // brings non-XWayland browsers (firefox-wayland, brave Wayland) forward.
+    if std::env::var("SWAYSOCK").is_ok() {
+        for criterion in [
+            format!("[app_id=\"(?i){wm_class}\"] focus"),
+            format!("[class=\"(?i){wm_class}\"] focus"),
+            format!("[instance=\"(?i){wm_class}\"] focus"),
+        ] {
+            if let Ok(output) = std::process::Command::new("swaymsg")
+                .arg(&criterion)
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::null())
+                .output()
+            {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                if stdout.contains("\"success\":true") {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     // i3 window manager — use i3-msg exclusively (i3 ignores raw X11
     // _NET_ACTIVE_WINDOW messages, so the x11rb fallback would report
     // success without actually focusing).  Try both class and instance

--- a/apps/linows/src-tauri/src/commands.rs
+++ b/apps/linows/src-tauri/src/commands.rs
@@ -199,7 +199,7 @@ pub fn open_path(
             // sees no matching window yet.
             #[cfg(target_os = "linux")]
             {
-                std::thread::sleep(std::time::Duration::from_millis(150));
+                std::thread::sleep(std::time::Duration::from_millis(BROWSER_FOCUS_DELAY_MS));
                 focus_default_browser();
             }
         });
@@ -455,7 +455,12 @@ fn launch_app(exec: &str, id: Option<&str>) -> Result<(), String> {
     Ok(())
 }
 
+/// Delay between handing the URL to xdg-open and trying to focus the
+/// browser window — gives the browser time to receive the URL and surface
+/// its new tab so the focus call below sees a matching window.
 #[cfg(target_os = "linux")]
+const BROWSER_FOCUS_DELAY_MS: u64 = 150;
+
 /// Bring the user's default browser window to the foreground. Resolves the
 /// browser via `xdg-mime query default x-scheme-handler/https` so we focus
 /// the exact browser xdg-open just sent the URL to — not whichever browser

--- a/apps/linows/src-tauri/src/default_config.txt
+++ b/apps/linows/src-tauri/src/default_config.txt
@@ -21,5 +21,11 @@ arch_disable_blur=false
 # Running apps switcher: none, right
 running_apps_placement=right
 
+# AI / web answers — show an inline answer card for question-like queries
+# (currency/weather/crypto via the network, Wikipedia/DuckDuckGo lookups,
+# and Google autocomplete suggestions). Set to false to disable all network
+# answer features and run fully offline.
+ai_enabled=true
+
 # UI theme
 ui_theme=

--- a/apps/linows/src-tauri/src/default_config.txt
+++ b/apps/linows/src-tauri/src/default_config.txt
@@ -21,10 +21,14 @@ arch_disable_blur=false
 # Running apps switcher: none, right
 running_apps_placement=right
 
-# AI / web answers — show an inline answer card for question-like queries
+# Web answers — show an inline answer card for question-like queries
 # (currency/weather/crypto via the network, Wikipedia/DuckDuckGo lookups,
 # and Google autocomplete suggestions). Set to false to disable all network
 # answer features and run fully offline.
+#
+# Note: there is no on-device LLM on Linux/Windows — Apple Intelligence is
+# macOS-only. The key stays named `ai_enabled` to share config storage with
+# the macOS app (where it gates both web answers AND the on-device model).
 ai_enabled=true
 
 # UI theme

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -560,26 +560,42 @@ fn apply_transparency(window: &tauri::WebviewWindow) {
 /// Set up window event handlers (focus input on focus, auto-hide on blur).
 fn setup_window_events(window: &tauri::WebviewWindow) {
     let w = window.clone();
-    window.on_window_event(move |event| {
-        match event {
-            tauri::WindowEvent::Focused(true) => {
-                let _ = w.eval("{ let q = document.getElementById('query'); if (q) { q.focus(); q.select(); } }");
-            }
-            // On Linux, Focused(false) fires on mouse-leave (GNOME/Mutter
-            // with undecorated always-on-top windows), so auto-hide is
-            // handled entirely by the X11 active-window monitor instead.
-            // TODO: add Wayland auto-hide when Wayland support is added.
-            #[cfg(not(target_os = "linux"))]
-            tauri::WindowEvent::Focused(false)
-                if !PICKING_FILE.load(Ordering::Relaxed)
-                    && now_ms() - LAST_SHOWN_AT.load(Ordering::Relaxed) > AUTO_HIDE_GRACE_MS =>
-            {
-                LAST_AUTO_HIDDEN_AT.store(now_ms(), Ordering::Relaxed);
-                let _ = w.hide();
-            }
-            _ => {}
+    window.on_window_event(move |event| match event {
+        tauri::WindowEvent::Focused(true) => {
+            let _ = w.eval(
+                "{ let q = document.getElementById('query'); if (q) { q.focus(); q.select(); } }",
+            );
         }
+        tauri::WindowEvent::Focused(false)
+            if !PICKING_FILE.load(Ordering::Relaxed)
+                && now_ms() - LAST_SHOWN_AT.load(Ordering::Relaxed) > AUTO_HIDE_GRACE_MS
+                && focus_loss_means_dismiss() =>
+        {
+            LAST_AUTO_HIDDEN_AT.store(now_ms(), Ordering::Relaxed);
+            let _ = w.hide();
+        }
+        _ => {}
     });
+}
+
+/// Whether a `Focused(false)` event should auto-hide the launcher.
+///
+/// macOS / Windows: trustworthy, fire only on real focus loss → always true.
+/// Linux X11: GNOME/Mutter emit Focused(false) on mouse-leave even when the
+///   window still has keyboard focus; the X11 _NET_ACTIVE_WINDOW monitor
+///   handles auto-hide instead (it tracks the true active window). → false.
+/// Linux Wayland (Sway, GNOME Wayland, KDE Plasma): Focused(false) only
+///   fires on real focus changes, and the X11 monitor can't see Wayland
+///   windows at all (so without this path Look never auto-hides). → true.
+fn focus_loss_means_dismiss() -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        is_wayland()
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        true
+    }
 }
 
 fn main() {

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -580,22 +580,15 @@ fn setup_window_events(window: &tauri::WebviewWindow) {
 
 /// Whether a `Focused(false)` event should auto-hide the launcher.
 ///
-/// macOS / Windows: trustworthy, fire only on real focus loss → always true.
-/// Linux X11: GNOME/Mutter emit Focused(false) on mouse-leave even when the
-///   window still has keyboard focus; the X11 _NET_ACTIVE_WINDOW monitor
-///   handles auto-hide instead (it tracks the true active window). → false.
-/// Linux Wayland (Sway, GNOME Wayland, KDE Plasma): Focused(false) only
-///   fires on real focus changes, and the X11 monitor can't see Wayland
-///   windows at all (so without this path Look never auto-hides). → true.
+/// macOS / Windows: trustworthy, fire only on real focus loss → true.
+/// Linux (X11 + Wayland): false. On X11 the GNOME/Mutter mouse-leave race
+///   means Focused(false) fires even when the window still has keyboard
+///   focus, so the X11 _NET_ACTIVE_WINDOW monitor handles auto-hide
+///   instead. On Wayland we also stay false — Focused(false) fires when
+///   any screenshot / screencast tool grabs focus, which would dismiss
+///   Look before the capture lands. User dismisses via Esc.
 fn focus_loss_means_dismiss() -> bool {
-    #[cfg(target_os = "linux")]
-    {
-        is_wayland()
-    }
-    #[cfg(not(target_os = "linux"))]
-    {
-        true
-    }
+    !cfg!(target_os = "linux")
 }
 
 fn main() {

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -1,6 +1,7 @@
 // Prevents additional console window on Windows in release
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod answers;
 mod autostart;
 mod calc;
 mod clipboard;
@@ -722,6 +723,13 @@ fn main() {
             process::activate_running_app,
             // Translation
             translate::translate,
+            // AI / web answers (look-answers crate, shared with macOS)
+            answers::instant_has_match,
+            answers::definitional_entity,
+            answers::instant_answer,
+            answers::duckduckgo_answer,
+            answers::wikipedia_answer,
+            answers::web_suggestions,
             // Clipboard
             clipboard::get_clipboard_history,
             clipboard::delete_clipboard_entry,

--- a/apps/linows/src-tauri/src/platform/linux/window_focus.rs
+++ b/apps/linows/src-tauri/src/platform/linux/window_focus.rs
@@ -300,7 +300,7 @@ static MONITOR_RUNNING: AtomicBool = AtomicBool::new(false);
 
 /// Returns true for WMs that use focus-follows-mouse (i3, sway, etc.)
 /// where auto-hide on focus loss would fight the WM's focus policy.
-fn is_focus_follows_mouse_wm() -> bool {
+pub fn is_focus_follows_mouse_wm() -> bool {
     // I3SOCK is always set when running under i3
     if std::env::var("I3SOCK").is_ok() {
         return true;

--- a/apps/linows/src-tauri/tauri.conf.json
+++ b/apps/linows/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicoverbruggen/tauri-v2-schema/main/schema.json",
   "productName": "Look",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "identifier": "com.look.desktop",
   "build": {
     "frontendDist": "../src",

--- a/apps/linows/src/css/components/ai-card.css
+++ b/apps/linows/src/css/components/ai-card.css
@@ -1,0 +1,181 @@
+/* AI / web answer card. Mirrors macOS AIAnswerCardView:
+ *   10px corner radius, 12px padding, 1px white-8% border, control-fill bg
+ *   header row uses sparkles + question + spinner
+ *   blocks separated by 14px, each with a SOURCE LABEL (uppercased, accent
+ *   when clickable) + copy button, then an optional 96x96 image and the
+ *   answer text (selectable, generous line spacing).
+ *
+ * Three layouts (toggled by container classes in layout.css):
+ *   .ai-layout-full      — card fills the panel (no local results)
+ *   .ai-layout-two-col   — card on left, 320px web-suggestions list on right
+ *   .ai-layout-stacked   — card capped to 240px, results-list below
+ */
+
+.ai-card {
+  /* Top/bottom margin gives the card breathing room from the search bar
+   * above and the hint bar below — matches macOS, where the card has
+   * visible padding between the chrome edges instead of sitting flush. */
+  margin: 6px var(--content-padding) 8px;
+  padding: 12px;
+  background: var(--control-fill);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  /* User can select answer text without nuking selection on the rest of the
+   * launcher (which is `user-select: none` at the window level). */
+  user-select: text;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* The `display: flex` above otherwise wins against the UA `[hidden] { display: none }`
+ * default, leaving an empty bordered bar under the search field whenever the
+ * controller is idle. !important keeps this override winning regardless of
+ * specificity changes elsewhere. */
+.ai-card[hidden] {
+  display: none !important;
+}
+
+.ai-card-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.ai-card-icon {
+  width: 16px;
+  height: 16px;
+  color: var(--accent-color);
+  flex-shrink: 0;
+  display: inline-flex;
+}
+
+.ai-card-question {
+  font-size: var(--font-size);
+  font-weight: 600;
+  color: var(--font-color);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ai-card-spacer {
+  flex: 1;
+  min-width: 8px;
+}
+
+/* Streaming spinner — a thin border ring rotating. CSS-only so we don't have
+ * to ship an SVG; matches the visual weight of macOS ProgressView.small. */
+.ai-spinner {
+  width: 12px;
+  height: 12px;
+  border: 1.5px solid var(--font-muted);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: ai-spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes ai-spin {
+  to { transform: rotate(360deg); }
+}
+
+.ai-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  overflow-y: auto;
+  scrollbar-width: none;
+  min-height: 0;
+}
+
+.ai-card-body::-webkit-scrollbar { display: none; }
+
+.ai-card-block {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.ai-card-block-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* Uppercased source name — 3pt smaller than body, bold. Accent + chevron
+ * when the source has a URL (Wikipedia, DuckDuckGo); muted otherwise
+ * (Calculator). Whole .ai-card-source is the click target. */
+.ai-card-source {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px 6px 2px 0;
+  font-size: calc(var(--font-size) - 3px);
+  font-weight: 700;
+  color: var(--font-muted);
+  letter-spacing: 0.04em;
+  cursor: default;
+}
+
+.ai-card-source-linked {
+  color: var(--accent-color);
+  cursor: pointer;
+}
+
+.ai-card-source-chevron {
+  display: inline-flex;
+  width: calc(var(--font-size) - 5px);
+  height: calc(var(--font-size) - 5px);
+  color: var(--accent-color);
+}
+
+/* Copy button — same muted color as the source label until hover. */
+.ai-card-copy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: 0;
+  background: transparent;
+  color: var(--font-muted);
+  cursor: pointer;
+  border-radius: 4px;
+}
+.ai-card-copy:hover {
+  color: var(--font-color);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.ai-card-block-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.ai-card-image {
+  width: 96px;
+  height: 96px;
+  border-radius: 8px;
+  object-fit: cover;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.ai-card-text {
+  font-size: var(--font-size);
+  font-weight: 400;
+  color: var(--font-secondary);
+  line-height: 1.5; /* macOS uses fontSize * 1.18 line spacing; 1.5 reads close */
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+.ai-card-status {
+  font-size: var(--font-size);
+  color: var(--font-muted);
+}

--- a/apps/linows/src/css/components/preview.css
+++ b/apps/linows/src/css/components/preview.css
@@ -317,3 +317,57 @@
   margin: 0;
   user-select: text;
 }
+
+/* Web-suggestion preview — mirrors macOS WebSuggestionPreviewView. Centred
+ * search affordance for the selected Google-autocomplete row, since there's
+ * no file metadata to surface. */
+.preview-web-suggestion {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  padding: 20px;
+  height: 100%;
+  text-align: center;
+}
+
+.preview-web-suggestion-icon {
+  color: var(--accent-color);
+  display: inline-flex;
+}
+
+.preview-web-suggestion-title {
+  font-size: calc(var(--font-size) + 3px);
+  font-weight: 600;
+  color: var(--font-color);
+  line-height: 1.3;
+  max-width: 100%;
+  word-wrap: break-word;
+  user-select: text;
+  /* Match macOS lineLimit(3) — long suggestions truncate after three lines. */
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.preview-web-suggestion-subtitle {
+  font-size: calc(var(--font-size) - 1px);
+  font-weight: 600;
+  color: var(--font-muted);
+}
+
+.preview-web-suggestion-hint {
+  font-size: calc(var(--font-size) - 2px);
+  color: var(--font-secondary);
+}
+
+.preview-web-suggestion-hint kbd {
+  font: inherit;
+  font-weight: 600;
+  padding: 1px 6px;
+  margin: 0 2px;
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 4px;
+}

--- a/apps/linows/src/css/components/results.css
+++ b/apps/linows/src/css/components/results.css
@@ -89,6 +89,32 @@
   opacity: 0.8;
 }
 
+/* Web-suggestion rows wrap their title to up to 3 lines instead of truncating
+ * with ellipsis. They live in a narrow 320 px column when the AI card is
+ * showing, so "david beckham manchester united" reads better wrapped than
+ * cut off. Mirrors macOS WebSuggestionPreviewView's 3-line title cap.
+ *
+ * In normal/stacked mode they sit in column 1 mixed with app/file/folder
+ * rows, so they inherit the regular margin/padding to keep the magnifying
+ * glass icon visually aligned with the app icons above. The tighter inset
+ * only kicks in for the narrow 320 px column in two-col mode (see
+ * layout.css). */
+.result-row-web-suggest {
+  align-items: flex-start;
+}
+
+.result-row-web-suggest .result-title {
+  white-space: normal;
+  overflow: visible;
+  text-overflow: clip;
+  word-break: break-word;
+  line-height: 1.3;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 /* Kind badge */
 .result-badge {
   font-size: calc(var(--font-size) - 4px);

--- a/apps/linows/src/css/components/settings.css
+++ b/apps/linows/src/css/components/settings.css
@@ -362,6 +362,8 @@ html:not([data-os="linux"]) .settings-linux-only {
   position: relative;
   width: 36px;
   height: 20px;
+  flex-shrink: 0; /* keep its 36 px even when a long nowrap hint
+                     would otherwise squeeze it in the flex row */
   cursor: pointer;
 }
 

--- a/apps/linows/src/css/layout.css
+++ b/apps/linows/src/css/layout.css
@@ -19,7 +19,7 @@
 
 /* Background image layer (behind tint) */
 .launcher-window::before {
-  content: '';
+  content: "";
   position: absolute;
   inset: 0;
   background-image: var(--bg-image, none);
@@ -77,11 +77,12 @@ html[data-os="windows"] .launcher-window {
   -webkit-backdrop-filter: none !important;
 }
 
-/* Main pane: two-column CSS Grid that aligns the search bar with the
- * results-list, and the running apps strip with the preview panel.
- * Locking them to the same columns guarantees the chip's right edge
- * matches the row chips' right edge regardless of content sizing.
- * Right column expands only when one of its rows has visible content. */
+/* Main pane: 50/50 grid so the search bar's right edge lines up exactly with
+ * the result rows' right edge (and, when visible, the running-apps strip
+ * sits in column 2 above the preview pane, right-aligned to the same border).
+ * The split applies whenever there's anything in column 2 — either the
+ * running-apps strip up top or the preview pane below (the latter lives
+ * inside `.results-area`, so we test for its presence in the DOM via :has). */
 .main-pane {
   display: grid;
   grid-template-columns: 1fr;
@@ -110,12 +111,6 @@ html[data-os="windows"] .launcher-window {
   border-radius: var(--control-radius);
 }
 
-/* When running-apps toggle is off, let the search bar span both columns —
- * even if preview-panel is still showing below in column 2. */
-.main-pane:has(.running-apps-strip[hidden]) .search-bar {
-  grid-column: 1 / -1;
-}
-
 .search-icon {
   width: 16px;
   height: 16px;
@@ -142,22 +137,89 @@ html[data-os="windows"] .launcher-window {
   overflow: hidden;
 }
 
-.results-list {
+/* Results area — column 1 only by default, so its width matches the search
+ * bar's column exactly. The AI card sits on top, the engine results list
+ * below, both inheriting the same 50 % width as the search bar above them —
+ * which is what makes the search-bar right edge line up with the result rows
+ * in normal browsing and stacked AI mode. The two-col AI mode (knowledge
+ * lookup) deliberately overrides this so the answer card can read at a
+ * comfortable measure. */
+.results-area {
   grid-row: 3;
   grid-column: 1;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  overflow: hidden;
+}
+
+/* Stacked: card capped at 240 px on top, results-list fills the rest.
+ * Search-bar and result rows stay aligned (both in col 1). */
+.results-area.ai-mode-stacked .ai-card {
+  flex-shrink: 0;
+  max-height: 240px;
+}
+.results-area.ai-mode-stacked .results-list {
+  flex: 1;
+}
+
+/* Two-col: only web suggestions, no local results. Card extends across both
+ * grid columns so the answer reads at a comfortable measure; suggestions
+ * pin to a 320 px column on the right (matches macOS
+ * AppConstants.Launcher.aiAnswerSuggestionColumnWidth). Preview pane is
+ * suppressed — nothing useful to preview alongside a search list.
+ * Search-bar/results alignment is deliberately broken here: the wider card
+ * is the visual signal that the launcher has switched into knowledge mode.
+ *
+ * Tight inner gap (4 px) between the card and the suggestion column —
+ * the card and the suggestion rows already carry their own borders and
+ * background fills, so anything more reads as wasted gutter. Outer edges
+ * still keep the standard content-padding so the columns aren't flush
+ * against the window border. */
+.results-area.ai-mode-two-col {
+  grid-column: 1 / -1;
+  flex-direction: row;
+  align-items: stretch;
+  gap: 4px;
+}
+.results-area.ai-mode-two-col .ai-card {
+  flex: 1;
+  margin-right: 0;
+}
+.results-area.ai-mode-two-col .results-list {
+  flex: 0 0 320px;
+  width: 320px;
+}
+.results-area.ai-mode-two-col .result-row-web-suggest {
+  margin-left: 2px;
+  margin-right: 4px;
+  padding-left: 4px;
+}
+.results-area.ai-mode-two-col ~ .preview-panel {
+  display: none;
+}
+
+/* Card alone fills the column; results-list hidden. */
+.results-area.ai-mode-full .ai-card {
+  flex: 1;
+}
+.results-area.ai-mode-full .results-list {
+  display: none;
+}
+/* When the card is alone, the preview pane in column 2 has nothing useful
+ * to show — hide it so the answer card can read at a comfortable measure. */
+.results-area.ai-mode-full ~ .preview-panel {
+  display: none;
+}
+
+.results-list {
   min-width: 0;
   min-height: 0;
   overflow-y: auto;
   padding: var(--row-spacing) 0;
   scrollbar-width: none;
-}
-
-/* When the preview pane is hidden (discovery menus, etc.), let the results
- * list span both grid columns so it doesn't get squeezed into column 1 while
- * the running-apps strip occupies column 2's top row. Matches macOS, which
- * drops the preview pane entirely in `"` / `:` discovery modes. */
-.main-pane:has(.preview-panel[hidden]) .results-list {
-  grid-column: 1 / -1;
 }
 
 .results-list::-webkit-scrollbar {

--- a/apps/linows/src/html/screens/search.html
+++ b/apps/linows/src/html/screens/search.html
@@ -24,6 +24,14 @@
     </div>
   </div>
 
-  <div class="results-list" id="results-list"></div>
+  <!-- Results area lives in column 1 of the main grid alongside the search
+       bar, so its rows share the same effective width — their right edges
+       line up exactly with the search bar's right edge (mirrors macOS, where
+       both are siblings in the left panel). The preview pane lives in
+       column 2 with the running-apps strip. -->
+  <div class="results-area" id="results-area">
+    <div class="ai-card" id="ai-answer-card" hidden></div>
+    <div class="results-list" id="results-list"></div>
+  </div>
   <div class="preview-panel" id="preview-panel" hidden></div>
 </div>

--- a/apps/linows/src/html/screens/settings.html
+++ b/apps/linows/src/html/screens/settings.html
@@ -20,8 +20,7 @@
       <div class="settings-tab-content" id="settings-tab-appearance">
         <!-- Theme + Running Apps toggle -->
         <div class="settings-section-header">
-          <span class="settings-section-arrow">&#9654;</span>
-          <span>Theme</span>
+                    <span>Theme</span>
           <div class="settings-dropdown" id="settings-theme">
             <button class="settings-dropdown-btn" type="button">
               <span class="settings-dropdown-label">Catppuccin</span>
@@ -241,6 +240,28 @@
 
       <!-- Advanced tab -->
       <div class="settings-tab-content" id="settings-tab-advanced" hidden>
+        <!-- Web answers — Linux/Windows have no on-device LLM (Apple
+             Intelligence on macOS only), so this section advertises the
+             feature accurately as web-based instead of borrowing the macOS
+             "AI" label that would otherwise mislead. -->
+        <div class="settings-section-header"><span class="settings-section-arrow">&#9654;</span><span>Web answers</span></div>
+        <div class="settings-section">
+          <div class="settings-row">
+            <label class="settings-label">Enable</label>
+            <label class="settings-toggle" title="Inline answers for question-like queries (currency/weather/crypto, Wikipedia, DuckDuckGo) plus Google autocomplete suggestions">
+              <input type="checkbox" id="settings-ai-enabled" checked />
+              <span class="settings-toggle-track"></span>
+            </label>
+            <span class="settings-hint-text">Inline answers + Google autocomplete over HTTPS</span>
+          </div>
+          <div class="settings-row">
+            <label class="settings-label"></label>
+            <span class="settings-hint-text">On-device AI (model that rewrites queries, drafts answers) is macOS-only.</span>
+          </div>
+        </div>
+
+        <div class="settings-divider"></div>
+
         <!-- Background -->
         <div class="settings-section-header"><span class="settings-section-arrow">&#9654;</span><span>Background</span></div>
         <div class="settings-section">
@@ -326,14 +347,6 @@
         <!-- Privacy & Logs -->
         <div class="settings-section-header"><span class="settings-section-arrow">&#9654;</span><span>Privacy &amp; Logs</span></div>
         <div class="settings-section">
-          <div class="settings-row">
-            <label class="settings-label">Web answers</label>
-            <label class="settings-toggle" title="Show an inline answer card for question-like queries (currency/weather/crypto, Wikipedia, DuckDuckGo) and Google autocomplete suggestions">
-              <input type="checkbox" id="settings-ai-enabled" checked />
-              <span class="settings-toggle-track"></span>
-            </label>
-            <span class="settings-hint-text">When on, Look fetches inline answers and Google autocomplete over HTTPS. Disable for fully offline use.</span>
-          </div>
           <div class="settings-row">
             <label class="settings-label">Backend Log Level</label>
             <div class="settings-dropdown" id="settings-log-level">

--- a/apps/linows/src/html/screens/settings.html
+++ b/apps/linows/src/html/screens/settings.html
@@ -327,6 +327,14 @@
         <div class="settings-section-header"><span class="settings-section-arrow">&#9654;</span><span>Privacy &amp; Logs</span></div>
         <div class="settings-section">
           <div class="settings-row">
+            <label class="settings-label">Web answers</label>
+            <label class="settings-toggle" title="Show an inline answer card for question-like queries (currency/weather/crypto, Wikipedia, DuckDuckGo) and Google autocomplete suggestions">
+              <input type="checkbox" id="settings-ai-enabled" checked />
+              <span class="settings-toggle-track"></span>
+            </label>
+            <span class="settings-hint-text">When on, Look fetches inline answers and Google autocomplete over HTTPS. Disable for fully offline use.</span>
+          </div>
+          <div class="settings-row">
             <label class="settings-label">Backend Log Level</label>
             <div class="settings-dropdown" id="settings-log-level">
               <button class="settings-dropdown-btn" type="button">

--- a/apps/linows/src/index.html
+++ b/apps/linows/src/index.html
@@ -18,6 +18,7 @@
   <link rel="stylesheet" href="css/components/settings.css" />
   <link rel="stylesheet" href="css/components/help.css" />
   <link rel="stylesheet" href="css/components/update.css" />
+  <link rel="stylesheet" href="css/components/ai-card.css" />
 </head>
 <body>
   <div id="app" class="launcher-window"></div>

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -12,10 +12,11 @@ import * as translatePanel from './components/translate.js';
 import * as runningApps from './components/running-apps.js';
 import * as platform from './platform.js';
 import * as aiAnswer from './components/ai-answer.js';
+import { State as AiState } from './components/ai-answer.js';
 import * as aiCard from './components/ai-answer-card.js';
 import { load } from './html-loader.js';
 import {
-  onWindowShown, onIndexReady, requestIndexRefresh, getHomeDir, getQuickFolders, copyFilesToClipboard,
+  onWindowShown, onIndexReady, requestIndexRefresh, getQuickFolders, copyFilesToClipboard,
   evalCalc, runShellCommand, getSystemInfo,
   listProcesses, listProcessesOnPort, killProcess, getIcon,
   copyToClipboard, deleteClipboardEntry, isDevBuild,
@@ -45,6 +46,13 @@ const BANNER_DURATION_SHORT = 1.0;
 const BANNER_DURATION_MEDIUM = 1.2;
 const BANNER_DURATION_LONG = 1.5;
 const KILL_FEEDBACK_DELAY_MS = 300;
+
+// Layout modes applied to #results-area when the AI card is visible.
+// Stacked: card capped above results in col 1.
+// Two-col: wide card spans both cols + 320 px suggestion column on the right.
+const AI_LAYOUT_CLASSES = ['ai-mode-full', 'ai-mode-two-col', 'ai-mode-stacked'];
+const AI_LAYOUT_STACKED = 'ai-mode-stacked';
+const AI_LAYOUT_TWO_COL = 'ai-mode-two-col';
 
 document.addEventListener('DOMContentLoaded', async () => {
   const app = document.getElementById('app');
@@ -92,7 +100,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Snapshot of the latest results + AI state, used by applyAiLayoutMode()
   // to pick full / two-col / stacked. Mirrors macOS LauncherView resultsRow.
   let lastResults = [];
-  let lastAiState = 'idle';
+  let lastAiState = AiState.idle;
 
   hintBar.querySelector('.hint-bar-link').addEventListener('click', (e) => {
     e.preventDefault();
@@ -123,6 +131,12 @@ document.addEventListener('DOMContentLoaded', async () => {
       lastAiState = snapshot.state;
       aiCard.update(snapshot);
       applyAiLayoutMode();
+      // Switch the results-list empty-state mode in lockstep with the AI
+      // state so the right-column "No results" doesn't appear the instant
+      // AI flips from streaming to done with an empty suggestions list.
+      if (lastAiState !== AiState.idle) {
+        results.setEmptyState({ mode: 'ai-suggestion' });
+      }
     },
   });
   settings.init(() => {
@@ -231,14 +245,10 @@ document.addEventListener('DOMContentLoaded', async () => {
   // matters more than the empty column for those edge cases.
   function applyAiLayoutMode() {
     if (!resultsArea) return;
-    resultsArea.classList.remove('ai-mode-full', 'ai-mode-two-col', 'ai-mode-stacked');
-    if (lastAiState === 'idle') return;
-    const local = lastResults.filter((r) => webSuggestionFromResultId(r.id) == null);
-    if (local.length > 0) {
-      resultsArea.classList.add('ai-mode-stacked');
-    } else {
-      resultsArea.classList.add('ai-mode-two-col');
-    }
+    resultsArea.classList.remove(...AI_LAYOUT_CLASSES);
+    if (lastAiState === AiState.idle) return;
+    const hasLocal = lastResults.some((r) => webSuggestionFromResultId(r.id) == null);
+    resultsArea.classList.add(hasLocal ? AI_LAYOUT_STACKED : AI_LAYOUT_TWO_COL);
   }
 
   // :cmd <args> live trigger — jumps straight into that command's panel with
@@ -307,7 +317,14 @@ document.addEventListener('DOMContentLoaded', async () => {
       runningApps.setSuspended(false);
       if (runningApps.isEnabled()) runningApps.refresh();
       translatePanel.hide();
-      results.setEmptyState({ mode: search.isRecentMode() ? 'recent' : 'default' });
+      // While the AI card is active, the results list holds web-suggestion
+      // rows. Those routinely return empty (DDG rate-limits, transient
+      // failures) — render nothing instead of "No results" so the right
+      // column doesn't shout an error when the left card is working fine.
+      const empty = search.isRecentMode()
+        ? 'recent'
+        : (lastAiState !== AiState.idle ? 'ai-suggestion' : 'default');
+      results.setEmptyState({ mode: empty });
     }
   });
 
@@ -370,11 +387,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
   });
 
-  // Load home dir + resolved quick-folder paths (Desktop, Documents, …).
-  // Quick folders use SHGetKnownFolderPath on Windows to handle OneDrive
-  // redirection; on Linux/macOS they're $HOME/<name>.
-  Promise.all([getHomeDir(), getQuickFolders()]).then(([home, folders]) => {
-    if (home) search.setHomeDir(home);
+  // Load resolved quick-folder paths (Desktop, Documents, …). Uses
+  // SHGetKnownFolderPath on Windows so OneDrive-redirected folders resolve
+  // to their real location; $HOME/<name> on Linux/macOS.
+  getQuickFolders().then((folders) => {
     search.setQuickFolders(folders || []);
     search.handleQueryInput('');
   });

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -11,6 +11,8 @@ import { mountUpdateWidget } from './screens/update_widget.js';
 import * as translatePanel from './components/translate.js';
 import * as runningApps from './components/running-apps.js';
 import * as platform from './platform.js';
+import * as aiAnswer from './components/ai-answer.js';
+import * as aiCard from './components/ai-answer-card.js';
 import { load } from './html-loader.js';
 import {
   onWindowShown, onIndexReady, requestIndexRefresh, getHomeDir, getQuickFolders, copyFilesToClipboard,
@@ -19,7 +21,7 @@ import {
   copyToClipboard, deleteClipboardEntry, isDevBuild,
   getConfig,
 } from './ipc.js';
-import { prefixFromResultId, commandIdFromResultId } from './catalog.js';
+import { prefixFromResultId, commandIdFromResultId, webSuggestionFromResultId } from './catalog.js';
 
 // Item count and structure mirror the macOS app's `LauncherView.hintItems`
 // (apps/macos/.../LauncherView.swift:302) so both platforms surface the same
@@ -83,7 +85,14 @@ document.addEventListener('DOMContentLoaded', async () => {
   const hintBar = document.getElementById('hint-bar');
   const hintMessage = hintBar.querySelector('span');
   const contentArea = document.getElementById('search-content');
+  const resultsArea = document.getElementById('results-area');
+  const aiCardEl = document.getElementById('ai-answer-card');
   setHint(hintMessage, HINT_MAIN);
+
+  // Snapshot of the latest results + AI state, used by applyAiLayoutMode()
+  // to pick full / two-col / stacked. Mirrors macOS LauncherView resultsRow.
+  let lastResults = [];
+  let lastAiState = 'idle';
 
   hintBar.querySelector('.hint-bar-link').addEventListener('click', (e) => {
     e.preventDefault();
@@ -108,6 +117,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     onGetIcon: getIcon,
   });
   translatePanel.init(contentArea);
+  aiCard.init(aiCardEl);
+  aiAnswer.init({
+    onChange: (snapshot) => {
+      lastAiState = snapshot.state;
+      aiCard.update(snapshot);
+      applyAiLayoutMode();
+    },
+  });
   settings.init(() => {
     queryInput.value = '';
     search.handleQueryInput('');
@@ -123,6 +140,15 @@ document.addEventListener('DOMContentLoaded', async () => {
     const on = !placement || placement.value !== 'none';
     runningApps.setEnabled(on);
     if (on) runningApps.refresh();
+
+    // AI / web answers — default ON to match the default_config.txt setting
+    // (and macOS, which ships aiEnabled=true). Honour the persisted value if
+    // the user has flipped it. Propagated to both the controller (gates the
+    // card) and search.js (gates web suggestions).
+    const aiCfg = cfg.entries.find((e) => e.key === 'ai_enabled');
+    const aiOn = !aiCfg || aiCfg.value !== 'false';
+    aiAnswer.setEnabled(aiOn);
+    search.setAiEnabled(aiOn);
   });
 
   // Show DEV badge when running in dev mode (cargo tauri dev)
@@ -177,10 +203,43 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
   });
 
-  // Wire search -> results
+  // Wire search -> results. After rendering, drive the AI controller with
+  // the LOCAL result count (websuggest: rows don't count — a query that
+  // only matches web suggestions is treated as zero local results, which is
+  // the macOS knowledge-lookup trigger).
   search.setOnResults((items, query) => {
+    lastResults = items;
     results.render(items);
+    applyAiLayoutMode();
+    const localCount = items.filter((r) => webSuggestionFromResultId(r.id) == null).length;
+    aiAnswer.update(query, localCount);
   });
+
+  // Pick stacked / two-col purely from the local-result count, ignoring the
+  // controller state and the suggestion-arrival timing. This is what
+  // eliminates the 2–3 second "card width zooms out" shift the user sees:
+  // engine returns first (empty), then 2 s later web suggestions arrive,
+  // and the OLD logic reacted to every intermediate state with a different
+  // mode. Now the only thing that matters is "are there any local rows":
+  //   - has local results → stacked (card capped 240 px above rows, both
+  //     in col 1; search-bar and rows stay aligned)
+  //   - no local results  → two-col (wide card + 320 px suggestion column
+  //     on the right; alignment intentionally broken so the answer reads
+  //     at a comfortable measure)
+  // The 320 px column may be empty briefly while suggestions load, or
+  // permanently for queries that get none (e.g. "1+1=?"). Stable layout
+  // matters more than the empty column for those edge cases.
+  function applyAiLayoutMode() {
+    if (!resultsArea) return;
+    resultsArea.classList.remove('ai-mode-full', 'ai-mode-two-col', 'ai-mode-stacked');
+    if (lastAiState === 'idle') return;
+    const local = lastResults.filter((r) => webSuggestionFromResultId(r.id) == null);
+    if (local.length > 0) {
+      resultsArea.classList.add('ai-mode-stacked');
+    } else {
+      resultsArea.classList.add('ai-mode-two-col');
+    }
+  }
 
   // :cmd <args> live trigger — jumps straight into that command's panel with
   // the rest of the text prefilled (e.g. `:calc 2+2`, `:kill chrome`). Bare
@@ -274,6 +333,12 @@ document.addEventListener('DOMContentLoaded', async () => {
       queryInput.value = '';
       return;
     }
+    const suggestionText = webSuggestionFromResultId(item.id);
+    if (suggestionText != null) {
+      const url = `https://www.google.com/search?q=${encodeURIComponent(suggestionText)}`;
+      import('./ipc.js').then(({ openPath }) => openPath(url, 'browser', ''));
+      return;
+    }
 
     import('./ipc.js').then(({ openPath, recordUsage }) => {
       openPath(item.path, item.kind, item.id);
@@ -320,6 +385,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     resultsList.hidden = true;
     previewPanel.hidden = true;
     runningApps.setSuspended(true);
+    // Tear down any active AI card — command mode owns the whole content
+    // area, and a stale card would peek through. Matches macOS, which
+    // calls aiAnswer.cancel() whenever it switches into command mode.
+    aiAnswer.cancel();
     updateCommandHintBar();
     commands.enter();
     commands.setOnCommandChange(updateCommandHintBar);
@@ -449,11 +518,16 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
   }
 
-  // Sync running apps strip when config is reloaded from file
+  // Sync running apps strip + AI when config is reloaded from file. Both
+  // settings have live downstream consumers, so propagate on every reload.
   settings.setOnConfigReload((map) => {
     const on = (map.running_apps_placement || 'right') !== 'none';
     runningApps.setEnabled(on);
     if (on) runningApps.refresh();
+
+    const aiOn = map.ai_enabled !== 'false';
+    aiAnswer.setEnabled(aiOn);
+    search.setAiEnabled(aiOn);
   });
 
   // Live-update when the Settings → Appearance → Running Apps toggle changes.
@@ -461,6 +535,18 @@ document.addEventListener('DOMContentLoaded', async () => {
     const enabled = e.detail.enabled;
     runningApps.setEnabled(enabled);
     if (enabled) runningApps.refresh();
+  });
+
+  // Live-update when the Settings → Privacy & Logs → Web Answers toggle
+  // changes. Propagate immediately so the card and suggestion rows appear or
+  // disappear without a config reload.
+  document.addEventListener('look:ai-enabled-changed', (e) => {
+    const enabled = e.detail.enabled;
+    aiAnswer.setEnabled(enabled);
+    search.setAiEnabled(enabled);
+    // Re-run the current query so the new gate takes effect immediately
+    // (drops websuggest rows when disabled, fetches them when enabled).
+    search.handleQueryInput(queryInput.value);
   });
 
   // Expose enterCommandMode and settings for keyboard

--- a/apps/linows/src/js/catalog.js
+++ b/apps/linows/src/js/catalog.js
@@ -6,10 +6,16 @@
 import { calculator, timer, xCircle, terminal, info } from './icons.js';
 
 // Synthetic-row id namespaces — the renderer and Enter/click handlers tell
-// discovery rows apart from real candidates by id prefix.
+// synthetic rows apart from real candidates by id prefix.
 const PREFIX_HINT_ID = 'prefixhint:';
 const COMMAND_HINT_ID = 'cmdhint:';
+const WEB_SUGGEST_ID = 'websuggest:';
 const DISCOVERY_CHAR = '"';
+
+// Google-autocomplete row glyph — Lucide `search` (mirrors macOS, which uses
+// SF Symbols "magnifyingglass"). Inlined here rather than imported as a
+// dedicated icon constant since this is the only place that needs it.
+const SEARCH_GLYPH = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>`;
 
 const PREFIX_ENTRIES = [
   { prefix: 'a"',  argHint: 'word',    description: 'Apps only' },
@@ -99,4 +105,23 @@ export function prefixFromResultId(resultId) {
 
 export function commandIdFromResultId(resultId) {
   return resultId?.startsWith(COMMAND_HINT_ID) ? resultId.slice(COMMAND_HINT_ID.length) : null;
+}
+
+// Google-autocomplete rows. Sit at the bottom of the results list when AI is
+// on and the query is plain text (`>=2` chars, no mode prefix). Enter on one
+// opens Google for that text. Mirrors macOS AppConstants.Launcher.WebSuggestion.
+export function webSuggestionResults(suggestions) {
+  return suggestions.map((text, index) => ({
+    id: `${WEB_SUGGEST_ID}${text}`,
+    kind: 'app',
+    title: text,
+    subtitle: 'Search Google',
+    path: '',
+    score: -1 - index,
+    iconSvg: SEARCH_GLYPH,
+  }));
+}
+
+export function webSuggestionFromResultId(resultId) {
+  return resultId?.startsWith(WEB_SUGGEST_ID) ? resultId.slice(WEB_SUGGEST_ID.length) : null;
 }

--- a/apps/linows/src/js/components/ai-answer-card.js
+++ b/apps/linows/src/js/components/ai-answer-card.js
@@ -1,0 +1,128 @@
+// Renders the AI / web answer card. Pure view layer — subscribes to
+// ai-answer.js via onChange and re-paints on every state mutation.
+//
+// Matches macOS AIAnswerCardView.swift:
+//   - 10px corner radius, 12px padding, 1px white-8% border, control-fill bg
+//   - header row: sparkles icon + question + spinner (when streaming)
+//   - one block per source, 14px vertical spacing:
+//       SOURCE LABEL (uppercased, accent-colored if clickable, with chevron)
+//       copy button on the right
+//       optional 96x96 image (clickable → opens url)
+//       answer text (selectable, generous line height)
+//   - status line: "Thinking…" while streaming with no blocks yet;
+//                  "Couldn't find an answer." on failed.
+
+import { sparkles, copy as copyIcon, arrowUpRight } from '../icons.js';
+import { copyToClipboard, openPath } from '../ipc.js';
+import * as banner from './banner.js';
+
+let cardEl = null;
+
+export function init(el) {
+  cardEl = el;
+}
+
+export function update(snapshot) {
+  if (!cardEl) return;
+  const { state, question, items } = snapshot;
+
+  if (state === 'idle') {
+    cardEl.hidden = true;
+    cardEl.innerHTML = '';
+    return;
+  }
+
+  const headerLabel = question || 'Web answer';
+  const streamingDot = state === 'streaming' ? '<span class="ai-spinner" aria-label="Loading"></span>' : '';
+
+  const blocks = items.map(renderBlock).join('');
+  const status = renderStatusLine(state, items.length === 0);
+
+  cardEl.hidden = false;
+  cardEl.innerHTML = `
+    <div class="ai-card-header">
+      <span class="ai-card-icon">${sparkles}</span>
+      <span class="ai-card-question">${escapeHtml(headerLabel)}</span>
+      <span class="ai-card-spacer"></span>
+      ${streamingDot}
+    </div>
+    <div class="ai-card-body">
+      ${blocks}
+      ${status}
+    </div>
+  `;
+
+  wireBlockHandlers();
+}
+
+function renderBlock(item) {
+  const hasUrl = !!item.url;
+  const sourceClass = hasUrl ? 'ai-card-source ai-card-source-linked' : 'ai-card-source';
+  const chevron = hasUrl ? `<span class="ai-card-source-chevron">${arrowUpRight}</span>` : '';
+  const image = item.imageUrl
+    ? `<img class="ai-card-image" src="${escapeAttr(item.imageUrl)}" alt="" data-url="${escapeAttr(item.url || '')}" />`
+    : '';
+
+  return `
+    <div class="ai-card-block">
+      <div class="ai-card-block-head">
+        <span class="${sourceClass}" data-url="${escapeAttr(item.url || '')}">
+          <span class="ai-card-source-label">${escapeHtml(item.source.toUpperCase())}</span>
+          ${chevron}
+        </span>
+        <span class="ai-card-spacer"></span>
+        <button type="button" class="ai-card-copy" data-text="${escapeAttr(item.text)}" title="Copy this answer" tabindex="-1">${copyIcon}</button>
+      </div>
+      <div class="ai-card-block-body">
+        ${image}
+        <div class="ai-card-text">${escapeHtml(item.text)}</div>
+      </div>
+    </div>
+  `;
+}
+
+function renderStatusLine(state, isEmpty) {
+  if (!isEmpty) return '';
+  if (state === 'streaming') return `<div class="ai-card-status">Thinking…</div>`;
+  if (state === 'failed') return `<div class="ai-card-status">Couldn't find an answer.</div>`;
+  return '';
+}
+
+function wireBlockHandlers() {
+  cardEl.querySelectorAll('.ai-card-source-linked').forEach((el) => {
+    el.addEventListener('click', () => {
+      const url = el.dataset.url;
+      if (url) openPath(url, 'browser', '');
+    });
+  });
+  cardEl.querySelectorAll('.ai-card-image[data-url]').forEach((el) => {
+    el.addEventListener('click', () => {
+      const url = el.dataset.url;
+      if (url) openPath(url, 'browser', '');
+    });
+  });
+  cardEl.querySelectorAll('.ai-card-copy').forEach((el) => {
+    el.addEventListener('click', async (e) => {
+      e.stopPropagation();
+      const text = (el.dataset.text || '').trim();
+      if (!text) return;
+      try {
+        await copyToClipboard(text);
+        banner.show('Copied answer', 'success', 1.0);
+      } catch {
+        banner.show('Copy failed', 'error', 1.2);
+      }
+    });
+  });
+}
+
+function escapeHtml(s) {
+  return String(s ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function escapeAttr(s) {
+  return escapeHtml(s).replace(/"/g, '&quot;');
+}

--- a/apps/linows/src/js/components/ai-answer-card.js
+++ b/apps/linows/src/js/components/ai-answer-card.js
@@ -14,9 +14,20 @@
 
 import { sparkles, copy as copyIcon, arrowUpRight } from '../icons.js';
 import { copyToClipboard, openPath } from '../ipc.js';
+import { State } from './ai-answer.js';
 import * as banner from './banner.js';
 
+const COPY_OK_BANNER_S = 1.0;
+const COPY_FAIL_BANNER_S = 1.2;
+
 let cardEl = null;
+
+// Open a URL in the default browser. Reused by source-label and image
+// clicks; centralised here so the `('browser', '')` magic args don't drift
+// between sites.
+function openUrl(url) {
+  if (url) openPath(url, 'browser', '');
+}
 
 export function init(el) {
   cardEl = el;
@@ -26,14 +37,16 @@ export function update(snapshot) {
   if (!cardEl) return;
   const { state, question, items } = snapshot;
 
-  if (state === 'idle') {
+  if (state === State.idle) {
     cardEl.hidden = true;
     cardEl.innerHTML = '';
     return;
   }
 
   const headerLabel = question || 'Web answer';
-  const streamingDot = state === 'streaming' ? '<span class="ai-spinner" aria-label="Loading"></span>' : '';
+  const streamingDot = state === State.streaming
+    ? '<span class="ai-spinner" aria-label="Loading"></span>'
+    : '';
 
   const blocks = items.map(renderBlock).join('');
   const status = renderStatusLine(state, items.length === 0);
@@ -83,36 +96,33 @@ function renderBlock(item) {
 
 function renderStatusLine(state, isEmpty) {
   if (!isEmpty) return '';
-  if (state === 'streaming') return `<div class="ai-card-status">Thinking…</div>`;
-  if (state === 'failed') return `<div class="ai-card-status">Couldn't find an answer.</div>`;
+  if (state === State.streaming) return `<div class="ai-card-status">Thinking…</div>`;
+  if (state === State.failed) return `<div class="ai-card-status">Couldn't find an answer.</div>`;
   return '';
 }
 
+// Bind a click handler to every matching child inside the card. Small
+// helper to keep wireBlockHandlers terse — the three click handlers all
+// share the same querySelectorAll + addEventListener boilerplate.
+function bindClick(selector, handler) {
+  cardEl.querySelectorAll(selector).forEach((el) => {
+    el.addEventListener('click', (e) => handler(el, e));
+  });
+}
+
 function wireBlockHandlers() {
-  cardEl.querySelectorAll('.ai-card-source-linked').forEach((el) => {
-    el.addEventListener('click', () => {
-      const url = el.dataset.url;
-      if (url) openPath(url, 'browser', '');
-    });
-  });
-  cardEl.querySelectorAll('.ai-card-image[data-url]').forEach((el) => {
-    el.addEventListener('click', () => {
-      const url = el.dataset.url;
-      if (url) openPath(url, 'browser', '');
-    });
-  });
-  cardEl.querySelectorAll('.ai-card-copy').forEach((el) => {
-    el.addEventListener('click', async (e) => {
-      e.stopPropagation();
-      const text = (el.dataset.text || '').trim();
-      if (!text) return;
-      try {
-        await copyToClipboard(text);
-        banner.show('Copied answer', 'success', 1.0);
-      } catch {
-        banner.show('Copy failed', 'error', 1.2);
-      }
-    });
+  bindClick('.ai-card-source-linked', (el) => openUrl(el.dataset.url));
+  bindClick('.ai-card-image[data-url]', (el) => openUrl(el.dataset.url));
+  bindClick('.ai-card-copy', async (el, e) => {
+    e.stopPropagation();
+    const text = (el.dataset.text || '').trim();
+    if (!text) return;
+    try {
+      await copyToClipboard(text);
+      banner.show('Copied answer', 'success', COPY_OK_BANNER_S);
+    } catch {
+      banner.show('Copy failed', 'error', COPY_FAIL_BANNER_S);
+    }
   });
 }
 

--- a/apps/linows/src/js/components/ai-answer.js
+++ b/apps/linows/src/js/components/ai-answer.js
@@ -12,13 +12,25 @@ import {
 } from '../ipc.js';
 
 const DEBOUNCE_MS = 350;
+// Chars stripped from the trailing end of a calc query — people tack
+// "=?", "=", or "?" onto math expressions before pressing Enter.
+const CALC_TRIM_TRAILING = '=? ';
+// Require at least one arithmetic operator so a bare number or word
+// ("hello") isn't sent to the calculator.
+const CALC_OPERATOR = /[+\-*/^%]/;
+// Two answer texts are "the same" when their leading N chars match —
+// DuckDuckGo abstracts are often verbatim Wikipedia, so we don't show both.
+const SIMILARITY_PREFIX_LEN = 60;
+// Source labels — exposed as constants so the card view can match against
+// them without restating the magic string. Mirror macOS source names.
+export const SOURCE_CALCULATOR = 'Calculator';
 
 // State machine: same names + meanings as macOS AIAnswerController.State.
 //   idle      — not a question / AI off / no answer to show
 //   streaming — at least one async source is in flight
 //   done      — every source has settled (one or more blocks landed)
 //   failed    — every source returned null (only used to show the empty hint)
-const State = Object.freeze({
+export const State = Object.freeze({
   idle: 'idle', streaming: 'streaming', done: 'done', failed: 'failed',
 });
 
@@ -105,21 +117,26 @@ function emitChange() {
   if (onChangeCallback) onChangeCallback(getState());
 }
 
+// A run is "stale" when a newer update() has bumped runVersion. Every async
+// step checks this before mutating state, so a slow fetch from a previous
+// query can't paint over the answer for a later one.
+function isStale(myVersion) {
+  return myVersion !== runVersion;
+}
+
 // Fastest path: local arithmetic. No network, no provider — instant. The
 // macOS version uses CalcCommand.evaluate; we use the same backend
 // (`eval_calc` Tauri command) so behaviour matches.
 async function tryCalc(query, myVersion) {
   let expr = query;
-  while (expr.length && '=? '.includes(expr[expr.length - 1])) {
+  while (expr.length && CALC_TRIM_TRAILING.includes(expr[expr.length - 1])) {
     expr = expr.slice(0, -1);
   }
-  if (!expr) return false;
-  if (!/[+\-*/^%]/.test(expr)) return false;
+  if (!expr || !CALC_OPERATOR.test(expr)) return false;
   try {
     const result = await evalCalc(expr);
-    if (myVersion !== runVersion) return false;
-    if (!result) return false;
-    items = [{ text: `${expr} = ${result}`, source: 'Calculator', url: null, imageUrl: null }];
+    if (isStale(myVersion) || !result) return false;
+    items = [{ text: `${expr} = ${result}`, source: SOURCE_CALCULATOR, url: null, imageUrl: null }];
     state = State.done;
     emitChange();
     return true;
@@ -129,10 +146,10 @@ async function tryCalc(query, myVersion) {
 }
 
 async function runFetch(query, questionLike, instant, myVersion) {
-  if (myVersion !== runVersion) return;
+  if (isStale(myVersion)) return;
 
   if (await tryCalc(query, myVersion)) return;
-  if (myVersion !== runVersion) return;
+  if (isStale(myVersion)) return;
 
   // Choose what (if anything) to search Wikipedia for. Mirrors macOS
   // collectWebAnswers: definitionalEntity for "what is X" patterns; the raw
@@ -140,28 +157,26 @@ async function runFetch(query, questionLike, instant, myVersion) {
   let wikiTerm = null;
   if (!instant) {
     const entity = await definitionalEntity(query).catch(() => null);
-    if (myVersion !== runVersion) return;
+    if (isStale(myVersion)) return;
     if (entity) wikiTerm = entity;
     else if (!questionLike) wikiTerm = query;
   }
 
   // Fan out concurrently. A matched instant source (currency / weather /
   // crypto) is what the user wants — skip the generic encyclopedia lookups
-  // then.
+  // then. Each task is a Promise<Item | null> that the loop below appends as
+  // it resolves so the first available source surfaces immediately, and a
+  // single slow provider doesn't hold up the others.
   const tasks = instant
-    ? [instantAnswer(query).then((a) => tag(a))]
+    ? [instantAnswer(query).then(toItem)]
     : [
-        duckduckgoAnswer(query).then((a) => tag(a)),
-        ...(wikiTerm ? [wikipediaAnswer(wikiTerm).then((a) => tag(a))] : []),
+        duckduckgoAnswer(query).then(toItem),
+        ...(wikiTerm ? [wikipediaAnswer(wikiTerm).then(toItem)] : []),
       ];
 
-  // Append each block the moment it lands; the card re-renders per-source so
-  // the first available source surfaces immediately. Promise.allSettled keeps
-  // a single slow provider from holding up the others.
   await Promise.all(tasks.map(async (p) => {
     const result = await p;
-    if (myVersion !== runVersion) return;
-    if (!result) return;
+    if (isStale(myVersion) || !result) return;
     if (items.some((it) => it.source === result.source)) return;
     if (items.some((it) => similar(it.text, result.text))) return;
     items = [...items, result];
@@ -169,14 +184,14 @@ async function runFetch(query, questionLike, instant, myVersion) {
     emitChange();
   }));
 
-  if (myVersion !== runVersion) return;
+  if (isStale(myVersion)) return;
   state = items.length ? State.done : State.failed;
   emitChange();
 }
 
 // Normalise the Rust `Answer` (snake_case wire shape) to the controller's
 // item shape used by the card view.
-function tag(answer) {
+function toItem(answer) {
   if (!answer) return null;
   return {
     text: answer.text,
@@ -186,10 +201,8 @@ function tag(answer) {
   };
 }
 
-// Two extracts are "the same" if their leading text matches — DuckDuckGo
-// abstracts are often verbatim Wikipedia, so we don't show both.
 function similar(a, b) {
-  const key = (s) => s.toLowerCase().replace(/\s+/g, '').slice(0, 60);
+  const key = (s) => s.toLowerCase().replace(/\s+/g, '').slice(0, SIMILARITY_PREFIX_LEN);
   return key(a) === key(b);
 }
 

--- a/apps/linows/src/js/components/ai-answer.js
+++ b/apps/linows/src/js/components/ai-answer.js
@@ -1,0 +1,221 @@
+// Drives the inline AI / web answer card pinned at the top of the results
+// area. Faithful port of macOS AIAnswerController.swift: same trigger
+// heuristics, same 350 ms debounce, same source-fan-out + dedup, same state
+// names. linows has no on-device LLM, so the streaming fallback that macOS
+// uses ("Apple Intelligence" block) is intentionally absent — we surface
+// Calculator + DuckDuckGo + Wikipedia + the pattern-gated instant providers
+// (currency / weather / crypto) and stop there.
+
+import {
+  instantHasMatch, instantAnswer, duckduckgoAnswer,
+  wikipediaAnswer, definitionalEntity, evalCalc,
+} from '../ipc.js';
+
+const DEBOUNCE_MS = 350;
+
+// State machine: same names + meanings as macOS AIAnswerController.State.
+//   idle      — not a question / AI off / no answer to show
+//   streaming — at least one async source is in flight
+//   done      — every source has settled (one or more blocks landed)
+//   failed    — every source returned null (only used to show the empty hint)
+const State = Object.freeze({
+  idle: 'idle', streaming: 'streaming', done: 'done', failed: 'failed',
+});
+
+let state = State.idle;
+let question = '';           // The trimmed query backing the current card
+let items = [];              // Settled blocks, in arrival order
+let aiEnabled = true;        // Mirrors the config flag
+
+let debounceTimer = null;
+let runVersion = 0;          // Bumps on every update; in-flight runs check
+                             // this and bail when a newer query supersedes.
+
+let onChangeCallback = null; // View subscribes here; fires after every state
+                             // mutation so the card can re-render.
+
+export function init({ onChange }) {
+  onChangeCallback = onChange;
+}
+
+export function setEnabled(enabled) {
+  aiEnabled = !!enabled;
+  if (!aiEnabled) cancel();
+}
+
+export function isActive() {
+  return state !== State.idle;
+}
+
+export function getState() {
+  return { state, question, items };
+}
+
+// Re-evaluate for the current query. Cancels any in-flight generation.
+// `resultCount` is how many local results the launcher found — a multi-word
+// entity with no local match (e.g. "david beckham") is treated as a
+// knowledge lookup (see isEntityLookup).
+export async function update(rawQuery, resultCount) {
+  const query = (rawQuery || '').trim();
+
+  // Triggers (mirrors macOS): an explicit question, a multi-word entity with
+  // no local match, or a pattern-gated instant source (weather / currency /
+  // crypto). instantHasMatch is a network-free regex gate; everything else
+  // is local — so this can run on every keystroke without I/O.
+  const questionLike = isQuestionLike(query);
+  const orphanEntity = resultCount === 0 && isEntityLookup(query);
+  const instant = aiEnabled && query.length > 0 ? await instantHasMatch(query) : false;
+
+  if (!aiEnabled || !(questionLike || orphanEntity || instant)) {
+    cancel();
+    return;
+  }
+
+  // Same question already active — leave it be (avoid re-fetch on every
+  // keystroke that doesn't change the trimmed query).
+  if (query === question && state !== State.idle) return;
+
+  runVersion += 1;
+  const myVersion = runVersion;
+  question = query;
+  items = [];
+  state = State.streaming;
+  emitChange();
+
+  clearTimeout(debounceTimer);
+  debounceTimer = setTimeout(() => runFetch(query, questionLike, instant, myVersion), DEBOUNCE_MS);
+}
+
+// Tear down the card (query cleared, launcher hidden, AI turned off, mode
+// switched to clipboard/prefix/command discovery/translate).
+export function cancel() {
+  runVersion += 1;
+  clearTimeout(debounceTimer);
+  debounceTimer = null;
+  if (state === State.idle && !items.length && !question) return;
+  state = State.idle;
+  question = '';
+  items = [];
+  emitChange();
+}
+
+// ---- internals ----
+
+function emitChange() {
+  if (onChangeCallback) onChangeCallback(getState());
+}
+
+// Fastest path: local arithmetic. No network, no provider — instant. The
+// macOS version uses CalcCommand.evaluate; we use the same backend
+// (`eval_calc` Tauri command) so behaviour matches.
+async function tryCalc(query, myVersion) {
+  let expr = query;
+  while (expr.length && '=? '.includes(expr[expr.length - 1])) {
+    expr = expr.slice(0, -1);
+  }
+  if (!expr) return false;
+  if (!/[+\-*/^%]/.test(expr)) return false;
+  try {
+    const result = await evalCalc(expr);
+    if (myVersion !== runVersion) return false;
+    if (!result) return false;
+    items = [{ text: `${expr} = ${result}`, source: 'Calculator', url: null, imageUrl: null }];
+    state = State.done;
+    emitChange();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function runFetch(query, questionLike, instant, myVersion) {
+  if (myVersion !== runVersion) return;
+
+  if (await tryCalc(query, myVersion)) return;
+  if (myVersion !== runVersion) return;
+
+  // Choose what (if anything) to search Wikipedia for. Mirrors macOS
+  // collectWebAnswers: definitionalEntity for "what is X" patterns; the raw
+  // query for bare entities; nothing for how-to/why questions.
+  let wikiTerm = null;
+  if (!instant) {
+    const entity = await definitionalEntity(query).catch(() => null);
+    if (myVersion !== runVersion) return;
+    if (entity) wikiTerm = entity;
+    else if (!questionLike) wikiTerm = query;
+  }
+
+  // Fan out concurrently. A matched instant source (currency / weather /
+  // crypto) is what the user wants — skip the generic encyclopedia lookups
+  // then.
+  const tasks = instant
+    ? [instantAnswer(query).then((a) => tag(a))]
+    : [
+        duckduckgoAnswer(query).then((a) => tag(a)),
+        ...(wikiTerm ? [wikipediaAnswer(wikiTerm).then((a) => tag(a))] : []),
+      ];
+
+  // Append each block the moment it lands; the card re-renders per-source so
+  // the first available source surfaces immediately. Promise.allSettled keeps
+  // a single slow provider from holding up the others.
+  await Promise.all(tasks.map(async (p) => {
+    const result = await p;
+    if (myVersion !== runVersion) return;
+    if (!result) return;
+    if (items.some((it) => it.source === result.source)) return;
+    if (items.some((it) => similar(it.text, result.text))) return;
+    items = [...items, result];
+    state = State.streaming;
+    emitChange();
+  }));
+
+  if (myVersion !== runVersion) return;
+  state = items.length ? State.done : State.failed;
+  emitChange();
+}
+
+// Normalise the Rust `Answer` (snake_case wire shape) to the controller's
+// item shape used by the card view.
+function tag(answer) {
+  if (!answer) return null;
+  return {
+    text: answer.text,
+    source: answer.source,
+    url: answer.url || null,
+    imageUrl: answer.image_url || null,
+  };
+}
+
+// Two extracts are "the same" if their leading text matches — DuckDuckGo
+// abstracts are often verbatim Wikipedia, so we don't show both.
+function similar(a, b) {
+  const key = (s) => s.toLowerCase().replace(/\s+/g, '').slice(0, 60);
+  return key(a) === key(b);
+}
+
+// Cheap heuristic for "this looks like a question, not an app/file launch".
+// Keeps the network off the hot path for ordinary launches like "spotify".
+// Matches macOS AIAnswerController.isQuestionLike one-for-one.
+const QUESTION_STARTERS = new Set([
+  'how', 'what', 'why', 'who', 'when', 'where', 'which', 'whose',
+  'can', 'could', 'should', 'would', 'is', 'are', 'am', 'do', 'does',
+  'did', 'will', 'explain', 'tell', 'give', 'write', 'summarize',
+  'summarise', 'define', 'translate', 'convert', 'calculate',
+]);
+
+export function isQuestionLike(text) {
+  if (text.length < 3) return false;
+  if (text.endsWith('?')) return true;
+  const words = text.split(/[\s\n]+/).filter(Boolean);
+  if (words.length < 3) return false;
+  return QUESTION_STARTERS.has(words[0].toLowerCase());
+}
+
+// Multi-word, reasonably long query that's likely a name/entity rather than
+// a half-typed token. Combined with zero local results, this marks a
+// knowledge lookup ("david beckham") vs. an app launch ("activity monitor").
+export function isEntityLookup(text) {
+  if (text.length < 5) return false;
+  const words = text.split(/[\s\n]+/).filter(Boolean);
+  return words.length >= 2;
+}

--- a/apps/linows/src/js/components/preview.js
+++ b/apps/linows/src/js/components/preview.js
@@ -1,5 +1,6 @@
 import { getIcon, getFileMeta, getAppVersion, deleteClipboardEntry, highlightFile, listFolder, openPath } from '../ipc.js';
 import { clipboard as clipboardIcon, trash as trashIcon, appIcon, fileIcon, folderIcon, settingIcon } from '../icons.js';
+import { webSuggestionFromResultId } from '../catalog.js';
 
 let panel = null;
 let currentPath = null;
@@ -32,6 +33,15 @@ export function update(result) {
 
   if (result.kind === 'clipboard') {
     renderClipboardPreview(result);
+    return;
+  }
+
+  // Google autocomplete row — mirror macOS WebSuggestionPreviewView: a
+  // big magnifying-glass icon, the suggestion text, "Search Google", and
+  // an Enter hint. No file metadata to show.
+  const suggestionText = webSuggestionFromResultId(result.id);
+  if (suggestionText != null) {
+    renderWebSuggestionPreview(suggestionText);
     return;
   }
 
@@ -372,4 +382,34 @@ function formatSize(bytes) {
 
 function convertFileSrc(path) {
   return window.__TAURI__.core.convertFileSrc(path);
+}
+
+// Mirrors macOS WebSuggestionPreviewView.swift — a centred "search the web"
+// card. A web-suggestion row has no file metadata to render, so we show the
+// action affordance instead.
+function renderWebSuggestionPreview(query) {
+  const wrap = document.createElement('div');
+  wrap.className = 'preview-web-suggestion';
+
+  const icon = document.createElement('div');
+  icon.className = 'preview-web-suggestion-icon';
+  icon.innerHTML = `<svg width="44" height="44" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>`;
+  wrap.appendChild(icon);
+
+  const title = document.createElement('div');
+  title.className = 'preview-web-suggestion-title';
+  title.textContent = query;
+  wrap.appendChild(title);
+
+  const subtitle = document.createElement('div');
+  subtitle.className = 'preview-web-suggestion-subtitle';
+  subtitle.textContent = 'Search Google';
+  wrap.appendChild(subtitle);
+
+  const hint = document.createElement('div');
+  hint.className = 'preview-web-suggestion-hint';
+  hint.innerHTML = `Press <kbd>Enter</kbd> to search the web`;
+  wrap.appendChild(hint);
+
+  panel.appendChild(wrap);
 }

--- a/apps/linows/src/js/components/results.js
+++ b/apps/linows/src/js/components/results.js
@@ -1,6 +1,7 @@
 import { getIcon } from '../ipc.js';
 import { clipboard as clipboardIcon, check as checkIcon, appIcon, fileIcon, folderIcon, settingIcon, historyLg } from '../icons.js';
 import { getSettingsIcon as getWindowsSettingsIcon } from '../settings-icons/windows.js';
+import { webSuggestionFromResultId } from '../catalog.js';
 
 const iconCache = new Map();
 const pickedMap = new Map(); // key → result
@@ -187,6 +188,12 @@ function createRow(result, index) {
   const row = document.createElement('div');
   row.className = 'result-row';
   row.dataset.index = index;
+  // Web-suggestion rows live in a narrow 320 px column when the AI card is
+  // active; let their title wrap to multiple lines instead of truncating
+  // (matches macOS WebSuggestionPreviewView's 3-line title cap).
+  if (webSuggestionFromResultId(result.id) != null) {
+    row.classList.add('result-row-web-suggest');
+  }
 
   // Icon (kind-based SVG fallback, async-load real icon)
   const icon = document.createElement('div');

--- a/apps/linows/src/js/components/results.js
+++ b/apps/linows/src/js/components/results.js
@@ -42,6 +42,13 @@ function renderEmptyState() {
         <div class="empty-state-help">Open files/folders through Look, or download/create some — newest activity shows here. Type <kbd>rc"word</kbd> to filter.</div>
       </div>`;
   }
+  // AI two-col mode: the right column hosts web suggestions, which routinely
+  // return empty (DDG /ac/ rate-limits, transient curl failures). Showing
+  // a stark "No results" there reads as broken when the user can see the
+  // answer card on the left is working fine. Render nothing instead.
+  if (emptyState.mode === 'ai-suggestion') {
+    return '';
+  }
   return '<div class="empty-state">No results</div>';
 }
 

--- a/apps/linows/src/js/icons.js
+++ b/apps/linows/src/js/icons.js
@@ -28,6 +28,11 @@ export const check = s('<polyline points="20 6 9 17 4 12"/>');
 
 // Translate
 export const globe = s('<circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>');
+
+// AI / web answers — header glyph + source-label chevron. Matches macOS
+// SF Symbols "sparkles" and "arrow.up.forward".
+export const sparkles = s('<path d="M12 3l1.5 4.5L18 9l-4.5 1.5L12 15l-1.5-4.5L6 9l4.5-1.5z"/><path d="M19 14l.8 2.2L22 17l-2.2.8L19 20l-.8-2.2L16 17l2.2-.8z"/><path d="M5 16l.6 1.6L7 18l-1.4.4L5 20l-.6-1.6L3 18l1.4-.4z"/>');
+export const arrowUpRight = s('<line x1="7" y1="17" x2="17" y2="7"/><polyline points="7 7 17 7 17 17"/>');
 export const externalLink = s('<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/>');
 export const link = s('<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>');
 

--- a/apps/linows/src/js/ipc.js
+++ b/apps/linows/src/js/ipc.js
@@ -212,3 +212,30 @@ export async function countTrashItems() {
 export async function emptyTrash() {
   return invoke('empty_trash');
 }
+
+// AI / web answers — see src-tauri/src/answers.rs. Each returns an Answer
+// `{ text, source, url?, image_url? }` or null. The card UI ignores null.
+
+export async function instantHasMatch(query) {
+  return invoke('instant_has_match', { query });
+}
+
+export async function definitionalEntity(query) {
+  return invoke('definitional_entity', { query });
+}
+
+export async function instantAnswer(query) {
+  return invoke('instant_answer', { query });
+}
+
+export async function duckduckgoAnswer(query) {
+  return invoke('duckduckgo_answer', { query });
+}
+
+export async function wikipediaAnswer(term) {
+  return invoke('wikipedia_answer', { term });
+}
+
+export async function webSuggestions(query, limit) {
+  return invoke('web_suggestions', { query, limit });
+}

--- a/apps/linows/src/js/keyboard.js
+++ b/apps/linows/src/js/keyboard.js
@@ -6,7 +6,7 @@ import * as banner from './components/banner.js';
 import * as confirm from './components/confirm.js';
 import * as runningApps from './components/running-apps.js';
 import { trash as trashIcon } from './icons.js';
-import { prefixFromResultId, commandIdFromResultId } from './catalog.js';
+import { prefixFromResultId, commandIdFromResultId, webSuggestionFromResultId } from './catalog.js';
 
 let queryInput = null;
 let shiftHeld = false;
@@ -359,6 +359,13 @@ async function openSelected() {
     commandMode.enterById(hintedCmd);
     enterCommandModeFn();
     queryInput.value = '';
+    return;
+  }
+  // Google autocomplete row → open the search in the browser.
+  const suggestionText = webSuggestionFromResultId(item.id);
+  if (suggestionText != null) {
+    const url = `https://www.google.com/search?q=${encodeURIComponent(suggestionText)}`;
+    openPath(url, 'browser', '');
     return;
   }
 

--- a/apps/linows/src/js/screens/settings.js
+++ b/apps/linows/src/js/screens/settings.js
@@ -246,6 +246,17 @@ export function init(exitFn) {
     saveConfig({ lazy_indexing_enabled: e.target.checked ? 'true' : 'false' });
   });
 
+  // AI / web answers toggle — gates the inline answer card and Google
+  // autocomplete rows. Dispatches a custom event so app.js can apply the
+  // change live (it propagates to both the controller and search.js).
+  document.getElementById('settings-ai-enabled').addEventListener('change', (e) => {
+    const enabled = e.target.checked;
+    saveConfig({ ai_enabled: enabled ? 'true' : 'false' });
+    document.dispatchEvent(new CustomEvent('look:ai-enabled-changed', {
+      detail: { enabled },
+    }));
+  });
+
   // Running apps toggle (Appearance tab, next to Theme).
   // Persisted as `running_apps_placement` to share the macOS config key;
   // 'right' = visible, 'none' = hidden. Dispatches a custom event so
@@ -503,6 +514,7 @@ export function init(exitFn) {
       updates.file_scan_limit = document.getElementById('settings-file-limit').value;
       updates.lazy_indexing_enabled = document.getElementById('settings-lazy-indexing').checked ? 'true' : 'false';
       updates.running_apps_placement = document.getElementById('settings-running-apps').checked ? 'right' : 'none';
+      updates.ai_enabled = document.getElementById('settings-ai-enabled').checked ? 'true' : 'false';
 
       // Advanced: log level
       const logDD = document.getElementById('settings-log-level');
@@ -777,6 +789,7 @@ async function loadConfig() {
     document.getElementById('settings-file-limit').value = map.file_scan_limit || '8000';
     document.getElementById('settings-lazy-indexing').checked = map.lazy_indexing_enabled !== 'false';
     document.getElementById('settings-running-apps').checked = (map.running_apps_placement || 'right') !== 'none';
+    document.getElementById('settings-ai-enabled').checked = map.ai_enabled !== 'false';
     document.getElementById('settings-arch-disable-gpu').checked = map.arch_disable_gpu === 'true';
     document.getElementById('settings-arch-disable-blur').checked = map.arch_disable_blur === 'true';
     if (map.arch_disable_blur === 'true') {

--- a/apps/linows/src/js/search.js
+++ b/apps/linows/src/js/search.js
@@ -13,7 +13,6 @@ const CLIPBOARD_TITLE_MAX_CHARS = 80;
 let debounceTimer = null;
 let webSuggestionTimer = null;
 let onResultsCallback = null;
-let homeDir = null;
 let clipboardMode = false;
 let translateMode = false;
 let recentMode = false;
@@ -41,10 +40,6 @@ let quickFolders = [];
 
 export function setOnResults(callback) {
   onResultsCallback = callback;
-}
-
-export function setHomeDir(home) {
-  homeDir = home;
 }
 
 export function setQuickFolders(list) {
@@ -167,33 +162,35 @@ export function handleQueryInput(query) {
   webSuggestionTimer = setTimeout(() => fetchWebSuggestions(query, myVersion), DEBOUNCE_MS);
 }
 
+// A fetch is "stale" when handleQueryInput has bumped queryVersion since
+// the fetch started — used by both legs to bail before mutating shared
+// state. Cuts the `if (version !== queryVersion) return;` boilerplate.
+function isStale(version) {
+  return version !== queryVersion;
+}
+
 async function performSearch(query, version) {
   try {
     const payload = await ipcSearch(query, SEARCH_LIMIT);
-    if (version !== queryVersion) return;
+    if (isStale(version)) return;
     lastEnginePayload = recentMode ? payload.results : prependQuickFolders(payload.results, query);
-    publish(query, version);
   } catch (err) {
     console.error('Search failed:', err);
-    if (version !== queryVersion) return;
+    if (isStale(version)) return;
     lastEnginePayload = [];
-    publish(query, version);
   }
+  publish(query, version);
 }
 
 async function fetchWebSuggestions(query, version) {
-  if (!aiEnabled) {
-    webInFlight = false;
-    return;
-  }
   const trimmed = query.trim();
-  if (trimmed.length < MIN_WEB_SUGGESTION_QUERY_LENGTH) {
+  if (!aiEnabled || trimmed.length < MIN_WEB_SUGGESTION_QUERY_LENGTH) {
     webInFlight = false;
     return;
   }
   try {
     const list = await ipcWebSuggestions(trimmed, WEB_SUGGESTIONS_LIMIT);
-    if (version !== queryVersion) return;
+    if (isStale(version)) return;
     // Only replace the cached list when the response actually contains
     // suggestions. DDG /ac/ occasionally returns [] on a working query
     // (rate limit, curl glitch); overwriting the cache with that would
@@ -206,7 +203,7 @@ async function fetchWebSuggestions(query, version) {
     // Web suggestions are best-effort — silent failure mirrors macOS.
     console.warn('Web suggestions failed:', err);
   } finally {
-    if (version === queryVersion) {
+    if (!isStale(version)) {
       webInFlight = false;
       publish(query, version);
     }
@@ -214,8 +211,7 @@ async function fetchWebSuggestions(query, version) {
 }
 
 function publish(query, version) {
-  if (version !== queryVersion) return;
-  if (!onResultsCallback) return;
+  if (isStale(version) || !onResultsCallback) return;
   const suggestionRows = aiEnabled && lastWebSuggestions.length
     ? webSuggestionResults(lastWebSuggestions)
     : [];

--- a/apps/linows/src/js/search.js
+++ b/apps/linows/src/js/search.js
@@ -1,14 +1,17 @@
-import { search as ipcSearch, getClipboardHistory } from './ipc.js';
+import { search as ipcSearch, getClipboardHistory, webSuggestions as ipcWebSuggestions } from './ipc.js';
 import {
   isPrefixSuggestionQuery, isCommandSuggestionQuery,
-  prefixSuggestionResults, commandSuggestionResults,
+  prefixSuggestionResults, commandSuggestionResults, webSuggestionResults,
 } from './catalog.js';
 
 const DEBOUNCE_MS = 70;
 const MIN_QUICK_FOLDER_PREFIX = 2;
 const SEARCH_LIMIT = 40;
+const WEB_SUGGESTIONS_LIMIT = 6;
+const MIN_WEB_SUGGESTION_QUERY_LENGTH = 2;
 const CLIPBOARD_TITLE_MAX_CHARS = 80;
 let debounceTimer = null;
+let webSuggestionTimer = null;
 let onResultsCallback = null;
 let homeDir = null;
 let clipboardMode = false;
@@ -16,6 +19,21 @@ let translateMode = false;
 let recentMode = false;
 let prefixHintMode = false;
 let commandHintMode = false;
+let aiEnabled = true;
+
+// Per-query state. Each leg of the parallel fetch (engine + web suggestions)
+// writes into its slot; publish() merges them. Version counter discards
+// in-flight responses whose query has been superseded. lastQueryString lets
+// us tell same-query re-runs (e.g. window toggle) apart from a genuine new
+// query, so we don't wipe a still-valid suggestion list during a re-fetch.
+// webInFlight gates publish so we don't paint a "No results" empty state
+// during the gap between the engine returning instantly (~50 ms) and the
+// web-suggestions request settling (~500 ms–2 s).
+let queryVersion = 0;
+let lastEnginePayload = [];
+let lastWebSuggestions = [];
+let lastQueryString = null;
+let webInFlight = false;
 
 /** Resolved by the backend (Windows: SHGetKnownFolderPath; *nix: $HOME/<name>).
  *  Empty until setQuickFolders is called at boot. */
@@ -53,6 +71,14 @@ export function isCommandHintMode() {
   return commandHintMode;
 }
 
+export function setAiEnabled(enabled) {
+  aiEnabled = !!enabled;
+  if (!aiEnabled) {
+    lastWebSuggestions = [];
+    clearTimeout(webSuggestionTimer);
+  }
+}
+
 export function getTranslateText() {
   return translateMode ? _translateText : '';
 }
@@ -61,6 +87,18 @@ let _translateText = '';
 
 export function handleQueryInput(query) {
   clearTimeout(debounceTimer);
+  clearTimeout(webSuggestionTimer);
+  // Bump version + clear stale engine payload. Web-suggestion cache only
+  // resets when the query actually changes — on a same-query re-run (window
+  // toggle, manual refresh) the previous list is still valid, and we'd
+  // rather keep showing it than flash "No results" if the re-fetch is slow
+  // or returns empty (DuckDuckGo /ac/ is occasionally flaky).
+  queryVersion += 1;
+  lastEnginePayload = [];
+  if (query !== lastQueryString) {
+    lastWebSuggestions = [];
+  }
+  lastQueryString = query;
 
   // Discovery menus — `"` lists every query prefix, `:` lists every slash
   // command, both filterable by what follows the leading character. Must
@@ -106,33 +144,89 @@ export function handleQueryInput(query) {
 
   if (query.startsWith('rc"')) {
     recentMode = true;
-    debounceTimer = setTimeout(() => performSearch(query), DEBOUNCE_MS);
+    debounceTimer = setTimeout(() => performSearch(query, queryVersion), DEBOUNCE_MS);
     return;
   }
 
   recentMode = false;
 
+  const myVersion = queryVersion;
   if (query.trim() === '') {
-    performSearch('');
+    performSearch('', myVersion);
     return;
   }
 
-  debounceTimer = setTimeout(() => performSearch(query), DEBOUNCE_MS);
+  // Both fetches share the 70 ms debounce and run concurrently — engine
+  // results render the moment they land, then web suggestions append below
+  // when they arrive. Each leg version-checks before publishing. We mark
+  // webInFlight up-front (not inside fetchWebSuggestions) so publish() can
+  // see it the instant the engine returns and hold off on painting an
+  // empty list.
+  webInFlight = aiEnabled && query.trim().length >= MIN_WEB_SUGGESTION_QUERY_LENGTH;
+  debounceTimer = setTimeout(() => performSearch(query, myVersion), DEBOUNCE_MS);
+  webSuggestionTimer = setTimeout(() => fetchWebSuggestions(query, myVersion), DEBOUNCE_MS);
 }
 
-async function performSearch(query) {
+async function performSearch(query, version) {
   try {
     const payload = await ipcSearch(query, SEARCH_LIMIT);
-    const results = recentMode ? payload.results : prependQuickFolders(payload.results, query);
-    if (onResultsCallback) {
-      onResultsCallback(results, query);
-    }
+    if (version !== queryVersion) return;
+    lastEnginePayload = recentMode ? payload.results : prependQuickFolders(payload.results, query);
+    publish(query, version);
   } catch (err) {
     console.error('Search failed:', err);
-    if (onResultsCallback) {
-      onResultsCallback([], query);
+    if (version !== queryVersion) return;
+    lastEnginePayload = [];
+    publish(query, version);
+  }
+}
+
+async function fetchWebSuggestions(query, version) {
+  if (!aiEnabled) {
+    webInFlight = false;
+    return;
+  }
+  const trimmed = query.trim();
+  if (trimmed.length < MIN_WEB_SUGGESTION_QUERY_LENGTH) {
+    webInFlight = false;
+    return;
+  }
+  try {
+    const list = await ipcWebSuggestions(trimmed, WEB_SUGGESTIONS_LIMIT);
+    if (version !== queryVersion) return;
+    // Only replace the cached list when the response actually contains
+    // suggestions. DDG /ac/ occasionally returns [] on a working query
+    // (rate limit, curl glitch); overwriting the cache with that would
+    // wipe a perfectly good list and leave the user staring at
+    // "No results" on every re-open.
+    if (Array.isArray(list) && list.length > 0) {
+      lastWebSuggestions = list;
+    }
+  } catch (err) {
+    // Web suggestions are best-effort — silent failure mirrors macOS.
+    console.warn('Web suggestions failed:', err);
+  } finally {
+    if (version === queryVersion) {
+      webInFlight = false;
+      publish(query, version);
     }
   }
+}
+
+function publish(query, version) {
+  if (version !== queryVersion) return;
+  if (!onResultsCallback) return;
+  const suggestionRows = aiEnabled && lastWebSuggestions.length
+    ? webSuggestionResults(lastWebSuggestions)
+    : [];
+  const combined = [...lastEnginePayload, ...suggestionRows];
+  // Hold an empty render while web suggestions are still loading. The
+  // engine returns instantly (~50 ms) but DDG /ac/ takes 500 ms-2 s; on a
+  // fresh query we'd otherwise paint "No results" for a couple of seconds
+  // before the suggestion list pops in. Once both legs have settled (web
+  // returned or errored), webInFlight clears and we publish honestly.
+  if (combined.length === 0 && webInFlight) return;
+  onResultsCallback(combined, query);
 }
 
 function formatShortDate(timestamp) {


### PR DESCRIPTION
## Summary

- web answers for linows

## Why

- #219 #211 

## Changes

-

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [x] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
