### PR TITLE
fix: prefix queries won't return ai web result

### DIFF
--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -22,7 +22,9 @@ import {
   copyToClipboard, deleteClipboardEntry, isDevBuild,
   getConfig,
 } from './ipc.js';
-import { prefixFromResultId, commandIdFromResultId, webSuggestionFromResultId } from './catalog.js';
+import {
+  prefixFromResultId, commandIdFromResultId, webSuggestionFromResultId, isPrefixedQuery,
+} from './catalog.js';
 
 // Item count and structure mirror the macOS app's `LauncherView.hintItems`
 // (apps/macos/.../LauncherView.swift:302) so both platforms surface the same
@@ -220,11 +222,17 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Wire search -> results. After rendering, drive the AI controller with
   // the LOCAL result count (websuggest: rows don't count — a query that
   // only matches web suggestions is treated as zero local results, which is
-  // the macOS knowledge-lookup trigger).
+  // the macOS knowledge-lookup trigger). Prefix-driven modes (t"/c"/rc"/
+  // "/:) own the result area and must NOT trigger AI/web lookups. A query
+  // like `t"who is` would otherwise fire isEntityLookup and pull Wikipedia.
   search.setOnResults((items, query) => {
     lastResults = items;
     results.render(items);
     applyAiLayoutMode();
+    if (isPrefixedQuery(query)) {
+      aiAnswer.cancel();
+      return;
+    }
     const localCount = items.filter((r) => webSuggestionFromResultId(r.id) == null).length;
     aiAnswer.update(query, localCount);
   });

--- a/apps/linows/src/js/catalog.js
+++ b/apps/linows/src/js/catalog.js
@@ -52,6 +52,18 @@ export function isPrefixSuggestionQuery(query) {
   return query.trimStart().startsWith(DISCOVERY_CHAR);
 }
 
+// True when the query is in any prefix-driven mode: the `"`/`:` discovery
+// menus, an inline `:cmd <args>`, or one of the PREFIX_ENTRIES (a"/f"/d"/
+// rc"/r"/c"/t"). Web suggestions and AI/Wikipedia lookups are gated off
+// for these. The query is a launcher scope, not a knowledge question.
+// Adding a new prefix to PREFIX_ENTRIES picks up everywhere automatically.
+export function isPrefixedQuery(query) {
+  const trimmed = (query || '').trimStart();
+  if (!trimmed) return false;
+  if (trimmed.startsWith(DISCOVERY_CHAR) || trimmed.startsWith(':')) return true;
+  return PREFIX_ENTRIES.some((e) => trimmed.startsWith(e.prefix));
+}
+
 export function isCommandSuggestionQuery(query) {
   const trimmed = query.trimStart();
   return trimmed.startsWith(':') && !isInlineCommandWithArgs(trimmed);

--- a/apps/linows/src/js/search.js
+++ b/apps/linows/src/js/search.js
@@ -1,6 +1,6 @@
 import { search as ipcSearch, getClipboardHistory, webSuggestions as ipcWebSuggestions } from './ipc.js';
 import {
-  isPrefixSuggestionQuery, isCommandSuggestionQuery,
+  isPrefixSuggestionQuery, isCommandSuggestionQuery, isPrefixedQuery,
   prefixSuggestionResults, commandSuggestionResults, webSuggestionResults,
 } from './catalog.js';
 
@@ -156,10 +156,16 @@ export function handleQueryInput(query) {
   // when they arrive. Each leg version-checks before publishing. We mark
   // webInFlight up-front (not inside fetchWebSuggestions) so publish() can
   // see it the instant the engine returns and hold off on painting an
-  // empty list.
-  webInFlight = aiEnabled && query.trim().length >= MIN_WEB_SUGGESTION_QUERY_LENGTH;
+  // empty list. Skip web suggestions entirely for prefixed queries
+  // (a"chrome, f"doc, r"regex ...). The engine handles those as scoped
+  // filters; Google-autocomplete rows would be noise.
+  const wantsWeb = aiEnabled && !isPrefixedQuery(query)
+    && query.trim().length >= MIN_WEB_SUGGESTION_QUERY_LENGTH;
+  webInFlight = wantsWeb;
   debounceTimer = setTimeout(() => performSearch(query, myVersion), DEBOUNCE_MS);
-  webSuggestionTimer = setTimeout(() => fetchWebSuggestions(query, myVersion), DEBOUNCE_MS);
+  if (wantsWeb) {
+    webSuggestionTimer = setTimeout(() => fetchWebSuggestions(query, myVersion), DEBOUNCE_MS);
+  }
 }
 
 // A fetch is "stale" when handleQueryInput has bumped queryVersion since


### PR DESCRIPTION
## Summary

- prefix queries should not return web result

## Why

-

## Changes

-

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
