### PR TITLE
fix: open steam games 

### DIFF
--- a/apps/linows/src-tauri/src/commands.rs
+++ b/apps/linows/src-tauri/src/commands.rs
@@ -182,12 +182,24 @@ pub fn open_path(
     }
 
     #[cfg(target_os = "linux")]
-    if kind.as_deref() == Some("app") && !path.contains("://") {
-        let result = launch_app(&path, id.as_deref());
-        if result.is_ok() {
-            let _ = window.hide();
+    {
+        // An "app" path is a URL only when its FIRST token carries the scheme
+        // (e.g. `https://example.com`). Desktop Exec strings like
+        // `steam steam://run/570` have the `://` embedded in an argument and
+        // must still go through launch_app, otherwise we hand the whole
+        // command line to xdg-open and nothing happens.
+        let path_is_url = path
+            .split_whitespace()
+            .next()
+            .is_some_and(|tok| tok.contains("://"));
+        eprintln!("[open_path] path={path:?} kind={kind:?} id={id:?} path_is_url={path_is_url}");
+        if kind.as_deref() == Some("app") && !path_is_url {
+            let result = launch_app(&path, id.as_deref());
+            if result.is_ok() {
+                let _ = window.hide();
+            }
+            return result;
         }
-        return result;
     }
 
     if kind.as_deref() == Some("browser") {
@@ -388,8 +400,43 @@ fn launch_app(exec: &str, id: Option<&str>) -> Result<(), String> {
         .and_then(|f| f.strip_suffix(".desktop"))
         .map(String::from);
     let exec_cmd = exec.to_string();
+    // Steam game shortcuts (Exec like `steam steam://run/<id>` or
+    // `/usr/bin/steam steam://run/<id>`) need the Steam client up before the
+    // URL is issued; on cold start Steam's bootstrap drops the URL silently
+    // and nothing visible happens. Detect any Exec carrying a `steam://`
+    // URL and, when Steam isn't running, pre-start the client and wait for
+    // /proc + a short settle window so the launch chain below hands off to
+    // a Steam that's ready to receive the URL.
+    let exec_has_steam_url = exec_cmd.contains("steam://");
+    let steam_already_running = crate::platform::linux::process::is_running("steam");
+    let needs_steam_warmup = exec_has_steam_url && !steam_already_running;
+    eprintln!(
+        "[launch] exec={exec_cmd:?} desktop_name={desktop_name:?} \
+         steam_url={exec_has_steam_url} steam_running={steam_already_running} \
+         warmup={needs_steam_warmup}"
+    );
 
     std::thread::spawn(move || {
+        if needs_steam_warmup {
+            eprintln!("[launch] Steam URL exec on cold start; pre-starting steam");
+            let _ = user_session_cmd("steam")
+                .env_remove("LD_LIBRARY_PATH")
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn();
+            // Poll for the steam process (up to ~5s), then give the client a
+            // moment for its IPC to come up before issuing the URL.
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+            while std::time::Instant::now() < deadline {
+                if crate::platform::linux::process::is_running("steam") {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(150));
+            }
+            std::thread::sleep(std::time::Duration::from_millis(1500));
+        }
+
         if let Some(ref name) = desktop_name {
             eprintln!("[launch] trying gtk-launch {name}");
             let result = user_session_cmd("gtk-launch")

--- a/apps/linows/src-tauri/src/platform/linux/process.rs
+++ b/apps/linows/src-tauri/src/platform/linux/process.rs
@@ -512,6 +512,36 @@ pub(crate) fn list_on_port(port: u16) -> Vec<RunningApp> {
         .collect()
 }
 
+/// True when a process owned by the current user has /proc Name: == `name`.
+/// Used by launch to detect cold-start cases (Steam) whose URL handling
+/// requires the main process to be running before the URL is issued.
+pub(crate) fn is_running(name: &str) -> bool {
+    let my_uid = read_my_uid();
+    let Ok(entries) = fs::read_dir("/proc") else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let fname = entry.file_name();
+        let fname_str = fname.to_string_lossy();
+        if !fname_str.chars().all(|c| c.is_ascii_digit()) {
+            continue;
+        }
+        let Ok(status) = fs::read_to_string(format!("/proc/{fname_str}/status")) else {
+            continue;
+        };
+        let uid = parse_status_field(&status, "Uid:")
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(0);
+        if uid != my_uid {
+            continue;
+        }
+        if parse_status_field(&status, "Name:").as_deref() == Some(name) {
+            return true;
+        }
+    }
+    false
+}
+
 pub(crate) fn kill(pid: u32) -> Result<String, String> {
     let output = std::process::Command::new("kill")
         .arg("-9")


### PR DESCRIPTION
## Summary

- Open steam games -> open steam (silently)
- Note:  
  - Flatpak Steam (com.valvesoftware.Steam): the process inside the sandbox is still named steam, so is_running may detect it, but the cold-start spawn would fail -> steam isn't in the host PATH. The launch chain would fall back to gtk-launch on the .desktop file, which Flatpak's portal handles correctly, but the URL cold-start drop would still happen. Snap Steam same shape as Flatpak. 

## Why

- #222 

## Changes

-

## Testing

Tested with dota 2 on Nixos

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
