### PR TITLE
feat: open picked files

### DIFF
--- a/apps/linows/src/css/components/picked.css
+++ b/apps/linows/src/css/components/picked.css
@@ -12,6 +12,38 @@
   color: var(--font-color);
 }
 
+.picked-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.picked-open {
+  background: none;
+  border: none;
+  font: inherit;
+  font-size: calc(var(--font-size) - 2px);
+  color: var(--accent-color);
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.picked-open:hover {
+  background: var(--selection-fill);
+}
+
+.picked-shortcut {
+  font-size: calc(var(--font-size) - 3px);
+  color: var(--font-muted);
+  background: var(--control-fill);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
 .picked-clear {
   background: none;
   border: none;

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -120,6 +120,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   picked.init(previewPanel, {
     onRemoveItem: (key) => results.removePick(key),
     onClearAll: () => results.clearPicks(),
+    onOpenAll: () => keyboard.openAllPicked(),
   });
   commands.init(contentArea, queryInput, {
     onExitMode: exitCommandMode,

--- a/apps/linows/src/js/components/picked.js
+++ b/apps/linows/src/js/components/picked.js
@@ -3,11 +3,13 @@ import { getIcon } from '../ipc.js';
 let panel = null;
 let onRemove = null;
 let onClear = null;
+let onOpen = null;
 
-export function init(panelEl, { onRemoveItem, onClearAll }) {
+export function init(panelEl, { onRemoveItem, onClearAll, onOpenAll }) {
   panel = panelEl;
   onRemove = onRemoveItem;
   onClear = onClearAll;
+  onOpen = onOpenAll;
 }
 
 export function update(pickedItems) {
@@ -29,13 +31,26 @@ export function update(pickedItems) {
   label.textContent = `Picked (${pickedItems.length})`;
   header.appendChild(label);
 
+  const actions = document.createElement('div');
+  actions.className = 'picked-actions';
+
+  const openBtn = document.createElement('button');
+  openBtn.className = 'picked-open';
+  openBtn.innerHTML = 'Open all <span class="picked-shortcut">Shift+Enter</span>';
+  openBtn.addEventListener('click', () => {
+    if (onOpen) onOpen();
+  });
+  actions.appendChild(openBtn);
+
   const clearBtn = document.createElement('button');
   clearBtn.className = 'picked-clear';
   clearBtn.textContent = 'Clear all';
   clearBtn.addEventListener('click', () => {
     if (onClear) onClear();
   });
-  header.appendChild(clearBtn);
+  actions.appendChild(clearBtn);
+
+  header.appendChild(actions);
 
   panel.appendChild(header);
 

--- a/apps/linows/src/js/keyboard.js
+++ b/apps/linows/src/js/keyboard.js
@@ -202,6 +202,8 @@ function handleKeyDown(e) {
         copyClipboardEntry();
       } else if (e.ctrlKey) {
         searchWeb();
+      } else if ((e.shiftKey || shiftHeld) && results.hasPickedItems()) {
+        openAllPicked();
       } else {
         openSelected();
       }
@@ -252,7 +254,16 @@ function handleKeyDown(e) {
       } else if (e.ctrlKey) {
         e.preventDefault();
         if (isDiscoveryMode()) break;
-        results.togglePick(results.getSelected());
+        // Only files/folders are pickable — apps/settings/clipboard rows have
+        // no real path to copy and would leave the picked panel rendering
+        // nonsense. Mirrors macOS togglePickForSelectedResult.
+        const sel = results.getSelected();
+        if (!sel) break;
+        if (sel.kind !== 'file' && sel.kind !== 'folder') {
+          banner.show('Only files or folders can be picked', 'info', 1.2);
+          break;
+        }
+        results.togglePick(sel);
       }
       break;
 
@@ -337,6 +348,21 @@ async function handleEmptyTrash() {
   } catch (err) {
     banner.show(`Empty Trash failed: ${err}`, 'error', 2.0);
   }
+}
+
+export async function openAllPicked() {
+  const items = results.getPickedItems();
+  if (items.length === 0) return;
+  const actionMap = { app: 'open_app', file: 'open_file', folder: 'open_folder' };
+  for (const item of items) {
+    try {
+      await openPath(item.path, item.kind, item.id);
+      await recordUsage(item.id, actionMap[item.kind] || 'open_file');
+    } catch (err) {
+      console.error('Failed to open picked item:', item.path, err);
+    }
+  }
+  results.clearPicks();
 }
 
 async function openSelected() {

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
@@ -32,6 +32,8 @@ final class KeyboardSelectionMonitor {
         onCopySelection: @escaping @MainActor () -> Bool,
         onTogglePick: @escaping @MainActor () -> Void,
         onClearPicked: @escaping @MainActor () -> Void,
+        onOpenAllPicked: @escaping @MainActor () -> Void = {},
+        hasPickedItems: @escaping @MainActor () -> Bool = { false },
         onToggleHelp: @escaping @MainActor () -> Void,
         onDismissHelpIfVisible: @escaping @MainActor () -> Bool,
         onSelectCommandByIndex: @escaping @MainActor (Int) -> Void,
@@ -117,6 +119,17 @@ final class KeyboardSelectionMonitor {
                     onSelectCommandByIndex(1)
                 }
                 return nil
+            }
+
+            // Shift+Enter opens every picked file/folder at once. Only when
+            // there are picks; otherwise fall through so plain submit still
+            // opens the selected result.
+            if (event.keyCode == 36 || event.keyCode == 76) && flags == [.shift] {
+                if !inCommandMode() && hasPickedItems() {
+                    onOpenAllPicked()
+                    return nil
+                }
+                return event
             }
 
             // Cmd+D (keyCode 2) → trash the selection. Only in result mode; in

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
@@ -211,14 +211,28 @@ struct PickedItemsPanel: View {
     let themeStore: ThemeStore
     let onRemove: (String) -> Void
     let onClearAll: () -> Void
+    let onOpenAll: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            HStack {
+            HStack(spacing: 8) {
                 Text("Picked (\(pickedKeys.count))")
                     .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize), weight: .semibold))
                     .foregroundStyle(themeStore.fontColor())
                 Spacer()
+                Button(action: onOpenAll) {
+                    HStack(spacing: 6) {
+                        Text("Open all")
+                        Text("⇧↵")
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(themeStore.controlFillColor(), in: RoundedRectangle(cornerRadius: 3, style: .continuous))
+                            .foregroundStyle(themeStore.mutedTextColor())
+                    }
+                    .font(themeStore.uiFont(size: CGFloat(max(10, themeStore.settings.fontSize - 3)), weight: .regular))
+                }
+                .buttonStyle(.borderless)
+                .foregroundStyle(themeStore.accentColor())
                 Button(action: onClearAll) {
                     Text("Clear all")
                         .font(themeStore.uiFont(size: CGFloat(max(10, themeStore.settings.fontSize - 3)), weight: .regular))
@@ -395,6 +409,7 @@ private enum LauncherHelpContent {
         ("Enter", "Open selected app/file/folder or copy selected clipboard item"),
         ("Cmd+C", "Copy selected file/folder to pasteboard"),
         ("Cmd+P", "Toggle pick on selected file/folder (multi-select copy)"),
+        ("Shift+Enter", "Open all picked files/folders at once"),
         ("Cmd+Shift+P", "Clear all picked items"),
         ("Cmd+D", "Move selected file/folder to Trash (on the Trash folder: empty Trash)"),
         ("Tab / Shift+Tab", "Move selection"),

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
@@ -216,6 +216,34 @@ extension LauncherView {
         writePickedToPasteboard()
     }
 
+    /// Opens every picked file/folder in one shot, then clears the picks and
+    /// hides the launcher. The multi-target counterpart to `openSelectedApp`.
+    /// Mirrors linows `openAllPicked`. Picks are restricted to files/folders at
+    /// pick time, so apps/clipboard rows can't appear here, but we guard kind
+    /// anyway. Targets that no longer exist are skipped (and trigger a reindex
+    /// via `ensureTargetExists`) rather than aborting the whole batch.
+    func openAllPicked() {
+        guard !pickedKeys.isEmpty else { return }
+        let items = pickedKeys.compactMap { pickedResultsByKey[$0] }
+        var openedCount = 0
+        for item in items {
+            guard item.kind == .file || item.kind == .folder else { continue }
+            guard ensureTargetExists(item) else { continue }
+            openTargetAsync(item.path)
+            // Quick-folder entries are ephemeral suggestions, not indexed
+            // candidates, so don't record usage for them (matches openSelectedApp).
+            if !(item.kind == .folder && item.id.hasPrefix(AppConstants.Launcher.QuickFolder.idPrefix)) {
+                recordOpen(item, action: item.kind == .folder ? "open_folder" : "open_file")
+            }
+            openedCount += 1
+        }
+        guard openedCount > 0 else { return }
+        pickedKeys.removeAll()
+        pickedResultsByKey.removeAll()
+        NSPasteboard.general.clearContents()
+        hideLauncherWindow(restorePreviousApp: false)
+    }
+
     func removePicked(key: String) {
         guard let idx = pickedKeys.firstIndex(of: key) else { return }
         pickedKeys.remove(at: idx)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
@@ -177,6 +177,12 @@ extension LauncherView {
             onClearPicked: {
                 clearAllPicked()
             },
+            onOpenAllPicked: {
+                openAllPicked()
+            },
+            hasPickedItems: { [self] in
+                !pickedKeys.isEmpty
+            },
             onToggleHelp: {
                 toggleHelpScreen()
             },

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -867,7 +867,8 @@ struct LauncherView: View {
                     pickedByKey: pickedResultsByKey,
                     themeStore: themeStore,
                     onRemove: { removePicked(key: $0) },
-                    onClearAll: { clearAllPicked() }
+                    onClearAll: { clearAllPicked() },
+                    onOpenAll: { openAllPicked() }
                 )
             } else if !isPrefixSuggestionQuery, !isCommandSuggestionQuery,
                       let selectedID = selectedResultID,


### PR DESCRIPTION
## Summary

- Use shift + enter to open picked files. (notice: after opening all files, we release picked marks in Look) 

## Why

- #213 

## Changes

-

## Testing

- Tested on linows
- [ ] macos

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
