### PR TITLE
feat: Todo command

### DIFF
--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -19,6 +19,8 @@ struct AppCommand: Identifiable {
             return "info.circle"
         case AppConstants.Launcher.Command.pomo:
             return "timer"
+        case AppConstants.Launcher.Command.todo:
+            return "checklist"
         default:
             return "terminal"
         }
@@ -69,6 +71,7 @@ enum AppConstants {
             static let kill = "kill"
             static let sys = "sys"
             static let pomo = "pomo"
+            static let todo = "todo"
         }
 
         enum QueryPrefix {
@@ -299,9 +302,10 @@ enum AppConstants {
         static let commandCatalog: [AppCommand] = [
             AppCommand(id: Command.calc, title: "calc (⌘1)", detail: "Evaluate math expression", placeholder: "Type math expression"),
             AppCommand(id: Command.pomo, title: "pomo (⌘2)", detail: "Pomodoro focus timer", placeholder: "Manage focus sessions"),
-            AppCommand(id: Command.kill, title: "kill (⌘3)", detail: "Force kill app or process by port", placeholder: "Type app name, or :3000"),
-            AppCommand(id: Command.shell, title: "shell (⌘4)", detail: "Run a shell command", placeholder: "Type shell command"),
-            AppCommand(id: Command.sys, title: "sys (⌘5)", detail: "Show system information", placeholder: "View system info"),
+            AppCommand(id: Command.todo, title: "todo (⌘3)", detail: "Daily tasks & progress", placeholder: "Search tasks & dates"),
+            AppCommand(id: Command.kill, title: "kill (⌘4)", detail: "Force kill app or process by port", placeholder: "Type app name, or :3000"),
+            AppCommand(id: Command.shell, title: "shell (⌘5)", detail: "Run a shell command", placeholder: "Type shell command"),
+            AppCommand(id: Command.sys, title: "sys (⌘6)", detail: "Show system information", placeholder: "View system info"),
         ]
 
         /// Commands narrowed by `filter` - the text typed after a leading `:`.

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
@@ -160,14 +160,14 @@ final class KeyboardSelectionMonitor {
                 }
                 if let key = cmdNumberKey {
                     if inCommandMode() {
-                        if key <= 5 {
+                        if key <= 6 {
                             Self.logger.debug("⌘+\(key, privacy: .public) -> command catalog")
                             DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
                                 onSelectCommandByIndex(key)
                             }
                             return nil
                         }
-                        Self.logger.debug("⌘+\(key, privacy: .public) ignored (command mode only maps 1-5)")
+                        Self.logger.debug("⌘+\(key, privacy: .public) ignored (command mode only maps 1-6)")
                     } else {
                         Self.logger.debug("⌘+\(key, privacy: .public) -> running-apps switcher")
                         if onActivateRunningApp(key) {

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
@@ -173,7 +173,7 @@ final class KeyboardSelectionMonitor {
                             return nil
                         }
                         Self.logger.debug(
-                            "⌘+\(key, privacy: .public) ignored (command mode only maps 1-6)")
+                            "⌘+\(key, privacy: .public) ignored (command mode maps 1-\(AppConstants.Launcher.commandCatalog.count, privacy: .public))")
                     } else {
                         Self.logger.debug("⌘+\(key, privacy: .public) -> running-apps switcher")
                         if onActivateRunningApp(key) {

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
@@ -10,7 +10,8 @@ final class KeyboardSelectionMonitor {
     nonisolated private static let debugKeyLoggingEnabled: Bool = {
         let env = ProcessInfo.processInfo.environment
         let raw = env["LOOK_UI_DEBUG_EVENTS"] ?? env["LOOK_DEV_HINT"] ?? ""
-        return ["1", "true", "yes", "on"].contains(raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased())
+        return ["1", "true", "yes", "on"].contains(
+            raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased())
     }()
 
     nonisolated private static func logKey(_ message: String) {
@@ -51,7 +52,9 @@ final class KeyboardSelectionMonitor {
 
         monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
             let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            Self.logKey("down keyCode=\(event.keyCode) chars=\(event.charactersIgnoringModifiers ?? "") flagsRaw=\(flags.rawValue) inCommand=\(inCommandMode())")
+            Self.logKey(
+                "down keyCode=\(event.keyCode) chars=\(event.charactersIgnoringModifiers ?? "") flagsRaw=\(flags.rawValue) inCommand=\(inCommandMode())"
+            )
 
             if flags.contains(.command)
                 && !flags.contains(.control)
@@ -143,7 +146,9 @@ final class KeyboardSelectionMonitor {
                 return nil
             }
 
-            if event.modifierFlags.contains(.command) && !event.modifierFlags.contains(.control) && !event.modifierFlags.contains(.option) {
+            if event.modifierFlags.contains(.command) && !event.modifierFlags.contains(.control)
+                && !event.modifierFlags.contains(.option)
+            {
                 // macOS digit keyCodes are not contiguous: 1=18, 2=19, 3=20, 4=21, 5=23, 6=22, 7=26, 8=28, 9=25.
                 let cmdNumberKey: Int?
                 switch event.keyCode {
@@ -160,20 +165,23 @@ final class KeyboardSelectionMonitor {
                 }
                 if let key = cmdNumberKey {
                     if inCommandMode() {
-                        if key <= 6 {
+                        if key <= AppConstants.Launcher.commandCatalog.count {
                             Self.logger.debug("⌘+\(key, privacy: .public) -> command catalog")
                             DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
                                 onSelectCommandByIndex(key)
                             }
                             return nil
                         }
-                        Self.logger.debug("⌘+\(key, privacy: .public) ignored (command mode only maps 1-6)")
+                        Self.logger.debug(
+                            "⌘+\(key, privacy: .public) ignored (command mode only maps 1-6)")
                     } else {
                         Self.logger.debug("⌘+\(key, privacy: .public) -> running-apps switcher")
                         if onActivateRunningApp(key) {
                             return nil
                         }
-                        Self.logger.debug("⌘+\(key, privacy: .public) running-apps activation declined, falling through")
+                        Self.logger.debug(
+                            "⌘+\(key, privacy: .public) running-apps activation declined, falling through"
+                        )
                     }
                 }
             }

--- a/apps/macos/LauncherApp/look-app/Views/Commands/TodoAnalyticsView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/TodoAnalyticsView.swift
@@ -11,56 +11,78 @@ struct TodoAnalyticsPage: View {
     private let weeks = TodoAnalytics.heatmapWeeks()
 
     var body: some View {
-        ScrollView(.vertical, showsIndicators: false) {
-            VStack(alignment: .leading, spacing: 14) {
-                TodoStatStrip(
-                    themeStore: themeStore,
-                    week: TodoAnalytics.week,
-                    month: TodoAnalytics.month,
-                    streak: TodoAnalytics.streakDays
-                )
-
-                VStack(alignment: .leading, spacing: 8) {
-                    sectionLabel("chart.bar", "Completion trend · 30 days")
-                    VStack(spacing: 4) {
-                        TodoLineChart(data: trend, themeStore: themeStore)
-                            .frame(height: 92)
-                        HStack {
-                            Text("Jun 5")
-                            Spacer()
-                            Text("Jun 20")
-                            Spacer()
-                            Text("Jul 4")
-                        }
-                        .font(.system(size: 9.5, design: .monospaced))
-                        .foregroundStyle(themeStore.mutedTextColor())
-                    }
-                    .padding(.horizontal, 12)
-                    .padding(.top, 10)
-                    .padding(.bottom, 6)
-                    .todoCard(themeStore)
+        // Fill the height on large screens by letting the four sections
+        // spread apart, while still scrolling (at a compact min gap) when
+        // the panel is too short to fit them.
+        GeometryReader { geo in
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 0) {
+                    statStrip
+                    Spacer(minLength: 14)
+                    trendSection
+                    Spacer(minLength: 14)
+                    heatmapSection
+                    Spacer(minLength: 14)
+                    insightsSection
                 }
-
-                VStack(alignment: .leading, spacing: 8) {
-                    HStack(alignment: .center) {
-                        sectionLabel("calendar", "Activity · last 18 weeks")
-                        Spacer()
-                        TodoHeatLegend(themeStore: themeStore)
-                    }
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        TodoHeatmap(weeks: weeks, themeStore: themeStore)
-                    }
-                    .padding(12)
-                    .todoCard(themeStore)
-                }
-
-                VStack(alignment: .leading, spacing: 8) {
-                    sectionLabel("sparkles", "Insights · last 30 days (Tasks)")
-                    TodoInsightsStrip(themeStore: themeStore, trend: trend)
-                }
+                .padding(.horizontal, 4)
+                .padding(.vertical, 2)
+                .frame(minHeight: geo.size.height, alignment: .top)
             }
-            .padding(.horizontal, 4)
-            .padding(.vertical, 2)
+        }
+    }
+
+    private var statStrip: some View {
+        TodoStatStrip(
+            themeStore: themeStore,
+            week: TodoAnalytics.week,
+            month: TodoAnalytics.month,
+            streak: TodoAnalytics.streakDays
+        )
+    }
+
+    private var trendSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionLabel("chart.bar", "Completion trend · 30 days")
+            VStack(spacing: 4) {
+                TodoLineChart(data: trend, themeStore: themeStore)
+                    .frame(height: 92)
+                HStack {
+                    Text("Jun 5")
+                    Spacer()
+                    Text("Jun 20")
+                    Spacer()
+                    Text("Jul 4")
+                }
+                .font(.system(size: 9.5, design: .monospaced))
+                .foregroundStyle(themeStore.mutedTextColor())
+            }
+            .padding(.horizontal, 12)
+            .padding(.top, 10)
+            .padding(.bottom, 6)
+            .todoCard(themeStore)
+        }
+    }
+
+    private var heatmapSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .center) {
+                sectionLabel("calendar", "Activity · last 18 weeks")
+                Spacer()
+                TodoHeatLegend(themeStore: themeStore)
+            }
+            ScrollView(.horizontal, showsIndicators: false) {
+                TodoHeatmap(weeks: weeks, themeStore: themeStore)
+            }
+            .padding(12)
+            .todoCard(themeStore)
+        }
+    }
+
+    private var insightsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionLabel("sparkles", "Insights · last 30 days (Tasks)")
+            TodoInsightsStrip(themeStore: themeStore, trend: trend)
         }
     }
 
@@ -132,7 +154,7 @@ struct TodoStatStrip: View {
     let streak: Int
 
     var body: some View {
-        HStack(spacing: 4) {
+        HStack(alignment: .top, spacing: 4) {
             TodoMetricColumn(themeStore: themeStore, label: "This week", stat: week)
             divider
             TodoMetricColumn(themeStore: themeStore, label: "This month", stat: month)
@@ -147,31 +169,44 @@ struct TodoStatStrip: View {
     private var divider: some View { TodoVDivider(themeStore: themeStore) }
 }
 
+// Shared caption used for each column's title.
+private func metricTitle(_ text: String, _ themeStore: ThemeStore) -> some View {
+    Text(text.uppercased())
+        .font(.system(size: 12, design: .monospaced))
+        .tracking(0.7)
+        .foregroundStyle(themeStore.mutedTextColor())
+}
+
 struct TodoMetricColumn: View {
     let themeStore: ThemeStore
     let label: String
     let stat: TodoStat
 
+    private var percent: Int { Int((stat.fraction * 100).rounded()) }
+
     var body: some View {
-        HStack(spacing: 12) {
-            TodoDonut(fraction: stat.fraction, themeStore: themeStore)
-            VStack(alignment: .leading, spacing: 3) {
-                Text(label.uppercased())
-                    .font(.system(size: 10, design: .monospaced))
-                    .tracking(0.7)
-                    .foregroundStyle(themeStore.mutedTextColor())
-                HStack(alignment: .firstTextBaseline, spacing: 3) {
+        VStack(spacing: 10) {
+            HStack(spacing: 5) {
+                metricTitle(label, themeStore)
+                Text("\(percent)%")
+                    .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(themeStore.accentColor())
+            }
+            ZStack {
+                TodoDonut(fraction: stat.fraction, themeStore: themeStore, size: 62)
+                VStack(spacing: 2) {
                     Text("\(stat.done)")
-                        .font(themeStore.uiFont(size: 22, weight: .bold))
+                        .font(themeStore.uiFont(size: 16, weight: .bold))
                         .foregroundStyle(themeStore.fontColor())
-                    Text("/ \(stat.total)")
-                        .font(themeStore.uiFont(size: 13))
+                    Rectangle()
+                        .fill(themeStore.dividerColor())
+                        .frame(width: 16, height: 1)
+                    Text("\(stat.total)")
+                        .font(themeStore.uiFont(size: 12))
                         .foregroundStyle(themeStore.mutedTextColor())
                 }
             }
-            Spacer(minLength: 0)
         }
-        .padding(.horizontal, 6)
         .frame(maxWidth: .infinity)
     }
 }
@@ -181,45 +216,46 @@ struct TodoStreakColumn: View {
     let days: Int
 
     var body: some View {
-        HStack(spacing: 12) {
-            Image(systemName: "flame")
-                .font(.system(size: 24, weight: .light))
-                .foregroundStyle(themeStore.accentColor())
-                .frame(width: 46, height: 46)
-            VStack(alignment: .leading, spacing: 5) {
-                Text("STREAK")
-                    .font(.system(size: 10, design: .monospaced))
-                    .tracking(0.7)
-                    .foregroundStyle(themeStore.mutedTextColor())
-                HStack(alignment: .firstTextBaseline, spacing: 4) {
-                    Text("\(days)")
-                        .font(themeStore.uiFont(size: 22, weight: .bold))
-                        .foregroundStyle(themeStore.fontColor())
-                    Text("days")
-                        .font(themeStore.uiFont(size: 12.5))
-                        .foregroundStyle(themeStore.secondaryTextColor())
-                }
-                HStack(spacing: 4) {
-                    let filled = min(days, 7)
-                    ForEach(0..<7, id: \.self) { i in
-                        let on = i >= 7 - filled
-                        Circle()
-                            .fill(on ? themeStore.accentColor() : Color.clear)
-                            .overlay(
-                                Circle().stroke(
-                                    on ? Color.clear : themeStore.dividerColor(), lineWidth: 1)
-                            )
-                            .frame(width: 6, height: 6)
+        VStack(spacing: 8) {
+            metricTitle("Streak", themeStore)
+
+            HStack(spacing: 12) {
+                Image(systemName: "flame.fill")
+                    .font(.system(size: 24))
+                    .foregroundStyle(themeStore.accentColor())
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(alignment: .firstTextBaseline, spacing: 3) {
+                        Text("\(days)")
+                            .font(themeStore.uiFont(size: 18, weight: .bold))
+                            .foregroundStyle(themeStore.fontColor())
+                        Text("days")
+                            .font(themeStore.uiFont(size: 12))
+                            .foregroundStyle(themeStore.secondaryTextColor())
+                    }
+                    HStack(spacing: 4) {
+                        let filled = min(days, 7)
+                        ForEach(0..<7, id: \.self) { i in
+                            let on = i >= 7 - filled
+                            Circle()
+                                .fill(on ? themeStore.accentColor() : Color.clear)
+                                .overlay(
+                                    Circle().stroke(
+                                        on ? Color.clear : themeStore.dividerColor(), lineWidth: 1)
+                                )
+                                .frame(width: 6, height: 6)
+                        }
                     }
                 }
             }
-            Spacer(minLength: 0)
+            .frame(height: 62)
         }
-        .padding(.horizontal, 6)
         .frame(maxWidth: .infinity)
     }
 }
 
+/// Thin progress ring. The percentage is conveyed by the arc and the
+/// exact counts sit beside it (see TodoMetricColumn), so the ring keeps
+/// no redundant center label.
 struct TodoDonut: View {
     let fraction: Double
     let themeStore: ThemeStore
@@ -235,9 +271,6 @@ struct TodoDonut: View {
                     themeStore.accentColor(), style: StrokeStyle(lineWidth: stroke, lineCap: .round)
                 )
                 .rotationEffect(.degrees(-90))
-            Text("\(Int((fraction * 100).rounded()))" + "%")
-                .font(themeStore.uiFont(size: size * 0.28, weight: .bold))
-                .foregroundStyle(themeStore.fontColor())
         }
         .frame(width: size, height: size)
     }

--- a/apps/macos/LauncherApp/look-app/Views/Commands/TodoAnalyticsView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/TodoAnalyticsView.swift
@@ -1,0 +1,304 @@
+import SwiftUI
+
+// Week / month done-total donuts, a current streak, a 30-day completion
+// trend line, and a GitHub-style activity heatmap. Series come from
+// TodoAnalytics (deterministic placeholders until storage exists).
+
+struct TodoAnalyticsPage: View {
+    let themeStore: ThemeStore
+
+    private let trend = TodoAnalytics.monthTrend()
+    private let weeks = TodoAnalytics.heatmapWeeks()
+
+    var body: some View {
+        ScrollView(.vertical, showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 14) {
+                TodoStatStrip(
+                    themeStore: themeStore,
+                    week: TodoAnalytics.week,
+                    month: TodoAnalytics.month,
+                    streak: TodoAnalytics.streakDays
+                )
+
+                VStack(alignment: .leading, spacing: 8) {
+                    sectionLabel("chart.bar", "Completion trend · 30 days")
+                    VStack(spacing: 4) {
+                        TodoLineChart(data: trend, themeStore: themeStore)
+                            .frame(height: 92)
+                        HStack {
+                            Text("Jun 5"); Spacer(); Text("Jun 20"); Spacer(); Text("Jul 4")
+                        }
+                        .font(.system(size: 9.5, design: .monospaced))
+                        .foregroundStyle(themeStore.mutedTextColor())
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.top, 10)
+                    .padding(.bottom, 6)
+                    .background(themeStore.controlFillColor(), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+                    .overlay(RoundedRectangle(cornerRadius: 10, style: .continuous).stroke(themeStore.borderColor(), lineWidth: 1))
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(alignment: .center) {
+                        sectionLabel("calendar", "Activity · last 18 weeks")
+                        Spacer()
+                        TodoHeatLegend(themeStore: themeStore)
+                    }
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        TodoHeatmap(weeks: weeks, themeStore: themeStore)
+                    }
+                    .padding(12)
+                    .background(themeStore.controlFillColor(), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+                    .overlay(RoundedRectangle(cornerRadius: 10, style: .continuous).stroke(themeStore.borderColor(), lineWidth: 1))
+                }
+            }
+            .padding(.horizontal, 4)
+            .padding(.vertical, 2)
+        }
+    }
+
+    private func sectionLabel(_ icon: String, _ text: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.system(size: 11))
+                .foregroundStyle(themeStore.mutedTextColor())
+            Text(text.uppercased())
+                .font(.system(size: 11, design: .monospaced))
+                .tracking(0.6)
+                .foregroundStyle(themeStore.secondaryTextColor())
+        }
+    }
+}
+
+
+struct TodoStatStrip: View {
+    let themeStore: ThemeStore
+    let week: TodoStat
+    let month: TodoStat
+    let streak: Int
+
+    var body: some View {
+        HStack(spacing: 4) {
+            TodoMetricColumn(themeStore: themeStore, label: "This week", stat: week)
+            divider
+            TodoMetricColumn(themeStore: themeStore, label: "This month", stat: month)
+            divider
+            TodoStreakColumn(themeStore: themeStore, days: streak)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 14)
+        .background(themeStore.controlFillColor(), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous).stroke(themeStore.borderColor(), lineWidth: 1))
+    }
+
+    private var divider: some View {
+        Rectangle().fill(themeStore.dividerColor()).frame(width: 1).padding(.vertical, 4)
+    }
+}
+
+struct TodoMetricColumn: View {
+    let themeStore: ThemeStore
+    let label: String
+    let stat: TodoStat
+
+    var body: some View {
+        HStack(spacing: 12) {
+            TodoDonut(fraction: stat.fraction, themeStore: themeStore)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(label.uppercased())
+                    .font(.system(size: 10, design: .monospaced))
+                    .tracking(0.7)
+                    .foregroundStyle(themeStore.mutedTextColor())
+                HStack(alignment: .firstTextBaseline, spacing: 3) {
+                    Text("\(stat.done)")
+                        .font(themeStore.uiFont(size: 22, weight: .bold))
+                        .foregroundStyle(themeStore.fontColor())
+                    Text("/ \(stat.total)")
+                        .font(themeStore.uiFont(size: 13))
+                        .foregroundStyle(themeStore.mutedTextColor())
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 6)
+        .frame(maxWidth: .infinity)
+    }
+}
+
+struct TodoStreakColumn: View {
+    let themeStore: ThemeStore
+    let days: Int
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "flame")
+                .font(.system(size: 24, weight: .light))
+                .foregroundStyle(themeStore.accentColor())
+                .frame(width: 46, height: 46)
+            VStack(alignment: .leading, spacing: 5) {
+                Text("STREAK")
+                    .font(.system(size: 10, design: .monospaced))
+                    .tracking(0.7)
+                    .foregroundStyle(themeStore.mutedTextColor())
+                HStack(alignment: .firstTextBaseline, spacing: 4) {
+                    Text("\(days)")
+                        .font(themeStore.uiFont(size: 22, weight: .bold))
+                        .foregroundStyle(themeStore.fontColor())
+                    Text("days")
+                        .font(themeStore.uiFont(size: 12.5))
+                        .foregroundStyle(themeStore.secondaryTextColor())
+                }
+                HStack(spacing: 4) {
+                    let filled = min(days, 7)
+                    ForEach(0..<7, id: \.self) { i in
+                        let on = i >= 7 - filled
+                        Circle()
+                            .fill(on ? themeStore.accentColor() : Color.clear)
+                            .overlay(Circle().stroke(on ? Color.clear : themeStore.dividerColor(), lineWidth: 1))
+                            .frame(width: 6, height: 6)
+                    }
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 6)
+        .frame(maxWidth: .infinity)
+    }
+}
+
+struct TodoDonut: View {
+    let fraction: Double
+    let themeStore: ThemeStore
+    var size: CGFloat = 46
+    var stroke: CGFloat = 4.5
+
+    var body: some View {
+        ZStack {
+            Circle().stroke(themeStore.dividerColor(), lineWidth: stroke)
+            Circle()
+                .trim(from: 0, to: max(0, min(1, fraction)))
+                .stroke(themeStore.accentColor(), style: StrokeStyle(lineWidth: stroke, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+            Text("\(Int((fraction * 100).rounded()))")
+                .font(themeStore.uiFont(size: size * 0.28, weight: .bold))
+                .foregroundStyle(themeStore.fontColor())
+        }
+        .frame(width: size, height: size)
+    }
+}
+
+
+struct TodoLineChart: View {
+    let data: [Int]
+    let themeStore: ThemeStore
+
+    var body: some View {
+        Canvas { ctx, size in
+            guard data.count > 1 else { return }
+            let padL: CGFloat = 4, padR: CGFloat = 4, padT: CGFloat = 10, padB: CGFloat = 8
+            let w = size.width - padL - padR
+            let h = size.height - padT - padB
+            let maxV = CGFloat(max(5, data.max() ?? 5))
+            let stepX = w / CGFloat(data.count - 1)
+
+            let pts: [CGPoint] = data.enumerated().map { i, v in
+                CGPoint(x: padL + CGFloat(i) * stepX,
+                        y: padT + h - (CGFloat(v) / maxV) * h)
+            }
+
+            // Baseline.
+            var baseline = Path()
+            baseline.move(to: CGPoint(x: padL, y: padT + h))
+            baseline.addLine(to: CGPoint(x: size.width - padR, y: padT + h))
+            ctx.stroke(baseline, with: .color(themeStore.dividerColor()), lineWidth: 1)
+
+            // Trend line.
+            var line = Path()
+            line.addLines(pts)
+            ctx.stroke(line, with: .color(themeStore.accentColor()),
+                       style: StrokeStyle(lineWidth: 1.6, lineCap: .round, lineJoin: .round))
+
+            // Dots, last one emphasized.
+            let accent = themeStore.accentColor()
+            let bg = themeStore.commandModeBackgroundColor()
+            for (i, p) in pts.enumerated() {
+                let last = i == pts.count - 1
+                let r: CGFloat = last ? 3 : 1.5
+                let rect = CGRect(x: p.x - r, y: p.y - r, width: r * 2, height: r * 2)
+                if last {
+                    ctx.fill(Path(ellipseIn: rect), with: .color(accent))
+                } else {
+                    ctx.fill(Path(ellipseIn: rect), with: .color(bg))
+                    ctx.stroke(Path(ellipseIn: rect), with: .color(accent), lineWidth: 1.2)
+                }
+            }
+        }
+    }
+}
+
+
+struct TodoHeatmap: View {
+    let weeks: [[Int]]
+    let themeStore: ThemeStore
+    var cell: CGFloat = 12
+    var gap: CGFloat = 3
+
+    private let dayLabels = ["", "M", "", "W", "", "F", ""]
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 5) {
+            VStack(spacing: gap) {
+                ForEach(0..<7, id: \.self) { i in
+                    Text(dayLabels[i])
+                        .font(.system(size: 8, design: .monospaced))
+                        .foregroundStyle(themeStore.mutedTextColor())
+                        .frame(width: 10, height: cell, alignment: .leading)
+                }
+            }
+            HStack(spacing: gap) {
+                ForEach(Array(weeks.enumerated()), id: \.offset) { _, week in
+                    VStack(spacing: gap) {
+                        ForEach(Array(week.enumerated()), id: \.offset) { _, level in
+                            RoundedRectangle(cornerRadius: 3, style: .continuous)
+                                .fill(TodoHeatColors.color(level, themeStore: themeStore))
+                                .frame(width: cell, height: cell)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct TodoHeatLegend: View {
+    let themeStore: ThemeStore
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Text("Less")
+            ForEach(0..<5, id: \.self) { l in
+                RoundedRectangle(cornerRadius: 2, style: .continuous)
+                    .fill(TodoHeatColors.color(l, themeStore: themeStore))
+                    .frame(width: 10, height: 10)
+            }
+            Text("More")
+        }
+        .font(.system(size: 10, design: .monospaced))
+        .foregroundStyle(themeStore.mutedTextColor())
+    }
+}
+
+/// Stepped intensity ramp derived from the theme accent so the heatmap
+/// stays theme-aware (level 0 is a faint recess, 1 through 4 ramp up the
+/// accent).
+enum TodoHeatColors {
+    static func color(_ level: Int, themeStore: ThemeStore) -> Color {
+        switch level {
+        case 1: return themeStore.accentColor().opacity(0.28)
+        case 2: return themeStore.accentColor().opacity(0.50)
+        case 3: return themeStore.accentColor().opacity(0.74)
+        case 4: return themeStore.accentColor()
+        default: return themeStore.mutedTextColor().opacity(0.12)
+        }
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Commands/TodoAnalyticsView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/TodoAnalyticsView.swift
@@ -8,7 +8,7 @@ struct TodoAnalyticsPage: View {
     let themeStore: ThemeStore
 
     private let trend = TodoAnalytics.monthTrend()
-    private let weeks = TodoAnalytics.heatmapWeeks()
+    private let heatDays = TodoAnalytics.heatmapDays()
 
     var body: some View {
         // Fill the height on large screens by letting the four sections
@@ -67,15 +67,13 @@ struct TodoAnalyticsPage: View {
     private var heatmapSection: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .center) {
-                sectionLabel("calendar", "Activity · last 18 weeks")
+                sectionLabel("calendar", "Activity · last year")
                 Spacer()
                 TodoHeatLegend(themeStore: themeStore)
             }
-            ScrollView(.horizontal, showsIndicators: false) {
-                TodoHeatmap(weeks: weeks, themeStore: themeStore)
-            }
-            .padding(12)
-            .todoCard(themeStore)
+            TodoHeatmap(columns: heatDays, themeStore: themeStore)
+                .padding(12)
+                .todoCard(themeStore)
         }
     }
 
@@ -330,35 +328,54 @@ struct TodoLineChart: View {
 }
 
 struct TodoHeatmap: View {
-    let weeks: [[Int]]
+    let columns: [[TodoHeatDay]]
     let themeStore: ThemeStore
     var cell: CGFloat = 12
     var gap: CGFloat = 3
 
     private let dayLabels = ["", "M", "", "W", "", "F", ""]
+    private let labelColWidth: CGFloat = 12
+    private let labelSpacing: CGFloat = 5
+    private var gridHeight: CGFloat { cell * 7 + gap * 6 }
 
     var body: some View {
-        HStack(alignment: .top, spacing: 5) {
-            VStack(spacing: gap) {
-                ForEach(0..<7, id: \.self) { i in
-                    Text(dayLabels[i])
-                        .font(.system(size: 8, design: .monospaced))
-                        .foregroundStyle(themeStore.mutedTextColor())
-                        .frame(width: 10, height: cell, alignment: .leading)
+        // Render only the most recent weeks that fit the available width,
+        // so the grid never clips on the right regardless of screen size.
+        GeometryReader { geo in
+            let available = geo.size.width - labelColWidth - labelSpacing
+            let fit = max(1, Int((available + gap) / (cell + gap)))
+            let shown = Array(columns.suffix(min(fit, columns.count)))
+
+            HStack(alignment: .top, spacing: labelSpacing) {
+                VStack(spacing: gap) {
+                    ForEach(0..<7, id: \.self) { i in
+                        Text(dayLabels[i])
+                            .font(.system(size: 8, design: .monospaced))
+                            .foregroundStyle(themeStore.mutedTextColor())
+                            .frame(width: labelColWidth, height: cell, alignment: .leading)
+                    }
                 }
-            }
-            HStack(spacing: gap) {
-                ForEach(Array(weeks.enumerated()), id: \.offset) { _, week in
-                    VStack(spacing: gap) {
-                        ForEach(Array(week.enumerated()), id: \.offset) { _, level in
-                            RoundedRectangle(cornerRadius: 3, style: .continuous)
-                                .fill(TodoHeatColors.color(level, themeStore: themeStore))
-                                .frame(width: cell, height: cell)
+                HStack(spacing: gap) {
+                    ForEach(Array(shown.enumerated()), id: \.offset) { _, week in
+                        VStack(spacing: gap) {
+                            ForEach(week) { day in
+                                RoundedRectangle(cornerRadius: 3, style: .continuous)
+                                    .fill(TodoHeatColors.color(day.level, themeStore: themeStore))
+                                    .frame(width: cell, height: cell)
+                                    .hoverTooltip(tooltip(day), width: 160, edge: .top)
+                            }
                         }
                     }
                 }
+                Spacer(minLength: 0)
             }
         }
+        .frame(height: gridHeight)
+    }
+
+    private func tooltip(_ day: TodoHeatDay) -> String {
+        let date = TodoAnalytics.heatDateFormatter.string(from: day.date)
+        return day.hasTasks ? "\(date): \(day.done)/\(day.total) done" : "\(date): no tasks"
     }
 }
 

--- a/apps/macos/LauncherApp/look-app/Views/Commands/TodoAnalyticsView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/TodoAnalyticsView.swift
@@ -51,6 +51,11 @@ struct TodoAnalyticsPage: View {
                     .background(themeStore.controlFillColor(), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
                     .overlay(RoundedRectangle(cornerRadius: 10, style: .continuous).stroke(themeStore.borderColor(), lineWidth: 1))
                 }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    sectionLabel("sparkles", "Insights · last 30 days (Tasks)")
+                    TodoInsightsStrip(themeStore: themeStore, trend: trend)
+                }
             }
             .padding(.horizontal, 4)
             .padding(.vertical, 2)
@@ -70,6 +75,53 @@ struct TodoAnalyticsPage: View {
     }
 }
 
+
+struct TodoInsightsStrip: View {
+    let themeStore: ThemeStore
+    let trend: [Int]
+
+    private var total: Int { trend.reduce(0, +) }
+    private var avgPerDay: String {
+        guard !trend.isEmpty else { return "0" }
+        return String(format: "%.1f", Double(total) / Double(trend.count))
+    }
+    private var bestDay: Int { trend.max() ?? 0 }
+    private var activeDays: Int { trend.filter { $0 > 0 }.count }
+
+    var body: some View {
+        HStack(spacing: 4) {
+            tile("Avg / day", avgPerDay, help: "Average tasks completed per day over the last 30 days")
+            divider
+            tile("Best day", "\(bestDay)", help: "Most tasks completed in a single day")
+            divider
+            tile("Active days", "\(activeDays)/\(trend.count)", help: "Days with at least one task completed")
+            divider
+            tile("Done · 30d", "\(total)", help: "Total tasks completed in the last 30 days")
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 14)
+        .background(themeStore.controlFillColor(), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous).stroke(themeStore.borderColor(), lineWidth: 1))
+    }
+
+    private func tile(_ label: String, _ value: String, help: String) -> some View {
+        VStack(spacing: 4) {
+            Text(value)
+                .font(themeStore.uiFont(size: 20, weight: .bold))
+                .foregroundStyle(themeStore.fontColor())
+            Text(label.uppercased())
+                .font(.system(size: 10, design: .monospaced))
+                .tracking(0.7)
+                .foregroundStyle(themeStore.mutedTextColor())
+        }
+        .frame(maxWidth: .infinity)
+        .help(help)
+    }
+
+    private var divider: some View {
+        Rectangle().fill(themeStore.dividerColor()).frame(width: 1).padding(.vertical, 4)
+    }
+}
 
 struct TodoStatStrip: View {
     let themeStore: ThemeStore
@@ -198,7 +250,7 @@ struct TodoLineChart: View {
             let padL: CGFloat = 4, padR: CGFloat = 4, padT: CGFloat = 10, padB: CGFloat = 8
             let w = size.width - padL - padR
             let h = size.height - padT - padB
-            let maxV = CGFloat(max(5, data.max() ?? 5))
+            let maxV = CGFloat(max(TodoCommand.taskLimit, data.max() ?? TodoCommand.taskLimit))
             let stepX = w / CGFloat(data.count - 1)
 
             let pts: [CGPoint] = data.enumerated().map { i, v in

--- a/apps/macos/LauncherApp/look-app/Views/Commands/TodoAnalyticsView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/TodoAnalyticsView.swift
@@ -26,7 +26,11 @@ struct TodoAnalyticsPage: View {
                         TodoLineChart(data: trend, themeStore: themeStore)
                             .frame(height: 92)
                         HStack {
-                            Text("Jun 5"); Spacer(); Text("Jun 20"); Spacer(); Text("Jul 4")
+                            Text("Jun 5")
+                            Spacer()
+                            Text("Jun 20")
+                            Spacer()
+                            Text("Jul 4")
                         }
                         .font(.system(size: 9.5, design: .monospaced))
                         .foregroundStyle(themeStore.mutedTextColor())
@@ -87,11 +91,15 @@ struct TodoInsightsStrip: View {
 
     var body: some View {
         HStack(spacing: 4) {
-            tile("Avg / day", avgPerDay, help: "Average tasks completed per day over the last 30 days")
+            tile(
+                "Avg / day", avgPerDay,
+                help: "Average tasks completed per day over the last 30 days")
             divider
             tile("Best day", "\(bestDay)", help: "Most tasks completed in a single day")
             divider
-            tile("Active days", "\(activeDays)/\(trend.count)", help: "Days with at least one task completed")
+            tile(
+                "Active days", "\(activeDays)/\(trend.count)",
+                help: "Days with at least one task completed")
             divider
             tile("Done · 30d", "\(total)", help: "Total tasks completed in the last 30 days")
         }
@@ -197,7 +205,10 @@ struct TodoStreakColumn: View {
                         let on = i >= 7 - filled
                         Circle()
                             .fill(on ? themeStore.accentColor() : Color.clear)
-                            .overlay(Circle().stroke(on ? Color.clear : themeStore.dividerColor(), lineWidth: 1))
+                            .overlay(
+                                Circle().stroke(
+                                    on ? Color.clear : themeStore.dividerColor(), lineWidth: 1)
+                            )
                             .frame(width: 6, height: 6)
                     }
                 }
@@ -212,7 +223,7 @@ struct TodoStreakColumn: View {
 struct TodoDonut: View {
     let fraction: Double
     let themeStore: ThemeStore
-    var size: CGFloat = 46
+    var size: CGFloat = 52
     var stroke: CGFloat = 4.5
 
     var body: some View {
@@ -220,9 +231,11 @@ struct TodoDonut: View {
             Circle().stroke(themeStore.dividerColor(), lineWidth: stroke)
             Circle()
                 .trim(from: 0, to: max(0, min(1, fraction)))
-                .stroke(themeStore.accentColor(), style: StrokeStyle(lineWidth: stroke, lineCap: .round))
+                .stroke(
+                    themeStore.accentColor(), style: StrokeStyle(lineWidth: stroke, lineCap: .round)
+                )
                 .rotationEffect(.degrees(-90))
-            Text("\(Int((fraction * 100).rounded()))")
+            Text("\(Int((fraction * 100).rounded()))" + "%")
                 .font(themeStore.uiFont(size: size * 0.28, weight: .bold))
                 .foregroundStyle(themeStore.fontColor())
         }
@@ -237,15 +250,19 @@ struct TodoLineChart: View {
     var body: some View {
         Canvas { ctx, size in
             guard data.count > 1 else { return }
-            let padL: CGFloat = 4, padR: CGFloat = 4, padT: CGFloat = 10, padB: CGFloat = 8
+            let padL: CGFloat = 4
+            let padR: CGFloat = 4
+            let padT: CGFloat = 10
+            let padB: CGFloat = 8
             let w = size.width - padL - padR
             let h = size.height - padT - padB
             let maxV = CGFloat(max(TodoCommand.taskLimit, data.max() ?? TodoCommand.taskLimit))
             let stepX = w / CGFloat(data.count - 1)
 
             let pts: [CGPoint] = data.enumerated().map { i, v in
-                CGPoint(x: padL + CGFloat(i) * stepX,
-                        y: padT + h - (CGFloat(v) / maxV) * h)
+                CGPoint(
+                    x: padL + CGFloat(i) * stepX,
+                    y: padT + h - (CGFloat(v) / maxV) * h)
             }
 
             // Baseline.
@@ -257,8 +274,9 @@ struct TodoLineChart: View {
             // Trend line.
             var line = Path()
             line.addLines(pts)
-            ctx.stroke(line, with: .color(themeStore.accentColor()),
-                       style: StrokeStyle(lineWidth: 1.6, lineCap: .round, lineJoin: .round))
+            ctx.stroke(
+                line, with: .color(themeStore.accentColor()),
+                style: StrokeStyle(lineWidth: 1.6, lineCap: .round, lineJoin: .round))
 
             // Dots, last one emphasized.
             let accent = themeStore.accentColor()

--- a/apps/macos/LauncherApp/look-app/Views/Commands/TodoAnalyticsView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/TodoAnalyticsView.swift
@@ -34,8 +34,7 @@ struct TodoAnalyticsPage: View {
                     .padding(.horizontal, 12)
                     .padding(.top, 10)
                     .padding(.bottom, 6)
-                    .background(themeStore.controlFillColor(), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
-                    .overlay(RoundedRectangle(cornerRadius: 10, style: .continuous).stroke(themeStore.borderColor(), lineWidth: 1))
+                    .todoCard(themeStore)
                 }
 
                 VStack(alignment: .leading, spacing: 8) {
@@ -48,8 +47,7 @@ struct TodoAnalyticsPage: View {
                         TodoHeatmap(weeks: weeks, themeStore: themeStore)
                     }
                     .padding(12)
-                    .background(themeStore.controlFillColor(), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
-                    .overlay(RoundedRectangle(cornerRadius: 10, style: .continuous).stroke(themeStore.borderColor(), lineWidth: 1))
+                    .todoCard(themeStore)
                 }
 
                 VStack(alignment: .leading, spacing: 8) {
@@ -75,7 +73,6 @@ struct TodoAnalyticsPage: View {
     }
 }
 
-
 struct TodoInsightsStrip: View {
     let themeStore: ThemeStore
     let trend: [Int]
@@ -100,8 +97,7 @@ struct TodoInsightsStrip: View {
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 14)
-        .background(themeStore.controlFillColor(), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous).stroke(themeStore.borderColor(), lineWidth: 1))
+        .todoCard(themeStore, cornerRadius: 12)
     }
 
     private func tile(_ label: String, _ value: String, help: String) -> some View {
@@ -118,9 +114,7 @@ struct TodoInsightsStrip: View {
         .help(help)
     }
 
-    private var divider: some View {
-        Rectangle().fill(themeStore.dividerColor()).frame(width: 1).padding(.vertical, 4)
-    }
+    private var divider: some View { TodoVDivider(themeStore: themeStore) }
 }
 
 struct TodoStatStrip: View {
@@ -139,13 +133,10 @@ struct TodoStatStrip: View {
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 14)
-        .background(themeStore.controlFillColor(), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous).stroke(themeStore.borderColor(), lineWidth: 1))
+        .todoCard(themeStore, cornerRadius: 12)
     }
 
-    private var divider: some View {
-        Rectangle().fill(themeStore.dividerColor()).frame(width: 1).padding(.vertical, 4)
-    }
+    private var divider: some View { TodoVDivider(themeStore: themeStore) }
 }
 
 struct TodoMetricColumn: View {
@@ -239,7 +230,6 @@ struct TodoDonut: View {
     }
 }
 
-
 struct TodoLineChart: View {
     let data: [Int]
     let themeStore: ThemeStore
@@ -287,7 +277,6 @@ struct TodoLineChart: View {
         }
     }
 }
-
 
 struct TodoHeatmap: View {
     let weeks: [[Int]]

--- a/apps/macos/LauncherApp/look-app/Views/Commands/TodoCommand.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/TodoCommand.swift
@@ -294,6 +294,25 @@ enum TodoPersistence {
     static func save(_ groups: [TodoGroup]) { /* no DB yet */ }
 }
 
+/// One day cell in the activity heatmap: a real date with that day's
+/// done/total counts. `level` buckets `done` into the color ramp.
+struct TodoHeatDay: Identifiable, Equatable {
+    let date: Date
+    let done: Int
+    let total: Int
+
+    var id: Date { date }
+    var hasTasks: Bool { total > 0 }
+    var level: Int {
+        switch done {
+        case 0: return 0
+        case 1: return 1
+        case 2: return 3
+        default: return 4
+        }
+    }
+}
+
 // Deterministic seeded series so the charts render a stable shape.
 // Placeholder aggregates until storage exists.
 
@@ -325,24 +344,43 @@ enum TodoAnalytics {
         return arr
     }
 
-    /// 18 weeks × 7 days, intensity level 0...4.
-    static func heatmapWeeks() -> [[Int]] {
+    /// A year of activity as GitHub-style week columns (each column is a
+    /// Sun...Sat week; the last column contains today). Days after today
+    /// in the current week are empty placeholders.
+    static let heatmapWeekCount = 52
+
+    static func heatmapDays() -> [[TodoHeatDay]] {
+        let cal = Calendar.current
+        let today = cal.startOfDay(for: Date())
+        let daysSinceSunday = cal.component(.weekday, from: today) - 1
+        guard let lastSunday = cal.date(byAdding: .day, value: -daysSinceSunday, to: today)
+        else { return [] }
+
         var r = Seeded(21)
-        var weeks: [[Int]] = []
-        for _ in 0..<18 {
-            var days: [Int] = []
-            for _ in 0..<7 {
+        var columns: [[TodoHeatDay]] = []
+        for w in stride(from: heatmapWeekCount - 1, through: 0, by: -1) {
+            guard let colSunday = cal.date(byAdding: .day, value: -7 * w, to: lastSunday)
+            else { continue }
+            var col: [TodoHeatDay] = []
+            for d in 0..<7 {
+                guard let date = cal.date(byAdding: .day, value: d, to: colSunday) else { continue }
+                if date > today {
+                    col.append(TodoHeatDay(date: date, done: 0, total: 0))
+                    continue
+                }
                 let v = r.next()
-                let level: Int
-                if v > 0.82 { level = 4 }
-                else if v > 0.62 { level = 3 }
-                else if v > 0.42 { level = 2 }
-                else if v > 0.24 { level = 1 }
-                else { level = 0 }
-                days.append(level)
+                let done = v > 0.82 ? 3 : (v > 0.60 ? 2 : (v > 0.36 ? 1 : 0))
+                let total = done + (r.next() > 0.55 ? 1 : 0)
+                col.append(TodoHeatDay(date: date, done: done, total: total))
             }
-            weeks.append(days)
+            columns.append(col)
         }
-        return weeks
+        return columns
     }
+
+    static let heatDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "EEE, MMM d"
+        return f
+    }()
 }

--- a/apps/macos/LauncherApp/look-app/Views/Commands/TodoCommand.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/TodoCommand.swift
@@ -1,0 +1,358 @@
+import Foundation
+import Observation
+
+// TodoState is the source of truth for the panel, mirroring how
+// PomoState works for /pomo.
+//
+// State runs on in-memory data. There is no database yet: TodoState
+// seeds a fresh set of groups on launch and Save just clears the dirty
+// flag. TodoPersistence is the storage seam; wiring real one-year
+// retention (ideally in core/ so linows can reuse it) is a change to
+// that type alone, with TodoState untouched.
+
+
+/// A task's lifecycle. The spec considered an `inProgress` state but
+/// dropped it ("makes tasks more chaotic without value"), so it is a
+/// plain two-state todo/done.
+enum TodoTaskState: String, Codable {
+    case todo
+    case done
+}
+
+struct TodoTask: Identifiable, Equatable {
+    let id: String
+    var name: String
+    var done: Bool
+
+    var state: TodoTaskState { done ? .done : .todo }
+
+    static func newID() -> String {
+        "n" + UUID().uuidString.prefix(6).lowercased()
+    }
+}
+
+/// A date bucket relative to today. `today`/`future` are editable;
+/// `past` days are read-mostly (names still editable, but no bulk
+/// complete/clear and no adding tasks).
+enum TodoDayKind {
+    case past
+    case today
+    case future
+}
+
+struct TodoGroup: Identifiable, Equatable {
+    /// ISO `yyyy-MM-dd`, also used as the stable identity + sort key.
+    let key: String
+    let date: Date
+    var tasks: [TodoTask]
+
+    var id: String { key }
+
+    var kind: TodoDayKind {
+        let cal = Calendar.current
+        if cal.isDateInToday(date) { return .today }
+        return date < cal.startOfDay(for: Date()) ? .past : .future
+    }
+
+    var doneCount: Int { tasks.filter(\.done).count }
+    var total: Int { tasks.count }
+
+
+    /// Short weekday, e.g. "Sat". "Today" is rendered by the header,
+    /// not here.
+    var weekday: String {
+        Self.weekdayFormatter.string(from: date)
+    }
+
+    /// e.g. "Jul 5".
+    var monthDay: String {
+        Self.monthDayFormatter.string(from: date)
+    }
+
+    /// Relative phrase like "Today", "Tomorrow", "Yesterday", "In 3
+    /// days". Empty when the day is far enough away that a relative
+    /// phrase reads oddly (the month/day already communicates it).
+    var relative: String {
+        let cal = Calendar.current
+        let days = cal.dateComponents([.day],
+            from: cal.startOfDay(for: Date()),
+            to: cal.startOfDay(for: date)).day ?? 0
+        switch days {
+        case 0: return "Today"
+        case 1: return "Tomorrow"
+        case -1: return "Yesterday"
+        case 2...6: return "In \(days) days"
+        default: return ""
+        }
+    }
+
+    private static let weekdayFormatter: DateFormatter = {
+        let f = DateFormatter(); f.dateFormat = "EEE"; return f
+    }()
+    private static let monthDayFormatter: DateFormatter = {
+        let f = DateFormatter(); f.dateFormat = "MMM d"; return f
+    }()
+    static let keyFormatter: DateFormatter = {
+        let f = DateFormatter(); f.dateFormat = "yyyy-MM-dd"; return f
+    }()
+}
+
+
+struct TodoStat: Equatable {
+    var done: Int
+    var total: Int
+    var fraction: Double { total > 0 ? Double(done) / Double(total) : 0 }
+}
+
+
+enum TodoCommand {
+    /// Max tasks per day. Spec allows 3 or 5; design default is 3.
+    static let taskLimit = 3
+    /// Max upcoming (future) date groups the user can add ahead.
+    static let dateGroupLimit = 3
+    /// Max characters in a task name. Clamped at the input field and
+    /// truncated in the model as a backstop.
+    static let taskNameMaxLength = 256
+
+    /// Case-insensitive subsequence match, ignoring whitespace in the
+    /// query, so "jul3", "jul 3", and "j3" all match "Jul 3".
+    static func fuzzyMatch(_ query: String, _ target: String) -> Bool {
+        let needle = query.lowercased().filter { !$0.isWhitespace }
+        guard !needle.isEmpty else { return true }
+        let hay = target.lowercased()
+        var ni = needle.startIndex
+        for ch in hay where ch == needle[ni] {
+            ni = needle.index(after: ni)
+            if ni == needle.endIndex { return true }
+        }
+        return false
+    }
+}
+
+
+@Observable
+final class TodoState {
+    private(set) var groups: [TodoGroup]
+    /// Unsaved edits pending. Save clears it (no DB yet).
+    var dirty: Bool = false
+
+    /// Number of `future` placeholder days already generated, so
+    /// "Add date" walks forward one calendar day at a time.
+    @ObservationIgnored private var futureDaysAdded = 0
+
+    init() {
+        groups = TodoState.seed()
+    }
+
+
+    var today: TodoGroup? { groups.first { $0.kind == .today } }
+
+    var todayStat: TodoStat {
+        guard let t = today else { return TodoStat(done: 0, total: 0) }
+        return TodoStat(done: t.doneCount, total: t.total)
+    }
+
+    var futureCount: Int { groups.filter { $0.kind == .future }.count }
+    var canAddDateGroup: Bool { futureCount < TodoCommand.dateGroupLimit }
+    var groupsLeft: Int { max(0, TodoCommand.dateGroupLimit - futureCount) }
+
+
+    private func mutate(_ body: (inout [TodoGroup]) -> Void) {
+        body(&groups)
+        dirty = true
+    }
+
+    private func withGroup(_ key: String, _ body: (inout TodoGroup) -> Void) {
+        mutate { gs in
+            guard let i = gs.firstIndex(where: { $0.key == key }) else { return }
+            body(&gs[i])
+        }
+    }
+
+    func toggleTask(group key: String, task id: String) {
+        withGroup(key) { g in
+            guard let i = g.tasks.firstIndex(where: { $0.id == id }) else { return }
+            g.tasks[i].done.toggle()
+        }
+    }
+
+    func removeTask(group key: String, task id: String) {
+        withGroup(key) { g in g.tasks.removeAll { $0.id == id } }
+    }
+
+    func editTask(group key: String, task id: String, name: String) {
+        let trimmed = Self.clampName(name)
+        guard !trimmed.isEmpty else { return }
+        withGroup(key) { g in
+            guard let i = g.tasks.firstIndex(where: { $0.id == id }) else { return }
+            g.tasks[i].name = trimmed
+        }
+    }
+
+    /// Trims whitespace and caps length at `taskNameMaxLength`.
+    static func clampName(_ name: String) -> String {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return String(trimmed.prefix(TodoCommand.taskNameMaxLength))
+    }
+
+    func completeAll(group key: String) {
+        withGroup(key) { g in
+            for i in g.tasks.indices { g.tasks[i].done = true }
+        }
+    }
+
+    func clearAll(group key: String) {
+        withGroup(key) { g in g.tasks.removeAll() }
+    }
+
+    /// Adds a task, respecting the per-day limit. Returns false when the
+    /// day is full so the caller can leave the field intact.
+    @discardableResult
+    func addTask(group key: String, name: String) -> Bool {
+        let trimmed = Self.clampName(name)
+        guard !trimmed.isEmpty else { return false }
+        guard let g = groups.first(where: { $0.key == key }),
+              g.tasks.count < TodoCommand.taskLimit else { return false }
+        withGroup(key) { g in
+            g.tasks.append(TodoTask(id: TodoTask.newID(), name: trimmed, done: false))
+        }
+        return true
+    }
+
+    /// Adds the next future day group (tomorrow, then the day after,
+    /// etc.), up to `dateGroupLimit` upcoming groups.
+    func addDateGroup() {
+        guard canAddDateGroup else { return }
+        let cal = Calendar.current
+        // Walk forward until we hit a day not already present.
+        var offset = futureDaysAdded + 1
+        while offset < 60 {
+            guard let date = cal.date(byAdding: .day, value: offset, to: cal.startOfDay(for: Date())) else { return }
+            let key = TodoGroup.keyFormatter.string(from: date)
+            if !groups.contains(where: { $0.key == key }) {
+                mutate { gs in
+                    gs.append(TodoGroup(key: key, date: date, tasks: []))
+                    gs.sort { $0.date > $1.date }   // latest on top
+                }
+                futureDaysAdded = offset
+                return
+            }
+            offset += 1
+        }
+    }
+
+
+    func save() {
+        // TODO(todo-db): persist `groups` to core storage with one-year
+        // retention. For now, saving just acknowledges the edits.
+        TodoPersistence.save(groups)
+        dirty = false
+    }
+
+    // Sample content anchored to the real current date (today, plus two
+    // future and three past days) so the panel is usable before storage
+    // exists. Replaced by TodoPersistence.load() once that returns data.
+
+    static func seed() -> [TodoGroup] {
+        if let restored = TodoPersistence.load() { return restored }
+
+        let cal = Calendar.current
+        let base = cal.startOfDay(for: Date())
+
+        // (dayOffset, [(name, done)])
+        let plan: [(Int, [(String, Bool)])] = [
+            ( 2, [("Prep sprint demo slides", false),
+                  ("Book dentist appointment", false)]),
+            ( 1, [("Grocery run + meal prep", false)]),
+            ( 0, [("Ship running-apps switcher PR", true),
+                  ("Review Todo command spec", true),
+                  ("Reply to design feedback thread", false)]),
+            (-1, [("Merge theme presets", true),
+                  ("Fix hotkey race condition", true),
+                  ("Write bench notes", true)]),
+            (-2, [("Wire AI answer card", true),
+                  ("Add Rose Pine theme", true),
+                  ("QuickLook preview fix", true)]),
+            (-3, [("Single-instance lock", true),
+                  ("Update checker polling", true),
+                  ("Draft user guide section", false)]),
+        ]
+
+        var out: [TodoGroup] = []
+        for (offset, items) in plan {
+            guard let date = cal.date(byAdding: .day, value: offset, to: base) else { continue }
+            let key = TodoGroup.keyFormatter.string(from: date)
+            let tasks = items.map { TodoTask(id: TodoTask.newID(), name: $0.0, done: $0.1) }
+            out.append(TodoGroup(key: key, date: date, tasks: tasks))
+        }
+        out.sort { $0.date > $1.date }   // latest date on top, desc
+        return out
+    }
+}
+
+/// Kept in a static so edits survive the launcher window hiding (the
+/// WindowGroup retains its view tree while hidden), and so the hint-bar
+/// quick view can read today's counts later.
+enum TodoSharedState {
+    @MainActor static let shared = TodoState()
+}
+
+// Intentionally a no-op today. Kept as a named seam so wiring real
+// storage later is a one-file change and TodoState needs no edits.
+
+enum TodoPersistence {
+    static func load() -> [TodoGroup]? { nil }
+    static func save(_ groups: [TodoGroup]) { /* no DB yet */ }
+}
+
+// Deterministic seeded series so the charts render a stable shape.
+// Placeholder aggregates until storage exists.
+
+enum TodoAnalytics {
+    static let week = TodoStat(done: 12, total: 18)
+    static let month = TodoStat(done: 47, total: 62)
+    static let streakDays = 6
+
+    /// Deterministic linear congruential generator.
+    private struct Seeded {
+        var s: Int
+        init(_ n: Int) { s = n &* 9301 &+ 49297 }
+        mutating func next() -> Double {
+            s = (s &* 9301 &+ 49297) % 233_280
+            return Double(s) / 233_280.0
+        }
+    }
+
+    /// Last 30 days, done-count 0...5 per day.
+    static func monthTrend() -> [Int] {
+        var r = Seeded(7)
+        var arr: [Int] = []
+        for i in 0..<30 {
+            let base = sin(Double(i) / 4) * 1.4 + 2.4
+            let v = base + (r.next() - 0.5) * 2.2
+            arr.append(max(0, min(5, Int(v.rounded()))))
+        }
+        return arr
+    }
+
+    /// 18 weeks × 7 days, intensity level 0...4.
+    static func heatmapWeeks() -> [[Int]] {
+        var r = Seeded(21)
+        var weeks: [[Int]] = []
+        for _ in 0..<18 {
+            var days: [Int] = []
+            for _ in 0..<7 {
+                let v = r.next()
+                let level: Int
+                if v > 0.82 { level = 4 }
+                else if v > 0.62 { level = 3 }
+                else if v > 0.42 { level = 2 }
+                else if v > 0.24 { level = 1 }
+                else { level = 0 }
+                days.append(level)
+            }
+            weeks.append(days)
+        }
+        return weeks
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Commands/TodoCommand.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/TodoCommand.swift
@@ -56,6 +56,9 @@ struct TodoGroup: Identifiable, Equatable {
 
     var doneCount: Int { tasks.filter(\.done).count }
     var total: Int { tasks.count }
+    /// Unfinished (todo) tasks. This is what the per-day limit caps;
+    /// total tasks are unlimited.
+    var openCount: Int { total - doneCount }
 
 
     /// Short weekday, e.g. "Sat". "Today" is rendered by the header,
@@ -106,7 +109,8 @@ struct TodoStat: Equatable {
 
 
 enum TodoCommand {
-    /// Max tasks per day. Spec allows 3 or 5; design default is 3.
+    /// Max unfinished (todo) tasks per day. Completing a task frees a
+    /// slot; total tasks per day are unlimited. Spec allows 3 or 5.
     static let taskLimit = 3
     /// Max upcoming (future) date groups the user can add ahead.
     static let dateGroupLimit = 3
@@ -205,14 +209,15 @@ final class TodoState {
         withGroup(key) { g in g.tasks.removeAll() }
     }
 
-    /// Adds a task, respecting the per-day limit. Returns false when the
-    /// day is full so the caller can leave the field intact.
+    /// Adds a task, respecting the per-day limit on unfinished tasks.
+    /// Returns false when the day is at its open-task limit so the caller
+    /// can leave the field intact.
     @discardableResult
     func addTask(group key: String, name: String) -> Bool {
         let trimmed = Self.clampName(name)
         guard !trimmed.isEmpty else { return false }
         guard let g = groups.first(where: { $0.key == key }),
-              g.tasks.count < TodoCommand.taskLimit else { return false }
+              g.openCount < TodoCommand.taskLimit else { return false }
         withGroup(key) { g in
             g.tasks.append(TodoTask(id: TodoTask.newID(), name: trimmed, done: false))
         }
@@ -323,14 +328,15 @@ enum TodoAnalytics {
         }
     }
 
-    /// Last 30 days, done-count 0...5 per day.
+    /// Last 30 days, done-count per day, capped at the daily task limit.
     static func monthTrend() -> [Int] {
+        let cap = TodoCommand.taskLimit
         var r = Seeded(7)
         var arr: [Int] = []
         for i in 0..<30 {
-            let base = sin(Double(i) / 4) * 1.4 + 2.4
-            let v = base + (r.next() - 0.5) * 2.2
-            arr.append(max(0, min(5, Int(v.rounded()))))
+            let base = sin(Double(i) / 4) * Double(cap) * 0.45 + Double(cap) * 0.65
+            let v = base + (r.next() - 0.5) * Double(cap) * 0.9
+            arr.append(max(0, min(cap, Int(v.rounded()))))
         }
         return arr
     }

--- a/apps/macos/LauncherApp/look-app/Views/Commands/TodoCommand.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/TodoCommand.swift
@@ -10,21 +10,12 @@ import Observation
 // retention (ideally in core/ so linows can reuse it) is a change to
 // that type alone, with TodoState untouched.
 
-
-/// A task's lifecycle. The spec considered an `inProgress` state but
-/// dropped it ("makes tasks more chaotic without value"), so it is a
-/// plain two-state todo/done.
-enum TodoTaskState: String, Codable {
-    case todo
-    case done
-}
-
+// A task is two-state (todo / done). The spec considered an in-progress
+// state but dropped it, so completion is a plain `done` flag.
 struct TodoTask: Identifiable, Equatable {
     let id: String
     var name: String
     var done: Bool
-
-    var state: TodoTaskState { done ? .done : .todo }
 
     static func newID() -> String {
         "n" + UUID().uuidString.prefix(6).lowercased()
@@ -59,7 +50,6 @@ struct TodoGroup: Identifiable, Equatable {
     /// Unfinished (todo) tasks. This is what the per-day limit caps;
     /// total tasks are unlimited.
     var openCount: Int { total - doneCount }
-
 
     /// Short weekday, e.g. "Sat". "Today" is rendered by the header,
     /// not here.
@@ -100,13 +90,11 @@ struct TodoGroup: Identifiable, Equatable {
     }()
 }
 
-
 struct TodoStat: Equatable {
     var done: Int
     var total: Int
     var fraction: Double { total > 0 ? Double(done) / Double(total) : 0 }
 }
-
 
 enum TodoCommand {
     /// Max unfinished (todo) tasks per day. Completing a task frees a
@@ -133,7 +121,6 @@ enum TodoCommand {
     }
 }
 
-
 @Observable
 final class TodoState {
     private(set) var groups: [TodoGroup]
@@ -148,7 +135,6 @@ final class TodoState {
         groups = TodoState.seed()
     }
 
-
     var today: TodoGroup? { groups.first { $0.kind == .today } }
 
     var todayStat: TodoStat {
@@ -159,7 +145,6 @@ final class TodoState {
     var futureCount: Int { groups.filter { $0.kind == .future }.count }
     var canAddDateGroup: Bool { futureCount < TodoCommand.dateGroupLimit }
     var groupsLeft: Int { max(0, TodoCommand.dateGroupLimit - futureCount) }
-
 
     private func mutate(_ body: (inout [TodoGroup]) -> Void) {
         body(&groups)
@@ -245,7 +230,6 @@ final class TodoState {
             offset += 1
         }
     }
-
 
     func save() {
         // TODO(todo-db): persist `groups` to core storage with one-year

--- a/apps/macos/LauncherApp/look-app/Views/Commands/TodoView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/TodoView.swift
@@ -302,7 +302,7 @@ struct TodoDateGroupCard: View {
 
     private var isPast: Bool { group.kind == .past }
     private var isToday: Bool { group.kind == .today }
-    private var atLimit: Bool { group.total >= TodoCommand.taskLimit }
+    private var atLimit: Bool { group.openCount >= TodoCommand.taskLimit }
     private var overdue: Bool { isPast }
 
     var body: some View {
@@ -486,7 +486,7 @@ struct TodoAddRow: View {
                     .strokeBorder(style: StrokeStyle(lineWidth: 1.5, dash: [2, 2]))
                     .frame(width: 16, height: 16)
                     .foregroundStyle(themeStore.mutedTextColor())
-                Text("Day full · \(TodoCommand.taskLimit)/\(TodoCommand.taskLimit) tasks")
+                Text("\(TodoCommand.taskLimit) unfinished · complete one to add more")
                     .font(themeStore.uiFont(size: 11.5))
                     .foregroundStyle(themeStore.mutedTextColor())
                 Spacer(minLength: 0)

--- a/apps/macos/LauncherApp/look-app/Views/Commands/TodoView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/TodoView.swift
@@ -582,7 +582,7 @@ struct TodoProgressRing: View {
     let done: Int
     let total: Int
     let themeStore: ThemeStore
-    var size: CGFloat = 26
+    var size: CGFloat = 18
 
     private var fraction: Double { total > 0 ? Double(done) / Double(total) : 0 }
 

--- a/apps/macos/LauncherApp/look-app/Views/Commands/TodoView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/TodoView.swift
@@ -1,0 +1,712 @@
+import AppKit
+import SwiftUI
+
+// The panel owns its full chrome (top search bar, button bar, page
+// toggle, hint bar) the same way PomoView owns its header, so /todo is
+// marked as not accepting the outer command input (see
+// activeCommandAcceptsInput).
+
+enum TodoPage {
+    case tasks
+    case analytics
+}
+
+struct TodoView: View {
+    let themeStore: ThemeStore
+    @Bindable var state: TodoState
+
+    @State private var page: TodoPage
+    @State private var search = ""
+    @State private var savedToast = false
+    @State private var savedToastToken = UUID()
+    @FocusState private var searchFocused: Bool
+
+    init(themeStore: ThemeStore, state: TodoState? = nil, initialPage: TodoPage = .tasks) {
+        self.themeStore = themeStore
+        self.state = state ?? TodoSharedState.shared
+        _page = State(initialValue: initialPage)
+    }
+
+    var body: some View {
+        VStack(spacing: 8) {
+            topInputBar
+
+            if page == .tasks {
+                buttonBar
+            }
+
+            Group {
+                if page == .tasks {
+                    TodoTasksPage(themeStore: themeStore, state: state, search: search)
+                } else {
+                    TodoAnalyticsPage(themeStore: themeStore)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        }
+        .padding(8)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        // The launcher's global hint bar already covers /todo's shortcuts,
+        // so the panel shows a transient Save confirmation here instead of
+        // a second hint row.
+        .overlay(alignment: .bottom) {
+            if savedToast {
+                HStack(spacing: 6) {
+                    Image(systemName: "checkmark.circle.fill")
+                    Text("Saved")
+                }
+                .font(themeStore.uiFont(size: 12, weight: .semibold))
+                .foregroundStyle(themeStore.onAccentColor())
+                .padding(.horizontal, 12)
+                .padding(.vertical, 7)
+                .background(themeStore.accentColor(), in: Capsule())
+                .padding(.bottom, 8)
+                .transition(.opacity)
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: savedToast)
+        .background(
+            TodoKeyRecognizer(
+                onTogglePage: { page = (page == .tasks) ? .analytics : .tasks },
+                onSave: save
+            ))
+        // The launcher does not focus /todo (it owns its own field), so
+        // focus the search bar on entry and when returning to Tasks.
+        .onAppear { focusSearchIfTasks() }
+        .onChange(of: page) { _, _ in focusSearchIfTasks() }
+    }
+
+    private func focusSearchIfTasks() {
+        guard page == .tasks else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
+            if page == .tasks { searchFocused = true }
+        }
+    }
+
+    private func save() {
+        state.save()
+        savedToast = true
+        let token = UUID()
+        savedToastToken = token
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) {
+            if savedToastToken == token { savedToast = false }
+        }
+    }
+
+
+    private var topInputBar: some View {
+        HStack(spacing: 8) {
+            Image(systemName: page == .tasks ? "magnifyingglass" : "chart.bar")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(themeStore.accentColor())
+
+            if page == .tasks {
+                TextField("Search tasks & dates", text: $search)
+                    .textFieldStyle(.plain)
+                    .focused($searchFocused)
+                    .font(themeStore.uiFont(size: 13.5))
+                    .foregroundStyle(themeStore.fontColor())
+
+                if !search.isEmpty {
+                    Button {
+                        search = ""
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(themeStore.mutedTextColor())
+                    }
+                    .buttonStyle(.plain)
+                }
+            } else {
+                Text("Analytics & trends")
+                    .font(themeStore.uiFont(size: 13.5))
+                    .foregroundStyle(themeStore.secondaryTextColor())
+                Spacer(minLength: 0)
+                pageToggle
+            }
+
+            Text("/todo")
+                .font(themeStore.uiFont(size: 11))
+                .foregroundStyle(themeStore.fontColor())
+                .padding(.horizontal, 8)
+                .padding(.vertical, 3)
+                .background(themeStore.selectionFillColor(), in: Capsule())
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .background(
+            themeStore.controlFillColor(),
+            in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+
+
+    private var buttonBar: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "list.bullet")
+                .font(.system(size: 12))
+                .foregroundStyle(themeStore.mutedTextColor())
+            Text("\(state.todayStat.done)/\(state.todayStat.total) done today")
+                .font(themeStore.uiFont(size: 12))
+                .foregroundStyle(themeStore.mutedTextColor())
+
+            Spacer(minLength: 0)
+
+            pageToggle
+
+            addDateButton
+
+            saveButton
+        }
+        .padding(.horizontal, 4)
+    }
+
+    private var addDateButton: some View {
+        Button {
+            state.addDateGroup()
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: "calendar")
+                    .font(.system(size: 11))
+                Text(state.canAddDateGroup ? "Add date + \(state.groupsLeft)" : "Add date")
+                    .font(themeStore.uiFont(size: 12, weight: .medium))
+            }
+            .foregroundStyle(
+                state.canAddDateGroup
+                    ? themeStore.secondaryTextColor() : themeStore.mutedTextColor()
+            )
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .overlay(
+                RoundedRectangle(cornerRadius: 7, style: .continuous)
+                    .stroke(themeStore.borderColor(), lineWidth: 1)
+            )
+            .opacity(state.canAddDateGroup ? 1 : 0.5)
+        }
+        .buttonStyle(.plain)
+        .disabled(!state.canAddDateGroup)
+        .help(
+            state.canAddDateGroup
+                ? "\(state.groupsLeft) upcoming group\(state.groupsLeft == 1 ? "" : "s") left"
+                : "Max \(TodoCommand.dateGroupLimit) upcoming groups")
+    }
+
+    private var saveButton: some View {
+        Button(action: save) {
+            HStack(spacing: 5) {
+                Image(systemName: "square.and.arrow.down")
+                    .font(.system(size: 11, weight: .semibold))
+                Text("Save")
+                    .font(themeStore.uiFont(size: 12, weight: .semibold))
+                if state.dirty {
+                    Circle()
+                        .fill(themeStore.onAccentColor())
+                        .frame(width: 5, height: 5)
+                }
+            }
+            .foregroundStyle(state.dirty ? themeStore.onAccentColor() : themeStore.mutedTextColor())
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .background(
+                state.dirty ? themeStore.accentColor() : themeStore.controlFillColor(),
+                in: RoundedRectangle(cornerRadius: 7, style: .continuous)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+
+    private var pageToggle: some View {
+        HStack(spacing: 2) {
+            toggleSegment(.tasks, label: "Tasks", icon: "list.bullet")
+            toggleSegment(.analytics, label: "Stats", icon: "chart.bar")
+        }
+        .padding(2)
+        .background(
+            themeStore.commandModeBackgroundColor(),
+            in: RoundedRectangle(cornerRadius: 8, style: .continuous)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(themeStore.borderColor(), lineWidth: 1)
+        )
+    }
+
+    private func toggleSegment(_ target: TodoPage, label: String, icon: String) -> some View {
+        let active = page == target
+        return Button {
+            page = target
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: icon).font(.system(size: 10))
+                Text(label).font(themeStore.uiFont(size: 12, weight: active ? .semibold : .medium))
+            }
+            .foregroundStyle(active ? themeStore.fontColor() : themeStore.mutedTextColor())
+            .padding(.horizontal, 10)
+            .padding(.vertical, 3)
+            .background(
+                active ? themeStore.selectionFillColor() : Color.clear,
+                in: RoundedRectangle(cornerRadius: 6, style: .continuous)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+}
+
+
+struct TodoTasksPage: View {
+    let themeStore: ThemeStore
+    @Bindable var state: TodoState
+    let search: String
+
+    private var filteredGroups: [TodoGroup] {
+        let q = search.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !q.isEmpty else { return state.groups }
+        return state.groups.compactMap { g in
+            let groupHay = "\(g.weekday) \(g.monthDay) \(g.relative)"
+            if TodoCommand.fuzzyMatch(q, groupHay) { return g }
+            let tasks = g.tasks.filter { TodoCommand.fuzzyMatch(q, $0.name) }
+            guard !tasks.isEmpty else { return nil }
+            var copy = g
+            copy.tasks = tasks
+            return copy
+        }
+    }
+
+    var body: some View {
+        ScrollView(.vertical, showsIndicators: false) {
+            LazyVStack(spacing: 8) {
+                ForEach(filteredGroups) { group in
+                    TodoDateGroupCard(themeStore: themeStore, state: state, group: group)
+                }
+
+                if filteredGroups.isEmpty {
+                    Text("No tasks match \"\(search)\"")
+                        .font(themeStore.uiFont(size: 12.5))
+                        .foregroundStyle(themeStore.mutedTextColor())
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 24)
+                }
+            }
+            .padding(.horizontal, 4)
+            .padding(.vertical, 2)
+        }
+    }
+}
+
+
+struct TodoDateGroupCard: View {
+    let themeStore: ThemeStore
+    @Bindable var state: TodoState
+    let group: TodoGroup
+
+    private var isPast: Bool { group.kind == .past }
+    private var isToday: Bool { group.kind == .today }
+    private var atLimit: Bool { group.total >= TodoCommand.taskLimit }
+    private var overdue: Bool { isPast }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            header
+            VStack(spacing: 1) {
+                ForEach(group.tasks) { task in
+                    TodoTaskRow(
+                        themeStore: themeStore,
+                        task: task,
+                        overdue: overdue,
+                        canToggle: !isPast,
+                        onToggle: { state.toggleTask(group: group.key, task: task.id) },
+                        onRemove: { state.removeTask(group: group.key, task: task.id) },
+                        onEdit: { name in
+                            state.editTask(group: group.key, task: task.id, name: name)
+                        }
+                    )
+                }
+                if !isPast {
+                    TodoAddRow(
+                        themeStore: themeStore,
+                        atLimit: atLimit,
+                        onAdd: { name in state.addTask(group: group.key, name: name) }
+                    )
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(
+            themeStore.controlFillColor(),
+            in: RoundedRectangle(cornerRadius: 10, style: .continuous)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(themeStore.borderColor(), lineWidth: 1)
+        )
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            TodoProgressRing(done: group.doneCount, total: group.total, themeStore: themeStore)
+
+            HStack(alignment: .firstTextBaseline, spacing: 7) {
+                Text(isToday ? "Today" : group.weekday)
+                    .font(themeStore.uiFont(size: 13, weight: .semibold))
+                    .foregroundStyle(isToday ? themeStore.accentColor() : themeStore.fontColor())
+                Text(groupSubLabel)
+                    .font(themeStore.uiFont(size: 11.5))
+                    .foregroundStyle(themeStore.mutedTextColor())
+            }
+
+            Spacer(minLength: 0)
+
+            if !isPast {
+                TodoGhostButton(themeStore: themeStore, icon: "checklist", help: "Complete all") {
+                    state.completeAll(group: group.key)
+                }
+                TodoGhostButton(themeStore: themeStore, icon: "trash", help: "Clear all") {
+                    state.clearAll(group: group.key)
+                }
+            }
+        }
+    }
+
+    private var groupSubLabel: String {
+        let rel = group.relative
+        if rel.isEmpty || rel == "Today" { return group.monthDay }
+        return "\(group.monthDay) · \(rel)"
+    }
+}
+
+
+struct TodoTaskRow: View {
+    let themeStore: ThemeStore
+    let task: TodoTask
+    let overdue: Bool
+    let canToggle: Bool
+    let onToggle: () -> Void
+    let onRemove: () -> Void
+    let onEdit: (String) -> Void
+
+    @State private var hover = false
+    @State private var editing = false
+    @State private var draft = ""
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        HStack(spacing: 9) {
+            TodoCheckbox(done: task.done, enabled: canToggle, themeStore: themeStore, onToggle: onToggle)
+
+            if editing {
+                TextField("", text: $draft)
+                    .textFieldStyle(.plain)
+                    .focused($focused)
+                    .font(themeStore.uiFont(size: 13))
+                    .foregroundStyle(themeStore.fontColor())
+                    .onSubmit(commit)
+                    .onChange(of: draft) { _, v in
+                        if v.count > TodoCommand.taskNameMaxLength {
+                            draft = String(v.prefix(TodoCommand.taskNameMaxLength))
+                        }
+                    }
+                    .onChange(of: focused) { _, isFocused in
+                        if !isFocused { commit() }
+                    }
+            } else {
+                Text(task.name)
+                    .font(themeStore.uiFont(size: 13))
+                    .foregroundStyle(nameColor)
+                    .strikethrough(task.done, color: themeStore.mutedTextColor())
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+                    .onTapGesture { beginEdit() }
+            }
+
+            if overdue && !task.done && !editing {
+                Text("OVERDUE")
+                    .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(themeStore.dangerColor())
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 1)
+                    .background(
+                        themeStore.dangerColor().opacity(0.14),
+                        in: RoundedRectangle(cornerRadius: 4, style: .continuous))
+            }
+
+            if !editing {
+                Button(action: onRemove) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(themeStore.dangerColor())
+                }
+                .buttonStyle(.plain)
+                .help("Remove task")
+                .opacity(hover ? 1 : 0)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(
+            (editing || hover) ? themeStore.selectionFillColor() : Color.clear,
+            in: RoundedRectangle(cornerRadius: 6, style: .continuous)
+        )
+        .onHover { hover = $0 }
+    }
+
+    private var nameColor: Color {
+        if task.done { return themeStore.mutedTextColor() }
+        return overdue ? themeStore.dangerColor() : themeStore.fontColor()
+    }
+
+    private func beginEdit() {
+        draft = task.name
+        editing = true
+        DispatchQueue.main.async { focused = true }
+    }
+
+    private func commit() {
+        let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty && trimmed != task.name { onEdit(trimmed) }
+        editing = false
+    }
+}
+
+
+struct TodoAddRow: View {
+    let themeStore: ThemeStore
+    let atLimit: Bool
+    let onAdd: (String) -> Void
+
+    @State private var active = false
+    @State private var draft = ""
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        if atLimit {
+            HStack(spacing: 8) {
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .strokeBorder(style: StrokeStyle(lineWidth: 1.5, dash: [2, 2]))
+                    .frame(width: 16, height: 16)
+                    .foregroundStyle(themeStore.mutedTextColor())
+                Text("Day full · \(TodoCommand.taskLimit)/\(TodoCommand.taskLimit) tasks")
+                    .font(themeStore.uiFont(size: 11.5))
+                    .foregroundStyle(themeStore.mutedTextColor())
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+        } else if active {
+            HStack(spacing: 9) {
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .strokeBorder(themeStore.accentColor(), lineWidth: 1.5)
+                    .frame(width: 16, height: 16)
+                TextField("Task name, then ↵", text: $draft)
+                    .textFieldStyle(.plain)
+                    .focused($focused)
+                    .font(themeStore.uiFont(size: 13))
+                    .foregroundStyle(themeStore.fontColor())
+                    .onSubmit(commit)
+                    .onChange(of: draft) { _, v in
+                        if v.count > TodoCommand.taskNameMaxLength {
+                            draft = String(v.prefix(TodoCommand.taskNameMaxLength))
+                        }
+                    }
+                    .onChange(of: focused) { _, isFocused in
+                        if !isFocused && draft.trimmingCharacters(in: .whitespaces).isEmpty {
+                            active = false
+                        }
+                    }
+                Text("↵ add · esc")
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundStyle(themeStore.mutedTextColor())
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .background(
+                themeStore.selectionFillColor(),
+                in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+        } else {
+            Button {
+                active = true
+                DispatchQueue.main.async { focused = true }
+            } label: {
+                HStack(spacing: 9) {
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .strokeBorder(style: StrokeStyle(lineWidth: 1.5, dash: [2, 2]))
+                        .frame(width: 16, height: 16)
+                        .overlay(Image(systemName: "plus").font(.system(size: 8, weight: .bold)))
+                        .foregroundStyle(themeStore.mutedTextColor())
+                    Text("Add task")
+                        .font(themeStore.uiFont(size: 13))
+                        .foregroundStyle(themeStore.mutedTextColor())
+                    Spacer(minLength: 0)
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 6)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private func commit() {
+        let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty { onAdd(trimmed) }
+        draft = ""
+        // Keep the field active for rapid entry of several tasks.
+        DispatchQueue.main.async { focused = true }
+    }
+}
+
+
+struct TodoCheckbox: View {
+    let done: Bool
+    var enabled: Bool = true
+    let themeStore: ThemeStore
+    let onToggle: () -> Void
+
+    var body: some View {
+        Button(action: { if enabled { onToggle() } }) {
+            box
+                // The unchecked box is a clear fill, which SwiftUI does not
+                // reliably hit-test. Back it with an opaque hit region and
+                // pad it out so clicks near the box still land.
+                .padding(4)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(-4)
+        .disabled(!enabled)
+        // Past days are read-only for completion state; the name stays
+        // editable but the box cannot be toggled.
+        .help(enabled ? "" : "Past days are read-only")
+    }
+
+    private var box: some View {
+        RoundedRectangle(cornerRadius: 5, style: .continuous)
+            .fill(done ? themeStore.accentColor() : Color.clear)
+            .frame(width: 16, height: 16)
+            .overlay(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .stroke(borderColor, lineWidth: 1.5)
+            )
+            .overlay {
+                if done {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 9, weight: .heavy))
+                        .foregroundStyle(themeStore.onAccentColor())
+                }
+            }
+            .opacity(enabled ? 1 : 0.55)
+    }
+
+    private var borderColor: Color {
+        done ? themeStore.accentColor() : themeStore.mutedTextColor()
+    }
+}
+
+struct TodoProgressRing: View {
+    let done: Int
+    let total: Int
+    let themeStore: ThemeStore
+    var size: CGFloat = 26
+
+    private var fraction: Double { total > 0 ? Double(done) / Double(total) : 0 }
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(themeStore.dividerColor(), lineWidth: 2.5)
+            Circle()
+                .trim(from: 0, to: max(0, min(1, fraction)))
+                .stroke(
+                    themeStore.accentColor(), style: StrokeStyle(lineWidth: 2.5, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+        }
+        .frame(width: size, height: size)
+    }
+}
+
+struct TodoGhostButton: View {
+    let themeStore: ThemeStore
+    let icon: String
+    let help: String
+    let action: () -> Void
+
+    @State private var hover = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .font(.system(size: 12))
+                .foregroundStyle(hover ? themeStore.fontColor() : themeStore.mutedTextColor())
+                .padding(4)
+                .background(
+                    hover ? themeStore.controlFillColor() : Color.clear,
+                    in: RoundedRectangle(cornerRadius: 6, style: .continuous)
+                )
+        }
+        .buttonStyle(.plain)
+        .help(help)
+        .onHover { hover = $0 }
+    }
+}
+
+// Mirrors PomoView's KeyCommandsRecognizer: a local NSEvent monitor
+// installed only while the panel is on screen. Only fires on the ⌘
+// chord, so it never steals plain typing from the search / add fields.
+
+struct TodoKeyRecognizer: NSViewRepresentable {
+    var onTogglePage: () -> Void
+    var onSave: () -> Void
+
+    func makeNSView(context: Context) -> TodoKeyHostView {
+        let v = TodoKeyHostView()
+        v.onTogglePage = onTogglePage
+        v.onSave = onSave
+        return v
+    }
+
+    func updateNSView(_ nsView: TodoKeyHostView, context: Context) {
+        nsView.onTogglePage = onTogglePage
+        nsView.onSave = onSave
+    }
+}
+
+final class TodoKeyHostView: NSView {
+    var onTogglePage: (() -> Void)?
+    var onSave: (() -> Void)?
+    nonisolated(unsafe) private var monitor: Any?
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if window != nil { install() } else { remove() }
+    }
+
+    deinit {
+        if let monitor { NSEvent.removeMonitor(monitor) }
+    }
+
+    private func install() {
+        guard monitor == nil else { return }
+        monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self else { return event }
+            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            guard mods == .command else { return event }
+            let chars = event.charactersIgnoringModifiers?.lowercased() ?? ""
+            if chars == "n" {
+                self.onTogglePage?()
+                return nil
+            }
+            if chars == "s" {
+                self.onSave?()
+                return nil
+            }
+            return event
+        }
+    }
+
+    private func remove() {
+        if let monitor { NSEvent.removeMonitor(monitor) }
+        monitor = nil
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Commands/TodoView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/TodoView.swift
@@ -93,7 +93,6 @@ struct TodoView: View {
         }
     }
 
-
     private var topInputBar: some View {
         HStack(spacing: 8) {
             Image(systemName: page == .tasks ? "magnifyingglass" : "chart.bar")
@@ -134,11 +133,8 @@ struct TodoView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 9)
-        .background(
-            themeStore.controlFillColor(),
-            in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .todoCard(themeStore, bordered: false)
     }
-
 
     private var buttonBar: some View {
         HStack(spacing: 8) {
@@ -214,7 +210,6 @@ struct TodoView: View {
         .buttonStyle(.plain)
     }
 
-
     private var pageToggle: some View {
         HStack(spacing: 2) {
             toggleSegment(.tasks, label: "Tasks", icon: "list.bullet")
@@ -252,7 +247,6 @@ struct TodoView: View {
     }
 
 }
-
 
 struct TodoTasksPage: View {
     let themeStore: ThemeStore
@@ -294,7 +288,6 @@ struct TodoTasksPage: View {
     }
 }
 
-
 struct TodoDateGroupCard: View {
     let themeStore: ThemeStore
     @Bindable var state: TodoState
@@ -333,14 +326,7 @@ struct TodoDateGroupCard: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
-        .background(
-            themeStore.controlFillColor(),
-            in: RoundedRectangle(cornerRadius: 10, style: .continuous)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .stroke(themeStore.borderColor(), lineWidth: 1)
-        )
+        .todoCard(themeStore)
     }
 
     private var header: some View {
@@ -376,7 +362,6 @@ struct TodoDateGroupCard: View {
     }
 }
 
-
 struct TodoTaskRow: View {
     let themeStore: ThemeStore
     let task: TodoTask
@@ -402,11 +387,7 @@ struct TodoTaskRow: View {
                     .font(themeStore.uiFont(size: 13))
                     .foregroundStyle(themeStore.fontColor())
                     .onSubmit(commit)
-                    .onChange(of: draft) { _, v in
-                        if v.count > TodoCommand.taskNameMaxLength {
-                            draft = String(v.prefix(TodoCommand.taskNameMaxLength))
-                        }
-                    }
+                    .limitLength($draft, to: TodoCommand.taskNameMaxLength)
                     .onChange(of: focused) { _, isFocused in
                         if !isFocused { commit() }
                     }
@@ -469,7 +450,6 @@ struct TodoTaskRow: View {
     }
 }
 
-
 struct TodoAddRow: View {
     let themeStore: ThemeStore
     let atLimit: Bool
@@ -504,11 +484,7 @@ struct TodoAddRow: View {
                     .font(themeStore.uiFont(size: 13))
                     .foregroundStyle(themeStore.fontColor())
                     .onSubmit(commit)
-                    .onChange(of: draft) { _, v in
-                        if v.count > TodoCommand.taskNameMaxLength {
-                            draft = String(v.prefix(TodoCommand.taskNameMaxLength))
-                        }
-                    }
+                    .limitLength($draft, to: TodoCommand.taskNameMaxLength)
                     .onChange(of: focused) { _, isFocused in
                         if !isFocused && draft.trimmingCharacters(in: .whitespaces).isEmpty {
                             active = false
@@ -555,7 +531,6 @@ struct TodoAddRow: View {
         DispatchQueue.main.async { focused = true }
     }
 }
-
 
 struct TodoCheckbox: View {
     let done: Bool
@@ -708,5 +683,37 @@ final class TodoKeyHostView: NSView {
     private func remove() {
         if let monitor { NSEvent.removeMonitor(monitor) }
         monitor = nil
+    }
+}
+
+// Shared surface for /todo cards and controls: a control-fill background
+// with rounded corners and an optional hairline border.
+extension View {
+    func todoCard(_ themeStore: ThemeStore, cornerRadius: CGFloat = 10, bordered: Bool = true) -> some View {
+        background(
+            themeStore.controlFillColor(),
+            in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        )
+        .overlay {
+            if bordered {
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .stroke(themeStore.borderColor(), lineWidth: 1)
+            }
+        }
+    }
+
+    /// Clamps a text binding to `max` characters as the user types.
+    func limitLength(_ text: Binding<String>, to max: Int) -> some View {
+        onChange(of: text.wrappedValue) { _, value in
+            if value.count > max { text.wrappedValue = String(value.prefix(max)) }
+        }
+    }
+}
+
+// Thin vertical rule used between columns in the analytics strips.
+struct TodoVDivider: View {
+    let themeStore: ThemeStore
+    var body: some View {
+        Rectangle().fill(themeStore.dividerColor()).frame(width: 1).padding(.vertical, 4)
     }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
@@ -284,13 +284,46 @@ struct PickedItemsPanel: View {
 }
 
 struct HintBar: View {
+    /// Today's done/total quick view, clickable to open /todo. Shown on
+    /// the home screen in place of the command-mode hint.
+    struct TodoQuickView {
+        let done: Int
+        let total: Int
+        let onTap: () -> Void
+    }
+
     let hint: String
+    var todo: TodoQuickView? = nil
     let themeStore: ThemeStore
 
+    private var hintFont: Font {
+        themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular)
+    }
+
     var body: some View {
-        Text(hint)
-            .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular))
-            .foregroundStyle(themeStore.secondaryTextColor())
+        HStack(spacing: 0) {
+            Text(hint)
+                .font(hintFont)
+                .foregroundStyle(themeStore.secondaryTextColor())
+
+            if let todo {
+                Text("  •  ")
+                    .font(hintFont)
+                    .foregroundStyle(themeStore.secondaryTextColor())
+                Button(action: todo.onTap) {
+                    HStack(spacing: 5) {
+                        Image(systemName: "checklist")
+                            .font(.system(size: CGFloat(themeStore.settings.fontSize - 3)))
+                        Text("Todo \(todo.done)/\(todo.total)")
+                            .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .semibold))
+                    }
+                    .foregroundStyle(themeStore.accentColor())
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help("Open /todo")
+            }
+        }
     }
 }
 

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+CommandMode.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+CommandMode.swift
@@ -270,9 +270,10 @@ extension LauncherView {
                                 themeStore: themeStore,
                                 onSubmit: handleSubmit
                             )
-                        } else if activeCommandID != AppConstants.Launcher.Command.pomo {
-                            // /pomo renders its own header (with "Running: <name>"
-                            // status) inside its panel — skip the redundant outer one.
+                        } else if activeCommandID != AppConstants.Launcher.Command.pomo
+                            && activeCommandID != AppConstants.Launcher.Command.todo {
+                            // /pomo and /todo render their own header inside
+                            // their panels, so skip the redundant outer one.
                             CommandHeaderBar(
                                 command: activeCommand,
                                 themeStore: themeStore,
@@ -318,6 +319,9 @@ extension LauncherView {
                                 .padding(8)
                         } else if activeCommandID == AppConstants.Launcher.Command.pomo {
                             PomoView(themeStore: themeStore)
+                                .padding(2)
+                        } else if activeCommandID == AppConstants.Launcher.Command.todo {
+                            TodoView(themeStore: themeStore)
                                 .padding(2)
                         } else {
                             VStack(alignment: .leading, spacing: 0) {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -453,7 +453,32 @@ struct LauncherView: View {
             return ["Enter copy clip", "Delete remove clip", "Cmd+H help", "Cmd+/ command mode"]
         }
 
-        return ["Enter open", "Cmd+F reveal", "Cmd+H help", "Cmd+/ command mode"]
+        // The home screen replaces the "Cmd+/ command mode" hint with a
+        // clickable today done/total quick view (see todoQuickView), so it
+        // is intentionally omitted here.
+        return ["Enter open", "Cmd+F reveal", "Cmd+H help"]
+    }
+
+    /// True when the launcher is on its default/home screen (the state
+    /// whose hint falls through to the list above), where the /todo quick
+    /// view is shown in place of the command-mode hint.
+    var isHomeHintScreen: Bool {
+        guard !appUIState.showsThemeSettings, !isCommandMode, !showsHelpScreen else { return false }
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        if extractTranslationQuery(from: trimmed) != nil { return false }
+        if isPrefixSuggestionQuery || isCommandSuggestionQuery || isClipboardQuery { return false }
+        return true
+    }
+
+    /// Today's done/total quick view for the home hint bar, or nil when
+    /// off the home screen or today has no tasks (then it stays empty).
+    var todoQuickView: HintBar.TodoQuickView? {
+        guard isHomeHintScreen else { return nil }
+        let stat = TodoSharedState.shared.todayStat
+        guard stat.total > 0 else { return nil }
+        return HintBar.TodoQuickView(done: stat.done, total: stat.total) {
+            enterCommandMode(commandID: AppConstants.Launcher.Command.todo, prefilledInput: "")
+        }
     }
 
     var commandNamePart: String {
@@ -786,7 +811,7 @@ struct LauncherView: View {
             }
 
             if !isKillConfirmationVisible && !isDeleteConfirmationVisible {
-                HintBar(hint: currentHint, themeStore: themeStore)
+                HintBar(hint: currentHint, todo: todoQuickView, themeStore: themeStore)
             }
         }
     }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -417,12 +417,15 @@ struct LauncherView: View {
                 return ["Y confirm", "N cancel", "Tab/Cmd+1-4 switch", "Esc back"]
             }
             if activeCommandID == AppConstants.Launcher.Command.sys {
-                return ["Esc back", "Tab/Cmd+1-5 switch", "Cmd+/ command mode", "Cmd+Shift+, settings"]
+                return ["Esc back", "Tab/Cmd+1-6 switch", "Cmd+/ command mode", "Cmd+Shift+, settings"]
             }
             if activeCommandID == AppConstants.Launcher.Command.pomo {
-                return ["Space start/pause", "R reset", "P music", "Esc back", "Tab/Cmd+1-5 switch"]
+                return ["Space start/pause", "R reset", "P music", "Esc back", "Tab/Cmd+1-6 switch"]
             }
-            return ["Enter run", "Tab select", "Cmd+1-5 switch", "Esc back"]
+            if activeCommandID == AppConstants.Launcher.Command.todo {
+                return ["Cmd+N switch page", "Cmd+S save", "Cmd+1-6 switch", "Esc back"]
+            }
+            return ["Enter run", "Tab select", "Cmd+1-6 switch", "Esc back"]
         }
 
         if let command = extractTranslationQuery(from: query.trimmingCharacters(in: .whitespacesAndNewlines)) {
@@ -479,6 +482,8 @@ struct LauncherView: View {
         guard let activeCommandID else { return false }
         if activeCommandID == AppConstants.Launcher.Command.sys { return false }
         if activeCommandID == AppConstants.Launcher.Command.pomo { return false }
+        // /todo owns its own top search bar, like /pomo owns its header.
+        if activeCommandID == AppConstants.Launcher.Command.todo { return false }
         return true
     }
 

--- a/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Shortcuts.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Shortcuts.swift
@@ -46,7 +46,7 @@ enum ShortcutDocs {
                 ShortcutItem(keys: "Cmd+Enter", action: "Search query on Google"),
                 ShortcutItem(keys: "Cmd+/", action: "Enter command mode"),
                 ShortcutItem(keys: ":cmd", action: "Jump to a command from home (e.g. :calc 2+2, :kill chrome, :sys, :pomo)"),
-                ShortcutItem(keys: "Cmd+1..5", action: "Switch directly to /shell, /calc, /kill, /sys, /pomo"),
+                ShortcutItem(keys: "Cmd+1..6", action: "Switch directly to /calc, /pomo, /todo, /kill, /shell, /sys"),
                 ShortcutItem(keys: "Cmd+Shift+,", action: "Open/close settings panel"),
                 ShortcutItem(keys: "Cmd+Shift+;", action: "Reload .look.config"),
                 ShortcutItem(keys: "Cmd+H", action: "Toggle in-window keyboard help screen"),


### PR DESCRIPTION
## Summary

- UI for todo command (MacOS first)
- Add, edit, remove tasks
- Grouping tasks by date
- Analytics (simple level)

Tiny: Remove Cmd + / in the hint bar. Replace with Todo (done/total)

## Why

- An internally agreed feature.

## Changes

- MacOS UI

## Testing

- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
- [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet test apps/windows/LauncherApp.Tests/LauncherApp.Tests.csproj`
- [ ] Windows app (if `apps/windows/**` touched): `dotnet build apps/windows/LauncherApp/LauncherApp.csproj -c Debug -p:Platform=x64 -r win-x64`
- [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [x] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered
