### PR TITLE
feat: shared todo backend

### DIFF
--- a/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
@@ -52,6 +52,14 @@ private func look_wikipedia_answer_json(_ searchTerm: UnsafePointer<CChar>?) -> 
 nonisolated
 private func look_definitional_entity_json(_ query: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
 
+@_silgen_name("look_todo_list_json")
+nonisolated
+private func look_todo_list_json() -> UnsafeMutablePointer<CChar>?
+
+@_silgen_name("look_todo_save_json")
+nonisolated
+private func look_todo_save_json(_ json: UnsafePointer<CChar>?) -> Bool
+
 final class EngineBridge: @unchecked Sendable {
     static let shared = EngineBridge()
 
@@ -137,6 +145,24 @@ final class EngineBridge: @unchecked Sendable {
 
     nonisolated func reloadConfig() -> Bool {
         look_reload_config()
+    }
+
+    /// Loads the full /todo task set from the shared core backend.
+    nonisolated func todoList() -> [TodoBackendTask] {
+        guard let ptr = look_todo_list_json() else { return [] }
+        defer { look_free_cstring(ptr) }
+        guard let data = String(cString: ptr).data(using: .utf8) else { return [] }
+        return (try? JSONDecoder().decode([TodoBackendTask].self, from: data)) ?? []
+    }
+
+    /// Persists the full /todo task set to the shared core backend
+    /// (lossless replace). Returns true on success.
+    @discardableResult
+    nonisolated func todoSave(_ tasks: [TodoBackendTask]) -> Bool {
+        guard let data = try? JSONEncoder().encode(tasks),
+            let json = String(data: data, encoding: .utf8)
+        else { return false }
+        return json.withCString { look_todo_save_json($0) }
     }
 
     @discardableResult

--- a/apps/macos/LauncherApp/look-app/Support/UI/HoverBubble.swift
+++ b/apps/macos/LauncherApp/look-app/Support/UI/HoverBubble.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+/// An in-window hover bubble. Attach with `.hoverBubble { … }` and a
+/// themed bubble appears above the view while the pointer is over it.
+///
+/// Complements `hoverTooltip`: that one presents an NSPopover, which is
+/// its own window and swallows the first click, so it suits read-only
+/// info icons. This bubble renders inside the host window and never
+/// hit-tests, so clicks always pass through to the anchor - use it on
+/// interactive controls (buttons) that need hover detail.
+///
+/// Placement: a zero-size anchor pinned at the view's top-leading corner
+/// with the bubble growing upward out of it, so the bubble's own height
+/// can never push it below the anchor or off the window's bottom edge.
+struct HoverBubbleModifier<BubbleContent: View>: ViewModifier {
+    let isEnabled: Bool
+    let width: CGFloat?
+    @ViewBuilder let bubble: () -> BubbleContent
+
+    @EnvironmentObject private var themeStore: ThemeStore
+    @State private var hovering = false
+
+    func body(content: Content) -> some View {
+        content
+            .onHover { hovering = $0 }
+            .overlay(alignment: .topLeading) {
+                if hovering, isEnabled {
+                    bubble()
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 9)
+                        .frame(width: width, alignment: .leading)
+                        .background(
+                            themeStore.commandModePanelColor(),
+                            in: RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                .stroke(themeStore.borderColor(), lineWidth: 1)
+                        )
+                        .shadow(color: .black.opacity(0.35), radius: 10, y: 4)
+                        .fixedSize()
+                        .frame(width: 0, height: 0, alignment: .bottomLeading)
+                        .offset(y: -8)
+                        .allowsHitTesting(false)
+                }
+            }
+    }
+}
+
+extension View {
+    /// Shows a click-through bubble with `content` above this view while
+    /// it is hovered.
+    /// - Parameters:
+    ///   - isEnabled: Gate for the bubble; pass false to suppress it
+    ///     (e.g. when there is nothing to show).
+    ///   - width: Fixed bubble width; text wraps to fit. Nil sizes the
+    ///     bubble to its content.
+    func hoverBubble<Content: View>(
+        isEnabled: Bool = true,
+        width: CGFloat? = nil,
+        @ViewBuilder content: @escaping () -> Content
+    ) -> some View {
+        modifier(HoverBubbleModifier(isEnabled: isEnabled, width: width, bubble: content))
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Commands/TodoAnalyticsView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/TodoAnalyticsView.swift
@@ -1,14 +1,16 @@
 import SwiftUI
 
 // Week / month done-total donuts, a current streak, a 30-day completion
-// trend line, and a GitHub-style activity heatmap. Series come from
-// TodoAnalytics (deterministic placeholders until storage exists).
+// trend line, and a GitHub-style activity heatmap. All series derive
+// from the live task set via TodoAnalytics, so the page reflects real
+// data and updates as tasks change.
 
 struct TodoAnalyticsPage: View {
     let themeStore: ThemeStore
+    var state: TodoState
 
-    private let trend = TodoAnalytics.monthTrend()
-    private let heatDays = TodoAnalytics.heatmapDays()
+    private var trend: [Int] { TodoAnalytics.monthTrend(state.groups) }
+    private var heatDays: [[TodoHeatDay]] { TodoAnalytics.heatmapDays(state.groups) }
 
     var body: some View {
         // Fill the height on large screens by letting the four sections
@@ -35,9 +37,9 @@ struct TodoAnalyticsPage: View {
     private var statStrip: some View {
         TodoStatStrip(
             themeStore: themeStore,
-            week: TodoAnalytics.week,
-            month: TodoAnalytics.month,
-            streak: TodoAnalytics.streakDays
+            week: TodoAnalytics.stat(state.groups, sameAs: .weekOfYear),
+            month: TodoAnalytics.stat(state.groups, sameAs: .month),
+            streak: TodoAnalytics.streakDays(state.groups)
         )
     }
 
@@ -48,11 +50,11 @@ struct TodoAnalyticsPage: View {
                 TodoLineChart(data: trend, themeStore: themeStore)
                     .frame(height: 92)
                 HStack {
-                    Text("Jun 5")
+                    Text(axisLabel(daysAgo: 29))
                     Spacer()
-                    Text("Jun 20")
+                    Text(axisLabel(daysAgo: 15))
                     Spacer()
-                    Text("Jul 4")
+                    Text(axisLabel(daysAgo: 0))
                 }
                 .font(.system(size: 9.5, design: .monospaced))
                 .foregroundStyle(themeStore.mutedTextColor())
@@ -82,6 +84,12 @@ struct TodoAnalyticsPage: View {
             sectionLabel("sparkles", "Insights · last 30 days (Tasks)")
             TodoInsightsStrip(themeStore: themeStore, trend: trend)
         }
+    }
+
+    private func axisLabel(daysAgo: Int) -> String {
+        let cal = Calendar.current
+        let date = cal.date(byAdding: .day, value: -daysAgo, to: cal.startOfDay(for: Date())) ?? Date()
+        return TodoAnalytics.axisDateFormatter.string(from: date)
     }
 
     private func sectionLabel(_ icon: String, _ text: String) -> some View {

--- a/apps/macos/LauncherApp/look-app/Views/Commands/TodoCommand.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/TodoCommand.swift
@@ -16,9 +16,27 @@ struct TodoTask: Identifiable, Equatable {
     let id: String
     var name: String
     var done: Bool
+    /// When the task was created, for backend round-tripping.
+    var createdAtUnixS: Int64 = Int64(Date().timeIntervalSince1970)
 
     static func newID() -> String {
         "n" + UUID().uuidString.prefix(6).lowercased()
+    }
+}
+
+/// Flat task shape exchanged with the shared core backend (matches
+/// `look_todo::TodoTask`'s JSON). The app groups these by `dueDate`.
+struct TodoBackendTask: Codable {
+    let id: String
+    let name: String
+    let done: Bool
+    let dueDate: String
+    let createdAtUnixS: Int64
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, done
+        case dueDate = "due_date"
+        case createdAtUnixS = "created_at_unix_s"
     }
 }
 
@@ -85,8 +103,17 @@ struct TodoGroup: Identifiable, Equatable {
     private static let monthDayFormatter: DateFormatter = {
         let f = DateFormatter(); f.dateFormat = "MMM d"; return f
     }()
+    // Produces the due_date keys stored in the shared database, so it is
+    // pinned to POSIX/Gregorian: a system set to a non-Gregorian calendar
+    // (e.g. Buddhist) must not write "2569-07-05" into a cross-platform
+    // store that the Rust retention prune compares against Gregorian
+    // date('now'). Timezone stays local so "today" is the user's day.
     static let keyFormatter: DateFormatter = {
-        let f = DateFormatter(); f.dateFormat = "yyyy-MM-dd"; return f
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.calendar = Calendar(identifier: .gregorian)
+        f.dateFormat = "yyyy-MM-dd"
+        return f
     }()
 }
 
@@ -105,13 +132,18 @@ enum TodoCommand {
     /// Max characters in a task name. Clamped at the input field and
     /// truncated in the model as a backstop.
     static let taskNameMaxLength = 256
+    /// How many past days the Tasks list shows when not searching. The
+    /// full retained year stays searchable and feeds analytics; the
+    /// browse list only surfaces the recent window.
+    static let listWindowDays = 31
 
-    /// Case-insensitive subsequence match, ignoring whitespace in the
-    /// query, so "jul3", "jul 3", and "j3" all match "Jul 3".
+    /// Case- and diacritic-insensitive subsequence match, ignoring
+    /// whitespace in the query: "jul3" matches "Jul 3", and "di" matches
+    /// "đi" (Vietnamese and other accented text folds to ASCII).
     static func fuzzyMatch(_ query: String, _ target: String) -> Bool {
-        let needle = query.lowercased().filter { !$0.isWhitespace }
+        let needle = searchNormalize(query).filter { !$0.isWhitespace }
         guard !needle.isEmpty else { return true }
-        let hay = target.lowercased()
+        let hay = searchNormalize(target)
         var ni = needle.startIndex
         for ch in hay where ch == needle[ni] {
             ni = needle.index(after: ni)
@@ -119,12 +151,25 @@ enum TodoCommand {
         }
         return false
     }
+
+    /// Swift mirror of the engine's `normalize_for_search`
+    /// (core/engine/src/normalize.rs), which is what lets "tẻ" find
+    /// Terminal in the app list: fold case/diacritics/width, then map
+    /// the Vietnamese đ/Đ, a stroke letter that no diacritic fold
+    /// touches, to plain d. Keep the two in sync.
+    private static func searchNormalize(_ text: String) -> String {
+        text.folding(
+            options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive], locale: nil
+        )
+        .replacingOccurrences(of: "đ", with: "d")
+        .replacingOccurrences(of: "Đ", with: "d")
+    }
 }
 
 @Observable
 final class TodoState {
     private(set) var groups: [TodoGroup]
-    /// Unsaved edits pending. Save clears it (no DB yet).
+    /// Unsaved edits pending. Save persists them to the backend.
     var dirty: Bool = false
 
     /// Number of `future` placeholder days already generated, so
@@ -132,7 +177,22 @@ final class TodoState {
     @ObservationIgnored private var futureDaysAdded = 0
 
     init() {
-        groups = TodoState.seed()
+        groups = TodoPersistence.load()
+        ensureTodayGroup()
+    }
+
+    /// Keeps an empty Today group present. Groups derive from stored
+    /// tasks, so an empty store would leave nowhere to type. Also re-run
+    /// when the panel appears, so an app left resident across midnight
+    /// gets a fresh Today without a relaunch. Not a user edit, so it
+    /// deliberately does not mark the state dirty.
+    func ensureTodayGroup() {
+        let cal = Calendar.current
+        let today = cal.startOfDay(for: Date())
+        let key = TodoGroup.keyFormatter.string(from: today)
+        guard !groups.contains(where: { $0.key == key }) else { return }
+        groups.append(TodoGroup(key: key, date: today, tasks: []))
+        groups.sort { $0.date > $1.date }
     }
 
     var today: TodoGroup? { groups.first { $0.kind == .today } }
@@ -232,50 +292,8 @@ final class TodoState {
     }
 
     func save() {
-        // TODO(todo-db): persist `groups` to core storage with one-year
-        // retention. For now, saving just acknowledges the edits.
         TodoPersistence.save(groups)
         dirty = false
-    }
-
-    // Sample content anchored to the real current date (today, plus two
-    // future and three past days) so the panel is usable before storage
-    // exists. Replaced by TodoPersistence.load() once that returns data.
-
-    static func seed() -> [TodoGroup] {
-        if let restored = TodoPersistence.load() { return restored }
-
-        let cal = Calendar.current
-        let base = cal.startOfDay(for: Date())
-
-        // (dayOffset, [(name, done)])
-        let plan: [(Int, [(String, Bool)])] = [
-            ( 2, [("Prep sprint demo slides", false),
-                  ("Book dentist appointment", false)]),
-            ( 1, [("Grocery run + meal prep", false)]),
-            ( 0, [("Ship running-apps switcher PR", true),
-                  ("Review Todo command spec", true),
-                  ("Reply to design feedback thread", false)]),
-            (-1, [("Merge theme presets", true),
-                  ("Fix hotkey race condition", true),
-                  ("Write bench notes", true)]),
-            (-2, [("Wire AI answer card", true),
-                  ("Add Rose Pine theme", true),
-                  ("QuickLook preview fix", true)]),
-            (-3, [("Single-instance lock", true),
-                  ("Update checker polling", true),
-                  ("Draft user guide section", false)]),
-        ]
-
-        var out: [TodoGroup] = []
-        for (offset, items) in plan {
-            guard let date = cal.date(byAdding: .day, value: offset, to: base) else { continue }
-            let key = TodoGroup.keyFormatter.string(from: date)
-            let tasks = items.map { TodoTask(id: TodoTask.newID(), name: $0.0, done: $0.1) }
-            out.append(TodoGroup(key: key, date: date, tasks: tasks))
-        }
-        out.sort { $0.date > $1.date }   // latest date on top, desc
-        return out
     }
 }
 
@@ -286,12 +304,45 @@ enum TodoSharedState {
     @MainActor static let shared = TodoState()
 }
 
-// Intentionally a no-op today. Kept as a named seam so wiring real
-// storage later is a one-file change and TodoState needs no edits.
-
+// Bridges the panel's grouped model to the shared core backend (via
+// EngineBridge → look_todo). Load reads the flat task set and groups it
+// by date; save flattens the groups back and replaces the stored set.
 enum TodoPersistence {
-    static func load() -> [TodoGroup]? { nil }
-    static func save(_ groups: [TodoGroup]) { /* no DB yet */ }
+    static func load() -> [TodoGroup] {
+        groups(from: EngineBridge.shared.todoList())
+    }
+
+    static func save(_ groups: [TodoGroup]) {
+        EngineBridge.shared.todoSave(backendTasks(from: groups))
+    }
+
+    private static func groups(from tasks: [TodoBackendTask]) -> [TodoGroup] {
+        let cal = Calendar.current
+        var byDate: [String: [TodoTask]] = [:]
+        for task in tasks {
+            byDate[task.dueDate, default: []].append(
+                TodoTask(
+                    id: task.id, name: task.name, done: task.done,
+                    createdAtUnixS: task.createdAtUnixS))
+        }
+        var out: [TodoGroup] = []
+        for (key, list) in byDate {
+            guard let date = TodoGroup.keyFormatter.date(from: key) else { continue }
+            out.append(TodoGroup(key: key, date: cal.startOfDay(for: date), tasks: list))
+        }
+        out.sort { $0.date > $1.date }
+        return out
+    }
+
+    private static func backendTasks(from groups: [TodoGroup]) -> [TodoBackendTask] {
+        groups.flatMap { group in
+            group.tasks.map { task in
+                TodoBackendTask(
+                    id: task.id, name: task.name, done: task.done,
+                    dueDate: group.key, createdAtUnixS: task.createdAtUnixS)
+            }
+        }
+    }
 }
 
 /// One day cell in the activity heatmap: a real date with that day's
@@ -313,35 +364,65 @@ struct TodoHeatDay: Identifiable, Equatable {
     }
 }
 
-// Deterministic seeded series so the charts render a stable shape.
-// Placeholder aggregates until storage exists.
+// Real aggregates over the loaded task set. The client holds the full
+// retained year in memory, so every chart derives from `groups` and
+// updates live as tasks change.
 
 enum TodoAnalytics {
-    static let week = TodoStat(done: 12, total: 18)
-    static let month = TodoStat(done: 47, total: 62)
-    static let streakDays = 6
-
-    /// Deterministic linear congruential generator.
-    private struct Seeded {
-        var s: Int
-        init(_ n: Int) { s = n &* 9301 &+ 49297 }
-        mutating func next() -> Double {
-            s = (s &* 9301 &+ 49297) % 233_280
-            return Double(s) / 233_280.0
+    /// (done, total) per start-of-day.
+    static func dayCounts(_ groups: [TodoGroup]) -> [Date: (done: Int, total: Int)] {
+        var out: [Date: (done: Int, total: Int)] = [:]
+        for g in groups where !g.tasks.isEmpty {
+            let prior = out[g.date] ?? (0, 0)
+            out[g.date] = (prior.done + g.doneCount, prior.total + g.total)
         }
+        return out
     }
 
-    /// Last 30 days, done-count per day, capped at the daily task limit.
-    static func monthTrend() -> [Int] {
-        let cap = TodoCommand.taskLimit
-        var r = Seeded(7)
+    /// Done/total for the calendar period containing today (.weekOfYear
+    /// for the week card, .month for the month card).
+    static func stat(_ groups: [TodoGroup], sameAs component: Calendar.Component) -> TodoStat {
+        let cal = Calendar.current
+        let now = Date()
+        var done = 0
+        var total = 0
+        for g in groups where cal.isDate(g.date, equalTo: now, toGranularity: component) {
+            done += g.doneCount
+            total += g.total
+        }
+        return TodoStat(done: done, total: total)
+    }
+
+    /// Done-count per day for the last 30 days, oldest first.
+    static func monthTrend(_ groups: [TodoGroup]) -> [Int] {
+        let cal = Calendar.current
+        let today = cal.startOfDay(for: Date())
+        let counts = dayCounts(groups)
         var arr: [Int] = []
-        for i in 0..<30 {
-            let base = sin(Double(i) / 4) * Double(cap) * 0.45 + Double(cap) * 0.65
-            let v = base + (r.next() - 0.5) * Double(cap) * 0.9
-            arr.append(max(0, min(cap, Int(v.rounded()))))
+        for offset in -29...0 {
+            guard let date = cal.date(byAdding: .day, value: offset, to: today) else { continue }
+            arr.append(counts[date]?.done ?? 0)
         }
         return arr
+    }
+
+    /// Consecutive days with at least one completed task, counting back
+    /// from today. A doneless today doesn't break the streak until the
+    /// day is actually over, so the walk starts at yesterday and today
+    /// only extends it.
+    static func streakDays(_ groups: [TodoGroup]) -> Int {
+        let cal = Calendar.current
+        let today = cal.startOfDay(for: Date())
+        let counts = dayCounts(groups)
+        var streak = (counts[today]?.done ?? 0) > 0 ? 1 : 0
+        var cursor = today
+        while let prev = cal.date(byAdding: .day, value: -1, to: cursor),
+            (counts[prev]?.done ?? 0) > 0
+        {
+            streak += 1
+            cursor = prev
+        }
+        return streak
     }
 
     /// A year of activity as GitHub-style week columns (each column is a
@@ -349,14 +430,14 @@ enum TodoAnalytics {
     /// in the current week are empty placeholders.
     static let heatmapWeekCount = 52
 
-    static func heatmapDays() -> [[TodoHeatDay]] {
+    static func heatmapDays(_ groups: [TodoGroup]) -> [[TodoHeatDay]] {
         let cal = Calendar.current
         let today = cal.startOfDay(for: Date())
         let daysSinceSunday = cal.component(.weekday, from: today) - 1
         guard let lastSunday = cal.date(byAdding: .day, value: -daysSinceSunday, to: today)
         else { return [] }
 
-        var r = Seeded(21)
+        let counts = dayCounts(groups)
         var columns: [[TodoHeatDay]] = []
         for w in stride(from: heatmapWeekCount - 1, through: 0, by: -1) {
             guard let colSunday = cal.date(byAdding: .day, value: -7 * w, to: lastSunday)
@@ -364,14 +445,8 @@ enum TodoAnalytics {
             var col: [TodoHeatDay] = []
             for d in 0..<7 {
                 guard let date = cal.date(byAdding: .day, value: d, to: colSunday) else { continue }
-                if date > today {
-                    col.append(TodoHeatDay(date: date, done: 0, total: 0))
-                    continue
-                }
-                let v = r.next()
-                let done = v > 0.82 ? 3 : (v > 0.60 ? 2 : (v > 0.36 ? 1 : 0))
-                let total = done + (r.next() > 0.55 ? 1 : 0)
-                col.append(TodoHeatDay(date: date, done: done, total: total))
+                let day = date > today ? (done: 0, total: 0) : (counts[date] ?? (done: 0, total: 0))
+                col.append(TodoHeatDay(date: date, done: day.done, total: day.total))
             }
             columns.append(col)
         }
@@ -381,6 +456,12 @@ enum TodoAnalytics {
     static let heatDateFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "EEE, MMM d"
+        return f
+    }()
+
+    static let axisDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d"
         return f
     }()
 }

--- a/apps/macos/LauncherApp/look-app/Views/Commands/TodoView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/TodoView.swift
@@ -39,7 +39,7 @@ struct TodoView: View {
                 if page == .tasks {
                     TodoTasksPage(themeStore: themeStore, state: state, search: search)
                 } else {
-                    TodoAnalyticsPage(themeStore: themeStore)
+                    TodoAnalyticsPage(themeStore: themeStore, state: state)
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -72,7 +72,12 @@ struct TodoView: View {
             ))
         // The launcher does not focus /todo (it owns its own field), so
         // focus the search bar on entry and when returning to Tasks.
-        .onAppear { focusSearchIfTasks() }
+        // ensureTodayGroup covers day rollover while the app stays
+        // resident (state loads once, at first access).
+        .onAppear {
+            state.ensureTodayGroup()
+            focusSearchIfTasks()
+        }
         .onChange(of: page) { _, _ in focusSearchIfTasks() }
     }
 
@@ -253,18 +258,39 @@ struct TodoTasksPage: View {
     @Bindable var state: TodoState
     let search: String
 
+    private var query: String {
+        search.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    // Browsing shows future + today + the recent window; search spans
+    // the full retained year.
     private var filteredGroups: [TodoGroup] {
-        let q = search.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !q.isEmpty else { return state.groups }
+        guard !query.isEmpty else { return recentGroups }
         return state.groups.compactMap { g in
             let groupHay = "\(g.weekday) \(g.monthDay) \(g.relative)"
-            if TodoCommand.fuzzyMatch(q, groupHay) { return g }
-            let tasks = g.tasks.filter { TodoCommand.fuzzyMatch(q, $0.name) }
+            if TodoCommand.fuzzyMatch(query, groupHay) { return g }
+            let tasks = g.tasks.filter { TodoCommand.fuzzyMatch(query, $0.name) }
             guard !tasks.isEmpty else { return nil }
             var copy = g
             copy.tasks = tasks
             return copy
         }
+    }
+
+    private var recentGroups: [TodoGroup] {
+        let cal = Calendar.current
+        guard
+            let cutoff = cal.date(
+                byAdding: .day, value: -TodoCommand.listWindowDays,
+                to: cal.startOfDay(for: Date()))
+        else { return state.groups }
+        return state.groups.filter { $0.date >= cutoff }
+    }
+
+    /// Days hidden below the browse window (0 while searching, since
+    /// search already spans everything).
+    private var hiddenOlderDays: Int {
+        query.isEmpty ? state.groups.count - recentGroups.count : 0
     }
 
     var body: some View {
@@ -280,6 +306,14 @@ struct TodoTasksPage: View {
                         .foregroundStyle(themeStore.mutedTextColor())
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 24)
+                }
+
+                if hiddenOlderDays > 0 {
+                    Text("\(hiddenOlderDays) older day\(hiddenOlderDays == 1 ? "" : "s") not shown · search to find them")
+                        .font(themeStore.uiFont(size: 11))
+                        .foregroundStyle(themeStore.mutedTextColor())
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 6)
                 }
             }
             .padding(.horizontal, 4)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
@@ -289,6 +289,8 @@ struct HintBar: View {
     struct TodoQuickView {
         let done: Int
         let total: Int
+        /// Names of today's unfinished tasks, listed in the hover tooltip.
+        let openTasks: [String]
         let onTap: () -> Void
     }
 
@@ -321,7 +323,26 @@ struct HintBar: View {
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .help("Open /todo")
+                // hoverBubble (not hoverTooltip): the popover would
+                // swallow the first click; the bubble is click-through,
+                // so tapping always opens /todo directly.
+                .hoverBubble(isEnabled: !todo.openTasks.isEmpty, width: 240) {
+                    openTasksBubbleContent(todo)
+                }
+            }
+        }
+    }
+
+    private func openTasksBubbleContent(_ todo: TodoQuickView) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Unfinished today")
+                .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 3), weight: .semibold))
+                .foregroundStyle(themeStore.mutedTextColor())
+            ForEach(Array(todo.openTasks.enumerated()), id: \.offset) { _, name in
+                Text("• \(name)")
+                    .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2)))
+                    .foregroundStyle(themeStore.fontColor())
+                    .lineLimit(2)
             }
         }
     }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -474,9 +474,11 @@ struct LauncherView: View {
     /// off the home screen or today has no tasks (then it stays empty).
     var todoQuickView: HintBar.TodoQuickView? {
         guard isHomeHintScreen else { return nil }
-        let stat = TodoSharedState.shared.todayStat
+        let state = TodoSharedState.shared
+        let stat = state.todayStat
         guard stat.total > 0 else { return nil }
-        return HintBar.TodoQuickView(done: stat.done, total: stat.total) {
+        let open = state.today?.tasks.filter { !$0.done }.map(\.name) ?? []
+        return HintBar.TodoQuickView(done: stat.done, total: stat.total, openTasks: open) {
             enterCommandMode(commandID: AppConstants.Launcher.Command.todo, prefilledInput: "")
         }
     }

--- a/bridge/ffi/Cargo.lock
+++ b/bridge/ffi/Cargo.lock
@@ -313,6 +313,7 @@ dependencies = [
  "look-engine",
  "look-indexing",
  "look-storage",
+ "look-todo",
  "notify",
  "serde",
  "serde_json",
@@ -342,6 +343,14 @@ version = "0.1.0"
 dependencies = [
  "look-indexing",
  "rusqlite",
+]
+
+[[package]]
+name = "look-todo"
+version = "0.1.0"
+dependencies = [
+ "rusqlite",
+ "serde",
 ]
 
 [[package]]

--- a/bridge/ffi/Cargo.toml
+++ b/bridge/ffi/Cargo.toml
@@ -12,6 +12,7 @@ look-answers = { path = "../../core/answers" }
 look-engine = { path = "../../core/engine" }
 look-indexing = { path = "../../core/indexing" }
 look-storage = { path = "../../core/storage" }
+look-todo = { path = "../../core/todo" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 notify = "8"

--- a/bridge/ffi/src/lib.rs
+++ b/bridge/ffi/src/lib.rs
@@ -5,6 +5,7 @@ mod runtime_config;
 mod search_api;
 mod seed_api;
 mod state;
+mod todo_api;
 mod translate_api;
 mod usage_api;
 
@@ -87,6 +88,25 @@ pub extern "C" fn look_seed_uwp_apps_json(json: *const c_char) -> bool {
 pub extern "C" fn look_request_index_refresh() -> bool {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         state::request_background_index_refresh()
+    }))
+    .unwrap_or(false)
+}
+
+/// Returns the full /todo task set as a JSON array. Free with
+/// `look_free_cstring`.
+#[unsafe(no_mangle)]
+pub extern "C" fn look_todo_list_json() -> *mut c_char {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        todo_api::look_todo_list_json_impl()
+    }))
+    .unwrap_or(std::ptr::null_mut())
+}
+
+/// Replaces the /todo task set from a JSON array. Returns true on success.
+#[unsafe(no_mangle)]
+pub extern "C" fn look_todo_save_json(json: *const c_char) -> bool {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        todo_api::look_todo_save_json_impl(json)
     }))
     .unwrap_or(false)
 }
@@ -439,6 +459,56 @@ mod tests {
             .map(|d| d.as_nanos())
             .unwrap_or(0);
         env::temp_dir().join(format!("look-ffi-config-smoke-{nanos}.config"))
+    }
+
+    #[test]
+    fn ffi_todo_save_and_list_round_trip() {
+        let lock = TEST_MUTEX.get_or_init(|| Mutex::new(()));
+        let _guard = lock.lock().expect("test lock poisoned");
+
+        // The todo store resolves LOOK_DB_PATH on every call, so pointing
+        // it at a scratch database keeps the test off the real look.db.
+        let db_path = unique_test_db_path();
+        let _ = fs::remove_file(&db_path);
+        unsafe {
+            env::set_var("LOOK_DB_PATH", db_path.as_os_str());
+        }
+
+        // Far-future due_date so the retention prune never removes it.
+        let tasks = CString::new(
+            r#"[{"id":"t1","name":"Ship the todo backend","done":true,"due_date":"2999-01-01","created_at_unix_s":1000}]"#,
+        )
+        .expect("tasks cstring");
+        assert!(look_todo_save_json(tasks.as_ptr()), "save should succeed");
+
+        let ptr = look_todo_list_json();
+        assert!(!ptr.is_null());
+        let raw = unsafe { CStr::from_ptr(ptr) }
+            .to_string_lossy()
+            .into_owned();
+        look_free_cstring(ptr);
+        assert!(
+            raw.contains("Ship the todo backend"),
+            "list should return the saved task, got: {raw}"
+        );
+        assert!(raw.contains(r#""due_date":"2999-01-01""#));
+
+        // Save is a full replace: an empty set clears the table.
+        let empty = CString::new("[]").expect("empty cstring");
+        assert!(look_todo_save_json(empty.as_ptr()));
+        let ptr = look_todo_list_json();
+        assert!(!ptr.is_null());
+        let raw = unsafe { CStr::from_ptr(ptr) }
+            .to_string_lossy()
+            .into_owned();
+        look_free_cstring(ptr);
+        assert_eq!(raw, "[]");
+
+        // Malformed JSON is rejected without touching the store.
+        let bad = CString::new("not json").expect("bad cstring");
+        assert!(!look_todo_save_json(bad.as_ptr()));
+
+        let _ = fs::remove_file(&db_path);
     }
 
     #[test]

--- a/bridge/ffi/src/todo_api.rs
+++ b/bridge/ffi/src/todo_api.rs
@@ -1,0 +1,44 @@
+//! C-ABI wrappers over `look_todo`, so the macOS Swift shell persists the
+//! /todo command's tasks through the same store linows uses. Two endpoints:
+//! `list` returns the full task set as JSON, `save` replaces it from JSON.
+//! Both are best-effort and panic-safe at the `lib.rs` boundary.
+
+use crate::state::{cstr_to_string, default_db_path, store_json_allocation};
+use look_todo::{TodoStore, TodoTask};
+use std::ffi::CString;
+use std::os::raw::c_char;
+
+const JSON_EMPTY_ARRAY: &str = "[]";
+
+/// Opens the todo table in the same look.db the engine uses (separate
+/// connection, own table). Opened per call rather than held: /todo reads
+/// once per app launch and writes on explicit save, so connection reuse
+/// buys nothing, and resolving the path each call keeps `LOOK_DB_PATH`
+/// honored (tests point it at a scratch database).
+fn with_store<T>(f: impl FnOnce(&mut TodoStore) -> T) -> Option<T> {
+    let mut store = TodoStore::open(default_db_path()).ok()?;
+    Some(f(&mut store))
+}
+
+/// Returns every stored task (within the one-year retention window) as a
+/// JSON array of `TodoTask`. Empty array on any failure.
+pub(crate) fn look_todo_list_json_impl() -> *mut c_char {
+    let json = with_store(|store| store.list().ok())
+        .flatten()
+        .and_then(|tasks| serde_json::to_string(&tasks).ok())
+        .unwrap_or_else(|| JSON_EMPTY_ARRAY.to_string());
+    let cstring =
+        CString::new(json).unwrap_or_else(|_| CString::new(JSON_EMPTY_ARRAY).expect("valid"));
+    store_json_allocation(cstring)
+}
+
+/// Replaces the full task set with the JSON array of `TodoTask` in `json`.
+/// Returns true on success.
+pub(crate) fn look_todo_save_json_impl(json: *const c_char) -> bool {
+    let raw = cstr_to_string(json);
+    let tasks: Vec<TodoTask> = match serde_json::from_str(&raw) {
+        Ok(tasks) => tasks,
+        Err(_) => return false,
+    };
+    with_store(|store| store.save(&tasks).is_ok()).unwrap_or(false)
+}

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -271,6 +271,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "look-todo"
+version = "0.1.0"
+dependencies = [
+ "rusqlite",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "matching",
   "ranking",
   "storage",
+  "todo",
 ]
 resolver = "2"
 

--- a/core/todo/Cargo.toml
+++ b/core/todo/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "look-todo"
+edition = "2024"
+license = "MIT"
+version = "0.1.0"
+
+[dependencies]
+rusqlite = { version = "0.40", features = ["bundled"] }
+serde = { version = "1", features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1"

--- a/core/todo/src/lib.rs
+++ b/core/todo/src/lib.rs
@@ -1,0 +1,279 @@
+//! Shared todo backend for Look.
+//!
+//! Persists the /todo command's tasks in SQLite so both the macOS app
+//! (via `bridge/ffi`) and linows (via its Tauri command layer) use the
+//! same store. The crate owns only the `todo_tasks` table and its
+//! migration; the caller passes the path to the app's existing database
+//! (`look.db`), so todos live alongside candidates/usage rather than in
+//! a second file. Data is kept for one year (see [`RETENTION_DAYS`]);
+//! older days are pruned on load and save.
+//!
+//! Persistence contract mirrors the app's "edit in memory, hit Save"
+//! model: the client loads the full task set with [`TodoStore::list`],
+//! edits it locally, and writes the whole set back with
+//! [`TodoStore::save`], which is a lossless full replace.
+
+use rusqlite::{Connection, params};
+use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
+use std::path::Path;
+
+/// Retention window. Tasks whose `due_date` is older than this are
+/// pruned. A little over a year to give leap-day slack.
+pub const RETENTION_DAYS: i64 = 366;
+
+#[derive(Debug)]
+pub enum TodoError {
+    Io(std::io::Error),
+    Sql(rusqlite::Error),
+}
+
+impl Display for TodoError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TodoError::Io(err) => write!(f, "io error: {err}"),
+            TodoError::Sql(err) => write!(f, "sqlite error: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for TodoError {}
+
+impl From<std::io::Error> for TodoError {
+    fn from(value: std::io::Error) -> Self {
+        TodoError::Io(value)
+    }
+}
+
+impl From<rusqlite::Error> for TodoError {
+    fn from(value: rusqlite::Error) -> Self {
+        TodoError::Sql(value)
+    }
+}
+
+pub type TodoResult<T> = Result<T, TodoError>;
+
+/// A single task. `due_date` is the day it belongs to, `yyyy-MM-dd`, and
+/// also how the client groups tasks into date sections.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TodoTask {
+    pub id: String,
+    pub name: String,
+    pub done: bool,
+    pub due_date: String,
+    pub created_at_unix_s: i64,
+}
+
+pub struct TodoStore {
+    conn: Connection,
+}
+
+impl TodoStore {
+    pub fn open(path: impl AsRef<Path>) -> TodoResult<Self> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let conn = Connection::open(path)?;
+        let store = Self { conn };
+        store.migrate()?;
+        Ok(store)
+    }
+
+    pub fn open_in_memory() -> TodoResult<Self> {
+        let conn = Connection::open_in_memory()?;
+        let store = Self { conn };
+        store.migrate()?;
+        Ok(store)
+    }
+
+    fn migrate(&self) -> TodoResult<()> {
+        self.conn.execute_batch(
+            // The table shares look.db with the engine's connection, so WAL
+            // (already the file's mode) plus a busy timeout keeps the two
+            // writers from tripping over each other.
+            "PRAGMA journal_mode = WAL;
+             PRAGMA busy_timeout = 2000;
+
+             CREATE TABLE IF NOT EXISTS todo_tasks (
+                 id TEXT PRIMARY KEY,
+                 name TEXT NOT NULL,
+                 done INTEGER NOT NULL DEFAULT 0,
+                 due_date TEXT NOT NULL,
+                 created_at_unix_s INTEGER NOT NULL
+             );
+
+             CREATE INDEX IF NOT EXISTS idx_todo_due ON todo_tasks(due_date);",
+        )?;
+        Ok(())
+    }
+
+    /// All tasks, newest day first, after pruning anything past the
+    /// one-year retention window.
+    pub fn list(&self) -> TodoResult<Vec<TodoTask>> {
+        self.prune_expired()?;
+        let mut stmt = self.conn.prepare(
+            "SELECT id, name, done, due_date, created_at_unix_s
+             FROM todo_tasks
+             ORDER BY due_date DESC, created_at_unix_s ASC, id ASC",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(TodoTask {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                done: row.get::<_, i64>(2)? != 0,
+                due_date: row.get(3)?,
+                created_at_unix_s: row.get(4)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row?);
+        }
+        Ok(out)
+    }
+
+    /// Replaces the entire task set with `tasks`. The client always holds
+    /// the full set it loaded, so a full replace is lossless. Tasks with a
+    /// blank name are dropped. Expired days are pruned afterwards.
+    pub fn save(&mut self, tasks: &[TodoTask]) -> TodoResult<()> {
+        let tx = self.conn.transaction()?;
+        tx.execute("DELETE FROM todo_tasks", [])?;
+        {
+            let mut stmt = tx.prepare(
+                "INSERT OR REPLACE INTO todo_tasks
+                     (id, name, done, due_date, created_at_unix_s)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+            )?;
+            for task in tasks {
+                let name = task.name.trim();
+                if name.is_empty() {
+                    continue;
+                }
+                stmt.execute(params![
+                    task.id,
+                    name,
+                    task.done as i64,
+                    task.due_date,
+                    task.created_at_unix_s,
+                ])?;
+            }
+        }
+        tx.commit()?;
+        self.prune_expired()?;
+        Ok(())
+    }
+
+    /// Deletes tasks whose day is older than the retention window. Uses
+    /// SQLite's own date math so it stays correct without a date crate.
+    pub fn prune_expired(&self) -> TodoResult<usize> {
+        let removed = self.conn.execute(
+            "DELETE FROM todo_tasks WHERE due_date < date('now', ?1)",
+            params![format!("-{RETENTION_DAYS} days")],
+        )?;
+        Ok(removed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn task(id: &str, name: &str, done: bool, due: &str) -> TodoTask {
+        TodoTask {
+            id: id.into(),
+            name: name.into(),
+            done,
+            due_date: due.into(),
+            created_at_unix_s: 1_000,
+        }
+    }
+
+    #[test]
+    fn open_in_memory_creates_schema() {
+        let store = TodoStore::open_in_memory().expect("open");
+        assert!(store.list().expect("list").is_empty());
+    }
+
+    #[test]
+    fn save_then_list_round_trips() {
+        let mut store = TodoStore::open_in_memory().expect("open");
+        store
+            .save(&[
+                task("a", "Ship PR", true, "2026-07-05"),
+                task("b", "Review spec", false, "2026-07-05"),
+                task("c", "Grocery run", false, "2026-07-04"),
+            ])
+            .expect("save");
+
+        let loaded = store.list().expect("list");
+        assert_eq!(loaded.len(), 3);
+        // Newest day first.
+        assert_eq!(loaded[0].due_date, "2026-07-05");
+        assert_eq!(loaded[2].due_date, "2026-07-04");
+        assert!(loaded[0].done);
+    }
+
+    #[test]
+    fn save_is_a_full_replace() {
+        let mut store = TodoStore::open_in_memory().expect("open");
+        store
+            .save(&[task("a", "First", false, "2026-07-05")])
+            .expect("save 1");
+        store
+            .save(&[task("b", "Second", false, "2026-07-05")])
+            .expect("save 2");
+
+        let loaded = store.list().expect("list");
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].id, "b");
+    }
+
+    #[test]
+    fn save_drops_blank_names() {
+        let mut store = TodoStore::open_in_memory().expect("open");
+        store
+            .save(&[
+                task("a", "Real", false, "2026-07-05"),
+                task("b", "   ", false, "2026-07-05"),
+            ])
+            .expect("save");
+        assert_eq!(store.list().expect("list").len(), 1);
+    }
+
+    #[test]
+    fn json_shape_is_the_ffi_contract() {
+        // The Swift and (future) linows clients decode these exact keys;
+        // a rename here is a breaking cross-layer change.
+        let t = task("a", "Ship PR", true, "2026-07-05");
+        let json = serde_json::to_string(&t).expect("serialize");
+        for key in [
+            "\"id\"",
+            "\"name\"",
+            "\"done\"",
+            "\"due_date\"",
+            "\"created_at_unix_s\"",
+        ] {
+            assert!(json.contains(key), "missing {key} in {json}");
+        }
+        let back: TodoTask = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, t);
+    }
+
+    #[test]
+    fn expired_days_are_pruned() {
+        let mut store = TodoStore::open_in_memory().expect("open");
+        // A day well outside the retention window is dropped; a recent day
+        // is kept. `date('now')` is evaluated by SQLite at prune time.
+        store
+            .save(&[
+                task("old", "Ancient", true, "2000-01-01"),
+                task("new", "Recent", false, "2999-01-01"),
+            ])
+            .expect("save");
+        let loaded = store.list().expect("list");
+        let ids: Vec<&str> = loaded.iter().map(|t| t.id.as_str()).collect();
+        assert!(!ids.contains(&"old"), "expired day pruned");
+        assert!(ids.contains(&"new"), "recent day kept");
+    }
+}


### PR DESCRIPTION
## Summary

- Shared back-end for **todo** command, linows can also use it.
- Create a todo_tasks table in the database
- Wire UI with the real Data Modification, Selection capabilities 

## Why

- #236 

## Changes

-

## Testing

- [x] `cargo check --workspace --manifest-path core/Cargo.toml`
- [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
- [x] MacOS


## Checklist

- [x] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [x] Backward compatibility considered
