### PR TITLE
feat: local build app image

### DIFF
--- a/apps/linows/BUILDING.md
+++ b/apps/linows/BUILDING.md
@@ -112,6 +112,31 @@ scripts\windows\with-vcvars.bat cargo clippy --manifest-path apps\linows\src-tau
 
 ---
 
+## Building an AppImage Locally
+
+Release AppImages are built by CI (`release-linux.yml`) on ubuntu-22.04. To build one locally from your current working tree, for example to test a fix on Fedora or openSUSE before releasing:
+
+```bash
+scripts/linux/build-appimage.sh
+```
+
+Requires docker. The script builds a `look-appimage-builder` image (ubuntu-22.04 with the same dependency list as CI) and runs `cargo tauri build --bundles appimage` inside it. The cargo target dir and caches live in named docker volumes (`look-appimage-target`, `look-appimage-registry`, `look-appimage-cache`), so incremental rebuilds are fast and host build dirs stay untouched.
+
+Output: `dist/Look_<version>_amd64.AppImage` at the repo root (gitignored).
+
+**Why a container:** Tauri's AppImage bundler runs linuxdeploy, which is itself an AppImage and needs an FHS system. On NixOS it fails outright, and even if forced, the produced binary would embed a `/nix/store` ELF interpreter path and not run on other distros. Building on ubuntu-22.04 also pins the glibc baseline to match releases.
+
+**Running on the target machine:**
+
+```bash
+chmod +x Look_*.AppImage
+./Look_*.AppImage
+```
+
+If FUSE is missing, run with `--appimage-extract-and-run`, or install it (Fedora: `sudo dnf install fuse fuse-libs`).
+
+---
+
 ## Runtime Dependencies
 
 | Dependency         | Purpose                         |
@@ -222,11 +247,6 @@ For non-NixOS Nix users: `cachix use look` then `nix profile install`.
 
 ### AppImage (universal)
 
-**Target:** Download from GitHub Releases, `chmod +x && ./lookapp_*.AppImage`
+**Status:** Available now.
 
-Steps to implement:
-
-1. Add `"appimage"` to `bundle.targets` in `tauri.conf.json`
-2. Built automatically alongside .deb by `cargo tauri build`
-3. CI uploads to GitHub Releases
-4. Test: run on a minimal distro (Fedora, openSUSE) to verify bundled deps
+Download `Look_<version>_amd64.AppImage` from GitHub Releases, then `chmod +x && ./Look_*.AppImage`. Built by CI alongside the .deb. For local builds see [Building an AppImage Locally](#building-an-appimage-locally).

--- a/scripts/linux/build-appimage.sh
+++ b/scripts/linux/build-appimage.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Build a portable Linux AppImage in an ubuntu-22.04 container, mirroring
+# .github/workflows/release-linux.yml so local builds match release builds.
+# Works on any docker host, including NixOS where Tauri's AppImage tooling
+# cannot run directly.
+#
+# Output: dist/Look_<version>_amd64.AppImage at the repo root.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+IMAGE=look-appimage-builder
+
+docker build -t "$IMAGE" - <<'EOF'
+FROM ubuntu:22.04
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libwebkit2gtk-4.1-dev libgtk-3-dev libsoup-3.0-dev libglib2.0-dev \
+    libcairo2-dev libpango1.0-dev libgdk-pixbuf-2.0-dev libharfbuzz-dev \
+    libdbus-1-dev libasound2-dev librsvg2-dev libssl-dev libappindicator3-dev \
+    pkg-config curl ca-certificates build-essential file wget xdg-utils \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+ENV PATH=/root/.cargo/bin:$PATH
+RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash \
+    && cargo binstall -y tauri-cli --version "^2"
+# linuxdeploy is itself an AppImage and there is no FUSE inside the container
+ENV APPIMAGE_EXTRACT_AND_RUN=1
+EOF
+
+docker run --rm \
+  -v "$REPO_ROOT":/work \
+  -v look-appimage-target:/target \
+  -v look-appimage-registry:/root/.cargo/registry \
+  -v look-appimage-cache:/root/.cache \
+  -e CARGO_TARGET_DIR=/target \
+  -e HOST_UID="$(id -u)" -e HOST_GID="$(id -g)" \
+  -w /work/apps/linows \
+  "$IMAGE" bash -euc '
+    cargo tauri build --bundles appimage
+    mkdir -p /work/dist
+    cp /target/release/bundle/appimage/*.AppImage /work/dist/
+    for f in /work/dist/*.AppImage; do
+      /work/scripts/linux/strip-appimage-wayland-libs.sh "$f"
+    done
+    chown -R "$HOST_UID:$HOST_GID" /work/dist
+  '
+
+echo "AppImage written to $REPO_ROOT/dist/"


### PR DESCRIPTION
## Summary

- Some users use AppImage in their machine -> we add this as a guideline of building app image in the local machine by docker.

## Why

- For testing purpose
