### PR TITLE
feat: sync prepare

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,6 @@
 
 ## Why
 
--
 
 ## Changes
 
@@ -13,22 +12,22 @@
 ## Testing
 
 - `core`
-- [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
-- [ ] `cargo test --workspace --manifest-path core/Cargo.toml`
+  - [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
+  - [ ] `cargo test --workspace --manifest-path core/Cargo.toml`
 
 - `bridge/ffi`
-- [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
-- [ ] `cargo test --manifest-path bridge/ffi/Cargo.toml`
+  - [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
+  - [ ] `cargo test --manifest-path bridge/ffi/Cargo.toml`
 
 - `apps/linows`
-- [ ] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
-- [ ] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
-- [ ] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
-- [ ] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
-- [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
-- [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
-- [ ] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
-- [ ] Manual verification completed (if UI/behavior changed)
+  - [ ] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
+  - [ ] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
+  - [ ] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
+  - [ ] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
+  - [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
+  - [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
+  - [ ] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
+  - [ ] Manual verification completed (if UI/behavior changed)
 
 ## Screenshots / Recordings (if UI changed)
 

--- a/apps/linows/src/js/platform.js
+++ b/apps/linows/src/js/platform.js
@@ -12,6 +12,10 @@ export async function init() {
   if (info.compositor) {
     document.documentElement.setAttribute('data-compositor', info.compositor);
   }
+  // Mirror of apply_transparency (main.rs) with the same has_compositor
+  // semantics: the Rust eval runs once at setup, so a page reload (dev hot
+  // reload) would otherwise lose the attribute and square the corners.
+  document.documentElement.setAttribute('data-transparent', String(hasCompositor()));
 }
 
 export function os() {
@@ -58,14 +62,10 @@ const WINDOWS_BLUR_RADIUS = {
  * - Linux bare (i3): no blur, tint-only
  */
 export function applyBlur(radius, style) {
-  if (isWindows()) {
-    const r = WINDOWS_BLUR_RADIUS[style] ?? WINDOWS_BLUR_RADIUS.balanced;
-    document.documentElement.style.setProperty('--blur-radius', r + 'px');
-  } else {
-    // Linux: CSS backdrop-filter (works if compositor supports it)
-    const r = hasCompositor() ? Math.round(radius) : 0;
-    document.documentElement.style.setProperty('--blur-radius', r + 'px');
-  }
+  const r = isWindows()
+    ? WINDOWS_BLUR_RADIUS[style] ?? WINDOWS_BLUR_RADIUS.balanced
+    : hasCompositor() ? Math.round(radius) : 0;
+  document.documentElement.style.setProperty('--blur-radius', r + 'px');
 }
 
 /**

--- a/apps/linows/src/js/screens/commands/todo.js
+++ b/apps/linows/src/js/screens/commands/todo.js
@@ -287,7 +287,8 @@ function relativePhrase(diff) {
   return '';
 }
 
-const newTaskId = () => `n${Math.random().toString(36).slice(2, 8)}`;
+// UUIDs so ids stay unique across machines once task sync lands.
+const newTaskId = () => crypto.randomUUID();
 const nowUnixS = () => Math.floor(Date.now() / 1000);
 
 // --- Mutations (in-memory; Save persists) ---

--- a/apps/macos/LauncherApp/look-app/Views/Commands/TodoCommand.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/TodoCommand.swift
@@ -19,8 +19,9 @@ struct TodoTask: Identifiable, Equatable {
     /// When the task was created, for backend round-tripping.
     var createdAtUnixS: Int64 = Int64(Date().timeIntervalSince1970)
 
+    // Full UUIDs so ids stay unique across machines once task sync lands.
     static func newID() -> String {
-        "n" + UUID().uuidString.prefix(6).lowercased()
+        UUID().uuidString.lowercased()
     }
 }
 

--- a/core/todo/src/lib.rs
+++ b/core/todo/src/lib.rs
@@ -2,21 +2,29 @@
 //!
 //! Persists the /todo command's tasks in SQLite so both the macOS app
 //! (via `bridge/ffi`) and linows (via its Tauri command layer) use the
-//! same store. The crate owns only the `todo_tasks` table and its
-//! migration; the caller passes the path to the app's existing database
-//! (`look.db`), so todos live alongside candidates/usage rather than in
-//! a second file. Data is kept for one year (see [`RETENTION_DAYS`]);
-//! older days are pruned on load and save.
+//! same store. The crate owns the `todo_tasks` and `todo_tombstones`
+//! tables and their migration; the caller passes the path to the app's
+//! existing database (`look.db`), so todos live alongside
+//! candidates/usage rather than in a second file. Data is kept for one
+//! year (see [`RETENTION_DAYS`]); older days are pruned on load and save.
 //!
 //! Persistence contract mirrors the app's "edit in memory, hit Save"
 //! model: the client loads the full task set with [`TodoStore::list`],
 //! edits it locally, and writes the whole set back with
 //! [`TodoStore::save`], which is a lossless full replace.
+//!
+//! The store also keeps per-task update stamps and deletion tombstones
+//! (see docs/todo-sync.md). Clients never see either; [`TodoStore::save`]
+//! maintains them by diffing the incoming set against what is stored, so
+//! a future cross-machine merge can order edits and tell "deleted here"
+//! from "created elsewhere".
 
 use rusqlite::{Connection, params};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Retention window. Tasks whose `due_date` is older than this are
 /// pruned. A little over a year to give leap-day slack.
@@ -68,6 +76,21 @@ pub struct TodoStore {
     conn: Connection,
 }
 
+/// Stored row content used to decide whether a saved task changed.
+struct StoredTask {
+    name: String,
+    done: bool,
+    due_date: String,
+    updated_at_unix_s: i64,
+}
+
+fn now_unix_s() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before unix epoch")
+        .as_secs() as i64
+}
+
 impl TodoStore {
     pub fn open(path: impl AsRef<Path>) -> TodoResult<Self> {
         let path = path.as_ref();
@@ -89,7 +112,7 @@ impl TodoStore {
 
     fn migrate(&self) -> TodoResult<()> {
         self.conn.execute_batch(
-            // The table shares look.db with the engine's connection, so WAL
+            // The tables share look.db with the engine's connection, so WAL
             // (already the file's mode) plus a busy timeout keeps the two
             // writers from tripping over each other.
             "PRAGMA journal_mode = WAL;
@@ -100,11 +123,33 @@ impl TodoStore {
                  name TEXT NOT NULL,
                  done INTEGER NOT NULL DEFAULT 0,
                  due_date TEXT NOT NULL,
-                 created_at_unix_s INTEGER NOT NULL
+                 created_at_unix_s INTEGER NOT NULL,
+                 updated_at_unix_s INTEGER NOT NULL DEFAULT 0
              );
 
-             CREATE INDEX IF NOT EXISTS idx_todo_due ON todo_tasks(due_date);",
+             CREATE INDEX IF NOT EXISTS idx_todo_due ON todo_tasks(due_date);
+
+             CREATE TABLE IF NOT EXISTS todo_tombstones (
+                 id TEXT PRIMARY KEY,
+                 deleted_at_unix_s INTEGER NOT NULL
+             );",
         )?;
+
+        // Databases created before the sync prep lack the update stamp;
+        // backfill from created_at so a first merge has usable timestamps.
+        let has_updated_at = self.conn.query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('todo_tasks')
+             WHERE name = 'updated_at_unix_s'",
+            [],
+            |row| row.get::<_, i64>(0).map(|n| n > 0),
+        )?;
+        if !has_updated_at {
+            self.conn.execute_batch(
+                "ALTER TABLE todo_tasks
+                     ADD COLUMN updated_at_unix_s INTEGER NOT NULL DEFAULT 0;
+                 UPDATE todo_tasks SET updated_at_unix_s = created_at_unix_s;",
+            )?;
+        }
         Ok(())
     }
 
@@ -136,27 +181,80 @@ impl TodoStore {
     /// Replaces the entire task set with `tasks`. The client always holds
     /// the full set it loaded, so a full replace is lossless. Tasks with a
     /// blank name are dropped. Expired days are pruned afterwards.
+    ///
+    /// Sync bookkeeping happens here, invisibly to callers: a task whose
+    /// content changed gets a fresh update stamp, an unchanged task keeps
+    /// its stored one, and an id that vanishes from the set is tombstoned.
+    /// Saving an id again clears its tombstone.
     pub fn save(&mut self, tasks: &[TodoTask]) -> TodoResult<()> {
+        self.save_at(tasks, now_unix_s())
+    }
+
+    fn save_at(&mut self, tasks: &[TodoTask], now_unix_s: i64) -> TodoResult<()> {
         let tx = self.conn.transaction()?;
+
+        let mut stored: HashMap<String, StoredTask> = HashMap::new();
+        {
+            let mut stmt =
+                tx.prepare("SELECT id, name, done, due_date, updated_at_unix_s FROM todo_tasks")?;
+            let rows = stmt.query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    StoredTask {
+                        name: row.get(1)?,
+                        done: row.get::<_, i64>(2)? != 0,
+                        due_date: row.get(3)?,
+                        updated_at_unix_s: row.get(4)?,
+                    },
+                ))
+            })?;
+            for row in rows {
+                let (id, task) = row?;
+                stored.insert(id, task);
+            }
+        }
+
         tx.execute("DELETE FROM todo_tasks", [])?;
         {
-            let mut stmt = tx.prepare(
+            let mut insert = tx.prepare(
                 "INSERT OR REPLACE INTO todo_tasks
-                     (id, name, done, due_date, created_at_unix_s)
-                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                     (id, name, done, due_date, created_at_unix_s, updated_at_unix_s)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             )?;
+            let mut clear_tombstone = tx.prepare("DELETE FROM todo_tombstones WHERE id = ?1")?;
             for task in tasks {
                 let name = task.name.trim();
                 if name.is_empty() {
                     continue;
                 }
-                stmt.execute(params![
+                let updated_at = match stored.remove(&task.id) {
+                    Some(old)
+                        if old.name == name
+                            && old.done == task.done
+                            && old.due_date == task.due_date =>
+                    {
+                        old.updated_at_unix_s
+                    }
+                    _ => now_unix_s,
+                };
+                insert.execute(params![
                     task.id,
                     name,
                     task.done as i64,
                     task.due_date,
                     task.created_at_unix_s,
+                    updated_at,
                 ])?;
+                clear_tombstone.execute(params![task.id])?;
+            }
+
+            // Whatever is left in `stored` was deleted by this save.
+            let mut add_tombstone = tx.prepare(
+                "INSERT OR REPLACE INTO todo_tombstones (id, deleted_at_unix_s)
+                 VALUES (?1, ?2)",
+            )?;
+            for id in stored.keys() {
+                add_tombstone.execute(params![id, now_unix_s])?;
             }
         }
         tx.commit()?;
@@ -164,12 +262,21 @@ impl TodoStore {
         Ok(())
     }
 
-    /// Deletes tasks whose day is older than the retention window. Uses
-    /// SQLite's own date math so it stays correct without a date crate.
+    /// Deletes tasks whose day is older than the retention window, and
+    /// tombstones old enough that every machine has pruned the task they
+    /// point at (same window, so a retention prune on one machine never
+    /// reads as a deletion to another). Uses SQLite's own date math so it
+    /// stays correct without a date crate.
     pub fn prune_expired(&self) -> TodoResult<usize> {
+        let window = format!("-{RETENTION_DAYS} days");
         let removed = self.conn.execute(
             "DELETE FROM todo_tasks WHERE due_date < date('now', ?1)",
-            params![format!("-{RETENTION_DAYS} days")],
+            params![window],
+        )?;
+        self.conn.execute(
+            "DELETE FROM todo_tombstones
+             WHERE deleted_at_unix_s < CAST(strftime('%s', 'now', ?1) AS INTEGER)",
+            params![window],
         )?;
         Ok(removed)
     }
@@ -258,6 +365,143 @@ mod tests {
         }
         let back: TodoTask = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back, t);
+    }
+
+    fn updated_at(store: &TodoStore, id: &str) -> i64 {
+        store
+            .conn
+            .query_row(
+                "SELECT updated_at_unix_s FROM todo_tasks WHERE id = ?1",
+                params![id],
+                |row| row.get(0),
+            )
+            .expect("updated_at")
+    }
+
+    fn tombstones(store: &TodoStore) -> Vec<(String, i64)> {
+        let mut stmt = store
+            .conn
+            .prepare("SELECT id, deleted_at_unix_s FROM todo_tombstones ORDER BY id")
+            .expect("prepare");
+        let rows = stmt
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .expect("query");
+        rows.map(|row| row.expect("row")).collect()
+    }
+
+    #[test]
+    fn unchanged_tasks_keep_their_update_stamp() {
+        let mut store = TodoStore::open_in_memory().expect("open");
+        store
+            .save_at(&[task("a", "First", false, "2999-01-01")], 100)
+            .expect("save 1");
+        assert_eq!(updated_at(&store, "a"), 100);
+
+        store
+            .save_at(&[task("a", "First", false, "2999-01-01")], 200)
+            .expect("save 2");
+        assert_eq!(updated_at(&store, "a"), 100, "unchanged keeps stamp");
+
+        store
+            .save_at(&[task("a", "First", true, "2999-01-01")], 300)
+            .expect("save 3");
+        assert_eq!(updated_at(&store, "a"), 300, "content change bumps stamp");
+    }
+
+    // Tombstone purging compares against the real clock, so stamps used in
+    // tombstone tests must sit inside the retention window. Far-future
+    // keeps them deterministic.
+    const NOW: i64 = 4_000_000_000;
+
+    #[test]
+    fn deleted_tasks_leave_tombstones() {
+        let mut store = TodoStore::open_in_memory().expect("open");
+        store
+            .save_at(
+                &[
+                    task("a", "Keep", false, "2999-01-01"),
+                    task("b", "Drop", false, "2999-01-01"),
+                ],
+                NOW,
+            )
+            .expect("save 1");
+        assert!(tombstones(&store).is_empty());
+
+        store
+            .save_at(&[task("a", "Keep", false, "2999-01-01")], NOW + 100)
+            .expect("save 2");
+        assert_eq!(tombstones(&store), vec![("b".to_string(), NOW + 100)]);
+    }
+
+    #[test]
+    fn blanking_a_name_counts_as_deletion() {
+        let mut store = TodoStore::open_in_memory().expect("open");
+        store
+            .save_at(&[task("a", "Real", false, "2999-01-01")], NOW)
+            .expect("save 1");
+        store
+            .save_at(&[task("a", "   ", false, "2999-01-01")], NOW + 100)
+            .expect("save 2");
+        assert_eq!(tombstones(&store), vec![("a".to_string(), NOW + 100)]);
+    }
+
+    #[test]
+    fn resaving_an_id_clears_its_tombstone() {
+        let mut store = TodoStore::open_in_memory().expect("open");
+        store
+            .save_at(&[task("a", "Task", false, "2999-01-01")], NOW)
+            .expect("save 1");
+        store.save_at(&[], NOW + 100).expect("save 2");
+        assert_eq!(tombstones(&store).len(), 1);
+
+        store
+            .save_at(&[task("a", "Task", false, "2999-01-01")], NOW + 200)
+            .expect("save 3");
+        assert!(tombstones(&store).is_empty());
+        assert_eq!(
+            updated_at(&store, "a"),
+            NOW + 200,
+            "resurrected counts as new"
+        );
+    }
+
+    #[test]
+    fn expired_tombstones_are_pruned() {
+        let store = TodoStore::open_in_memory().expect("open");
+        store
+            .conn
+            .execute(
+                "INSERT INTO todo_tombstones (id, deleted_at_unix_s) VALUES
+                     ('old', 1000), ('new', ?1)",
+                params![now_unix_s()],
+            )
+            .expect("insert");
+        store.prune_expired().expect("prune");
+        assert_eq!(tombstones(&store).len(), 1);
+        assert_eq!(tombstones(&store)[0].0, "new");
+    }
+
+    #[test]
+    fn migrate_backfills_updated_at_from_created_at() {
+        // A database from before the sync prep: no stamp column, no
+        // tombstone table.
+        let conn = Connection::open_in_memory().expect("open");
+        conn.execute_batch(
+            "CREATE TABLE todo_tasks (
+                 id TEXT PRIMARY KEY,
+                 name TEXT NOT NULL,
+                 done INTEGER NOT NULL DEFAULT 0,
+                 due_date TEXT NOT NULL,
+                 created_at_unix_s INTEGER NOT NULL
+             );
+             INSERT INTO todo_tasks VALUES ('a', 'Old row', 0, '2999-01-01', 4242);",
+        )
+        .expect("old schema");
+
+        let store = TodoStore { conn };
+        store.migrate().expect("migrate");
+        assert_eq!(updated_at(&store, "a"), 4242);
+        assert!(tombstones(&store).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- A thoughtful preparation if in the future, we implement data sync for Look

## Why

- We have data that need, nice, better to be kept in sync

## Changes

- todo_tasks entity and related crud functions

## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [x] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] Manual verification completed (if UI/behavior changed)

## Checklist

- [x] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered
