### PR TITLE
feat: Health and error notifications

### DIFF
--- a/apps/linows/src-tauri/src/crash.rs
+++ b/apps/linows/src-tauri/src/crash.rs
@@ -1,0 +1,156 @@
+//! Last-resort crash reporting for failures the health notice can't reach.
+//!
+//! The health banner needs a live webview; a panic during startup (WebView2
+//! missing on Windows, plugin init, the setup hook) kills the process before
+//! one exists, and a menu-launched Look dies as an invisible no-show. The
+//! panic hook writes the panic to a crash log and, for main-thread panics,
+//! shows a native dialog that doesn't depend on the webview.
+//!
+//! Out of scope: segfaults in native code (WebKitGTK, GPU drivers) never
+//! reach a Rust panic hook, and loader failures (missing shared libraries)
+//! kill the process before any of this runs.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+const CRASH_LOG_NAME: &str = "crash.log";
+const DIALOG_TITLE: &str = "Look";
+
+/// Install the panic hook. Must run first in `main` so even Tauri
+/// builder/setup failures are covered.
+pub fn install_panic_hook() {
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        // Keep the default stderr/backtrace output for terminal launches.
+        default_hook(info);
+
+        let message = panic_message(info);
+        let log_path = append_crash_log(&message);
+
+        // Background-thread panics don't take the process down - stay quiet
+        // beyond the log. A main-thread panic unwinds out of `main`, so this
+        // dialog is the only thing the user would ever see.
+        if std::thread::current().name() == Some("main") {
+            show_native_dialog(&message, log_path.as_deref());
+        }
+    }));
+}
+
+fn panic_message(info: &std::panic::PanicHookInfo) -> String {
+    let payload = info
+        .payload()
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| info.payload().downcast_ref::<String>().map(String::as_str))
+        .unwrap_or("unknown panic");
+    match info.location() {
+        Some(loc) => format!("{payload} (at {loc})"),
+        None => payload.to_string(),
+    }
+}
+
+/// Append the crash to `<state dir>/look/crash.log` and return its path.
+/// Linux: ~/.local/state/look (XDG state dir). Windows has no state-dir
+/// notion - falls back to %LOCALAPPDATA%\look, next to the index database.
+fn append_crash_log(message: &str) -> Option<PathBuf> {
+    let dir = dirs::state_dir()
+        .or_else(dirs::data_local_dir)?
+        .join("look");
+    std::fs::create_dir_all(&dir).ok()?;
+    let path = dir.join(CRASH_LOG_NAME);
+    let unix_s = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .ok()?;
+    writeln!(
+        file,
+        "[{unix_s}] lookapp {}: {message}",
+        env!("APP_VERSION")
+    )
+    .ok()?;
+    Some(path)
+}
+
+fn show_native_dialog(message: &str, log_path: Option<&Path>) {
+    let text = match log_path {
+        Some(path) => format!(
+            "Look crashed: {message}\n\nDetails were written to:\n{}",
+            path.display()
+        ),
+        None => format!("Look crashed: {message}"),
+    };
+    native_error_dialog(&text);
+}
+
+#[cfg(target_os = "windows")]
+fn native_error_dialog(text: &str) {
+    use windows::Win32::UI::WindowsAndMessaging::{MB_ICONERROR, MessageBoxW};
+    use windows::core::PCWSTR;
+
+    let to_wide = |s: &str| -> Vec<u16> { s.encode_utf16().chain(std::iter::once(0)).collect() };
+    let text_w = to_wide(text);
+    let title_w = to_wide(DIALOG_TITLE);
+    // MessageBoxW only needs user32.dll, so it works even when the crash is
+    // WebView2 itself failing to initialize.
+    unsafe {
+        MessageBoxW(
+            None,
+            PCWSTR(text_w.as_ptr()),
+            PCWSTR(title_w.as_ptr()),
+            MB_ICONERROR,
+        );
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn native_error_dialog(text: &str) {
+    use crate::platform::linux::host_command;
+
+    // zenity covers GNOME, kdialog KDE, notify-send most other desktops;
+    // xmessage is the bare-X11 last resort. First tool that reports success
+    // wins. host_command keeps the AppImage's LD_LIBRARY_PATH out of them.
+    let attempts: [(&str, Vec<String>); 4] = [
+        (
+            "zenity",
+            vec![
+                "--error".into(),
+                format!("--title={DIALOG_TITLE}"),
+                format!("--text={text}"),
+            ],
+        ),
+        (
+            "kdialog",
+            vec![
+                "--title".into(),
+                DIALOG_TITLE.into(),
+                "--error".into(),
+                text.into(),
+            ],
+        ),
+        (
+            "notify-send",
+            vec![
+                "-u".into(),
+                "critical".into(),
+                DIALOG_TITLE.into(),
+                text.into(),
+            ],
+        ),
+        ("xmessage", vec!["-center".into(), text.into()]),
+    ];
+    for (cmd, args) in attempts {
+        let shown = host_command(cmd)
+            .args(&args)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if shown {
+            return;
+        }
+    }
+}

--- a/apps/linows/src-tauri/src/health.rs
+++ b/apps/linows/src-tauri/src/health.rs
@@ -1,0 +1,101 @@
+//! Setup health issues surfaced to the user instead of stderr-only
+//! breadcrumbs.
+//!
+//! The app is usually launched from a menu entry, so `eprintln!` is invisible.
+//! When something the user must act on fails (the global hotkey can't be
+//! registered, the GNOME extension needs a re-login), modules report it here;
+//! the frontend shows the collected issues as a persistent, dismissible
+//! notice. Issues land at any time - during `setup` (before the webview runs
+//! JS) or minutes later from a background thread - so the frontend both pulls
+//! the list on init and listens for the change event.
+
+use serde::Serialize;
+use std::sync::Mutex;
+use tauri::Emitter;
+
+pub const EVENT_HEALTH_CHANGED: &str = "health-changed";
+
+/// Stable issue ids: reports are deduped by id and the frontend keys
+/// dismissal persistence on them.
+pub const ISSUE_HOTKEY: &str = "hotkey";
+#[cfg(target_os = "linux")]
+pub const ISSUE_GNOME_EXT: &str = "gnome-ext";
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HealthIssue {
+    pub id: &'static str,
+    pub message: String,
+}
+
+static ISSUES: Mutex<Vec<HealthIssue>> = Mutex::new(Vec::new());
+
+/// Record an issue and notify the frontend. The first report for an id wins;
+/// repeat reports (e.g. the stale-extension warning firing on every search)
+/// are silently dropped.
+pub fn report(id: &'static str, message: String) {
+    {
+        let Ok(mut issues) = ISSUES.lock() else {
+            return;
+        };
+        if issues.iter().any(|i| i.id == id) {
+            return;
+        }
+        eprintln!("[look:health] {message}");
+        issues.push(HealthIssue { id, message });
+    }
+    if let Some(handle) = crate::state::app_handle() {
+        let _ = handle.emit(EVENT_HEALTH_CHANGED, snapshot());
+    }
+}
+
+fn snapshot() -> Vec<HealthIssue> {
+    ISSUES.lock().map(|i| i.clone()).unwrap_or_default()
+}
+
+#[tauri::command]
+pub fn get_health_issues() -> Vec<HealthIssue> {
+    snapshot()
+}
+
+/// Debug-only test hook: `LOOK_FAKE_HEALTH_ISSUE=hotkey,late:gnome-ext`
+/// reports canned issues so the notice UI can be tested without reproducing
+/// real failures on each OS. Bare ids are reported during setup (exercises
+/// the get_health_issues pull path, before the webview runs JS); ids
+/// prefixed with `late:` arrive seconds after startup (exercises the
+/// health-changed push path). Compiled out of release builds.
+#[cfg(debug_assertions)]
+pub fn report_fake_issues_from_env() {
+    const LATE_DELAY: std::time::Duration = std::time::Duration::from_secs(5);
+
+    let Ok(spec) = std::env::var("LOOK_FAKE_HEALTH_ISSUE") else {
+        return;
+    };
+    for part in spec.split(',').map(str::trim).filter(|p| !p.is_empty()) {
+        let (late, name) = match part.strip_prefix("late:") {
+            Some(rest) => (true, rest),
+            None => (false, part),
+        };
+        let id: &'static str = match name {
+            "hotkey" => ISSUE_HOTKEY,
+            #[cfg(target_os = "linux")]
+            "gnome-ext" => ISSUE_GNOME_EXT,
+            other => {
+                eprintln!("[look:health] unknown fake issue id: {other}");
+                continue;
+            }
+        };
+        let message = format!(
+            "Fake '{id}' issue from LOOK_FAKE_HEALTH_ISSUE, with enough text \
+             to check how the notice wraps across lines. Unset the variable \
+             and restart to clear it."
+        );
+        if late {
+            std::thread::spawn(move || {
+                std::thread::sleep(LATE_DELAY);
+                report(id, message);
+            });
+        } else {
+            report(id, message);
+        }
+    }
+}

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -9,6 +9,7 @@ mod commands;
 mod config;
 mod consts;
 mod files;
+mod health;
 mod highlight;
 mod music;
 mod platform;
@@ -380,10 +381,12 @@ fn sync_autostart() {
 
 /// Register global shortcuts (Alt+Space to toggle, Alt+Shift+Q to quit).
 /// Uses compositor-specific keybinding on Wayland, tauri-plugin on X11/macOS/Windows.
-fn register_shortcuts(
-    app: &tauri::App,
-    use_wayland: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+///
+/// Registration failures never abort startup: a launcher with a dead hotkey
+/// is still reachable (relaunching it shows the window via single-instance),
+/// while one that exits during setup is gone with no message. Failures are
+/// reported as health issues so the frontend can explain what happened.
+fn register_shortcuts(app: &tauri::App, use_wayland: bool) {
     let app_handle = app.handle().clone();
 
     if use_wayland {
@@ -406,24 +409,38 @@ fn register_shortcuts(
     } else {
         use tauri_plugin_global_shortcut::GlobalShortcutExt;
         let handle = app_handle.clone();
-        app.global_shortcut()
-            .on_shortcut("Alt+Space", move |_app, _shortcut, event| {
-                if event.state != tauri_plugin_global_shortcut::ShortcutState::Pressed {
-                    return;
-                }
-                toggle_window(&handle);
-            })?;
-        app.global_shortcut()
+        if let Err(e) =
+            app.global_shortcut()
+                .on_shortcut("Alt+Space", move |_app, _shortcut, event| {
+                    if event.state != tauri_plugin_global_shortcut::ShortcutState::Pressed {
+                        return;
+                    }
+                    toggle_window(&handle);
+                })
+        {
+            health::report(
+                health::ISSUE_HOTKEY,
+                format!(
+                    "Alt+Space could not be registered ({e}). Another app may hold \
+                     the key - free it and restart Look. Until then, open Look \
+                     again from the app menu to show this window."
+                ),
+            );
+        }
+        if let Err(e) = app
+            .global_shortcut()
             .on_shortcut("Alt+Shift+Q", |app, _shortcut, event| {
                 if event.state != tauri_plugin_global_shortcut::ShortcutState::Pressed {
                     return;
                 }
                 eprintln!("look: quit via Alt+Shift+Q");
                 app.exit(0);
-            })?;
+            })
+        {
+            // Quit-shortcut loss is minor: quitting stays available in-app.
+            eprintln!("look: failed to register Alt+Shift+Q: {e}");
+        }
     }
-
-    Ok(())
 }
 
 /// Cache Look's X11 window ID and start monitoring _NET_ACTIVE_WINDOW for auto-hide.
@@ -540,7 +557,10 @@ fn main() {
             app.state::<AppState>().start_bootstrap();
             clipboard::start_monitor();
 
-            register_shortcuts(app, use_wayland)?;
+            register_shortcuts(app, use_wayland);
+
+            #[cfg(debug_assertions)]
+            health::report_fake_issues_from_env();
 
             // X11-window concerns (focus monitor, scrolling tweak) follow the
             // window backend: they also apply to the AppImage's XWayland
@@ -667,6 +687,8 @@ fn main() {
             // Autostart
             autostart::set_autostart,
             autostart::get_autostart,
+            // Setup health (hotkey/extension problems shown in the UI)
+            health::get_health_issues,
             // Highlight
             highlight::highlight_file_cmd,
             // About widget: version only. The update check itself runs in

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -8,6 +8,7 @@ mod clipboard;
 mod commands;
 mod config;
 mod consts;
+mod crash;
 mod files;
 mod health;
 mod highlight;
@@ -510,6 +511,8 @@ fn focus_loss_means_dismiss() -> bool {
 }
 
 fn main() {
+    crash::install_panic_hook();
+
     if std::env::args().any(|a| a == "--version" || a == "-V") {
         println!("lookapp {}", env!("APP_VERSION"));
         return;

--- a/apps/linows/src-tauri/src/platform/linux/gnome_ext.rs
+++ b/apps/linows/src-tauri/src/platform/linux/gnome_ext.rs
@@ -19,6 +19,11 @@ const DBUS_IFACE: &str = "com.look.ShellIntegration";
 const METADATA_JSON: &str = include_str!(concat!(env!("OUT_DIR"), "/gnome-ext-metadata.json"));
 const EXTENSION_JS: &str = include_str!("../../gnome-shell-extension/extension.js");
 
+/// User-facing notice when the on-disk extension isn't loaded in the running
+/// shell. Shared by the manual-install path and the post-install verification.
+const RELOGIN_MSG: &str = "Log out and back in to finish enabling Look's GNOME \
+     extension (it focuses already-running app windows).";
+
 /// Install the GNOME Shell extension if not already present, then enable it.
 pub fn ensure_installed() {
     let ext_dir = extension_dir();
@@ -35,30 +40,78 @@ pub fn ensure_installed() {
     };
 
     if needs_install {
-        // Use `gnome-extensions install` with a zip so GNOME Shell picks up
-        // the extension immediately - no re-login required on Wayland.
-        if install_via_gnome_extensions() {
-            eprintln!("[look] Installed GNOME Shell extension via gnome-extensions install");
-            enable_extension();
-            return;
-        }
-
-        // Fallback: write files manually (needs re-login on Wayland)
-        if let Err(e) = std::fs::create_dir_all(&ext_dir) {
-            eprintln!("[look] Failed to create extension dir: {e}");
-            return;
-        }
-        if let Err(e) = std::fs::write(&metadata_path, METADATA_JSON) {
-            eprintln!("[look] Failed to write metadata.json: {e}");
-            return;
-        }
-        if let Err(e) = std::fs::write(&extension_path, EXTENSION_JS) {
-            eprintln!("[look] Failed to write extension.js: {e}");
-            return;
-        }
-        eprintln!("[look] Installed GNOME Shell extension: {EXT_UUID} (manual, needs re-login)");
-        enable_extension();
+        install_current_version(&ext_dir, &metadata_path, &extension_path);
     }
+    verify_running_later();
+}
+
+fn install_current_version(
+    ext_dir: &std::path::Path,
+    metadata_path: &std::path::Path,
+    extension_path: &std::path::Path,
+) {
+    // Use `gnome-extensions install` with a zip so GNOME Shell picks up
+    // the extension immediately - no re-login required on Wayland.
+    if install_via_gnome_extensions() {
+        eprintln!("[look] Installed GNOME Shell extension via gnome-extensions install");
+        enable_extension();
+        return;
+    }
+
+    // Fallback: write files manually (needs re-login on Wayland)
+    if let Err(e) = std::fs::create_dir_all(ext_dir) {
+        eprintln!("[look] Failed to create extension dir: {e}");
+        return;
+    }
+    if let Err(e) = std::fs::write(metadata_path, METADATA_JSON) {
+        eprintln!("[look] Failed to write metadata.json: {e}");
+        return;
+    }
+    if let Err(e) = std::fs::write(extension_path, EXTENSION_JS) {
+        eprintln!("[look] Failed to write extension.js: {e}");
+        return;
+    }
+    eprintln!("[look] Installed GNOME Shell extension: {EXT_UUID} (manual, needs re-login)");
+    crate::health::report(crate::health::ISSUE_GNOME_EXT, RELOGIN_MSG.to_string());
+    enable_extension();
+}
+
+/// Delay before checking the extension answers on D-Bus: `gnome-extensions
+/// enable` loads it asynchronously, so an immediate ping right after a fresh
+/// install would report a false negative.
+const VERIFY_DELAY: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Verify in the background that the running shell actually loaded the
+/// extension, and report a re-login/stale notice when it didn't. Alt+Space
+/// works without the extension, but focus-existing-window and multi-monitor
+/// placement silently degrade - exactly the failures users can't diagnose.
+fn verify_running_later() {
+    std::thread::spawn(|| {
+        std::thread::sleep(VERIFY_DELAY);
+        let Some(conn) = dbus_conn() else {
+            return;
+        };
+        // ListWindowedApps is the newest method Rust calls: an old extension
+        // still loaded in memory answers other calls but fails this one.
+        let err = dbus_runtime().block_on(async {
+            conn.call_method(
+                Some(DBUS_NAME),
+                DBUS_PATH,
+                Some(DBUS_IFACE),
+                "ListWindowedApps",
+                &(),
+            )
+            .await
+            .err()
+        });
+        match err.map(|e| classify_dbus_error(&e)) {
+            Some(ExtensionError::NotRunning) => {
+                crate::health::report(crate::health::ISSUE_GNOME_EXT, RELOGIN_MSG.to_string());
+            }
+            Some(ExtensionError::Stale) => warn_stale_extension_once(),
+            _ => {}
+        }
+    });
 }
 
 /// Build a zip of the extension in /tmp and install via `gnome-extensions install --force`.
@@ -185,15 +238,15 @@ pub fn list_windowed_apps() -> Option<Vec<String>> {
     })
 }
 
+/// "Once" comes from health::report deduping by issue id: gnome-shell can't
+/// hot-reload extension JS on Wayland, so this fires until the user re-logs.
 fn warn_stale_extension_once() {
-    static WARNED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
-    WARNED.get_or_init(|| {
-        eprintln!(
-            "[look] GNOME Shell has an outdated Look extension loaded in memory \
-             (missing ListWindowedApps). Log out and back in to refresh - \
-             gnome-shell can't hot-reload extension JS on Wayland."
-        );
-    });
+    crate::health::report(
+        crate::health::ISSUE_GNOME_EXT,
+        "GNOME Shell is running an outdated Look extension. Log out and back \
+         in to refresh it."
+            .to_string(),
+    );
 }
 
 /// Try to focus an app by its desktop file ID using the GNOME Shell extension.

--- a/apps/linows/src-tauri/src/platform/linux/wayland_shortcut.rs
+++ b/apps/linows/src-tauri/src/platform/linux/wayland_shortcut.rs
@@ -11,6 +11,7 @@
 //!    - Hyprland: `hyprctl keyword bind ...`
 
 use super::host_command;
+use crate::health;
 use std::sync::Mutex;
 
 /// Saved original value of activate-window-menu before Look disabled it.
@@ -78,9 +79,12 @@ where
             // KDE registers via async D-Bus alongside the Toggle service below.
             Compositor::Kde => {}
             Compositor::Other => {
-                eprintln!(
-                    "[look] Unknown Wayland compositor: Alt+Space must be bound manually.\n\
-                     [look] Bind your hotkey to run: {TOGGLE_CMD}"
+                health::report(
+                    health::ISSUE_HOTKEY,
+                    format!(
+                        "This compositor has no supported hotkey API, so Alt+Space \
+                         is not set up. Bind a key manually to run: {TOGGLE_CMD}"
+                    ),
                 );
             }
         }
@@ -97,20 +101,34 @@ where
                 let toggle = on_toggle.clone();
                 tokio::task::spawn(async move {
                     if let Err(e) = run_kde_keybinding(move || toggle()).await {
-                        eprintln!(
-                            "[look] KDE keybinding error: {e}\n\
-                             [look] Bind your hotkey manually to run: {TOGGLE_CMD}"
+                        health::report(
+                            health::ISSUE_HOTKEY,
+                            format!(
+                                "KDE hotkey registration failed ({e}). Bind a key \
+                                 manually to run: {TOGGLE_CMD}"
+                            ),
                         );
                     }
                 });
             }
 
             if let Err(e) = run_dbus_service(move || on_toggle()).await {
-                eprintln!("[look] D-Bus service error: {e}");
-                // The KDE task toggles via the kglobalaccel signal alone;
-                // keep it alive.
                 if compositor == Compositor::Kde {
+                    // The KDE task toggles via the kglobalaccel signal alone;
+                    // keep it alive.
+                    eprintln!("[look] D-Bus service error: {e}");
                     std::future::pending::<()>().await;
+                } else {
+                    // Every other compositor binding toggles by calling this
+                    // service, so the hotkey is dead without it.
+                    health::report(
+                        health::ISSUE_HOTKEY,
+                        format!(
+                            "Look's D-Bus service failed to start ({e}), so the \
+                             Alt+Space binding cannot reach the app. Restart Look \
+                             to retry."
+                        ),
+                    );
                 }
             }
         });
@@ -135,11 +153,23 @@ fn ensure_sway_keybinding() {
         .output();
 
     // Bind Alt+Space to toggle Look via D-Bus
-    let _ = host_command("swaymsg")
+    let bound = host_command("swaymsg")
         .arg(format!("bindsym Alt+space exec {TOGGLE_CMD}"))
-        .output();
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
 
-    eprintln!("[look] Registered Sway keybinding: Alt+Space → Look toggle");
+    if bound {
+        eprintln!("[look] Registered Sway keybinding: Alt+Space → Look toggle");
+    } else {
+        health::report(
+            health::ISSUE_HOTKEY,
+            format!(
+                "Failed to register Alt+Space via swaymsg. Bind a key manually \
+                 to run: {TOGGLE_CMD}"
+            ),
+        );
+    }
 }
 
 fn cleanup_sway_keybinding() {
@@ -165,14 +195,9 @@ hl.window_rule({{ name = "look-noborder", match = {{ class = "lookapp" }}, borde
 hl.bind("ALT + space", hl.dsp.exec_cmd("{TOGGLE_CMD}"))"#
     );
 
-    let result = host_command("hyprctl").args(["eval", &lua]).output();
+    let used_lua = hyprctl_ok(host_command("hyprctl").args(["eval", &lua]).output());
 
-    let used_lua = result
-        .as_ref()
-        .map(|o| o.status.success() && !String::from_utf8_lossy(&o.stdout).contains("error"))
-        .unwrap_or(false);
-
-    if !used_lua {
+    let bound = used_lua || {
         // Fallback: legacy keyword syntax for older Hyprland
         let _ = host_command("hyprctl")
             .args(["keyword", "windowrulev2", "float, class:lookapp"])
@@ -180,12 +205,32 @@ hl.bind("ALT + space", hl.dsp.exec_cmd("{TOGGLE_CMD}"))"#
         let _ = host_command("hyprctl")
             .args(["keyword", "windowrulev2", "noborder, class:lookapp"])
             .output();
-        let _ = host_command("hyprctl")
-            .args(["keyword", "bind", &format!("ALT,space,exec,{TOGGLE_CMD}")])
-            .output();
-    }
+        hyprctl_ok(
+            host_command("hyprctl")
+                .args(["keyword", "bind", &format!("ALT,space,exec,{TOGGLE_CMD}")])
+                .output(),
+        )
+    };
 
-    eprintln!("[look] Registered Hyprland keybinding: Alt+Space → Look toggle");
+    if bound {
+        eprintln!("[look] Registered Hyprland keybinding: Alt+Space → Look toggle");
+    } else {
+        health::report(
+            health::ISSUE_HOTKEY,
+            format!(
+                "Failed to register Alt+Space via hyprctl. Bind a key manually \
+                 to run: {TOGGLE_CMD}"
+            ),
+        );
+    }
+}
+
+/// hyprctl exits 0 even for some rejected commands, reporting the failure as
+/// "error" text on stdout instead - check both.
+fn hyprctl_ok(result: std::io::Result<std::process::Output>) -> bool {
+    result
+        .map(|o| o.status.success() && !String::from_utf8_lossy(&o.stdout).contains("error"))
+        .unwrap_or(false)
 }
 
 fn cleanup_hyprland_keybinding() {
@@ -230,8 +275,8 @@ fn ensure_gnome_keybinding() {
         return;
     }
 
-    gsettings_set_at(KEYBINDING_SCHEMA, "name", "'Look Toggle'", KEYBINDING_PATH);
-    gsettings_set_at(
+    let mut ok = gsettings_set_at(KEYBINDING_SCHEMA, "name", "'Look Toggle'", KEYBINDING_PATH);
+    ok &= gsettings_set_at(
         KEYBINDING_SCHEMA,
         "command",
         &format!("'{TOGGLE_CMD}'"),
@@ -251,21 +296,31 @@ fn ensure_gnome_keybinding() {
             .collect::<Vec<_>>()
             .join(", ")
     );
-    gsettings_set(MEDIA_KEYS_SCHEMA, "custom-keybindings", &new_value);
+    ok &= gsettings_set(MEDIA_KEYS_SCHEMA, "custom-keybindings", &new_value);
 
     // Write the binding last, toggling it when it was shadowed: dconf drops
     // same-value writes and gsd only re-grabs on a change notification.
     if already_bound {
         gsettings_set_at(KEYBINDING_SCHEMA, "binding", "''", KEYBINDING_PATH);
     }
-    gsettings_set_at(
+    ok &= gsettings_set_at(
         KEYBINDING_SCHEMA,
         "binding",
         "'<Alt>space'",
         KEYBINDING_PATH,
     );
 
-    eprintln!("[look] Registered GNOME keybinding: Alt+Space → Look toggle");
+    if ok {
+        eprintln!("[look] Registered GNOME keybinding: Alt+Space → Look toggle");
+    } else {
+        health::report(
+            health::ISSUE_HOTKEY,
+            format!(
+                "Failed to register Alt+Space via gsettings. Bind a key manually \
+                 to run: {TOGGLE_CMD}"
+            ),
+        );
+    }
 }
 
 /// Disable GNOME's default Alt+Space (window menu) if it holds the key,
@@ -425,9 +480,13 @@ where
     if granted.contains(&QT_ALT_SPACE) {
         eprintln!("[look] Registered KDE keybinding: Alt+Space → Look toggle");
     } else {
-        eprintln!(
-            "[look] KDE assigned {granted:?} instead of Alt+Space. Rebind it in \
-             System Settings → Shortcuts → Look, or bind a key to run: {TOGGLE_CMD}"
+        health::report(
+            health::ISSUE_HOTKEY,
+            format!(
+                "KDE assigned a different key than Alt+Space (it may be taken). \
+                 Rebind it in System Settings → Shortcuts → Look, or bind a key \
+                 to run: {TOGGLE_CMD}"
+            ),
         );
     }
 
@@ -533,10 +592,12 @@ fn gsettings_get(schema: &str, key: &str) -> String {
         .to_string()
 }
 
-fn gsettings_set(schema: &str, key: &str, value: &str) {
-    let _ = host_command("gsettings")
+fn gsettings_set(schema: &str, key: &str, value: &str) -> bool {
+    host_command("gsettings")
         .args(["set", schema, key, value])
-        .output();
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
 }
 
 fn gsettings_get_at(schema: &str, key: &str, path: &str) -> String {
@@ -550,10 +611,12 @@ fn gsettings_get_at(schema: &str, key: &str, path: &str) -> String {
         .to_string()
 }
 
-fn gsettings_set_at(schema: &str, key: &str, value: &str, path: &str) {
-    let _ = host_command("gsettings")
+fn gsettings_set_at(schema: &str, key: &str, value: &str, path: &str) -> bool {
+    host_command("gsettings")
         .args(["set", &format!("{schema}:{path}"), key, value])
-        .output();
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
 }
 
 fn parse_gsettings_array(s: &str) -> Vec<String> {

--- a/apps/linows/src-tauri/src/state.rs
+++ b/apps/linows/src-tauri/src/state.rs
@@ -93,6 +93,12 @@ impl Drop for RefreshSlotGuard<'_> {
 
 static APP_HANDLE: OnceLock<tauri::AppHandle> = OnceLock::new();
 
+/// Global app handle for modules that emit events outside a command context
+/// (index-ready, health reports). `None` until `init_app_handle` runs.
+pub fn app_handle() -> Option<&'static tauri::AppHandle> {
+    APP_HANDLE.get()
+}
+
 /// Bundle of `AppState` field addresses shared with the watcher loop and each
 /// reindex worker it spawns. Stored as `usize` because raw pointers are not
 /// `Send`, and Rust 2021's disjoint closure capture would otherwise see each

--- a/apps/linows/src/css/components/banner.css
+++ b/apps/linows/src/css/components/banner.css
@@ -2,14 +2,39 @@
 .banner {
   grid-row: 2;
   grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
   padding: 8px var(--content-padding);
   border-bottom: var(--border-thickness) solid var(--divider-color);
   animation: banner-in 200ms ease-out;
 }
 
+/* `display: flex` above wins over the UA `[hidden] { display: none }` rule
+ * (author CSS beats user-agent specificity). Re-assert the hide. */
+.banner[hidden] {
+  display: none;
+}
+
 .banner-text {
+  flex: 1;
   font-size: calc(var(--font-size) - 1px);
   font-weight: 500;
+  /* Sticky health notices join multiple issues with newlines. */
+  white-space: pre-line;
+}
+
+.banner-dismiss {
+  border: none;
+  background: none;
+  font-size: calc(var(--font-size) - 1px);
+  font-family: var(--font-family);
+  color: var(--font-muted);
+  cursor: pointer;
+}
+
+.banner-dismiss:hover {
+  color: var(--font-color);
 }
 
 .banner-success { background: rgba(166, 227, 161, 0.12); }
@@ -20,6 +45,9 @@
 
 .banner-info { background: rgba(137, 180, 250, 0.12); }
 .banner-info .banner-text { color: var(--color-info); }
+
+.banner-warning { background: rgba(250, 179, 135, 0.12); }
+.banner-warning .banner-text { color: var(--color-warning); }
 
 @keyframes banner-in {
   from { opacity: 0; transform: translateY(-4px); }

--- a/apps/linows/src/html/screens/search.html
+++ b/apps/linows/src/html/screens/search.html
@@ -10,6 +10,7 @@
 
   <div class="banner" id="banner" hidden>
     <span class="banner-text"></span>
+    <button type="button" class="banner-dismiss" tabindex="-1" aria-label="Dismiss" hidden>✕</button>
   </div>
 
   <div class="confirm-bar" id="confirm-bar" hidden>

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -4,6 +4,7 @@ import * as keyboard from './keyboard.js';
 import * as preview from './components/preview.js';
 import * as picked from './components/picked.js';
 import * as banner from './components/banner.js';
+import * as health from './components/health.js';
 import * as confirm from './components/confirm.js';
 import * as commands from './screens/commands/index.js';
 import * as todoCmd from './screens/commands/todo.js';
@@ -170,6 +171,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   keyboard.init(queryInput);
   preview.init(previewPanel);
   banner.init(document.getElementById('banner'));
+  health.init();
   confirm.init(document.getElementById('confirm-bar'));
   picked.init(previewPanel, {
     onRemoveItem: (key) => results.removePick(key),

--- a/apps/linows/src/js/components/banner.js
+++ b/apps/linows/src/js/components/banner.js
@@ -1,22 +1,53 @@
 let bannerEl = null;
 let textEl = null;
+let dismissEl = null;
 let hideTimer = null;
+// Two layers share the banner slot: transient toasts (auto-hide) and a
+// sticky notice (stays until dismissed). An active toast wins; when it
+// expires the sticky notice resurfaces instead of the banner hiding.
+let toast = null;
+let sticky = null;
 
 export function init(el) {
   bannerEl = el;
   textEl = el.querySelector('.banner-text');
+  dismissEl = el.querySelector('.banner-dismiss');
+  dismissEl.addEventListener('click', () => {
+    const onDismiss = sticky?.onDismiss;
+    sticky = null;
+    render();
+    if (onDismiss) onDismiss();
+  });
 }
 
 export function show(message, style = 'info', duration = 1.5) {
-  if (!bannerEl || !textEl) return;
+  if (!bannerEl) return;
 
   clearTimeout(hideTimer);
-
-  textEl.textContent = message;
-  bannerEl.className = `banner banner-${style}`;
-  bannerEl.hidden = false;
+  toast = { message, style };
+  render();
 
   hideTimer = setTimeout(() => {
-    bannerEl.hidden = true;
+    toast = null;
+    render();
   }, duration * 1000);
+}
+
+// Sticky notice with a dismiss button. Pass a falsy message to clear it.
+export function showSticky(message, style = 'warning', onDismiss = null) {
+  if (!bannerEl) return;
+  sticky = message ? { message, style, onDismiss } : null;
+  render();
+}
+
+function render() {
+  const active = toast || sticky;
+  if (!active) {
+    bannerEl.hidden = true;
+    return;
+  }
+  textEl.textContent = active.message;
+  bannerEl.className = `banner banner-${active.style}`;
+  dismissEl.hidden = active !== sticky;
+  bannerEl.hidden = false;
 }

--- a/apps/linows/src/js/components/health.js
+++ b/apps/linows/src/js/components/health.js
@@ -1,0 +1,56 @@
+// Surfaces backend setup problems (dead hotkey, GNOME extension needing a
+// re-login) as a sticky banner. Issues can land before the webview runs
+// (pulled via get_health_issues on init) or minutes later from backend
+// threads (pushed via health-changed). Dismissals persist in localStorage so
+// the same problem doesn't nag on every launch.
+import { getHealthIssues, onHealthChanged } from '../ipc.js';
+import * as banner from './banner.js';
+
+const DISMISSED_KEY = 'look.health.dismissed';
+
+let issues = [];
+
+function dismissedSet() {
+  try {
+    return new Set(JSON.parse(localStorage.getItem(DISMISSED_KEY)) || []);
+  } catch {
+    return new Set();
+  }
+}
+
+// Keyed on id + message: a new failure mode under the same id should
+// surface again even if an older notice was dismissed.
+function issueKey(issue) {
+  return `${issue.id}:${issue.message}`;
+}
+
+function render() {
+  const dismissed = dismissedSet();
+  const visible = issues.filter((i) => !dismissed.has(issueKey(i)));
+  if (visible.length === 0) {
+    banner.showSticky(null);
+    return;
+  }
+  banner.showSticky(visible.map((i) => i.message).join('\n'), 'warning', dismissAll);
+}
+
+function dismissAll() {
+  const dismissed = dismissedSet();
+  issues.forEach((i) => dismissed.add(issueKey(i)));
+  try {
+    localStorage.setItem(DISMISSED_KEY, JSON.stringify([...dismissed]));
+  } catch {
+    // Best effort - worst case the notice reappears next launch.
+  }
+}
+
+export function init() {
+  onHealthChanged((event) => {
+    issues = event.payload || [];
+    render();
+  });
+  getHealthIssues().then((list) => {
+    issues = list || [];
+    render();
+  }).catch(() => {});
+}

--- a/apps/linows/src/js/ipc.js
+++ b/apps/linows/src/js/ipc.js
@@ -169,6 +169,14 @@ export async function onWindowShown(callback) {
   return listen('window-shown', callback);
 }
 
+export async function getHealthIssues() {
+  return invoke('get_health_issues');
+}
+
+export async function onHealthChanged(callback) {
+  return listen('health-changed', callback);
+}
+
 export async function onIndexReady(callback) {
   return listen('index-ready', callback);
 }


### PR DESCRIPTION
## Summary

- A health check service and notice user if any issues with installing Look
- Show a notice message and log errors in log files

## Why

- Related to #237 , but this is a wider cover (for both windows and linux)

## Changes

-

## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [x] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [x] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered
