### PR TITLE
fix: local toast in pomo screen

### DIFF
--- a/apps/linows/src/css/components/commands.css
+++ b/apps/linows/src/css/components/commands.css
@@ -720,6 +720,10 @@
   display: none !important;
 }
 
+#cmd-panel-todo {
+  position: relative;
+}
+
 .cmd-todo-toolbar {
   display: flex;
   align-items: center;
@@ -1036,6 +1040,36 @@ button.cmd-todo-add:hover {
   padding: 10px 0;
   font-size: calc(var(--font-size) - 1px);
   color: var(--font-muted);
+}
+
+.cmd-todo-toast {
+  position: absolute;
+  left: 50%;
+  bottom: 16px;
+  transform: translateX(-50%);
+  z-index: 4;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 12px;
+  border-radius: 999px;
+  font-size: calc(var(--font-size) - 2px);
+  font-weight: 600;
+  color: var(--on-accent-color, #fff);
+  background: var(--accent-color);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+  pointer-events: none;
+}
+
+.cmd-todo-toast svg {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.cmd-todo-toast-error {
+  color: #fff;
+  background: var(--color-danger);
 }
 
 /* Stats page */

--- a/apps/linows/src/js/screens/commands/todo.js
+++ b/apps/linows/src/js/screens/commands/todo.js
@@ -190,6 +190,8 @@ function hideToast() {
   }
 }
 
+// Stats reads directly from the in-memory task map, so block navigation while
+// Tasks is dirty to avoid implying the unsaved state has already been persisted.
 function canOpenStats() {
   if (page === 'tasks' && dirty) {
     showToast('Save changes before opening Stats', 'error', 2.0);

--- a/apps/linows/src/js/screens/commands/todo.js
+++ b/apps/linows/src/js/screens/commands/todo.js
@@ -190,14 +190,27 @@ function hideToast() {
   }
 }
 
+function canOpenStats() {
+  if (page === 'tasks' && dirty) {
+    showToast('Save changes before opening Stats', 'error', 2.0);
+    return false;
+  }
+  return true;
+}
+
 export function handleKey(e) {
   // Ctrl+N flips Tasks/Stats, Ctrl+S saves; same pair as macOS Cmd+N/Cmd+S.
   if (e.ctrlKey && !e.shiftKey && !e.altKey && (e.key === 'n' || e.key === 'N')) {
+    if (page === 'tasks' && !canOpenStats()) {
+      e.preventDefault();
+      return true;
+    }
     e.preventDefault();
     setPage(page === 'tasks' ? 'stats' : 'tasks');
     return true;
   }
   if (e.ctrlKey && !e.shiftKey && !e.altKey && (e.key === 's' || e.key === 'S')) {
+    if (page !== 'tasks') return false; //prevent user saves state in stats tab
     e.preventDefault();
     persist();
     return true;
@@ -450,6 +463,9 @@ const dateSearchText = (date, diff) =>
 // --- Rendering ---
 
 function setPage(p) {
+  if (p === 'stats' && !canOpenStats()) {
+    return;
+  }
   page = p;
   tooltipEl.hidden = true;
   searchBar.hidden = p !== 'tasks';

--- a/apps/linows/src/js/screens/commands/todo.js
+++ b/apps/linows/src/js/screens/commands/todo.js
@@ -5,10 +5,9 @@
 // Save (Ctrl+S). No autosave.
 
 import { todoList, todoSave } from '../../ipc.js';
-import * as banner from '../../components/banner.js';
 import {
   listChecks, barChart, flame, plus, save as saveIcon, calendarPlus,
-  trash as trashIcon, search as searchIcon, check as checkIcon, activity, calendar, zap,
+  trash as trashIcon, search as searchIcon, check as checkIcon, alertCircle, activity, calendar, zap,
 } from '../../icons.js';
 
 // Mirrors macOS TodoState limits: at most 3 unfinished tasks per day
@@ -43,10 +42,12 @@ let page = 'tasks';
 let editingAddKey = null; // day key with an open "Add task" field
 let editingTaskRef = null; // {key, id} being renamed
 let onQuickChange = null;
+let toastTimer = null;
 
 // --- DOM refs ---
 let panel, searchBar, searchInput, statsBar, toolbar;
 let countEl, addDateBtn, saveBtn, daysEl, statsEl, tooltipEl;
+let toastEl, toastIconEl, toastTextEl;
 
 export function init() {
   panel = document.getElementById('cmd-panel-todo');
@@ -105,6 +106,13 @@ export function init() {
   tooltipEl.className = 'cmd-todo-tooltip';
   tooltipEl.hidden = true;
   panel.appendChild(tooltipEl);
+  toastEl = document.createElement('div');
+  toastEl.className = 'cmd-todo-toast';
+  toastEl.hidden = true;
+  toastEl.innerHTML = '<span class="cmd-todo-toast-icon"></span><span class="cmd-todo-toast-text"></span>';
+  toastIconEl = toastEl.querySelector('.cmd-todo-toast-icon');
+  toastTextEl = toastEl.querySelector('.cmd-todo-toast-text');
+  panel.appendChild(toastEl);
   statsEl.addEventListener('mouseover', (e) => {
     const el = e.target.closest('[data-tip]');
     if (el) showTooltip(el);
@@ -140,6 +148,7 @@ export function exit() {
   visible = false;
   panel.hidden = true;
   tooltipEl.hidden = true;
+  hideToast();
   editingAddKey = null;
   editingTaskRef = null;
 }
@@ -153,6 +162,32 @@ function showTooltip(el) {
   const left = Math.min(Math.max(rect.left + rect.width / 2 - w / 2, 4), window.innerWidth - w - 4);
   tooltipEl.style.left = `${left}px`;
   tooltipEl.style.top = `${rect.top - tooltipEl.offsetHeight - 6}px`;
+}
+
+// Local save feedback stays inside /todo, mirroring macOS and avoiding the
+// launcher's shared banner area.
+function showToast(message, style = 'success', duration = SAVE_TOAST_SECS) {
+  if (!toastEl || !toastIconEl || !toastTextEl) {
+    return;
+  }
+  clearTimeout(toastTimer);
+  toastIconEl.innerHTML = style === 'error' ? alertCircle : checkIcon;
+  toastTextEl.textContent = message;
+  toastEl.className = `cmd-todo-toast cmd-todo-toast-${style}`;
+  toastEl.hidden = false;
+  toastTimer = setTimeout(() => {
+    toastEl.hidden = true;
+  }, duration * 1000);
+}
+
+// Closing the panel hides any active toast so a later reopen never shows a
+// stale save result from the previous session.
+function hideToast() {
+  clearTimeout(toastTimer);
+  toastTimer = null;
+  if (toastEl) {
+    toastEl.hidden = true;
+  }
 }
 
 export function handleKey(e) {
@@ -243,10 +278,10 @@ async function persist() {
   try {
     await todoSave(tasks);
     dirty = false;
-    banner.show('Saved', 'success', SAVE_TOAST_SECS);
+    showToast('Saved', 'success', SAVE_TOAST_SECS);
     renderToolbar();
   } catch (err) {
-    banner.show(`Save failed: ${err}`, 'error', 2.0);
+    showToast(`Save failed: ${err}`, 'error', 2.0);
   }
 }
 


### PR DESCRIPTION
## Summary

- move `/todo` save feedback from the shared banner to a local in-panel toast
- make Linux `/todo` save feedback match macOS more closely
- block access to the `Stats` tab while task changes are still unsaved

## Why

- saving in `/todo` is a panel-local action, so its feedback should stay inside that panel
- the previous global banner made the message feel like it belonged to the home/search screen
- `Stats` reads from the in-memory todo state, which can make unsaved edits look like persisted data
- matching macOS keeps the command behavior more consistent across platforms

## Changes

- remove the `/todo` screen's dependency on the shared banner component
- add a local toast element managed directly by `apps/linows/src/js/screens/commands/todo.js`
- show `Saved` as a bottom-aligned in-panel toast after successful saves
- prevent `Ctrl+S` from triggering save feedback in the `Stats` tab
- prevent switching to `Stats` while there are unsaved task changes, and show `Save changes before opening Stats`

## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [x] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [ ] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After
- Prevent use ctrl + s in **stats** tab 
https://github.com/user-attachments/assets/418bb475-1e77-4e27-8abf-62632425faf4

- Toast unsaved changes 
https://github.com/user-attachments/assets/0563dd58-3339-4f41-8efd-5da77da30bbc


## Risks / Notes

- [x] Dont allow use command ctrl + S to save todo in **stats** tab 
- [x] Prevent user cant switch **stats tab** when there are unsaved changes

## Checklist

- [x] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered
