### PR TITLE
fix: Toast on todo screen

### DIFF
--- a/apps/linows/src/css/components/commands.css
+++ b/apps/linows/src/css/components/commands.css
@@ -82,6 +82,7 @@
 }
 
 .cmd-panel {
+  position: relative;
   flex: 1;
   min-height: 0;
   display: flex;
@@ -810,6 +811,40 @@
   height: 6px;
   border-radius: 50%;
   background: var(--accent-color);
+}
+
+/* Save confirmation capsule, overlaid at the panel bottom like macOS */
+.cmd-todo-toast {
+  position: absolute;
+  bottom: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 12px;
+  border-radius: 999px;
+  background: var(--accent-color);
+  color: var(--on-accent-color, #fff);
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.cmd-todo-toast.show {
+  opacity: 1;
+}
+
+.cmd-todo-toast svg {
+  width: 13px;
+  height: 13px;
+}
+
+.cmd-todo-toast-error {
+  background: var(--color-danger);
 }
 
 /* Day cards */

--- a/apps/linows/src/html/screens/commands/todo.html
+++ b/apps/linows/src/html/screens/commands/todo.html
@@ -32,4 +32,8 @@
 
   <div class="cmd-content cmd-todo-days" id="cmd-todo-days"></div>
   <div class="cmd-content cmd-todo-stats" id="cmd-todo-stats" hidden></div>
+
+  <!-- Transient Save confirmation overlaid at the panel bottom, like the
+       macOS TodoView capsule toast -->
+  <div class="cmd-todo-toast" id="cmd-todo-toast"></div>
 </div>

--- a/apps/linows/src/js/screens/commands/todo.js
+++ b/apps/linows/src/js/screens/commands/todo.js
@@ -5,7 +5,6 @@
 // Save (Ctrl+S). No autosave.
 
 import { todoList, todoSave } from '../../ipc.js';
-import * as banner from '../../components/banner.js';
 import {
   listChecks, barChart, flame, plus, save as saveIcon, calendarPlus,
   trash as trashIcon, search as searchIcon, check as checkIcon, activity, calendar, zap,
@@ -47,6 +46,7 @@ let onQuickChange = null;
 // --- DOM refs ---
 let panel, searchBar, searchInput, statsBar, toolbar;
 let countEl, addDateBtn, saveBtn, daysEl, statsEl, tooltipEl;
+let toastEl, toastTimer;
 
 export function init() {
   panel = document.getElementById('cmd-panel-todo');
@@ -59,6 +59,7 @@ export function init() {
   saveBtn = document.getElementById('cmd-todo-save-btn');
   daysEl = document.getElementById('cmd-todo-days');
   statsEl = document.getElementById('cmd-todo-stats');
+  toastEl = document.getElementById('cmd-todo-toast');
 
   document.getElementById('cmd-todo-search-icon').innerHTML = searchIcon;
   document.getElementById('cmd-todo-stats-icon').innerHTML = barChart;
@@ -140,8 +141,19 @@ export function exit() {
   visible = false;
   panel.hidden = true;
   tooltipEl.hidden = true;
+  toastEl.classList.remove('show');
   editingAddKey = null;
   editingTaskRef = null;
+}
+
+// In-panel capsule toast at the panel bottom, matching the macOS TodoView
+// savedToast overlay (the global banner belongs to the home screen).
+function showToast(html, isError, secs) {
+  toastEl.innerHTML = html;
+  toastEl.classList.toggle('cmd-todo-toast-error', isError);
+  toastEl.classList.add('show');
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => toastEl.classList.remove('show'), secs * 1000);
 }
 
 // Anchored above the hovered cell, clamped to the window edges.
@@ -243,10 +255,10 @@ async function persist() {
   try {
     await todoSave(tasks);
     dirty = false;
-    banner.show('Saved', 'success', SAVE_TOAST_SECS);
+    showToast(`${checkIcon} Saved`, false, SAVE_TOAST_SECS);
     renderToolbar();
   } catch (err) {
-    banner.show(`Save failed: ${err}`, 'error', 2.0);
+    showToast(`Save failed: ${escapeHtml(String(err))}`, true, 2.0);
   }
 }
 


### PR DESCRIPTION
## Summary

- fix saved message on todo screen

## Why

- Currently, when hitting save on **todo** screen, message shows on **home** screen instead.

## Changes

- UI

## Testing

- `core`
  - [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [ ] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [ ] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [x] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered
