### PR TITLE
chore: inner gaps disable based on envs

### DIFF
--- a/apps/linows/src-tauri/src/platform/linux/gpu.rs
+++ b/apps/linows/src-tauri/src/platform/linux/gpu.rs
@@ -8,7 +8,17 @@
 
 use crate::config;
 use crate::consts;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tauri::Manager;
+
+/// Set once by detect_and_disable_virtual_gpu() at startup; read by
+/// get_platform so the frontend can force the blur fallback in VMs
+/// (software rendering + backdrop-filter ghost-renders).
+static VIRTUAL_GPU: AtomicBool = AtomicBool::new(false);
+
+pub fn virtual_gpu_detected() -> bool {
+    VIRTUAL_GPU.load(Ordering::Relaxed)
+}
 
 /// Detect if running inside a VM with a virtual GPU that doesn't support EGL.
 /// Returns true if GPU acceleration should be disabled.
@@ -47,6 +57,7 @@ pub fn detect_and_disable_virtual_gpu() -> bool {
             .unwrap_or(false)
     };
     if detected {
+        VIRTUAL_GPU.store(true, Ordering::Relaxed);
         unsafe {
             std::env::set_var("WEBKIT_DISABLE_GPU", "1");
             std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");

--- a/apps/linows/src-tauri/src/platform/mod.rs
+++ b/apps/linows/src-tauri/src/platform/mod.rs
@@ -89,6 +89,10 @@ pub struct PlatformInfo {
     /// Exposed to the frontend so CSS can branch on compositor-specific bugs
     /// (e.g. WebKitGTK backdrop-filter glitches on Hyprland).
     pub compositor: Option<String>,
+    /// True when a virtual GPU was detected at startup (VM). Hardware
+    /// acceleration is already off; the frontend must also drop backdrop
+    /// blur or software compositing ghost-renders stale layers.
+    pub virtual_gpu: bool,
 }
 
 #[tauri::command]
@@ -107,10 +111,17 @@ pub fn get_platform() -> PlatformInfo {
     #[cfg(not(target_os = "linux"))]
     let compositor: Option<String> = None;
 
+    #[cfg(target_os = "linux")]
+    let virtual_gpu = linux::gpu::virtual_gpu_detected();
+
+    #[cfg(not(target_os = "linux"))]
+    let virtual_gpu = false;
+
     PlatformInfo {
         os,
         has_compositor,
         compositor,
+        virtual_gpu,
     }
 }
 

--- a/apps/linows/src/css/components/settings.css
+++ b/apps/linows/src/css/components/settings.css
@@ -195,6 +195,13 @@ html:not([data-os="linux"]) .settings-linux-only {
   color: var(--font-secondary);
 }
 
+/* Rows disabled because the environment can't render the feature
+ * (e.g. Inner Gap without a compositing-capable stack). */
+.settings-row-disabled {
+  opacity: 0.45;
+}
+
+
 /* Slider - full width, no wrapper needed */
 .settings-slider {
   flex: 1;

--- a/apps/linows/src/html/screens/settings.html
+++ b/apps/linows/src/html/screens/settings.html
@@ -48,14 +48,10 @@
         <!-- Layout -->
         <div class="settings-section-header"><span class="settings-section-arrow">&#9654;</span><span>Layout</span></div>
         <div class="settings-section">
-          <div class="settings-row" data-key="inner_gap">
+          <div class="settings-row" data-key="inner_gap" title="i3-style gap between the top row, results list and preview. 0 = flat layout; higher turns each into its own card.">
             <label class="settings-label">Inner Gap</label>
             <input type="range" class="settings-slider" min="0" max="24" step="1" value="0" />
             <span class="settings-slider-value">0</span>
-          </div>
-          <div class="settings-row">
-            <label class="settings-label"></label>
-            <span class="settings-hint-text">0 = classic panel; above 0 the home screen splits into floating tiles</span>
           </div>
         </div>
 

--- a/apps/linows/src/js/layout.js
+++ b/apps/linows/src/js/layout.js
@@ -7,6 +7,8 @@
 // state - so the floating gate below reads coarse mode only (gap setting,
 // command/settings/help), never query text or result counts.
 
+import * as platform from './platform.js';
+
 const GAP_MIN = 0;
 const GAP_MAX = 24;
 
@@ -120,11 +122,21 @@ function drawnImageRect(winRect) {
   return { x: 0, y: 0, w: winRect.width, h: winRect.height };
 }
 
+// Re-evaluate the floating gate after environment state changes at runtime
+// (the settings blur-fallback toggle flips data-disable-blur).
+export function refresh() {
+  apply();
+}
+
 function apply() {
   if (!win) return;
+  // Degraded-rendering environments keep the classic framed panel: both the
+  // gaps and the resting bar depend on real transparency. Still coarse -
+  // platform info is static and the attribute only flips from settings.
+  const supported = platform.floatingSupported();
   const onHome = !modal.command && !modal.settings && !modal.help;
-  const floating = innerGap > 0 && onHome; // showsFloatingCards
-  const resting = queryEmpty && onHome; // hidesResultsForEmptyQuery
+  const floating = supported && innerGap > 0 && onHome; // showsFloatingCards
+  const resting = supported && queryEmpty && onHome; // hidesResultsForEmptyQuery
   const barFree = floating || resting; // barFloatsFree
   const floatingGrid = floating && !translateQuery && !recentEmptyQuery;
 

--- a/apps/linows/src/js/platform.js
+++ b/apps/linows/src/js/platform.js
@@ -16,6 +16,34 @@ export async function init() {
   // semantics: the Rust eval runs once at setup, so a page reload (dev hot
   // reload) would otherwise lose the attribute and square the corners.
   document.documentElement.setAttribute('data-transparent', String(hasCompositor()));
+  // Virtual GPU (VM): hardware acceleration is already off backend-side, but
+  // software compositing still ghost-renders backdrop-filter layers. Force
+  // the blur fallback without touching the user's config.
+  if (blurForcedOff()) {
+    document.documentElement.setAttribute('data-disable-blur', '');
+  }
+}
+
+// True when the blur fallback is forced by the platform (VM GPU) rather than
+// the arch_disable_blur config toggle. Settings must not remove the
+// attribute in this case.
+export function blurForcedOff() {
+  return info?.virtual_gpu ?? false;
+}
+
+// The floating inner-gap layout depends on see-through gaps and frosted
+// tiles, so it needs WebKitGTK to composite translucency faithfully. That
+// rules out the same environments applytint() degrades on: no compositor
+// (bare X11/i3 - "transparent" pixels come out opaque, gaps read as empty
+// boxes), the VM software-rendering fallback, and the ghost-rendering
+// stacks where blur is dropped (Hyprland auto, Arch toggle). Those render
+// the classic framed panel regardless of the inner_gap setting; the config
+// value stays untouched and applies again on a capable setup.
+export function floatingSupported() {
+  return hasCompositor()
+    && !blurForcedOff()
+    && compositor() !== 'hyprland'
+    && !document.documentElement.hasAttribute('data-disable-blur');
 }
 
 export function os() {

--- a/apps/linows/src/js/screens/settings.js
+++ b/apps/linows/src/js/screens/settings.js
@@ -360,11 +360,13 @@ export function init(exitFn) {
     const on = e.target.checked;
     if (on) {
       document.documentElement.setAttribute('data-disable-blur', '');
-    } else {
+    } else if (!platform.blurForcedOff()) {
       document.documentElement.removeAttribute('data-disable-blur');
     }
     saveConfig({ arch_disable_blur: on ? 'true' : 'false' });
     applytint();
+    updateInnerGapAvailability();
+    layout.refresh();
   });
 
   document.getElementById('settings-launch-login').addEventListener('change', (e) => {
@@ -735,9 +737,21 @@ async function loadConfigMap() {
   return map;
 }
 
+// Environments that can't render the floating layout (see
+// platform.floatingSupported) get the slider disabled; the config value is
+// preserved so it applies again on a capable setup.
+function updateInnerGapAvailability() {
+  const row = document.querySelector('.settings-row[data-key="inner_gap"]');
+  if (!row) return;
+  const ok = platform.floatingSupported();
+  row.querySelector('.settings-slider').disabled = !ok;
+  row.classList.toggle('settings-row-disabled', !ok);
+}
+
 async function loadConfig() {
   try {
     const cfg = await getConfig();
+    updateInnerGapAvailability();
 
     const map = {};
     for (const entry of cfg.entries) map[entry.key] = entry.value;
@@ -805,7 +819,7 @@ async function loadConfig() {
     document.getElementById('settings-arch-disable-blur').checked = map.arch_disable_blur === 'true';
     if (map.arch_disable_blur === 'true') {
       document.documentElement.setAttribute('data-disable-blur', '');
-    } else {
+    } else if (!platform.blurForcedOff()) {
       document.documentElement.removeAttribute('data-disable-blur');
     }
 


### PR DESCRIPTION
## Summary

- Some DE like VMs, X11 don't have right built-in transparent, blur render effects. We decide to disable inner gaps feature for these environments

## Testing

- [x] UI Manual verification (if UI/behavior changed)
  - [x] Ubuntu vm
  - [x] X11 @dont-wait 
  - [x] X11, i3 (on VM)

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
