### PR TITLE
feat(macos): navigate the folder preview with arrow keys

### DIFF
--- a/apps/macos/LauncherApp/LauncherLogicTests/FolderBrowseLogicTests.swift
+++ b/apps/macos/LauncherApp/LauncherLogicTests/FolderBrowseLogicTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import LauncherLogic
+
+final class FolderBrowseLogicTests: XCTestCase {
+    // MARK: - childPath(parent:name:)
+
+    func testJoinsParentAndChildName() {
+        XCTAssertEqual(
+            FolderBrowseLogic.childPath(parent: "/Users/me/Documents", name: "Projects"),
+            "/Users/me/Documents/Projects"
+        )
+    }
+
+    func testJoinHandlesTrailingSlashOnParent() {
+        let joined = FolderBrowseLogic.childPath(parent: "/Users/me/Desktop/", name: "a.txt")
+        XCTAssertEqual(joined, "/Users/me/Desktop/a.txt")
+        XCTAssertFalse(joined.contains("//"))
+    }
+
+    func testJoinPreservesNamesWithSpacesAndUnicode() {
+        XCTAssertEqual(
+            FolderBrowseLogic.childPath(parent: "/Users/me/Desktop", name: "Giục nữa thì vào mà làm!"),
+            "/Users/me/Desktop/Giục nữa thì vào mà làm!"
+        )
+    }
+
+    // MARK: - steppedIndex(from:count:delta:)
+
+    func testStepsDownWithinBounds() {
+        XCTAssertEqual(FolderBrowseLogic.steppedIndex(from: 0, count: 5, delta: 1), 1)
+        XCTAssertEqual(FolderBrowseLogic.steppedIndex(from: 3, count: 5, delta: 1), 4)
+    }
+
+    func testStepsUpWithinBounds() {
+        XCTAssertEqual(FolderBrowseLogic.steppedIndex(from: 4, count: 5, delta: -1), 3)
+    }
+
+    func testWrapsPastLastRowToFirst() {
+        XCTAssertEqual(FolderBrowseLogic.steppedIndex(from: 4, count: 5, delta: 1), 0)
+    }
+
+    func testWrapsBeforeFirstRowToLast() {
+        XCTAssertEqual(FolderBrowseLogic.steppedIndex(from: 0, count: 5, delta: -1), 4)
+    }
+
+    func testClampsStaleOutOfRangeIndexBeforeStepping() {
+        // A re-list can shrink the folder while the old index is still held.
+        XCTAssertEqual(FolderBrowseLogic.steppedIndex(from: 9, count: 3, delta: 1), 0)
+        XCTAssertEqual(FolderBrowseLogic.steppedIndex(from: -2, count: 3, delta: -1), 2)
+    }
+
+    func testEmptyListingAlwaysYieldsZero() {
+        XCTAssertEqual(FolderBrowseLogic.steppedIndex(from: 0, count: 0, delta: 1), 0)
+        XCTAssertEqual(FolderBrowseLogic.steppedIndex(from: 5, count: 0, delta: -1), 0)
+    }
+
+    func testSingleRowStaysSelectedInBothDirections() {
+        XCTAssertEqual(FolderBrowseLogic.steppedIndex(from: 0, count: 1, delta: 1), 0)
+        XCTAssertEqual(FolderBrowseLogic.steppedIndex(from: 0, count: 1, delta: -1), 0)
+    }
+}

--- a/apps/macos/LauncherApp/Package.swift
+++ b/apps/macos/LauncherApp/Package.swift
@@ -18,6 +18,8 @@ let package = Package(
                 "Support/AppConstants.swift",
                 "Support/Launcher/LauncherSearchLogic.swift",
                 "Support/Launcher/DeleteTargetLogic.swift",
+                "Support/Launcher/FolderBrowseLogic.swift",
+                "Support/FolderListingService.swift",
                 "Support/Launcher/BridgeErrorMapping.swift",
                 "Support/SingleInstanceLock.swift",
                 "Models/LauncherResult.swift",

--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -216,6 +216,13 @@ enum AppConstants {
             ]
         }
 
+        enum FolderBrowse {
+            // Rows synthesized while browsing a folder's children with the
+            // arrow keys. Not indexed candidates - openSelectedApp skips
+            // usage recording for them (same rule as QuickFolder rows).
+            static let resultIDPrefix = "browse-item:"
+        }
+
         enum Clipboard {
             static let resultIDPrefix = "clipboard:"
             static let resultPath = "clipboard://history"

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/FolderBrowseLogic.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/FolderBrowseLogic.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Pure helpers for folder-browse: keyboard navigation of the preview pane's
+/// folder listing. Kept UI-free so they can be unit-tested in the
+/// LauncherLogic package.
+enum FolderBrowseLogic {
+    /// Absolute path of a listed child inside its parent folder.
+    static func childPath(parent: String, name: String) -> String {
+        URL(fileURLWithPath: parent).appendingPathComponent(name).path
+    }
+
+    /// Steps the highlighted row by `delta`, wrapping at both ends (matches
+    /// the results list's Up/Down behavior). Out-of-range `current` values
+    /// (e.g. after a re-list shrank the folder) are clamped first.
+    static func steppedIndex(from current: Int, count: Int, delta: Int) -> Int {
+        guard count > 0 else { return 0 }
+        let clamped = min(max(current, 0), count - 1)
+        return ((clamped + delta) % count + count) % count
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
@@ -24,6 +24,13 @@ final class KeyboardSelectionMonitor {
         onPrevious: @escaping @MainActor () -> Void,
         onArrowDown: (@MainActor () -> Void)? = nil,
         onArrowUp: (@MainActor () -> Void)? = nil,
+        // Folder-browse navigation. Both return whether they consumed the
+        // key; false lets the event through so the caret keeps moving in the
+        // query field.
+        onArrowRight: (@MainActor () -> Bool)? = nil,
+        onArrowLeft: (@MainActor () -> Bool)? = nil,
+        onExitFolderBrowse: (@MainActor () -> Void)? = nil,
+        folderBrowseActive: @escaping @MainActor () -> Bool = { false },
         onEnterCommandMode: @escaping @MainActor () -> Void,
         onExitCommandMode: @escaping @MainActor () -> Void,
         onHideLauncher: @escaping @MainActor () -> Void,
@@ -209,6 +216,11 @@ final class KeyboardSelectionMonitor {
                     return nil
                 }
 
+                if folderBrowseActive() {
+                    onExitFolderBrowse?()
+                    return nil
+                }
+
                 if inCommandMode() {
                     if flags.contains(.shift) {
                         onHideLauncher()
@@ -276,6 +288,22 @@ final class KeyboardSelectionMonitor {
                     onNext()
                 }
                 return nil
+            }
+
+            // Right/Left drive folder browsing only when the handler reports
+            // the key as consumed; otherwise they stay text-caret keys.
+            if event.keyCode == 124, let onArrowRight {
+                if onArrowRight() {
+                    return nil
+                }
+                return event
+            }
+
+            if event.keyCode == 123, let onArrowLeft {
+                if onArrowLeft() {
+                    return nil
+                }
+                return event
             }
 
             return event

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/FolderPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/FolderPreviewView.swift
@@ -6,6 +6,9 @@ struct FolderPreviewView: View {
     @EnvironmentObject private var themeStore: ThemeStore
     let path: String
     let listing: FolderListing?
+    // Highlighted row while the keyboard selection lives in this pane
+    // (folder-browse); nil renders the classic static preview.
+    var selectedIndex: Int? = nil
 
     private var rowFont: Font {
         themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular)
@@ -47,24 +50,33 @@ struct FolderPreviewView: View {
 
     @ViewBuilder
     private func list(_ listing: FolderListing) -> some View {
-        ScrollView {
-            LazyVStack(alignment: .leading, spacing: 0) {
-                ForEach(Array(listing.items.enumerated()), id: \.offset) { index, entry in
-                    if index > 0,
-                       entry.isDir == false,
-                       listing.items[index - 1].isDir == true {
-                        Divider()
-                            .padding(.vertical, 4)
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(listing.items.enumerated()), id: \.offset) { index, entry in
+                        if index > 0,
+                           entry.isDir == false,
+                           listing.items[index - 1].isDir == true {
+                            Divider()
+                                .padding(.vertical, 4)
+                        }
+                        row(entry, isSelected: index == selectedIndex)
+                            .id(index)
                     }
-                    row(entry)
-                }
 
-                if listing.truncated {
-                    Text("Showing \(listing.items.count) of \(listing.folderCount + listing.fileCount)")
-                        .font(sizeFont)
-                        .foregroundStyle(themeStore.mutedTextColor())
-                        .padding(.vertical, 6)
-                        .frame(maxWidth: .infinity, alignment: .center)
+                    if listing.truncated {
+                        Text("Showing \(listing.items.count) of \(listing.folderCount + listing.fileCount)")
+                            .font(sizeFont)
+                            .foregroundStyle(themeStore.mutedTextColor())
+                            .padding(.vertical, 6)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                    }
+                }
+            }
+            .onChange(of: selectedIndex) { _, newIndex in
+                guard let newIndex else { return }
+                withAnimation(.easeOut(duration: 0.12)) {
+                    proxy.scrollTo(newIndex, anchor: nil)
                 }
             }
         }
@@ -73,7 +85,7 @@ struct FolderPreviewView: View {
     }
 
     @ViewBuilder
-    private func row(_ entry: FolderEntry) -> some View {
+    private func row(_ entry: FolderEntry, isSelected: Bool) -> some View {
         HStack(spacing: 8) {
             Image(nsImage: icon(for: entry))
                 .resizable()
@@ -87,6 +99,12 @@ struct FolderPreviewView: View {
 
             Spacer(minLength: 8)
 
+            if entry.isDir, isSelected {
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(themeStore.mutedTextColor())
+            }
+
             if !entry.isDir, let size = entry.size {
                 Text(formatSize(size))
                     .font(sizeFont)
@@ -96,6 +114,10 @@ struct FolderPreviewView: View {
         .contentShape(Rectangle())
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
+        .background(
+            isSelected ? themeStore.selectionFillColor() : .clear,
+            in: RoundedRectangle(cornerRadius: 6, style: .continuous)
+        )
         .onTapGesture { open(entry) }
     }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+FolderBrowse.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+FolderBrowse.swift
@@ -1,0 +1,188 @@
+import AppKit
+import SwiftUI
+
+// Folder-browse: arrow-key navigation of the preview pane's folder listing.
+// The classic two-pane layout stays as-is; only the selection moves.
+//
+//   Right   - with a folder result selected, jump the selection into the
+//             right-hand preview listing; on a highlighted subfolder, drill
+//             into it (the preview pane re-lists that subfolder)
+//   Up/Down - move the highlight through the preview rows
+//   Left    - back up one level; at the first folder, return the selection
+//             to the results list
+//   Enter   - open the highlighted child (file in its default app, folder
+//             in Finder)
+//   Esc     - return the selection to the results list
+//
+// Typing continues to edit the query as usual, which exits browse and runs
+// a fresh search.
+extension LauncherView {
+    var isFolderBrowseMode: Bool { !browseStack.isEmpty }
+
+    var currentBrowsePath: String? { browseStack.last }
+
+    /// Synthetic preview-pane subject while drilled below the selected
+    /// result's own folder, so the header/path/modified rows describe the
+    /// folder actually being listed. At depth 1 the real selected result is
+    /// previewed, exactly as before.
+    var browsePreviewResult: LauncherResult? {
+        guard browseStack.count > 1, let path = browseStack.last else { return nil }
+        return LauncherResult(
+            id: AppConstants.Launcher.FolderBrowse.resultIDPrefix + path,
+            kind: .folder,
+            title: URL(fileURLWithPath: path).lastPathComponent,
+            subtitle: path,
+            path: path,
+            score: 0
+        )
+    }
+
+    /// Up/Down while the preview selection is active. Returns true when the
+    /// key was consumed; false hands it back to the results list.
+    func handleBrowseArrowDown() -> Bool {
+        guard isFolderBrowseMode else { return false }
+        stepBrowseSelection(by: 1)
+        return true
+    }
+
+    func handleBrowseArrowUp() -> Bool {
+        guard isFolderBrowseMode else { return false }
+        stepBrowseSelection(by: -1)
+        return true
+    }
+
+    private func stepBrowseSelection(by delta: Int) {
+        guard let count = browseListing?.items.count, count > 0 else { return }
+        browseIndex = FolderBrowseLogic.steppedIndex(from: browseIndex, count: count, delta: delta)
+    }
+
+    /// Right arrow. Returns true when consumed; false lets the event fall
+    /// through to the text field so the caret still moves while editing.
+    func handleBrowseArrowRight() -> Bool {
+        if isFolderBrowseMode {
+            guard let currentBrowsePath,
+                let listing = browseListing,
+                listing.items.indices.contains(browseIndex)
+            else { return true }
+            let entry = listing.items[browseIndex]
+            // Right on a file is a no-op (still consumed - the selection
+            // lives in the preview, not the text field).
+            guard entry.isDir else { return true }
+            browseInto(path: FolderBrowseLogic.childPath(parent: currentBrowsePath, name: entry.name))
+            return true
+        }
+
+        guard !isCommandMode, !appUIState.showsThemeSettings, !showsHelpScreen,
+            !isPrefixSuggestionQuery, !isCommandSuggestionQuery, !isClipboardQuery,
+            pendingKillCandidate == nil, pendingEmptyTrashCount == nil
+        else { return false }
+        guard isQueryCaretAtEndOrTextEmpty else { return false }
+        guard let selectedResultID,
+            let selected = displayedResults.first(where: { $0.id == selectedResultID }),
+            selected.kind == .folder,
+            !DeleteTargetLogic.isURLScheme(selected.path),
+            // ~/.Trash is TCC-protected and gets a Finder-backed summary
+            // instead of a listing - nothing to browse into.
+            !DeleteTargetLogic.isTrashPath(selected.path, homeDirectory: NSHomeDirectory())
+        else { return false }
+        guard FileManager.default.fileExists(atPath: selected.path) else {
+            showBanner("This folder no longer exists", style: .error, duration: 1.4)
+            return true
+        }
+        browseInto(path: selected.path)
+        return true
+    }
+
+    /// Left arrow. Returns true when consumed (stepped up / exited browse).
+    func handleBrowseArrowLeft() -> Bool {
+        guard isFolderBrowseMode else { return false }
+        browseBackToParent()
+        return true
+    }
+
+    func browseInto(path: String) {
+        browseStack.append(path)
+        loadBrowseListing(for: path, selecting: nil)
+    }
+
+    func browseBackToParent() {
+        guard let leavingPath = browseStack.popLast() else { return }
+        guard let parentPath = browseStack.last else {
+            exitFolderBrowse()
+            return
+        }
+        // Re-highlight the folder we just came out of so Left undoes Right.
+        loadBrowseListing(for: parentPath, selecting: leavingPath)
+    }
+
+    /// Returns the selection to the results list.
+    func exitFolderBrowse() {
+        browseLoadTask?.cancel()
+        browseLoadTask = nil
+        browseStack = []
+        browseListing = nil
+        browseIndex = 0
+    }
+
+    /// Window-hide teardown: next open starts with the selection in the
+    /// results list as usual.
+    func resetFolderBrowseStateOnHide() {
+        exitFolderBrowse()
+    }
+
+    /// Enter while the preview selection is active: open the highlighted
+    /// child. Browse rows aren't indexed candidates, so no usage is recorded
+    /// (same rule as quick-folder rows).
+    func openPreviewSelectionIfActive() -> Bool {
+        guard isFolderBrowseMode else { return false }
+        guard let currentBrowsePath,
+            let listing = browseListing,
+            listing.items.indices.contains(browseIndex)
+        else { return true }
+        let entry = listing.items[browseIndex]
+        let childPath = FolderBrowseLogic.childPath(parent: currentBrowsePath, name: entry.name)
+        guard FileManager.default.fileExists(atPath: childPath) else {
+            showBanner("This item no longer exists", style: .error, duration: 1.4)
+            return true
+        }
+        openTargetAsync(childPath)
+        hideLauncherWindow(restorePreviousApp: false)
+        return true
+    }
+
+    func loadBrowseListing(for path: String, selecting selectPath: String?) {
+        browseLoadTask?.cancel()
+        browseListing = nil
+        browseIndex = 0
+        browseLoadTask = Task {
+            let listing = await FolderListingService.list(path: path)
+            guard !Task.isCancelled, browseStack.last == path else { return }
+
+            guard let listing else {
+                // Unreadable folder (permissions, TCC): surface it and step
+                // back to wherever we came from.
+                showBanner("Cannot read this folder", style: .error, duration: 1.6)
+                browseBackToParent()
+                return
+            }
+
+            browseListing = listing
+            if let selectPath,
+                let index = listing.items.firstIndex(where: {
+                    FolderBrowseLogic.childPath(parent: path, name: $0.name) == selectPath
+                }) {
+                browseIndex = index
+            }
+        }
+    }
+
+    /// True when the caret sits at the end of the query text (or the field is
+    /// empty / not being edited), i.e. a Right arrow would be a no-op for text
+    /// editing and is safe to repurpose for folder navigation.
+    private var isQueryCaretAtEndOrTextEmpty: Bool {
+        if query.isEmpty { return true }
+        guard let editor = NSApp.keyWindow?.firstResponder as? NSTextView else { return true }
+        let range = editor.selectedRange()
+        return range.length == 0 && range.location >= (editor.string as NSString).length
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
@@ -8,6 +8,10 @@ nonisolated private let openLaunchLog = Logger(subsystem: "noah-code.Look", cate
 
 extension LauncherView {
     func openSelectedApp() {
+        // Enter while the preview-pane selection is active opens the
+        // highlighted child instead of the results-list row.
+        if openPreviewSelectionIfActive() { return }
+
         guard let selectedResultID,
             let selected = displayedResults.first(where: { $0.id == selectedResultID })
         else { return }
@@ -464,6 +468,13 @@ extension LauncherView {
             // background index refresh below is async and would otherwise leave
             // the now-gone items visible (and un-previewable) until the next search.
             backendResults.removeAll { trashed.contains($0.id) }
+
+            // Cmd+D acts on the results-list selection; if that folder was
+            // being browsed in the preview, the browse target may be gone -
+            // return the selection to the results list.
+            if isFolderBrowseMode, !trashed.isEmpty {
+                exitFolderBrowse()
+            }
 
             // Keep selection valid if it pointed at a now-removed row.
             if let selectedResultID, !displayedResults.contains(where: { $0.id == selectedResultID }) {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
@@ -133,6 +133,7 @@ extension LauncherView {
                 moveSelection(.up, shouldAutocompleteCommand: true, preferCommandListInCommandMode: true)
             },
             onArrowDown: {
+                if handleBrowseArrowDown() { return }
                 if isCommandMode {
                     if activeCommandID == AppConstants.Launcher.Command.kill {
                         moveSelection(.down)
@@ -142,6 +143,7 @@ extension LauncherView {
                 }
             },
             onArrowUp: {
+                if handleBrowseArrowUp() { return }
                 if isCommandMode {
                     if activeCommandID == AppConstants.Launcher.Command.kill {
                         moveSelection(.up)
@@ -150,6 +152,16 @@ extension LauncherView {
                     moveSelection(.up)
                 }
             },
+            onArrowRight: {
+                handleBrowseArrowRight()
+            },
+            onArrowLeft: {
+                handleBrowseArrowLeft()
+            },
+            onExitFolderBrowse: {
+                exitFolderBrowse()
+            },
+            folderBrowseActive: { isFolderBrowseMode },
             onEnterCommandMode: {
                 if !isCommandMode {
                     enterCommandMode()

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+WindowControl.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+WindowControl.swift
@@ -162,6 +162,9 @@ extension LauncherView {
         isQueryFocused = false
         // Don't leave a stale Empty Trash confirmation to reappear on next show.
         pendingEmptyTrashCount = nil
+        // Nor a stale folder-browse session - next show starts from the
+        // pre-browse query.
+        resetFolderBrowseStateOnHide()
         let wasVisible = window.isVisible
         window.orderOut(nil)
         hotkeyLog.notice("hide: orderOut wasVisible=\(wasVisible) restore=\(restorePreviousApp)")

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -71,6 +71,13 @@ struct LauncherView: View {
     @State var killListRefreshTick: Int = 0
     @State var recentlyKilledPIDs: Set<Int32> = []
     @State var showsHelpScreen = false
+    // Folder-browse (see LauncherView+FolderBrowse): arrow-key navigation of
+    // the preview pane's folder listing. Stack of drilled folder paths; empty
+    // = the selection lives in the results list as usual.
+    @State var browseStack: [String] = []
+    @State var browseListing: FolderListing?
+    @State var browseLoadTask: Task<Void, Never>?
+    @State var browseIndex = 0
     @State var focusRequestToken: UInt64 = 0
     @State var lookupDefinition: LookupDefinition?
     @State var pidToRestoreOnHide: pid_t?
@@ -434,6 +441,11 @@ struct LauncherView: View {
             return ["Enter run", "Tab select", "Cmd+1-6 switch", "Esc back"]
         }
 
+        if isFolderBrowseMode {
+            let folderName = currentBrowsePath.map { URL(fileURLWithPath: $0).lastPathComponent } ?? ""
+            return ["Browsing \(folderName)", "↑↓ move", "→ into folder", "← back", "Enter open", "Esc list"]
+        }
+
         if let command = extractTranslationQuery(from: query.trimmingCharacters(in: .whitespacesAndNewlines)) {
             switch command {
             case .network:
@@ -459,6 +471,12 @@ struct LauncherView: View {
             return ["Enter copy clip", "Delete remove clip"]
         }
 
+        // Surface the browse affordance whenever a folder row is selected.
+        if let selectedResultID,
+            displayedResults.first(where: { $0.id == selectedResultID })?.kind == .folder {
+            return ["Enter open", "→ browse folder", "Cmd+H help"]
+        }
+
         // The home screen replaces the "Cmd+/ command mode" hint with a
         // clickable today done/total quick view (see todoQuickView), so it
         // is intentionally omitted here.
@@ -469,7 +487,9 @@ struct LauncherView: View {
     /// whose hint falls through to the list above), where the /todo quick
     /// view is shown in place of the command-mode hint.
     var isHomeHintScreen: Bool {
-        guard !appUIState.showsThemeSettings, !isCommandMode, !showsHelpScreen else { return false }
+        guard !appUIState.showsThemeSettings, !isCommandMode, !showsHelpScreen,
+            !isFolderBrowseMode
+        else { return false }
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         if extractTranslationQuery(from: trimmed) != nil { return false }
         if isPrefixSuggestionQuery || isCommandSuggestionQuery || isClipboardQuery { return false }
@@ -607,6 +627,11 @@ struct LauncherView: View {
             if pendingEmptyTrashCount != nil {
                 pendingEmptyTrashCount = nil
             }
+            // Typing while the preview selection is active returns the
+            // selection to the results list - the edit runs a fresh search.
+            if isFolderBrowseMode {
+                exitFolderBrowse()
+            }
             if !isCommandMode, let cmd = extractInlineCommand(from: query), cmd.hasSpace {
                 aiAnswer.cancel()
                 enterCommandMode(commandID: cmd.id, prefilledInput: cmd.args)
@@ -636,6 +661,13 @@ struct LauncherView: View {
             // Google autocomplete rows (appended after engine results). Self-gates
             // by mode and the online-features flag; never blocks search.
             refreshWebSuggestions()
+        }
+        .onChange(of: selectedResultID) { _, _ in
+            // Picking a different result (mouse click, arriving search
+            // results) returns the selection to the results list.
+            if isFolderBrowseMode {
+                exitFolderBrowse()
+            }
         }
         .onReceive(clipboardStore.$entries) { _ in
             refreshClipboardSelectionIfNeeded()
@@ -1005,7 +1037,9 @@ struct LauncherView: View {
                     result: selectedResult,
                     onDeleteClipboard: selectedResult.kind == .clipboard
                         ? { deleteClipboardResult(resultID: selectedResult.id) }
-                        : nil
+                        : nil,
+                    folderListingOverride: isFolderBrowseMode ? browseListing : nil,
+                    folderSelectionIndex: isFolderBrowseMode ? browseIndex : nil
                 )
             }
         }
@@ -1247,6 +1281,9 @@ struct LauncherView: View {
     /// The selected result eligible for the right-hand preview pane, or nil when
     /// the list should span full width (suggestions, nothing selected, etc.).
     private var previewResult: LauncherResult? {
+        // Drilled below the selected folder: preview the folder actually
+        // being listed (see LauncherView+FolderBrowse).
+        if let browsePreviewResult { return browsePreviewResult }
         guard pickedKeys.isEmpty,
               !isPrefixSuggestionQuery, !isCommandSuggestionQuery,
               let selectedID = selectedResultID,

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
@@ -6,6 +6,11 @@ struct ResultPreviewView: View {
     @EnvironmentObject private var themeStore: ThemeStore
     let result: LauncherResult
     var onDeleteClipboard: (() -> Void)? = nil
+    // Folder-browse (keyboard navigation of the listing): the launcher owns
+    // the listing + highlighted row while browsing, so the pane renders that
+    // state instead of its self-loaded listing.
+    var folderListingOverride: FolderListing? = nil
+    var folderSelectionIndex: Int? = nil
 
     @State private var folderListing: FolderListing?
     @State private var trashItemCount: Int?
@@ -131,7 +136,7 @@ struct ResultPreviewView: View {
                                             .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular))
                                             .foregroundStyle(themeStore.secondaryTextColor())
                                     }
-                                } else if let listing = folderListing,
+                                } else if let listing = folderListingOverride ?? folderListing,
                                    let counts = folderCountText(listing) {
                                     Text(counts)
                                         .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular))
@@ -159,7 +164,11 @@ struct ResultPreviewView: View {
                     if isTrash {
                         TrashSummaryView(itemCount: trashItemCount, themeStore: themeStore)
                     } else {
-                        FolderPreviewView(path: result.path, listing: folderListing)
+                        FolderPreviewView(
+                            path: result.path,
+                            listing: folderListingOverride ?? folderListing,
+                            selectedIndex: folderSelectionIndex
+                        )
                     }
                 }
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -18,6 +18,7 @@ This document tracks what `look` supports today and what is planned next.
 - scoped query prefixes: `a"`, `f"`, `d"`, `r"`, and `rc"` (recent files/folders, newest first - blends opened-through-Look with recently added/changed on disk; macOS for now)
 - path-fragment friendly matching (slash-biased queries)
 - open with `Enter`, reveal in Finder with `Cmd+F`
+- folder browse (macOS): with a folder result selected, `Right` moves the selection into the preview pane's folder listing - `Up`/`Down` move the highlight there, `Right` on a subfolder drills into it, `Left` steps back up (returning to the results list at the first folder), `Enter` opens the highlighted child, `Esc` returns to the results list
 - copy selected file/folder path/content handle with `Cmd+C`
 - multi-pick files/folders with `Cmd+P` (toggle); picked set is mirrored to the system pasteboard for paste anywhere. `Cmd+Shift+P` clears the set
 - move selected file/folder (or all picked items) to the Trash with `Cmd+D` - recoverable, no confirmation (macOS only for now)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -280,6 +280,7 @@ Note: `Settings Blur` is stored as local app UI state (UserDefaults) and is not 
 - `Enter`: open selected result / run command
 - `Tab` / `Shift+Tab`: next/previous result (app list) or command (command mode)
 - `Up` / `Down`: move selection (and in `kill`, move process selection)
+- `Right` / `Left` (macOS): with a folder result selected, `Right` moves the selection into the preview pane's folder listing (`Up`/`Down` move the highlight, `Right` on a subfolder drills in, `Enter` opens the highlighted item); `Left` steps back up, returning to the results list at the first folder. `Esc` also returns to the list
 - `Cmd+/`: command mode
 - `:cmd` (e.g. `:calc 2+2`, `:kill chrome`, `:sys`, `:todo`): jump to a command directly from the home screen
 - `Cmd+1`..`Cmd+6`: in command mode, direct command switch (`calc`, `pomo`, `todo`, `kill`, `shell`, `sys`)


### PR DESCRIPTION
## Why

The preview pane already lists a selected folder's children, but they are mouse-only (click to open). For a keyboard-first launcher it feels natural to keep going with the arrow keys: jump the selection into that listing, walk into subfolders, and open a child - all without touching the mouse.

## What this does (macOS)

With a folder result selected in the results list:

- `Right` moves the selection into the preview pane's folder listing (the classic two-pane layout stays exactly as-is - only the highlight moves)
- `Up` / `Down` step through the listed children, wrapping like the results list, with auto-scroll
- `Right` on a highlighted subfolder drills into it - the preview re-lists that subfolder and the header/path/modified rows follow
- `Left` steps back up a level (re-highlighting the folder you came out of); at the first folder it returns the selection to the results list
- `Enter` opens the highlighted child: files in their default app, folders in Finder
- `Esc` returns the selection to the results list

Guardrails:

- `Right`/`Left` only claim the key when it would not edit the query text (caret at end / empty field), so text-caret movement keeps working
- typing, or selecting a different result, exits browse and runs a normal search
- children opened from the preview are not recorded in the usage index (same rule as quick-folder rows)
- the TCC-protected Trash summary is excluded from browsing; unreadable folders show a banner and step back
- inherits the existing preview cap of 30 listed children (the "Showing X of Y" row still appears)

## Implementation notes

- pure helpers (child-path join, wrapping index step) live in `FolderBrowseLogic`, added to the `LauncherLogic` SwiftPM package with unit tests
- browse state (drill stack, listing, highlighted index) lives on `LauncherView`; `ResultPreviewView`/`FolderPreviewView` only gained optional props (listing override, selected index), so non-browse rendering is unchanged
- `KeyboardSelectionMonitor` gained optional `onArrowRight`/`onArrowLeft` (Bool-returning: unconsumed keys fall through to the text field) and an Esc hook
- no Rust/FFI changes

## Base branch

CONTRIBUTING points feature PRs at `dev`, but `dev` is currently 74 commits behind `main` and predates the pieces this feature builds on (`FolderListingService`, `FolderPreviewView`, `DeleteTargetLogic`), so the branch cannot compile against it. Recent feature PRs (#230, #246, #247) merged to `main`, so this PR targets `main` - happy to retarget if you prefer.

## Test plan

- [x] `swift test` in `apps/macos/LauncherApp` - 42/42 pass (10 new `FolderBrowseLogicTests`)
- [x] `make -f scripts/Makefile.mac app-build` - BUILD SUCCEEDED
- [x] `cargo test --workspace --manifest-path core/Cargo.toml` and `cargo test --manifest-path bridge/ffi/Cargo.toml` - pass
- [x] docs updated (`docs/features.md`, `docs/user-guide.md`)
- [ ] manual pass: search a folder → `Right` into preview → `Up`/`Down`/`Right`/`Left` navigation, `Enter` opens file/folder, `Esc`/typing returns to the list, caret movement in the query field unaffected
