### PR TITLE
fix: spawn Look on active screen

### DIFF
--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+WindowControl.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+WindowControl.swift
@@ -118,7 +118,9 @@ extension LauncherView {
         let win = launcherWindow()
         let isActive = NSApplication.shared.isActive
         let visibleWindowCount = NSApplication.shared.windows.filter { $0.isVisible }.count
-        hotkeyLog.notice("toggle: isActive=\(isActive) windowCount=\(NSApplication.shared.windows.count) visibleCount=\(visibleWindowCount) keyWindow=\(NSApplication.shared.keyWindow != nil) winIsVisible=\(win?.isVisible ?? false) winIsHidden=\(NSApp.isHidden)")
+        hotkeyLog.notice(
+            "toggle: isActive=\(isActive) windowCount=\(NSApplication.shared.windows.count) visibleCount=\(visibleWindowCount) keyWindow=\(NSApplication.shared.keyWindow != nil) winIsVisible=\(win?.isVisible ?? false) winIsHidden=\(NSApp.isHidden)"
+        )
 
         if let window = win, window.isVisible && isActive {
             hotkeyLog.notice("toggle: -> HIDE branch")
@@ -142,7 +144,9 @@ extension LauncherView {
             window.makeKeyAndOrderFront(nil)
             activateLauncherModeAndFocus()
             let frameStr = NSStringFromRect(window.frame)
-            hotkeyLog.notice("toggle: SHOW done - visible=\(window.isVisible) onActiveSpace=\(window.isOnActiveSpace) frame=\(frameStr, privacy: .public)")
+            hotkeyLog.notice(
+                "toggle: SHOW done - visible=\(window.isVisible) onActiveSpace=\(window.isOnActiveSpace) frame=\(frameStr, privacy: .public)"
+            )
             return
         }
 
@@ -157,20 +161,23 @@ extension LauncherView {
         }
     }
 
-    /// Places the launcher at its fixed Spotlight-style position on whichever
+    /// Places the launcher at its fixed position on whichever
     /// screen currently holds the mouse cursor. Called on every show so the
     /// launcher always appears on the display the user is working on (issue
     /// #260). The window is not draggable, so its position is owned entirely here.
     func positionOnActiveScreen(_ window: NSWindow) {
         let cursor = NSEvent.mouseLocation
-        guard let screen = NSScreen.screens.first(where: { NSMouseInRect(cursor, $0.frame, false) })
-            ?? NSScreen.main
+        guard
+            let screen = NSScreen.screens.first(where: { NSMouseInRect(cursor, $0.frame, false) })
+                ?? NSScreen.main
         else { return }
         let frame = WindowAutoScale.spotlightFrame(on: screen)
         // Log the real screen + placement so the spotlight fraction can be
         // calibrated from actual displays rather than estimates.
         let topGap = screen.visibleFrame.maxY - frame.maxY
-        hotkeyLog.debug("position: visible=\(NSStringFromRect(screen.visibleFrame), privacy: .public) frame=\(NSStringFromRect(frame), privacy: .public) topGap=\(topGap, privacy: .public)")
+        hotkeyLog.debug(
+            "position: visible=\(NSStringFromRect(screen.visibleFrame), privacy: .public) frame=\(NSStringFromRect(frame), privacy: .public) topGap=\(topGap, privacy: .public)"
+        )
         window.setFrame(frame, display: true)
     }
 

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+WindowControl.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+WindowControl.swift
@@ -166,7 +166,12 @@ extension LauncherView {
         guard let screen = NSScreen.screens.first(where: { NSMouseInRect(cursor, $0.frame, false) })
             ?? NSScreen.main
         else { return }
-        window.setFrame(WindowAutoScale.spotlightFrame(on: screen), display: true)
+        let frame = WindowAutoScale.spotlightFrame(on: screen)
+        // Log the real screen + placement so the spotlight fraction can be
+        // calibrated from actual displays rather than estimates.
+        let topGap = screen.visibleFrame.maxY - frame.maxY
+        hotkeyLog.debug("position: visible=\(NSStringFromRect(screen.visibleFrame), privacy: .public) frame=\(NSStringFromRect(frame), privacy: .public) topGap=\(topGap, privacy: .public)")
+        window.setFrame(frame, display: true)
     }
 
     func hideLauncherWindow(restorePreviousApp: Bool = true) {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+WindowControl.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+WindowControl.swift
@@ -138,6 +138,7 @@ extension LauncherView {
         NSApplication.shared.activate(ignoringOtherApps: true)
 
         if let window = launcherWindow() {
+            positionOnActiveScreen(window)
             window.makeKeyAndOrderFront(nil)
             activateLauncherModeAndFocus()
             let frameStr = NSStringFromRect(window.frame)
@@ -148,9 +149,24 @@ extension LauncherView {
         openWindow(id: "main")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
             NSApplication.shared.activate(ignoringOtherApps: true)
-            launcherWindow()?.makeKeyAndOrderFront(nil)
+            if let window = launcherWindow() {
+                positionOnActiveScreen(window)
+                window.makeKeyAndOrderFront(nil)
+            }
             activateLauncherModeAndFocus()
         }
+    }
+
+    /// Places the launcher at its fixed Spotlight-style position on whichever
+    /// screen currently holds the mouse cursor. Called on every show so the
+    /// launcher always appears on the display the user is working on (issue
+    /// #260). The window is not draggable, so its position is owned entirely here.
+    func positionOnActiveScreen(_ window: NSWindow) {
+        let cursor = NSEvent.mouseLocation
+        guard let screen = NSScreen.screens.first(where: { NSMouseInRect(cursor, $0.frame, false) })
+            ?? NSScreen.main
+        else { return }
+        window.setFrame(WindowAutoScale.spotlightFrame(on: screen), display: true)
     }
 
     func hideLauncherWindow(restorePreviousApp: Bool = true) {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -704,18 +704,9 @@ struct LauncherView: View {
             NotificationCenter.default.publisher(for: NSApplication.didResignActiveNotification)
         ) { _ in
             if launcherWindow()?.isVisible == true {
-                let log = Logger(subsystem: "noah-code.Look", category: "window-resize")
-                // Dragging the launcher across screens triggers a
-                // programmatic resize, which briefly drops Look's frontmost
-                // status and fires this notification. Ignore the auto-hide
-                // when that just happened - the user is still interacting
-                // with the launcher, not switching to another app.
-                if WindowAutoScale.didProgrammaticallyResizeRecently() {
-                    log.debug("didResignActiveNotification ignored (within \(WindowAutoScale.resizeSettleWindow, privacy: .public)s of a programmatic resize)")
-                } else {
-                    log.debug("didResignActiveNotification -> hideLauncherWindow(restorePreviousApp: false)")
-                    hideLauncherWindow(restorePreviousApp: false)
-                }
+                Logger(subsystem: "noah-code.Look", category: "window-resize")
+                    .debug("didResignActiveNotification -> hideLauncherWindow(restorePreviousApp: false)")
+                hideLauncherWindow(restorePreviousApp: false)
             }
             refreshClipboardMonitoringMode()
         }

--- a/apps/macos/LauncherApp/look-app/Window/WindowAutoScale.swift
+++ b/apps/macos/LauncherApp/look-app/Window/WindowAutoScale.swift
@@ -1,10 +1,7 @@
 import AppKit
 import Foundation
-import OSLog
 
-private let windowAutoScaleLog = Logger(subsystem: "noah-code.Look", category: "window-resize")
-
-/// Screen-based auto-scale for the launcher window.
+/// Screen-based auto-scale and placement for the launcher window.
 ///
 /// Mirrors the Linux/Windows formula in
 /// apps/linows/src-tauri/src/main.rs (`scaled_window_size`):
@@ -16,15 +13,18 @@ private let windowAutoScaleLog = Logger(subsystem: "noah-code.Look", category: "
 /// NSScreen height on a 2× Retina 4K is already 1080 points, matching
 /// the Tauri `logical_h = physical_h / scale` derivation.
 ///
-/// Recentering on every show is intentionally omitted: the macOS
-/// launcher is draggable (isMovableByWindowBackground), so users
-/// place it where they want. We size and center once, on first
-/// window attach.
+/// The launcher is not draggable: it opens at a fixed Spotlight-style
+/// position on whichever screen holds the mouse cursor, recomputed on
+/// every show (see `LauncherView.toggleWindowVisibility`).
 enum WindowAutoScale {
     // Base size matches the Linux/Windows build (apps/linows/src-tauri):
     // 860×580 logical, landscape - list pane + preview pane side by side.
     static let baseWidth: CGFloat = 860
     static let baseHeight: CGFloat = 600
+
+    /// Fraction of the screen's visible height between its top edge and the top
+    /// of the launcher window, biasing the panel upward like Spotlight.
+    static let spotlightTopFraction: CGFloat = 0.15
 
     static func ratio(forScreenHeightPoints h: CGFloat) -> CGFloat {
         guard h > 1080 else { return 1.0 }
@@ -48,111 +48,15 @@ enum WindowAutoScale {
         )
     }
 
-    /// Frame that centers the scaled launcher within the screen's
-    /// visibleFrame (so it doesn't overlap the menu bar or Dock).
-    static func centeredFrame(on screen: NSScreen) -> NSRect {
+    /// Frame that places the scaled launcher horizontally centered and biased
+    /// toward the top (Spotlight-style) within the screen's visibleFrame, so it
+    /// clears the menu bar and Dock. The launcher opens here on every show.
+    static func spotlightFrame(on screen: NSScreen) -> NSRect {
         let size = size(for: screen)
         let visible = screen.visibleFrame
         let x = visible.origin.x + (visible.width - size.width) / 2
-        let y = visible.origin.y + (visible.height - size.height) / 2
+        let topGap = visible.height * spotlightTopFraction
+        let y = max(visible.minY, visible.maxY - topGap - size.height)
         return NSRect(x: x.rounded(), y: y.rounded(), width: size.width, height: size.height)
-    }
-
-    /// Resize the window to match the current screen's scale, keeping the
-    /// existing position anchor (top-left). Used when the user drags the
-    /// window to a different display - we adjust the scale but never the
-    /// position, since the macOS launcher is user-draggable.
-    ///
-    /// Clamps the result inside the screen's visibleFrame so we never
-    /// leave the window partially off-screen (e.g. tucked behind a notch
-    /// or menu bar after a screen with different geometry).
-    @MainActor
-    static func resizeKeepingTopLeft(_ window: NSWindow) {
-        guard let screen = window.screen else {
-            windowAutoScaleLog.debug("resize: window.screen is nil, skipping")
-            return
-        }
-        let newSize = size(for: screen)
-        let currentFrame = window.frame
-        let visible = screen.visibleFrame
-        windowAutoScaleLog.debug("resize start: screen=\(screen.frame.debugDescription, privacy: .public) visible=\(visible.debugDescription, privacy: .public) current=\(currentFrame.debugDescription, privacy: .public) newSize=\(newSize.debugDescription, privacy: .public) isVisible=\(window.isVisible, privacy: .public)")
-
-        if currentFrame.size == newSize {
-            windowAutoScaleLog.debug("resize: size unchanged, skipping")
-            return
-        }
-
-        // AppKit's frame origin is bottom-left; preserve the visual top by
-        // shifting origin.y when height changes.
-        var newOrigin = NSPoint(
-            x: currentFrame.origin.x,
-            y: currentFrame.origin.y + currentFrame.height - newSize.height
-        )
-
-        let maxX = visible.maxX - newSize.width
-        let minX = visible.minX
-        let maxY = visible.maxY - newSize.height
-        let minY = visible.minY
-        newOrigin.x = min(max(newOrigin.x, minX), maxX)
-        newOrigin.y = min(max(newOrigin.y, minY), maxY)
-
-        let newFrame = NSRect(origin: newOrigin, size: newSize)
-        windowAutoScaleLog.debug("resize -> newFrame=\(newFrame.debugDescription, privacy: .public) (clamp bounds x=\(minX, privacy: .public)..\(maxX, privacy: .public), y=\(minY, privacy: .public)..\(maxY, privacy: .public))")
-        if newFrame != currentFrame {
-            Self.lastProgrammaticResizeAt = Date()
-            window.setFrame(newFrame, display: true, animate: false)
-            windowAutoScaleLog.debug("resize done: applied=\(window.frame.debugDescription, privacy: .public) isVisible=\(window.isVisible, privacy: .public)")
-        }
-    }
-
-    /// Defer a resize until the user is no longer holding the mouse
-    /// (i.e. the drag has ended). Calling `setFrame` mid-drag fights
-    /// AppKit's mouse tracking and leaves the window in a broken state.
-    /// Each call supersedes any pending resize for the same window so
-    /// rapid screen crossings collapse to a single resize when the
-    /// drag finishes.
-    @MainActor private static var pendingResizeTokens: [ObjectIdentifier: UUID] = [:]
-
-    /// Timestamp of the most recent programmatic `setFrame` from this module.
-    /// `didResignActiveNotification` can fire shortly after a screen-drag
-    /// resize because the size change briefly knocks the launcher off
-    /// "frontmost" status. Surface a "did we just resize?" check so the
-    /// launcher's auto-hide-on-resign handler can ignore those events.
-    @MainActor private static var lastProgrammaticResizeAt: Date?
-
-    static let resizeSettleWindow: TimeInterval = 1.0
-
-    @MainActor
-    static func didProgrammaticallyResizeRecently() -> Bool {
-        guard let t = lastProgrammaticResizeAt else { return false }
-        return Date().timeIntervalSince(t) < resizeSettleWindow
-    }
-
-    @MainActor
-    static func scheduleResize(for window: NSWindow) {
-        let id = ObjectIdentifier(window)
-        let token = UUID()
-        pendingResizeTokens[id] = token
-        // Start the suppression window NOW (at notification time) - even
-        // if the resize turns out to be a no-op (e.g., same scale across
-        // screens), the screen change itself can briefly drop the
-        // launcher's frontmost status and trigger the auto-hide.
-        Self.lastProgrammaticResizeAt = Date()
-
-        Task { @MainActor in
-            try? await Task.sleep(nanoseconds: 50_000_000)
-            while pendingResizeTokens[id] == token {
-                // Mouse button still down → user is still dragging.
-                // Resize only after the button is released so we don't
-                // fight AppKit's mouse tracking mid-drag.
-                if NSEvent.pressedMouseButtons & 1 != 0 {
-                    try? await Task.sleep(nanoseconds: 80_000_000)
-                    continue
-                }
-                pendingResizeTokens[id] = nil
-                resizeKeepingTopLeft(window)
-                return
-            }
-        }
     }
 }

--- a/apps/macos/LauncherApp/look-app/Window/WindowAutoScale.swift
+++ b/apps/macos/LauncherApp/look-app/Window/WindowAutoScale.swift
@@ -13,7 +13,7 @@ import Foundation
 /// NSScreen height on a 2× Retina 4K is already 1080 points, matching
 /// the Tauri `logical_h = physical_h / scale` derivation.
 ///
-/// The launcher is not draggable: it opens at a fixed Spotlight-style
+/// The launcher is not draggable: it opens at a fixed
 /// position on whichever screen holds the mouse cursor, recomputed on
 /// every show (see `LauncherView.toggleWindowVisibility`).
 enum WindowAutoScale {

--- a/apps/macos/LauncherApp/look-app/Window/WindowAutoScale.swift
+++ b/apps/macos/LauncherApp/look-app/Window/WindowAutoScale.swift
@@ -22,9 +22,11 @@ enum WindowAutoScale {
     static let baseWidth: CGFloat = 860
     static let baseHeight: CGFloat = 600
 
-    /// Fraction of the screen's visible height between its top edge and the top
-    /// of the launcher window, biasing the panel upward like Spotlight.
-    static let spotlightTopFraction: CGFloat = 0.15
+    /// Extra points to lift the launcher above vertical center. The window is
+    /// centered on the screen (middle - height/2), then raised by this so the
+    /// search bar sits a little above center like Spotlight. Absolute, so
+    /// placement is consistent on any display size or orientation.
+    static let spotlightLift: CGFloat = 25
 
     static func ratio(forScreenHeightPoints h: CGFloat) -> CGFloat {
         guard h > 1080 else { return 1.0 }
@@ -48,15 +50,18 @@ enum WindowAutoScale {
         )
     }
 
-    /// Frame that places the scaled launcher horizontally centered and biased
-    /// toward the top (Spotlight-style) within the screen's visibleFrame, so it
-    /// clears the menu bar and Dock. The launcher opens here on every show.
+    /// Frame that places the scaled launcher horizontally centered, with its
+    /// search bar (the window's top edge) a little above the screen's vertical
+    /// center, so results grow downward from just above center - Spotlight-style,
+    /// consistent on any display size or orientation. Clamped to stay fully
+    /// within the visible area so it never runs off a short display.
     static func spotlightFrame(on screen: NSScreen) -> NSRect {
         let size = size(for: screen)
         let visible = screen.visibleFrame
-        let x = visible.origin.x + (visible.width - size.width) / 2
-        let topGap = visible.height * spotlightTopFraction
-        let y = max(visible.minY, visible.maxY - topGap - size.height)
+        let x = visible.midX - size.width / 2
+        // middle + height/2 + lift = window top; center the panel, then lift it.
+        let windowTop = visible.midY + size.height / 2 + spotlightLift
+        let y = min(max(windowTop - size.height, visible.minY), visible.maxY - size.height)
         return NSRect(x: x.rounded(), y: y.rounded(), width: size.width, height: size.height)
     }
 }

--- a/apps/macos/LauncherApp/look-app/Window/WindowConfigurator.swift
+++ b/apps/macos/LauncherApp/look-app/Window/WindowConfigurator.swift
@@ -109,7 +109,7 @@ struct WindowConfigurator: NSViewRepresentable {
         window.toolbar = nil
         window.isOpaque = false
         window.backgroundColor = .clear
-        // The launcher is not user-movable: it opens at a fixed Spotlight-style
+        // The launcher is not user-movable: it opens at a fixed
         // position on the active (cursor) screen every show, so movement would
         // only let its position drift out of sync. See toggleWindowVisibility.
         window.isMovableByWindowBackground = false

--- a/apps/macos/LauncherApp/look-app/Window/WindowConfigurator.swift
+++ b/apps/macos/LauncherApp/look-app/Window/WindowConfigurator.swift
@@ -1,5 +1,4 @@
 import AppKit
-import OSLog
 import SwiftUI
 
 struct WindowConfigurator: NSViewRepresentable {
@@ -110,7 +109,11 @@ struct WindowConfigurator: NSViewRepresentable {
         window.toolbar = nil
         window.isOpaque = false
         window.backgroundColor = .clear
-        window.isMovableByWindowBackground = true
+        // The launcher is not user-movable: it opens at a fixed Spotlight-style
+        // position on the active (cursor) screen every show, so movement would
+        // only let its position drift out of sync. See toggleWindowVisibility.
+        window.isMovableByWindowBackground = false
+        window.isMovable = false
         window.hasShadow = false
         window.setContentBorderThickness(0, for: .maxY)
         window.collectionBehavior.insert(.moveToActiveSpace)
@@ -136,26 +139,10 @@ struct WindowConfigurator: NSViewRepresentable {
             contentView.layer?.masksToBounds = true
         }
 
+        // Initial placement; toggleWindowVisibility re-places it on the active
+        // screen every show, so this only seeds a sane frame before first show.
         if let screen = window.screen ?? NSScreen.main {
-            window.setFrame(WindowAutoScale.centeredFrame(on: screen), display: true)
-        }
-
-        // Re-apply scaling when the window crosses to a different display.
-        // Position is preserved (top-left anchor) - only size changes,
-        // since the macOS launcher is user-draggable.
-        NotificationCenter.default.addObserver(
-            forName: NSWindow.didChangeScreenNotification,
-            object: window,
-            queue: .main
-        ) { note in
-            guard let w = note.object as? NSWindow else { return }
-            Logger(subsystem: "noah-code.Look", category: "window-resize")
-                .debug("didChangeScreenNotification fired - scheduling resize")
-            // The observer is registered with `queue: .main`, so this already
-            // runs on the main actor - assert it to reach the isolated method.
-            MainActor.assumeIsolated {
-                WindowAutoScale.scheduleResize(for: w)
-            }
+            window.setFrame(WindowAutoScale.spotlightFrame(on: screen), display: true)
         }
     }
 }


### PR DESCRIPTION
## Summary

- Currently, with drag and drop feature, Look latest position is saved, and when it's spawned, no matter what is the activating screen, Look appears in the latest position. 
-> as linows, spawn look on the activating screen (cursor, active windows, ...)
- Recalculate position to keep Look above center point a few pixels.

## Why

- #260 

## Changes

- Pos = Center pos + Look height / 2 + fixed value

## Testing

  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)


## Risks / Notes

-

## Checklist

- [x] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered
