### PR TITLE
Feat: Quick actions with bluetooth template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,10 @@ Please include:
 
 User-facing feature documentation lives in `docs/` (`features.md`, `user-guide.md`) and is enough for end users and most contributors. Maintainers may also keep internal design specs under `specs/` (purpose, behavior, edge cases, non-goals); that directory is `.gitignore`d and not required reading.
 
+## Adding a Quick Action control
+
+Quick Actions are the interactive toggles/buttons in the launcher's right panel (e.g. Bluetooth on/off). Adding one is designed to be small: one shared descriptor, one native adapter file, one registry line. See [docs/writing-controls.md](docs/writing-controls.md) for the step-by-step guide and the reference implementation.
+
 ## Development setup
 
 [DEVELOPMENT.md](DEVELOPMENT.md) has the full per-platform prerequisites and build walkthrough. In short: Rust stable plus GNU Make everywhere, with Xcode on macOS and Visual Studio 2022 Build Tools (Desktop C++ workload) for the Tauri app on Windows and Linux.

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Built-in: Catppuccin, Tokyo Night, Rose Pine, Gruvbox, Dracula, Kanagawa, plus C
 - [Architecture](docs/architecture.md) - how the Swift app + Rust core fit together
 - [Features](docs/features.md) - what's shipped, what's planned
 - [Contributing](CONTRIBUTING.md) - how to contribute
+- [Writing a control](docs/writing-controls.md) - add a Quick Action toggle/button to the panel
 - [Development](DEVELOPMENT.md) - building locally, repo layout, release process
 
 ## Scope

--- a/apps/macos/LauncherApp/look-app.xcodeproj/project.pbxproj
+++ b/apps/macos/LauncherApp/look-app.xcodeproj/project.pbxproj
@@ -291,6 +291,7 @@
 				INFOPLIST_KEY_CFBundleIconFile = AppIcon;
 				INFOPLIST_KEY_LSMultipleInstancesProhibited = NO;
 				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Look uses Finder to empty the Trash and read how many items it contains.";
+				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "Look reads and toggles Bluetooth power from the launcher's quick actions.";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				OTHER_LDFLAGS = (
@@ -333,6 +334,7 @@
 				INFOPLIST_KEY_CFBundleIconFile = AppIcon;
 				INFOPLIST_KEY_LSMultipleInstancesProhibited = NO;
 				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Look uses Finder to empty the Trash and read how many items it contains.";
+				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "Look reads and toggles Bluetooth power from the launcher's quick actions.";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				OTHER_LDFLAGS = (

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
@@ -60,6 +60,10 @@ private func look_record_url_hit(_ url: UnsafePointer<CChar>?) -> Bool
 nonisolated
 private func look_recent_urls_json(_ query: UnsafePointer<CChar>?, _ limit: UInt32) -> UnsafeMutablePointer<CChar>?
 
+@_silgen_name("look_qactions_json")
+nonisolated
+private func look_qactions_json(_ resultID: UnsafePointer<CChar>?, _ kind: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
+
 @_silgen_name("look_definitional_entity_json")
 nonisolated
 private func look_definitional_entity_json(_ query: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
@@ -269,6 +273,23 @@ final class EngineBridge: @unchecked Sendable {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         return (try? decoder.decode([URLHistoryEntry].self, from: data)) ?? []
+    }
+
+    /// Quick Action descriptors for a result, from the shared `look_qactions`
+    /// catalog (see docs/writing-controls.md). Empty when the result has none.
+    /// Pure catalog lookup - cheap, safe to call while typing.
+    nonisolated func quickActions(forResultID resultID: String, kind: String) -> [QuickActionDescriptor] {
+        let ptr = resultID.withCString { idCstr in
+            kind.withCString { kindCstr in
+                look_qactions_json(idCstr, kindCstr)
+            }
+        }
+        guard let ptr else { return [] }
+        defer { look_free_cstring(ptr) }
+        guard let data = String(cString: ptr).data(using: .utf8) else { return [] }
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return (try? decoder.decode([QuickActionDescriptor].self, from: data)) ?? []
     }
 
     /// The entity from a definitional query ("what is vim" -> "vim"), or nil.

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
@@ -45,7 +45,8 @@ final class KeyboardSelectionMonitor {
         onRequestDelete: (@MainActor () -> Void)? = nil,
         onConfirmDelete: (@MainActor () -> Void)? = nil,
         onCancelDelete: (@MainActor () -> Void)? = nil,
-        deleteConfirmationActive: @escaping @MainActor () -> Bool = { false }
+        deleteConfirmationActive: @escaping @MainActor () -> Bool = { false },
+        onToggleQuickAction: (@MainActor () -> Void)? = nil
     ) {
         guard monitor == nil else { return }
         self.isKillConfirmationActive = killConfirmationActive
@@ -143,6 +144,16 @@ final class KeyboardSelectionMonitor {
                 && !inCommandMode()
             {
                 onRequestDelete?()
+                return nil
+            }
+
+            // Cmd+O toggles the selected result's toggle Quick Action (Bluetooth,
+            // etc.). Multi-choice controls will use Cmd+J/K in a later pass.
+            if (event.keyCode == 31 || event.charactersIgnoringModifiers?.lowercased() == "o")
+                && flags == [.command]
+                && !inCommandMode()
+            {
+                onToggleQuickAction?()
                 return nil
             }
 

--- a/apps/macos/LauncherApp/look-app/Support/QuickActions/ActionAdapterRegistry.swift
+++ b/apps/macos/LauncherApp/look-app/Support/QuickActions/ActionAdapterRegistry.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Quick Actions framework - the single registration point for native control
+/// adapters (see `specs/quick-actions.md`).
+///
+/// TO ADD A CONTROL: implement a `SystemControl` in `Controls/`, then add ONE
+/// line to `adapters` below. That is the only edit outside your own file and the
+/// shared `core/qactions` descriptor. If an action id has no adapter on this OS,
+/// the panel still shows the info and marks the action unavailable.
+enum ActionAdapterRegistry {
+    /// Maps a descriptor's `action_id` (declared in the shared `core/qactions`
+    /// catalog) to the native adapter that runs it on macOS.
+    static let adapters: [String: any SystemControl] = [
+        "bluetooth": BluetoothControl(),
+    ]
+
+    static func adapter(for actionID: String) -> (any SystemControl)? {
+        adapters[actionID]
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/QuickActions/Controls/BluetoothControl.swift
+++ b/apps/macos/LauncherApp/look-app/Support/QuickActions/Controls/BluetoothControl.swift
@@ -32,6 +32,11 @@ private func IOBluetoothPreferenceSetControllerPowerState(_ state: Int32)
 struct BluetoothControl: SystemControl {
     private static let log = Logger(subsystem: "noah-code.Look", category: "actions.bluetooth")
 
+    /// How long to wait for the controller to apply a power change, and how often
+    /// to re-check while waiting. The controller applies asynchronously (~100ms).
+    private static let settleTimeout: TimeInterval = 1.5
+    private static let pollInterval: UInt64 = 80_000_000  // 80ms in nanoseconds
+
     private func isPoweredOn() -> Bool {
         IOBluetoothPreferenceGetControllerPowerState() == 1
     }
@@ -53,10 +58,25 @@ struct BluetoothControl: SystemControl {
         }
 
         IOBluetoothPreferenceSetControllerPowerState(target ? 1 : 0)
-        // The controller applies the change asynchronously, so we report the
-        // intended result optimistically; the panel re-reads `state()` shortly
-        // after and will reflect reality if the change did not take.
-        Self.log.debug("bluetooth apply -> target=\(target, privacy: .public)")
+        // The controller applies the change asynchronously (~100ms), so wait
+        // until the power state actually reflects the target before returning.
+        // Otherwise an immediate `state()` read would still see the old value
+        // and the panel would trail a press behind.
+        let settled = await waitForPowerState(target)
+        Self.log.debug("bluetooth apply -> target=\(target, privacy: .public) settled=\(settled, privacy: .public)")
+        guard settled else {
+            return .failed("Could not turn Bluetooth \(target ? "on" : "off")")
+        }
         return .ok(banner: "Bluetooth \(target ? "on" : "off")")
+    }
+
+    /// Polls the power state until it reaches `target` or the settle timeout.
+    private func waitForPowerState(_ target: Bool) async -> Bool {
+        let deadline = Date().addingTimeInterval(Self.settleTimeout)
+        while Date() < deadline {
+            if isPoweredOn() == target { return true }
+            try? await Task.sleep(nanoseconds: Self.pollInterval)
+        }
+        return isPoweredOn() == target
     }
 }

--- a/apps/macos/LauncherApp/look-app/Support/QuickActions/Controls/BluetoothControl.swift
+++ b/apps/macos/LauncherApp/look-app/Support/QuickActions/Controls/BluetoothControl.swift
@@ -1,0 +1,62 @@
+import Foundation
+import IOBluetooth
+import OSLog
+
+// ============================================================================
+// REFERENCE ADAPTER - copy this file to add a new system control.
+//
+// A control conforms to `SystemControl` and keeps ALL of its OS-specific code
+// (private APIs, AppleScript, CLI calls) inside itself. To add your own:
+//
+//   1. Copy this file and rename the type (e.g. `WiFiControl`).
+//   2. Implement `state()` - read the current state, or `.unavailable(reason)`.
+//   3. Implement `apply(_:)` - perform the change, return an `ActionOutcome`.
+//   4. Register it in `ActionAdapterRegistry` under your action id.
+//   5. Declare the matching descriptor in the shared `core/qactions` catalog.
+//
+// Nothing else (panel, keyboard, rendering) changes. That is the whole point.
+// ============================================================================
+
+// macOS has no public API to toggle system Bluetooth power. These private
+// IOBluetooth C symbols do it; they are not in the public headers but have been
+// stable for years and are what `blueutil` uses. They resolve at link time via
+// `import IOBluetooth` (the framework autolinks). This is exactly the kind of
+// OS-specific detail the adapter exists to contain.
+@_silgen_name("IOBluetoothPreferenceGetControllerPowerState")
+private func IOBluetoothPreferenceGetControllerPowerState() -> Int32
+
+@_silgen_name("IOBluetoothPreferenceSetControllerPowerState")
+private func IOBluetoothPreferenceSetControllerPowerState(_ state: Int32)
+
+/// Toggles and reports macOS system Bluetooth power. Action id: `"bluetooth"`.
+struct BluetoothControl: SystemControl {
+    private static let log = Logger(subsystem: "noah-code.Look", category: "actions.bluetooth")
+
+    private func isPoweredOn() -> Bool {
+        IOBluetoothPreferenceGetControllerPowerState() == 1
+    }
+
+    func state() async -> ActionState {
+        // The read is cheap and synchronous; no need to hop threads.
+        isPoweredOn() ? .on : .off
+    }
+
+    func apply(_ intent: ActionIntent) async -> ActionOutcome {
+        let target: Bool
+        switch intent {
+        case .toggle:
+            target = !isPoweredOn()
+        case .setOn(let on):
+            target = on
+        case .run:
+            return .failed("Bluetooth has no run action")
+        }
+
+        IOBluetoothPreferenceSetControllerPowerState(target ? 1 : 0)
+        // The controller applies the change asynchronously, so we report the
+        // intended result optimistically; the panel re-reads `state()` shortly
+        // after and will reflect reality if the change did not take.
+        Self.log.debug("bluetooth apply -> target=\(target, privacy: .public)")
+        return .ok(banner: "Bluetooth \(target ? "on" : "off")")
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/QuickActions/Controls/README.md
+++ b/apps/macos/LauncherApp/look-app/Support/QuickActions/Controls/README.md
@@ -1,0 +1,10 @@
+# Controls
+
+Per-control adapters for the Quick Actions panel. Each file is one
+`SystemControl` (read + set some system state); the framework around them
+(`../SystemControl.swift`, `../ActionAdapterRegistry.swift`, the panel, the
+keyboard) is written once and you should not need to touch it.
+
+**Adding a control:** see [docs/writing-controls.md](../../../../../../../docs/writing-controls.md).
+
+`BluetoothControl.swift` is the reference implementation — read it first.

--- a/apps/macos/LauncherApp/look-app/Support/QuickActions/QuickActionModels.swift
+++ b/apps/macos/LauncherApp/look-app/Support/QuickActions/QuickActionModels.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Swift mirror of the shared `look_qactions` descriptor (see
+/// `docs/writing-controls.md`). Decoded from the FFI JSON with
+/// `.convertFromSnakeCase`, so `action_id` -> `actionId`, `on_label` ->
+/// `onLabel`, etc. This is the declarative half; execution is a `SystemControl`
+/// adapter resolved by `actionId` in `ActionAdapterRegistry`.
+
+/// How the action's control renders in the panel.
+enum QuickActionControlKind: String, Decodable {
+    case toggle
+    case button
+}
+
+/// A read-only field shown above the actions. `valueKey` is resolved to a live
+/// value by the native adapter (the descriptor only declares the label + key).
+struct QuickActionInfoField: Decodable, Equatable {
+    let label: String
+    let valueKey: String
+}
+
+/// A declared Quick Action for a result.
+struct QuickActionDescriptor: Decodable, Equatable, Identifiable {
+    let actionId: String
+    let title: String
+    let control: QuickActionControlKind
+    let onLabel: String?
+    let offLabel: String?
+    let keyHint: String
+    let info: [QuickActionInfoField]
+
+    var id: String { actionId }
+}

--- a/apps/macos/LauncherApp/look-app/Support/QuickActions/QuickActionModels.swift
+++ b/apps/macos/LauncherApp/look-app/Support/QuickActions/QuickActionModels.swift
@@ -26,7 +26,6 @@ struct QuickActionDescriptor: Decodable, Equatable, Identifiable {
     let control: QuickActionControlKind
     let onLabel: String?
     let offLabel: String?
-    let keyHint: String
     let info: [QuickActionInfoField]
 
     var id: String { actionId }

--- a/apps/macos/LauncherApp/look-app/Support/QuickActions/SystemControl.swift
+++ b/apps/macos/LauncherApp/look-app/Support/QuickActions/SystemControl.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Quick Actions framework — Layer 1 contract (see `specs/quick-actions.md`).
+///
+/// A `SystemControl` is the ONE piece a contributor writes to add a new
+/// actionable control (a settings toggle, an app action). It reads the current
+/// state for display and applies an intent when the user runs the action. All
+/// OS-specific and private-API code is quarantined inside the conforming type;
+/// nothing else in the framework (panel, keyboard, registry) needs to change.
+///
+/// `BluetoothControl` is the reference implementation - copy it to add a control.
+
+/// Current state of a control's value, read for display in the panel.
+enum ActionState: Equatable {
+    case on
+    case off
+    /// A non-boolean value shown as-is (e.g. a level or a mode name).
+    case value(String)
+    /// The control cannot act here: no hardware, unsupported OS, or blocked.
+    /// The associated string is a short human reason shown in the panel.
+    case unavailable(String)
+}
+
+/// What the user asked a control to do.
+enum ActionIntent: Equatable {
+    /// Flip a boolean control (on <-> off).
+    case toggle
+    /// Force a boolean control to a specific value.
+    case setOn(Bool)
+    /// Trigger a non-toggle action (a plain button).
+    case run
+}
+
+/// Result of applying an intent, surfaced to the user as a banner.
+enum ActionOutcome: Equatable {
+    /// Success. Optional banner text; nil shows a default confirmation.
+    case ok(banner: String?)
+    /// The action failed; the string is shown to the user.
+    case failed(String)
+    /// The action needs an OS permission; the string guides the user to grant it.
+    case needsPermission(String)
+}
+
+/// The adapter a contributor implements per control. Keep it small and pure:
+/// read state, apply an intent, return an outcome. Async so controls backed by
+/// AppleScript, a CLI, or the network can await without blocking the UI; simple
+/// controls (like Bluetooth) satisfy it trivially.
+protocol SystemControl: Sendable {
+    /// Read the current state for display. Return `.unavailable(reason)` when the
+    /// control does not apply on this machine.
+    func state() async -> ActionState
+
+    /// Perform `intent` and report the outcome. Best-effort: never throw, never
+    /// block; surface problems as `.failed` / `.needsPermission`.
+    func apply(_ intent: ActionIntent) async -> ActionOutcome
+}

--- a/apps/macos/LauncherApp/look-app/Support/UI/ToggleSwitch.swift
+++ b/apps/macos/LauncherApp/look-app/Support/UI/ToggleSwitch.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+/// A macOS-style toggle switch: a capsule track with a sliding knob, green when
+/// on. `isOn == nil` renders a dimmed, disabled switch (e.g. while state loads).
+/// Reusable across the app; the Quick Actions panel uses it for toggle controls.
+struct ToggleSwitch: View {
+    let isOn: Bool?
+    var themeStore: ThemeStore
+    var onToggle: () -> Void = {}
+
+    private enum Layout {
+        static let trackWidth: CGFloat = 42
+        static let trackHeight: CGFloat = 24
+        static let knobSize: CGFloat = 20
+        static let knobPadding: CGFloat = 2
+        static let knobShadowRadius: CGFloat = 1
+        static let animationDuration = 0.15
+        static let loadingOpacity = 0.5
+    }
+
+    private enum Track {
+        static let onOpacity = 0.9
+        static let offOpacity = 0.55
+        static let loadingOpacity = 0.35
+    }
+
+    var body: some View {
+        Button(action: onToggle) {
+            ZStack(alignment: isOn == true ? .trailing : .leading) {
+                Capsule()
+                    .fill(trackColor)
+                    .frame(width: Layout.trackWidth, height: Layout.trackHeight)
+                Circle()
+                    .fill(.white)
+                    .frame(width: Layout.knobSize, height: Layout.knobSize)
+                    .padding(Layout.knobPadding)
+                    .shadow(color: .black.opacity(0.25), radius: Layout.knobShadowRadius, x: 0, y: 0.5)
+            }
+        }
+        .buttonStyle(.plain)
+        .disabled(isOn == nil)
+        .opacity(isOn == nil ? Layout.loadingOpacity : 1)
+        .animation(.easeInOut(duration: Layout.animationDuration), value: isOn)
+    }
+
+    private var trackColor: Color {
+        switch isOn {
+        case true: return Color.green.opacity(Track.onOpacity)
+        case false: return themeStore.dividerColor().opacity(Track.offOpacity)
+        case nil: return themeStore.dividerColor().opacity(Track.loadingOpacity)
+        }
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ActionPanelView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ActionPanelView.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+
+/// Right-column panel for a result's Quick Actions (see docs/writing-controls.md).
+/// Renders each declared action with its live state (a toggle shows On/Off), the
+/// focused action highlighted, and the Cmd+J/K + Enter hints. Info-field values
+/// are resolved by adapters in a later pass; today a toggle's state is its status.
+struct ActionPanelView: View {
+    let title: String
+    let descriptors: [QuickActionDescriptor]
+    let states: [String: ActionState]
+    let focusIndex: Int?
+    let themeStore: ThemeStore
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title)
+                .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize + 2), weight: .semibold))
+                .foregroundStyle(themeStore.fontColor())
+                .lineLimit(1)
+
+            ForEach(Array(descriptors.enumerated()), id: \.element.id) { index, descriptor in
+                actionRow(descriptor, isFocused: focusIndex == index)
+            }
+
+            Spacer(minLength: 0)
+
+            Text("⌘J / ⌘K move  •  ⏎ run")
+                .font(themeStore.uiFont(size: CGFloat(max(10, themeStore.settings.fontSize - 3)), weight: .regular))
+                .foregroundStyle(themeStore.mutedTextColor())
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(14)
+    }
+
+    @ViewBuilder
+    private func actionRow(_ descriptor: QuickActionDescriptor, isFocused: Bool) -> some View {
+        HStack(spacing: 10) {
+            Text(descriptor.title)
+                .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize), weight: .medium))
+                .foregroundStyle(themeStore.fontColor())
+            Spacer(minLength: 0)
+            stateBadge(for: descriptor)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(
+            isFocused ? themeStore.selectionFillColor() : .clear,
+            in: RoundedRectangle(cornerRadius: 8, style: .continuous)
+        )
+        .overlay {
+            if isFocused {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(themeStore.dividerColor(), lineWidth: 1)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func stateBadge(for descriptor: QuickActionDescriptor) -> some View {
+        switch states[descriptor.actionId] {
+        case .on:
+            pill(descriptor.onLabel ?? "On", on: true)
+        case .off:
+            pill(descriptor.offLabel ?? "Off", on: false)
+        case .value(let text):
+            pill(text, on: false)
+        case .unavailable(let reason):
+            Text(reason)
+                .font(themeStore.uiFont(size: CGFloat(max(10, themeStore.settings.fontSize - 3)), weight: .regular))
+                .foregroundStyle(themeStore.mutedTextColor())
+        case nil:
+            // State still loading.
+            Text("…").foregroundStyle(themeStore.mutedTextColor())
+        }
+    }
+
+    private func pill(_ text: String, on: Bool) -> some View {
+        Text(text)
+            .font(themeStore.uiFont(size: CGFloat(max(11, themeStore.settings.fontSize - 2)), weight: .semibold))
+            .foregroundStyle(on ? Color.white : themeStore.fontColor())
+            .padding(.horizontal, 10)
+            .padding(.vertical, 3)
+            .background(
+                (on ? Color.green.opacity(0.75) : themeStore.dividerColor().opacity(0.6)),
+                in: Capsule()
+            )
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+QuickActions.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+QuickActions.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+/// Quick Actions - data loading and execution for the info+actions panel (see
+/// docs/writing-controls.md). Descriptors come from the shared `look_qactions`
+/// catalog; each action's live state and its execution come from a native
+/// `SystemControl` adapter resolved by `actionId`.
+///
+/// Interaction: a `.toggle` control is flipped with Cmd+O (no navigation).
+/// Multi-choice controls (future) will move between options with Cmd+J/K.
+extension LauncherView {
+    /// Banner durations (seconds) for action outcomes.
+    private enum Banner {
+        static let success: TimeInterval = 1.2
+        static let error: TimeInterval = 1.6
+        static let needsPermission: TimeInterval = 2.2
+        static let unavailable: TimeInterval = 1.4
+    }
+
+    /// The selected result, if it is a real candidate (not a synthesized row).
+    private var selectedResultForActions: LauncherResult? {
+        guard let id = selectedResultID else { return nil }
+        return displayedResults.first(where: { $0.id == id })
+    }
+
+    /// The selected result's primary toggle action, if any (drives Cmd+O).
+    var toggleQuickAction: QuickActionDescriptor? {
+        quickActionDescriptors.first(where: { $0.control == .toggle })
+    }
+
+    /// Whether Cmd+O has a toggle to act on for the current selection.
+    var hasToggleQuickAction: Bool { toggleQuickAction != nil }
+
+    /// Loads the selected result's Quick Actions and reads each one's live state
+    /// off the main thread. Cancels any in-flight read so a stale result never
+    /// populates the panel. Called on selection/query change.
+    func refreshQuickActions() {
+        quickActionTask?.cancel()
+
+        guard let result = selectedResultForActions else {
+            if !quickActionDescriptors.isEmpty { quickActionDescriptors = [] }
+            if !quickActionStates.isEmpty { quickActionStates = [:] }
+            return
+        }
+
+        let descriptors = bridge.quickActions(forResultID: result.id, kind: result.kind.rawValue)
+        quickActionDescriptors = descriptors
+        quickActionStates = [:]
+        guard !descriptors.isEmpty else { return }
+
+        let resultID = result.id
+        quickActionTask = Task {
+            for descriptor in descriptors {
+                guard !Task.isCancelled else { return }
+                let state: ActionState
+                if let adapter = ActionAdapterRegistry.adapter(for: descriptor.actionId) {
+                    state = await adapter.state()
+                } else {
+                    state = .unavailable("Not supported on this Mac")
+                }
+                guard !Task.isCancelled else { return }
+                await MainActor.run {
+                    // Drop the read if the selection moved on while we awaited.
+                    guard selectedResultID == resultID else { return }
+                    quickActionStates[descriptor.actionId] = state
+                }
+            }
+        }
+    }
+
+    /// Flips the selected result's primary toggle (Cmd+O).
+    func togglePrimaryQuickAction() {
+        guard let descriptor = toggleQuickAction else { return }
+        runQuickAction(descriptor, intent: .toggle)
+    }
+
+    /// Runs a specific action's intent (from a click or a key), shows the
+    /// outcome, and refreshes its state. Shared by the toggle switch and Cmd+O.
+    func runQuickAction(_ descriptor: QuickActionDescriptor, intent: ActionIntent) {
+        guard let adapter = ActionAdapterRegistry.adapter(for: descriptor.actionId) else {
+            showBanner("\(descriptor.title) is not available", style: .info, duration: Banner.unavailable)
+            return
+        }
+
+        // Flip a toggle immediately for instant feedback; the re-read below
+        // confirms (and corrects it if the change did not take).
+        if intent == .toggle {
+            switch quickActionStates[descriptor.actionId] {
+            case .on?: quickActionStates[descriptor.actionId] = .off
+            case .off?: quickActionStates[descriptor.actionId] = .on
+            default: break
+            }
+        }
+
+        Task {
+            let outcome = await adapter.apply(intent)
+            await MainActor.run {
+                switch outcome {
+                case .ok(let banner):
+                    showBanner(banner ?? "\(descriptor.title) done", style: .success, duration: Banner.success)
+                case .failed(let message):
+                    showBanner(message, style: .error, duration: Banner.error)
+                case .needsPermission(let message):
+                    showBanner(message, style: .info, duration: Banner.needsPermission)
+                }
+            }
+            let state = await adapter.state()
+            await MainActor.run {
+                quickActionStates[descriptor.actionId] = state
+            }
+        }
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
@@ -225,6 +225,9 @@ extension LauncherView {
             },
             deleteConfirmationActive: { [self] in
                 pendingEmptyTrashCount != nil
+            },
+            onToggleQuickAction: { [self] in
+                togglePrimaryQuickAction()
             }
         )
     }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -44,6 +44,10 @@ struct LauncherView: View {
     @State var webSuggestionTask: Task<Void, Never>?
     @State var recentURLEntries: [URLHistoryEntry] = []
     @State var recentURLTask: Task<Void, Never>?
+    // Quick Actions for the selected result (see docs/writing-controls.md).
+    @State var quickActionDescriptors: [QuickActionDescriptor] = []
+    @State var quickActionStates: [String: ActionState] = [:]
+    @State var quickActionTask: Task<Void, Never>?
     @State var selectedResultID: String?
     @State var pickedKeys: [String] = []
     @State var pickedResultsByKey: [String: LauncherResult] = [:]
@@ -660,6 +664,10 @@ struct LauncherView: View {
             // Previously-opened URLs matching the query (url-history spec).
             refreshRecentURLs()
         }
+        .onChange(of: selectedResultID) { _, _ in
+            // Load Quick Actions + read their live state for the new selection.
+            refreshQuickActions()
+        }
         .onReceive(clipboardStore.$entries) { _ in
             refreshClipboardSelectionIfNeeded()
         }
@@ -1015,8 +1023,14 @@ struct LauncherView: View {
                     onOpenAll: { openAllPicked() }
                 )
             } else if let selectedResult = previewResult {
+                // Info + actions panel: the preview plus any Quick Actions.
                 ResultPreviewView(
                     result: selectedResult,
+                    quickActions: quickActionDescriptors,
+                    quickActionStates: quickActionStates,
+                    onRunQuickAction: { descriptor, intent in
+                        runQuickAction(descriptor, intent: intent)
+                    },
                     onDeleteClipboard: selectedResult.kind == .clipboard
                         ? { deleteClipboardResult(resultID: selectedResult.id) }
                         : nil

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/QuickActionsSection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/QuickActionsSection.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+
+/// The actions portion of the info+actions panel (see docs/writing-controls.md).
+/// A vertical stack of control components, one per declared action, rendered
+/// beneath the result's info in `ResultPreviewView`. Each `ControlKind` maps to
+/// its own building block (toggle switch, button, ...), so supporting a new
+/// control type is adding a case in `QuickActionControl` - the rest of the panel
+/// stays the same. This is the reusable template contributors compose against.
+struct QuickActionsSection: View {
+    let descriptors: [QuickActionDescriptor]
+    let states: [String: ActionState]
+    let themeStore: ThemeStore
+    /// Called when a control is activated by click (Cmd+O runs the same path).
+    var onRun: (QuickActionDescriptor, ActionIntent) -> Void = { _, _ in }
+
+    private enum Layout {
+        static let rowSpacing: CGFloat = 6
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Layout.rowSpacing) {
+            ForEach(descriptors) { descriptor in
+                QuickActionControl(
+                    descriptor: descriptor,
+                    state: states[descriptor.actionId],
+                    themeStore: themeStore,
+                    onRun: { intent in onRun(descriptor, intent) }
+                )
+            }
+        }
+    }
+}
+
+/// One action row: the title, the control for its kind, and its key hint.
+private struct QuickActionControl: View {
+    let descriptor: QuickActionDescriptor
+    let state: ActionState?
+    let themeStore: ThemeStore
+    let onRun: (ActionIntent) -> Void
+
+    private enum Layout {
+        static let contentSpacing: CGFloat = 10
+        static let controlSpacing: CGFloat = 8
+        static let horizontalPadding: CGFloat = 10
+        static let verticalPadding: CGFloat = 8
+        static let cornerRadius: CGFloat = 8
+        static let rowBackgroundOpacity = 0.18
+        static let toggleKeyHint = "⌘O"
+        static let hintFontSizeDelta: CGFloat = 3
+        static let minHintFontSize: CGFloat = 10
+    }
+
+    var body: some View {
+        HStack(spacing: Layout.contentSpacing) {
+            Text(descriptor.title)
+                .font(titleFont)
+                .foregroundStyle(themeStore.fontColor())
+            Spacer(minLength: 0)
+            control
+        }
+        .padding(.horizontal, Layout.horizontalPadding)
+        .padding(.vertical, Layout.verticalPadding)
+        .background(
+            themeStore.dividerColor().opacity(Layout.rowBackgroundOpacity),
+            in: RoundedRectangle(cornerRadius: Layout.cornerRadius, style: .continuous)
+        )
+    }
+
+    @ViewBuilder
+    private var control: some View {
+        if case .unavailable(let reason)? = state {
+            Text(reason).font(hintFont).foregroundStyle(themeStore.mutedTextColor())
+        } else {
+            switch descriptor.control {
+            case .toggle:
+                HStack(spacing: Layout.controlSpacing) {
+                    ToggleSwitch(isOn: isOn, themeStore: themeStore) { onRun(.toggle) }
+                    keyHint(Layout.toggleKeyHint)
+                }
+            case .button:
+                Button(descriptor.title) { onRun(.run) }
+                    .buttonStyle(.borderless)
+                    .font(hintFont)
+            }
+        }
+    }
+
+    private var isOn: Bool? {
+        switch state {
+        case .on?: return true
+        case .off?: return false
+        case .value?, .unavailable?, nil: return nil
+        }
+    }
+
+    private var titleFont: Font {
+        themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize), weight: .medium)
+    }
+
+    /// Size for hints and secondary labels: a few points below the base, floored.
+    private var hintFontSize: CGFloat {
+        max(Layout.minHintFontSize, CGFloat(themeStore.settings.fontSize) - Layout.hintFontSizeDelta)
+    }
+
+    private var hintFont: Font {
+        themeStore.uiFont(size: hintFontSize, weight: .regular)
+    }
+
+    private func keyHint(_ text: String) -> some View {
+        Text(text)
+            .font(themeStore.uiFont(size: hintFontSize, weight: .semibold))
+            .foregroundStyle(themeStore.mutedTextColor())
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
@@ -5,10 +5,20 @@ import UniformTypeIdentifiers
 struct ResultPreviewView: View {
     @EnvironmentObject private var themeStore: ThemeStore
     let result: LauncherResult
+    /// Quick Actions for this result, rendered beneath the header (info + actions
+    /// panel). Empty for results with no actions.
+    var quickActions: [QuickActionDescriptor] = []
+    var quickActionStates: [String: ActionState] = [:]
+    var onRunQuickAction: (QuickActionDescriptor, ActionIntent) -> Void = { _, _ in }
     var onDeleteClipboard: (() -> Void)? = nil
 
     @State private var folderListing: FolderListing?
     @State private var trashItemCount: Int?
+
+    /// A System Settings pane result (its "path" is a URL scheme, not a file).
+    private var isSetting: Bool {
+        result.id.hasPrefix("setting:")
+    }
 
     /// The pinned Trash quick folder is TCC-protected, so it can't be listed
     /// like a normal folder - it gets a Finder-backed summary instead.
@@ -147,6 +157,15 @@ struct ResultPreviewView: View {
                     Spacer()
                 }
 
+                if !quickActions.isEmpty {
+                    QuickActionsSection(
+                        descriptors: quickActions,
+                        states: quickActionStates,
+                        themeStore: themeStore,
+                        onRun: onRunQuickAction
+                    )
+                }
+
                 if result.kind == .file {
                     if QuickLookPreviewService.isTextFile(path: result.path) {
                         TextFilePreview(path: result.path, maxHeight: .infinity)
@@ -169,18 +188,22 @@ struct ResultPreviewView: View {
 
                 InfoRow(label: "Kind", value: result.kind.rawValue.capitalized)
 
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Path")
-                        .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular))
-                        .foregroundStyle(themeStore.mutedTextColor())
-                    Text(result.path)
-                        .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular))
-                        .foregroundStyle(themeStore.secondaryTextColor())
-                        .lineLimit(3)
-                }
+                // Settings panes have a URL-scheme "path" and a meaningless file
+                // date; hide both for them (only the actions matter there).
+                if !isSetting {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Path")
+                            .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular))
+                            .foregroundStyle(themeStore.mutedTextColor())
+                        Text(result.path)
+                            .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular))
+                            .foregroundStyle(themeStore.secondaryTextColor())
+                            .lineLimit(3)
+                    }
 
-                if let modified = info.modified {
-                    InfoRow(label: "Modified", value: modified)
+                    if let modified = info.modified {
+                        InfoRow(label: "Modified", value: modified)
+                    }
                 }
 
                 if result.kind != .file && result.kind != .folder {

--- a/bridge/ffi/Cargo.lock
+++ b/bridge/ffi/Cargo.lock
@@ -280,6 +280,7 @@ dependencies = [
  "look-answers",
  "look-engine",
  "look-indexing",
+ "look-qactions",
  "look-ranking",
  "look-storage",
  "look-todo",
@@ -298,6 +299,13 @@ dependencies = [
 [[package]]
 name = "look-matching"
 version = "0.1.0"
+
+[[package]]
+name = "look-qactions"
+version = "0.1.0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "look-ranking"

--- a/bridge/ffi/Cargo.toml
+++ b/bridge/ffi/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 look-answers = { path = "../../core/answers" }
 look-engine = { path = "../../core/engine" }
 look-indexing = { path = "../../core/indexing" }
+look-qactions = { path = "../../core/qactions" }
 look-ranking = { path = "../../core/ranking" }
 look-storage = { path = "../../core/storage" }
 look-todo = { path = "../../core/todo" }

--- a/bridge/ffi/src/lib.rs
+++ b/bridge/ffi/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(unsafe_code)]
 
 mod answers_api;
+mod qactions_api;
 mod runtime_config;
 mod search_api;
 mod seed_api;
@@ -201,6 +202,15 @@ pub extern "C" fn look_record_url_hit(url: *const c_char) -> bool {
 pub extern "C" fn look_recent_urls_json(query: *const c_char, limit: u32) -> *mut c_char {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         url_history_api::look_recent_urls_json_impl(query, limit)
+    }))
+    .unwrap_or(std::ptr::null_mut())
+}
+
+/// Quick Action descriptors JSON for the result `(result_id, kind)` (or `[]`).
+#[unsafe(no_mangle)]
+pub extern "C" fn look_qactions_json(result_id: *const c_char, kind: *const c_char) -> *mut c_char {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        qactions_api::look_qactions_json_impl(result_id, kind)
     }))
     .unwrap_or(std::ptr::null_mut())
 }

--- a/bridge/ffi/src/qactions_api.rs
+++ b/bridge/ffi/src/qactions_api.rs
@@ -1,0 +1,24 @@
+//! C-ABI wrapper over `look_qactions`, so the platform shells can fetch the
+//! Quick Action descriptors for a selected result. Read the result id + kind,
+//! call the shared catalog, hand back a JSON array (empty `[]` on no match or
+//! any failure). Mirrors `answers_api`.
+
+use crate::state::{cstr_to_string, store_json_allocation};
+use std::ffi::CString;
+use std::os::raw::c_char;
+
+const JSON_EMPTY_ARRAY: &str = "[]";
+
+/// JSON array of `ActionDescriptor` for the result `(result_id, kind)`, or `[]`.
+pub(crate) fn look_qactions_json_impl(
+    result_id: *const c_char,
+    kind: *const c_char,
+) -> *mut c_char {
+    let result_id = cstr_to_string(result_id);
+    let kind = cstr_to_string(kind);
+    let descriptors = look_qactions::descriptors_for(&result_id, &kind);
+    let json = serde_json::to_string(&descriptors).unwrap_or_else(|_| JSON_EMPTY_ARRAY.to_string());
+    let cstring =
+        CString::new(json).unwrap_or_else(|_| CString::new(JSON_EMPTY_ARRAY).expect("valid"));
+    store_json_allocation(cstring)
+}

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -224,6 +224,13 @@ name = "look-matching"
 version = "0.1.0"
 
 [[package]]
+name = "look-qactions"
+version = "0.1.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "look-ranking"
 version = "0.1.0"
 dependencies = [

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+  "qactions",
   "answers",
   "engine",
   "indexing",

--- a/core/qactions/Cargo.toml
+++ b/core/qactions/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "look-qactions"
+edition = "2024"
+license = "MIT"
+version = "0.1.0"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }

--- a/core/qactions/src/lib.rs
+++ b/core/qactions/src/lib.rs
@@ -1,0 +1,120 @@
+//! Quick Actions - shared action catalog
+//!
+//! This crate is the platform-neutral half of the framework: it declares WHICH
+//! actions exist and their presentation (labels, control kind, info fields). It
+//! knows nothing about how to execute them - that is a native `SystemControl`
+//! adapter, keyed by `action_id`, in each platform shell.
+//!
+//! A contributor adds a control by (1) declaring its descriptor here, (2) binding
+//! the platform result id(s) that trigger it, and (3) implementing the native
+//! adapter. Only steps 1-2 live in this crate.
+
+use serde::Serialize;
+
+/// How an action's control renders in the panel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ControlKind {
+    /// A boolean on/off switch.
+    Toggle,
+    /// A plain trigger button.
+    Button,
+}
+
+/// A read-only field shown above the actions. The core declares the label and a
+/// `value_key`; the native adapter resolves the key to a live value for display.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct InfoFieldSpec {
+    pub label: String,
+    pub value_key: String,
+}
+
+/// A declared action. Serialized to the platform shells; `action_id` selects the
+/// native adapter that runs it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ActionDescriptor {
+    pub action_id: String,
+    pub title: String,
+    pub control: ControlKind,
+    pub on_label: Option<String>,
+    pub off_label: Option<String>,
+    /// Keyboard hint shown in the panel. Navigation is Cmd+J / Cmd+K; this is the
+    /// per-action label a control may show (e.g. the toggle key).
+    pub key_hint: String,
+    pub info: Vec<InfoFieldSpec>,
+}
+
+/// The action definition for `action_id`, or `None` if unknown. This is the
+/// shared, platform-neutral catalog - add new controls here.
+pub fn descriptor(action_id: &str) -> Option<ActionDescriptor> {
+    match action_id {
+        "bluetooth" => Some(ActionDescriptor {
+            action_id: "bluetooth".to_string(),
+            title: "Bluetooth".to_string(),
+            control: ControlKind::Toggle,
+            on_label: Some("On".to_string()),
+            off_label: Some("Off".to_string()),
+            key_hint: "cmd+j".to_string(),
+            info: vec![InfoFieldSpec {
+                label: "Status".to_string(),
+                value_key: "status".to_string(),
+            }],
+        }),
+        _ => None,
+    }
+}
+
+/// Descriptors that apply to a search result. Resolves the (platform-specific)
+/// result id to a shared `action_id` via [`binding_for`], then looks up the
+/// definition. Empty when the result has no actions.
+pub fn descriptors_for(result_id: &str, kind: &str) -> Vec<ActionDescriptor> {
+    binding_for(result_id, kind)
+        .and_then(descriptor)
+        .into_iter()
+        .collect()
+}
+
+/// Maps a platform result to a shared `action_id`. The action DEFINITIONS above
+/// are shared; only which platform result triggers them is per-OS, so this is
+/// `cfg`-gated. A contributor adding an OS binds its result id here.
+#[cfg(target_os = "macos")]
+fn binding_for(result_id: &str, _kind: &str) -> Option<&'static str> {
+    match result_id {
+        "setting:com.apple.bluetoothsettings" => Some("bluetooth"),
+        _ => None,
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn binding_for(_result_id: &str, _kind: &str) -> Option<&'static str> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bluetooth_descriptor_is_a_toggle_with_labels() {
+        let d = descriptor("bluetooth").expect("bluetooth defined");
+        assert_eq!(d.control, ControlKind::Toggle);
+        assert_eq!(d.on_label.as_deref(), Some("On"));
+        assert_eq!(d.off_label.as_deref(), Some("Off"));
+        assert_eq!(d.info.len(), 1);
+    }
+
+    #[test]
+    fn unknown_action_is_none() {
+        assert!(descriptor("nope").is_none());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_bluetooth_setting_resolves_to_the_toggle() {
+        let found = descriptors_for("setting:com.apple.bluetoothsettings", "app");
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].action_id, "bluetooth");
+        // A non-actionable result yields nothing.
+        assert!(descriptors_for("setting:com.apple.wifi-settings-extension", "app").is_empty());
+    }
+}

--- a/core/qactions/src/lib.rs
+++ b/core/qactions/src/lib.rs
@@ -38,9 +38,6 @@ pub struct ActionDescriptor {
     pub control: ControlKind,
     pub on_label: Option<String>,
     pub off_label: Option<String>,
-    /// Keyboard hint shown in the panel. Navigation is Cmd+J / Cmd+K; this is the
-    /// per-action label a control may show (e.g. the toggle key).
-    pub key_hint: String,
     pub info: Vec<InfoFieldSpec>,
 }
 
@@ -54,7 +51,6 @@ pub fn descriptor(action_id: &str) -> Option<ActionDescriptor> {
             control: ControlKind::Toggle,
             on_label: Some("On".to_string()),
             off_label: Some("Off".to_string()),
-            key_hint: "cmd+j".to_string(),
             info: vec![InfoFieldSpec {
                 label: "Status".to_string(),
                 value_key: "status".to_string(),

--- a/docs/writing-controls.md
+++ b/docs/writing-controls.md
@@ -1,0 +1,81 @@
+# Writing a Quick Action control
+
+A **control** is a system feature Look can act on from its right-hand panel:
+toggle Bluetooth, toggle Wi-Fi, switch appearance, and so on. This guide is for
+contributors adding a new one. (Maintainers: the design rationale lives in the
+internal `specs/quick-actions.md`.)
+
+The goal of the framework is that a new control is a small, mostly-declarative
+contribution: **one shared descriptor, one native adapter file, one registry
+line.** You never touch the panel, keyboard, or rendering code.
+
+## How the pieces split
+
+Look targets macOS and linows (Linux/Windows). Reading and setting system state
+has no cross-platform implementation, so we share the *declaration* and keep the
+*execution* native:
+
+| Piece | Location | Scope |
+|-------|----------|-------|
+| **Descriptor** — what it is: id, match, control kind, on/off labels, key, info fields | `core/qactions` catalog | shared, all OSes |
+| **Adapter** — how it runs: read + set the OS state (`state()` / `apply()`) | `apps/<platform>/…/QuickActions/Controls/<Name>Control.swift` | native, per OS |
+| **Registration** — wire the adapter to its action id | `…/QuickActions/ActionAdapterRegistry.swift` | native, one line |
+
+A control is searchable **and** actionable from its single descriptor; you do not
+separately register it with the search engine. If an OS has no adapter for a
+declared action, the panel still shows the info and marks the action unavailable
+there, rather than the action vanishing inconsistently.
+
+## Steps
+
+1. **Declare** the descriptor once in the shared `core/qactions` catalog: id,
+   what result it matches (`setting:<x>`, an app kind, a bundle id), the control
+   kind (toggle/button), on/off labels, the key hint, and any info fields.
+2. **Implement** the adapter. Copy the reference (`BluetoothControl.swift`),
+   rename the type, and fill in `state()` and `apply(_:)`. Keep **all**
+   OS-specific and private-API code inside this one file.
+3. **Register** it: add one line to `ActionAdapterRegistry.adapters`, e.g.
+   `"wifi": WiFiControl()`.
+
+## Adapter contract
+
+A control conforms to `SystemControl`:
+
+- `state() async -> ActionState` — read current state for display. Return
+  `.on` / `.off` for a toggle, `.value("…")` for a non-boolean control, or
+  `.unavailable("reason")` when it does not apply on this machine.
+- `apply(_ intent: ActionIntent) async -> ActionOutcome` — perform the change and
+  report the outcome. It is best-effort: never throw, never block; surface
+  problems as `.failed("…")` or `.needsPermission("…")`.
+
+### Skeleton
+
+```swift
+import Foundation
+
+/// Toggles and reports <feature>. Action id: `"<id>"`.
+struct <Name>Control: SystemControl {
+    func state() async -> ActionState {
+        // Read current state; `.on` / `.off`, `.value("…")`,
+        // or `.unavailable("reason")`.
+    }
+
+    func apply(_ intent: ActionIntent) async -> ActionOutcome {
+        switch intent {
+        case .toggle:        // flip it
+        case .setOn(let on): // force on/off
+        case .run:           return .failed("<feature> has no run action")
+        }
+        // Perform the change, then return one of:
+        return .ok(banner: "…")          // success
+        // return .failed("…")           // could not do it
+        // return .needsPermission("…")  // OS permission required
+    }
+}
+```
+
+## Reference
+
+Read [`BluetoothControl.swift`](../apps/macos/LauncherApp/look-app/Support/QuickActions/Controls/BluetoothControl.swift)
+first: it is a complete, commented adapter (including how it quarantines a private
+macOS API) and the template every other control follows.

--- a/docs/writing-controls.md
+++ b/docs/writing-controls.md
@@ -17,7 +17,7 @@ has no cross-platform implementation, so we share the *declaration* and keep the
 
 | Piece | Location | Scope |
 |-------|----------|-------|
-| **Descriptor** — what it is: id, match, control kind, on/off labels, key, info fields | `core/qactions` catalog | shared, all OSes |
+| **Descriptor** — what it is: id, match, control kind, on/off labels, info fields | `core/qactions` catalog | shared, all OSes |
 | **Adapter** — how it runs: read + set the OS state (`state()` / `apply()`) | `apps/<platform>/…/QuickActions/Controls/<Name>Control.swift` | native, per OS |
 | **Registration** — wire the adapter to its action id | `…/QuickActions/ActionAdapterRegistry.swift` | native, one line |
 
@@ -26,11 +26,38 @@ separately register it with the search engine. If an OS has no adapter for a
 declared action, the panel still shows the info and marks the action unavailable
 there, rather than the action vanishing inconsistently.
 
+## File map
+
+The three files you touch are grouped together; the rest is framework you leave
+alone. (The repo organizes by layer, `Support/` vs `Views/`, so the framework
+pieces sit with their peers rather than in one feature folder.)
+
+You edit:
+
+```
+core/qactions/src/lib.rs                                  declare the descriptor
+apps/macos/…/Support/QuickActions/
+  Controls/<Name>Control.swift                            your adapter (copy Bluetooth)
+  ActionAdapterRegistry.swift                             one line: "id": Control()
+```
+
+Framework, for reference only, do not edit:
+
+```
+apps/macos/…/Support/QuickActions/SystemControl.swift     the adapter contract
+apps/macos/…/Support/QuickActions/QuickActionModels.swift decodes the descriptor
+apps/macos/…/Support/UI/ToggleSwitch.swift                reusable switch component
+apps/macos/…/Views/Launcher/QuickActionsSection.swift     renders the controls
+apps/macos/…/Views/Launcher/LauncherView+QuickActions.swift  loads state, runs actions
+bridge/ffi/src/qactions_api.rs                            exposes the catalog to Swift
+```
+
 ## Steps
 
 1. **Declare** the descriptor once in the shared `core/qactions` catalog: id,
    what result it matches (`setting:<x>`, an app kind, a bundle id), the control
-   kind (toggle/button), on/off labels, the key hint, and any info fields.
+   kind (toggle/button), on/off labels, and any info fields. The key hint is
+   derived from the control kind (a toggle shows `⌘O`), so you do not set it.
 2. **Implement** the adapter. Copy the reference (`BluetoothControl.swift`),
    rename the type, and fill in `state()` and `apply(_:)`. Keep **all**
    OS-specific and private-API code inside this one file.


### PR DESCRIPTION
## Summary

- The 2 columns layout of Look is designed with a far idea. Not only previewing files, folders but also proceeding quick actions with apps, settings if feasible. 
-> I created a template with docs here for anyone who want to contribute to Look can follow and add their wanted actions for apss, settings.
- Added an example for bluetooth. With bluetooth, you can cmd + o to switch on/off bluetooth with-in Look -> you don't need to go to the bluetooth setting panel.

- Windows seems possible to do, with linux, I need to investigate more and more before implementing. -> There are chances that this feature will not be shipped to linows (or only linux) in the next release

## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [x] `cargo test --manifest-path bridge/ffi/Cargo.toml`
  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

In comments

## Checklist

- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered
