### PR TITLE
Linows: Url like queries

### DIFF
--- a/apps/linows/README.md
+++ b/apps/linows/README.md
@@ -26,6 +26,7 @@ apps/linows/
       sysinfo.rs         System info (OS, memory, CPU, battery, uptime, disk)
       todo.rs            Daily tasks (shared look-todo store in look.db)
       translate.rs       Translation
+      weburl.rs          URL-like query detection + opened-URL history (shared core)
       autostart.rs       Autostart management
       platform/          Platform-specific code
         linux/           Icons, WM detection, Wayland shortcuts, GNOME ext, …

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -21,6 +21,7 @@ mod sysinfo;
 mod todo;
 mod translate;
 mod trash;
+mod weburl;
 
 #[cfg(target_os = "linux")]
 use platform::linux::gpu;
@@ -673,6 +674,11 @@ fn main() {
             answers::duckduckgo_answer,
             answers::wikipedia_answer,
             answers::web_suggestions,
+            // URL-like queries + opened-URL history (shared core, same
+            // url_history table macOS uses)
+            weburl::classify_url,
+            weburl::record_url_hit,
+            weburl::recent_urls,
             // Clipboard
             clipboard::get_clipboard_history,
             clipboard::delete_clipboard_entry,

--- a/apps/linows/src-tauri/src/weburl.rs
+++ b/apps/linows/src-tauri/src/weburl.rs
@@ -1,0 +1,51 @@
+//! Tauri commands for URL-like queries (issue #232) and the launcher-opened
+//! URL history (url-history spec). Classification lives in `look_answers`,
+//! storage in `look_storage`, frecency ranking in `look_engine::url_history` -
+//! all shared with macOS, so this file is only the command layer. The store
+//! calls do SQLite I/O and run on the blocking pool.
+
+use crate::state::default_db_path;
+use look_answers::UrlMatch;
+use look_engine::url_history::{ScoredUrlEntry, ranked_url_history};
+use look_storage::SqliteStore;
+use tauri::async_runtime;
+
+/// Classify `query` as a URL to offer as an "Open <url>" row, or `None` to
+/// leave it as a search term. Pure and network-free, stays on the calling
+/// thread.
+#[tauri::command]
+pub fn classify_url(query: String) -> Option<UrlMatch> {
+    look_answers::classify_url(&query)
+}
+
+/// Records that `url` was opened. Best-effort: returns false on empty input
+/// or any store failure; the frontend fires and forgets.
+#[tauri::command]
+pub async fn record_url_hit(url: String) -> bool {
+    async_runtime::spawn_blocking(move || {
+        if url.trim().is_empty() {
+            return false;
+        }
+        let Ok(store) = SqliteStore::open(default_db_path()) else {
+            return false;
+        };
+        store.record_url_hit(&url).is_ok()
+    })
+    .await
+    .unwrap_or(false)
+}
+
+/// Up to `limit` remembered URLs matching `query`, in frecency order. Empty
+/// vec on any failure - history rows are a convenience, never an error.
+#[tauri::command]
+pub async fn recent_urls(query: String, limit: u32) -> Vec<ScoredUrlEntry> {
+    async_runtime::spawn_blocking(move || {
+        SqliteStore::open(default_db_path())
+            .ok()
+            .and_then(|store| store.recent_urls(&query, limit as usize).ok())
+            .map(|entries| ranked_url_history(entries, &query))
+            .unwrap_or_default()
+    })
+    .await
+    .unwrap_or_default()
+}

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -27,7 +27,8 @@ import {
   getConfig,
 } from './ipc.js';
 import {
-  prefixFromResultId, commandIdFromResultId, webSuggestionFromResultId, isPrefixedQuery,
+  prefixFromResultId, commandIdFromResultId, webSuggestionFromResultId, webUrlFromResultId,
+  isPrefixedQuery,
 } from './catalog.js';
 
 // Item count and structure mirror the macOS app's `LauncherView.hintItems`
@@ -335,9 +336,16 @@ document.addEventListener('DOMContentLoaded', async () => {
       aiAnswer.cancel();
       return;
     }
-    const localCount = items.filter((r) => webSuggestionFromResultId(r.id) == null).length;
+    const localCount = items.filter((r) => !isSyntheticSuggestionRow(r)).length;
     aiAnswer.update(query, localCount);
   });
+
+  // Synthesized suggestion rows (Google autocomplete, URL open/history) are
+  // not local results: they never count toward the AI knowledge-lookup
+  // trigger or the stacked/two-col layout choice.
+  function isSyntheticSuggestionRow(r) {
+    return webSuggestionFromResultId(r.id) != null || webUrlFromResultId(r.id) != null;
+  }
 
   // Pick stacked / two-col purely from the local-result count, ignoring the
   // controller state and the suggestion-arrival timing. This is what
@@ -358,7 +366,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     resultsArea.classList.remove(...AI_LAYOUT_CLASSES);
     let mode = null;
     if (lastAiState !== AiState.idle) {
-      const hasLocal = lastResults.some((r) => webSuggestionFromResultId(r.id) == null);
+      const hasLocal = lastResults.some((r) => !isSyntheticSuggestionRow(r));
       mode = hasLocal ? AI_LAYOUT_STACKED : AI_LAYOUT_TWO_COL;
       resultsArea.classList.add(mode);
     }
@@ -470,6 +478,15 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (suggestionText != null) {
       const url = `https://www.google.com/search?q=${encodeURIComponent(suggestionText)}`;
       import('./ipc.js').then(({ openPath }) => openPath(url, 'browser', ''));
+      return;
+    }
+    // URL row: same behavior on click as on Enter (keyboard.js openSelected).
+    const urlTarget = webUrlFromResultId(item.id);
+    if (urlTarget != null) {
+      import('./ipc.js').then(({ openPath, recordUrlHit }) => {
+        openPath(urlTarget, 'browser', '');
+        recordUrlHit(urlTarget);
+      });
       return;
     }
 

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -320,7 +320,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   // like `t"who is` would otherwise fire isEntityLookup and pull Wikipedia.
   search.setOnResults((items, query) => {
     lastResults = items;
-    results.render(items);
+    results.render(items, query);
     applyAiLayoutMode();
     // Recent-empty renders as one wide card, which sends the hint bar back
     // to the bottom while the panes float (macOS showsFloatingGrid).

--- a/apps/linows/src/js/catalog.js
+++ b/apps/linows/src/js/catalog.js
@@ -3,13 +3,14 @@
 // `"` menu, the `:` menu, and the Help screen can't drift. linows omits
 // `tw"` (no dictionary lookup yet).
 
-import { calculator, timer, listChecks, xCircle, terminal, info } from './icons.js';
+import { calculator, timer, listChecks, xCircle, terminal, info, globe } from './icons.js';
 
 // Synthetic-row id namespaces: the renderer and Enter/click handlers tell
 // synthetic rows apart from real candidates by id prefix.
 const PREFIX_HINT_ID = 'prefixhint:';
 const COMMAND_HINT_ID = 'cmdhint:';
 const WEB_SUGGEST_ID = 'websuggest:';
+const WEB_URL_ID = 'weburl:';
 const DISCOVERY_CHAR = '"';
 
 // Google-autocomplete row glyph: Lucide `search` (mirrors macOS, which uses
@@ -137,4 +138,27 @@ export function webSuggestionResults(suggestions) {
 
 export function webSuggestionFromResultId(resultId) {
   return resultId?.startsWith(WEB_SUGGEST_ID) ? resultId.slice(WEB_SUGGEST_ID.length) : null;
+}
+
+// Synthesized "Open <url>" rows (issue #232 + url-history spec). One shape
+// shared by the live-classified row and history rows, so the open handler and
+// preview key off the same id encoding. Mirrors macOS
+// AppConstants.Launcher.WebURL.
+export const WEB_URL_OPEN_SUBTITLE = 'Open in browser';
+export const WEB_URL_RECENT_SUBTITLE = 'Recently opened';
+
+export function webUrlResult(url, subtitle, score) {
+  return {
+    id: `${WEB_URL_ID}${url}`,
+    kind: 'app',
+    title: url,
+    subtitle,
+    path: url,
+    score,
+    iconSvg: globe,
+  };
+}
+
+export function webUrlFromResultId(resultId) {
+  return resultId?.startsWith(WEB_URL_ID) ? resultId.slice(WEB_URL_ID.length) : null;
 }

--- a/apps/linows/src/js/components/preview.js
+++ b/apps/linows/src/js/components/preview.js
@@ -1,6 +1,6 @@
 import { getIcon, getFileMeta, getAppVersion, deleteClipboardEntry, highlightFile, listFolder, openPath } from '../ipc.js';
-import { clipboard as clipboardIcon, trash as trashIcon, appIcon, fileIcon, folderIcon, settingIcon } from '../icons.js';
-import { webSuggestionFromResultId } from '../catalog.js';
+import { clipboard as clipboardIcon, trash as trashIcon, appIcon, fileIcon, folderIcon, settingIcon, globeLg } from '../icons.js';
+import { webSuggestionFromResultId, webUrlFromResultId, WEB_URL_OPEN_SUBTITLE } from '../catalog.js';
 
 let panel = null;
 let currentPath = null;
@@ -42,6 +42,16 @@ export function update(result) {
   const suggestionText = webSuggestionFromResultId(result.id);
   if (suggestionText != null) {
     renderWebSuggestionPreview(suggestionText);
+    return;
+  }
+
+  // URL row (live or history) - same layout as the web-suggestion preview
+  // but with a globe and the row's subtitle ("Open in browser" / "Recently
+  // opened"). Must run before the generic app branch: the row's kind is
+  // `app` and its path is a URL, so the file/app metadata path would break.
+  const urlTarget = webUrlFromResultId(result.id);
+  if (urlTarget != null) {
+    renderWebUrlPreview(urlTarget, result.subtitle || WEB_URL_OPEN_SUBTITLE);
     return;
   }
 
@@ -425,6 +435,35 @@ function renderWebSuggestionPreview(query) {
   const hint = document.createElement('div');
   hint.className = 'preview-web-suggestion-hint';
   hint.innerHTML = `Press <kbd>Enter</kbd> to search the web`;
+  wrap.appendChild(hint);
+
+  panel.appendChild(wrap);
+}
+
+// URL rows share the web-suggestion preview layout/classes; only the glyph,
+// subtitle and hint differ, so no new CSS.
+function renderWebUrlPreview(url, subtitle) {
+  const wrap = document.createElement('div');
+  wrap.className = 'preview-web-suggestion';
+
+  const icon = document.createElement('div');
+  icon.className = 'preview-web-suggestion-icon';
+  icon.innerHTML = globeLg;
+  wrap.appendChild(icon);
+
+  const title = document.createElement('div');
+  title.className = 'preview-web-suggestion-title';
+  title.textContent = url;
+  wrap.appendChild(title);
+
+  const sub = document.createElement('div');
+  sub.className = 'preview-web-suggestion-subtitle';
+  sub.textContent = subtitle;
+  wrap.appendChild(sub);
+
+  const hint = document.createElement('div');
+  hint.className = 'preview-web-suggestion-hint';
+  hint.innerHTML = `Press <kbd>Enter</kbd> to open in browser`;
   wrap.appendChild(hint);
 
   panel.appendChild(wrap);

--- a/apps/linows/src/js/components/results.js
+++ b/apps/linows/src/js/components/results.js
@@ -1,15 +1,7 @@
-import { getIcon } from "../ipc.js";
-import {
-    clipboard as clipboardIcon,
-    check as checkIcon,
-    appIcon,
-    fileIcon,
-    folderIcon,
-    settingIcon,
-    historyLg,
-} from "../icons.js";
-import { getSettingsIcon as getWindowsSettingsIcon } from "../settings-icons/windows.js";
-import { webSuggestionFromResultId } from "../catalog.js";
+import { getIcon } from '../ipc.js';
+import { clipboard as clipboardIcon, check as checkIcon, appIcon, fileIcon, folderIcon, settingIcon, historyLg } from '../icons.js';
+import { getSettingsIcon as getWindowsSettingsIcon } from '../settings-icons/windows.js';
+import { webSuggestionFromResultId } from '../catalog.js';
 
 const iconCache = new Map();
 const pickedMap = new Map(); // key → result
@@ -19,7 +11,7 @@ let selectedIndex = -1;
 let container = null;
 let onSelectionChange = null;
 let onPickChange = null;
-let emptyState = { mode: "default" };
+let emptyState = { mode: 'default' };
 // True once the user moves the cursor (arrows/Tab/click) within the current
 // query. Gates selection preservation in render(): a cursor the user parked
 // somewhere survives re-renders, but an auto-selected row does not - search
@@ -30,197 +22,194 @@ let userNavigated = false;
 let lastRenderQuery = null;
 
 export function init(containerEl) {
-    container = containerEl;
+  container = containerEl;
 }
 
 export function setOnSelectionChange(callback) {
-    onSelectionChange = callback;
+  onSelectionChange = callback;
 }
 
 export function setOnPickChange(callback) {
-    onPickChange = callback;
+  onPickChange = callback;
 }
 
 export function setEmptyState(state) {
-    emptyState = state || { mode: "default" };
-    if (currentResults.length === 0 && container) {
-        container.innerHTML = renderEmptyState();
-    }
+  emptyState = state || { mode: 'default' };
+  if (currentResults.length === 0 && container) {
+    container.innerHTML = renderEmptyState();
+  }
 }
 
 function renderEmptyState() {
-    // Left half of the clipboard empty state; the preview column shows the
-    // "How to use" half (macOS ClipboardEmptyInfoView / ClipboardEmptyHelpView).
-    if (emptyState.mode === "clipboard") {
-        return `
+  // Left half of the clipboard empty state; the preview column shows the
+  // "How to use" half (macOS ClipboardEmptyInfoView / ClipboardEmptyHelpView).
+  if (emptyState.mode === 'clipboard') {
+    return `
       <div class="empty-state empty-state-rich">
         <div class="empty-state-icon">${clipboardIcon}</div>
         <div class="empty-state-title">Clipboard History</div>
         <div class="empty-state-body">No clipboard items yet</div>
         <div class="empty-state-help">Copy any text, then search with <kbd>c"word</kbd> to find it here.</div>
       </div>`;
-    }
-    if (emptyState.mode === "recent") {
-        return `
+  }
+  if (emptyState.mode === 'recent') {
+    return `
       <div class="empty-state empty-state-rich">
         <div class="empty-state-icon">${historyLg}</div>
         <div class="empty-state-title">Recent files &amp; folders</div>
         <div class="empty-state-body">Nothing recent yet</div>
         <div class="empty-state-help">Open files/folders through Look, or download/create some - newest activity shows here. Type <kbd>rc"word</kbd> to filter.</div>
       </div>`;
-    }
-    // AI two-col mode: the right column hosts web suggestions, which routinely
-    // return empty (DDG /ac/ rate-limits, transient curl failures). Showing
-    // a stark "No results" there reads as broken when the user can see the
-    // answer card on the left is working fine. Render nothing instead.
-    if (emptyState.mode === "ai-suggestion") {
-        return "";
-    }
-    return '<div class="empty-state">No results</div>';
+  }
+  // AI two-col mode: the right column hosts web suggestions, which routinely
+  // return empty (DDG /ac/ rate-limits, transient curl failures). Showing
+  // a stark "No results" there reads as broken when the user can see the
+  // answer card on the left is working fine. Render nothing instead.
+  if (emptyState.mode === 'ai-suggestion') {
+    return '';
+  }
+  return '<div class="empty-state">No results</div>';
 }
 
 export function render(results, query = null) {
-    // A new query invalidates any manual cursor position.
-    if (query !== lastRenderQuery) {
-        lastRenderQuery = query;
-        userNavigated = false;
-    }
+  // A new query invalidates any manual cursor position.
+  if (query !== lastRenderQuery) {
+    lastRenderQuery = query;
+    userNavigated = false;
+  }
 
-    // Preserve the selected row across re-renders, but only when the user put
-    // the cursor there: a file-watcher index refresh fires `index-ready`, which
-    // re-runs the current query and re-publishes the (often identical) result
-    // set. Without this, the cursor snaps back to row 0 mid-scroll a couple
-    // seconds after the user picks another row. Auto-selected rows are exempt
-    // (see userNavigated above) so the cursor lands on row 0 once the full
-    // result order settles.
-    const prevSelectedId =
-        userNavigated &&
-        selectedIndex >= 0 &&
-        selectedIndex < currentResults.length
-            ? currentResults[selectedIndex].id
-            : null;
+  // Preserve the selected row across re-renders, but only when the user put
+  // the cursor there: a file-watcher index refresh fires `index-ready`, which
+  // re-runs the current query and re-publishes the (often identical) result
+  // set. Without this, the cursor snaps back to row 0 mid-scroll a couple
+  // seconds after the user picks another row. Auto-selected rows are exempt
+  // (see userNavigated above) so the cursor lands on row 0 once the full
+  // result order settles.
+  const prevSelectedId = (userNavigated && selectedIndex >= 0 && selectedIndex < currentResults.length)
+    ? currentResults[selectedIndex].id
+    : null;
 
-    currentResults = results;
-    container.innerHTML = "";
+  currentResults = results;
+  container.innerHTML = '';
 
-    if (results.length === 0) {
-        container.innerHTML = renderEmptyState();
-        selectedIndex = -1;
-        return;
-    }
+  if (results.length === 0) {
+    container.innerHTML = renderEmptyState();
+    selectedIndex = -1;
+    return;
+  }
 
-    results.forEach((result, index) => {
-        const row = createRow(result, index);
-        container.appendChild(row);
-    });
+  results.forEach((result, index) => {
+    const row = createRow(result, index);
+    container.appendChild(row);
+  });
 
-    let nextIndex = 0;
-    if (prevSelectedId != null) {
-        const idx = results.findIndex((r) => r.id === prevSelectedId);
-        if (idx >= 0) nextIndex = idx;
-    }
-    select(nextIndex);
+  let nextIndex = 0;
+  if (prevSelectedId != null) {
+    const idx = results.findIndex((r) => r.id === prevSelectedId);
+    if (idx >= 0) nextIndex = idx;
+  }
+  select(nextIndex);
 }
 
 export function getSelected() {
-    if (selectedIndex >= 0 && selectedIndex < currentResults.length) {
-        return currentResults[selectedIndex];
-    }
-    return null;
+  if (selectedIndex >= 0 && selectedIndex < currentResults.length) {
+    return currentResults[selectedIndex];
+  }
+  return null;
 }
 
 export function getSelectedIndex() {
-    return selectedIndex;
+  return selectedIndex;
 }
 
 export function selectNext() {
-    if (currentResults.length === 0) return;
-    userNavigated = true;
-    select((selectedIndex + 1) % currentResults.length);
+  if (currentResults.length === 0) return;
+  userNavigated = true;
+  select((selectedIndex + 1) % currentResults.length);
 }
 
 export function selectPrev() {
-    if (currentResults.length === 0) return;
-    userNavigated = true;
-    select((selectedIndex - 1 + currentResults.length) % currentResults.length);
+  if (currentResults.length === 0) return;
+  userNavigated = true;
+  select((selectedIndex - 1 + currentResults.length) % currentResults.length);
 }
 
 export function select(index) {
-    const prev = container.querySelector(".result-row.selected");
-    if (prev) prev.classList.remove("selected");
+  const prev = container.querySelector('.result-row.selected');
+  if (prev) prev.classList.remove('selected');
 
-    selectedIndex = index;
+  selectedIndex = index;
 
-    const rows = container.querySelectorAll(".result-row");
-    if (rows[index]) {
-        rows[index].classList.add("selected");
-        rows[index].scrollIntoView({ block: "nearest", behavior: "smooth" });
-    }
+  const rows = container.querySelectorAll('.result-row');
+  if (rows[index]) {
+    rows[index].classList.add('selected');
+    rows[index].scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+  }
 
-    if (onSelectionChange) {
-        onSelectionChange(getSelected());
-    }
+  if (onSelectionChange) {
+    onSelectionChange(getSelected());
+  }
 }
 
 // --- Pick management ---
 
 function pickKey(item) {
-    return `${item.kind}|${item.path}`;
+  return `${item.kind}|${item.path}`;
 }
 
 export function togglePick(item) {
-    if (!item) return;
-    const key = pickKey(item);
-    if (pickedMap.has(key)) {
-        pickedMap.delete(key);
-    } else {
-        pickedMap.set(key, item);
-    }
-    updatePickedIndicators();
-    if (onPickChange) onPickChange(getPickedItems());
+  if (!item) return;
+  const key = pickKey(item);
+  if (pickedMap.has(key)) {
+    pickedMap.delete(key);
+  } else {
+    pickedMap.set(key, item);
+  }
+  updatePickedIndicators();
+  if (onPickChange) onPickChange(getPickedItems());
 }
 
 export function removePick(key) {
-    pickedMap.delete(key);
-    updatePickedIndicators();
-    if (onPickChange) onPickChange(getPickedItems());
+  pickedMap.delete(key);
+  updatePickedIndicators();
+  if (onPickChange) onPickChange(getPickedItems());
 }
 
 export function clearPicks() {
-    pickedMap.clear();
-    updatePickedIndicators();
-    if (onPickChange) onPickChange(getPickedItems());
+  pickedMap.clear();
+  updatePickedIndicators();
+  if (onPickChange) onPickChange(getPickedItems());
 }
 
 export function isPicked(item) {
-    return pickedMap.has(pickKey(item));
+  return pickedMap.has(pickKey(item));
 }
 
 export function getPickedItems() {
-    return [...pickedMap.entries()].map(([key, item]) => ({ key, ...item }));
+  return [...pickedMap.entries()].map(([key, item]) => ({ key, ...item }));
 }
 
 export function hasPickedItems() {
-    return pickedMap.size > 0;
+  return pickedMap.size > 0;
 }
 
 function updatePickedIndicators() {
-    const rows = container.querySelectorAll(".result-row");
-    rows.forEach((row, i) => {
-        const result = currentResults[i];
-        if (!result) return;
-        const check = row.querySelector(".pick-check");
-        if (pickedMap.has(pickKey(result))) {
-            if (!check) {
-                const el = document.createElement("div");
-                el.className = "pick-check";
-                el.innerHTML = checkIcon;
-                row.appendChild(el);
-            }
-        } else if (check) {
-            check.remove();
-        }
-    });
+  const rows = container.querySelectorAll('.result-row');
+  rows.forEach((row, i) => {
+    const result = currentResults[i];
+    if (!result) return;
+    const check = row.querySelector('.pick-check');
+    if (pickedMap.has(pickKey(result))) {
+      if (!check) {
+        const el = document.createElement('div');
+        el.className = 'pick-check';
+        el.innerHTML = checkIcon;
+        row.appendChild(el);
+      }
+    } else if (check) {
+      check.remove();
+    }
+  });
 }
 
 // --- Row creation ---
@@ -230,133 +219,118 @@ function updatePickedIndicators() {
 // for search but renders as a long noisy line ("Windows Settings settings
 // wifi wireless network ssid"). Trim the alias tail at render time - engine
 // keeps the full string for scoring.
-const SETTINGS_SUBTITLE_PREFIXES = ["Windows Settings", "System Settings"];
+const SETTINGS_SUBTITLE_PREFIXES = ['Windows Settings', 'System Settings'];
 
 function displaySubtitle(result) {
-    if (result.kind === "clipboard") return result.subtitle;
-    if (result.subtitle) {
-        for (const prefix of SETTINGS_SUBTITLE_PREFIXES) {
-            if (result.subtitle.startsWith(prefix + " ")) return prefix;
-        }
-        return result.subtitle;
+  if (result.kind === 'clipboard') return result.subtitle;
+  if (result.subtitle) {
+    for (const prefix of SETTINGS_SUBTITLE_PREFIXES) {
+      if (result.subtitle.startsWith(prefix + ' ')) return prefix;
     }
-    if (result.kind === "file" || result.kind === "folder") return result.path;
-    const kindLabels = { app: "App", setting: "Setting" };
-    return kindLabels[result.kind] || result.kind;
+    return result.subtitle;
+  }
+  if (result.kind === 'file' || result.kind === 'folder') return result.path;
+  const kindLabels = { app: 'App', setting: 'Setting' };
+  return kindLabels[result.kind] || result.kind;
 }
 
 function createRow(result, index) {
-    const row = document.createElement("div");
-    row.className = "result-row";
-    row.dataset.index = index;
-    // Web-suggestion rows live in a narrow 320 px column when the AI card is
-    // active; let their title wrap to multiple lines instead of truncating
-    // (matches macOS WebSuggestionPreviewView's 3-line title cap).
-    if (webSuggestionFromResultId(result.id) != null) {
-        row.classList.add("result-row-web-suggest");
-    }
+  const row = document.createElement('div');
+  row.className = 'result-row';
+  row.dataset.index = index;
+  // Web-suggestion rows live in a narrow 320 px column when the AI card is
+  // active; let their title wrap to multiple lines instead of truncating
+  // (matches macOS WebSuggestionPreviewView's 3-line title cap).
+  if (webSuggestionFromResultId(result.id) != null) {
+    row.classList.add('result-row-web-suggest');
+  }
 
-    // Icon (kind-based SVG fallback, async-load real icon)
-    const icon = document.createElement("div");
-    icon.className = "result-icon";
-    const isLinuxSettings =
-        result.path?.startsWith("settings://") ||
-        result.subtitle?.toLowerCase().startsWith("settings");
-    // Windows ms-settings: panels share one icon at the OS level (the gear) - we
-    // map each panel to a category-specific Lucide glyph via the catalog so the
-    // list scans visually. Returns null if the path isn't an ms-settings URI.
-    const windowsSettingsSvg = getWindowsSettingsIcon(result.path);
-    const fallbacks = {
-        file: fileIcon,
-        folder: folderIcon,
-        setting: settingIcon,
-        clipboard: clipboardIcon,
-    };
-    // Synthetic discovery rows (prefix/command menus) ship their own glyph in
-    // result.iconSvg so the list scans visually; everything else falls back to
-    // the kind-based stub until the backend icon fetch resolves.
-    icon.innerHTML =
-        result.iconSvg ||
-        windowsSettingsSvg ||
-        (isLinuxSettings ? settingIcon : fallbacks[result.kind] || appIcon);
-    icon.style.background = "var(--control-fill)";
-    icon.style.color = "var(--font-secondary)";
-    row.appendChild(icon);
+  // Icon (kind-based SVG fallback, async-load real icon)
+  const icon = document.createElement('div');
+  icon.className = 'result-icon';
+  const isLinuxSettings = result.path?.startsWith('settings://') || result.subtitle?.toLowerCase().startsWith('settings');
+  // Windows ms-settings: panels share one icon at the OS level (the gear) - we
+  // map each panel to a category-specific Lucide glyph via the catalog so the
+  // list scans visually. Returns null if the path isn't an ms-settings URI.
+  const windowsSettingsSvg = getWindowsSettingsIcon(result.path);
+  const fallbacks = { file: fileIcon, folder: folderIcon, setting: settingIcon, clipboard: clipboardIcon };
+  // Synthetic discovery rows (prefix/command menus) ship their own glyph in
+  // result.iconSvg so the list scans visually; everything else falls back to
+  // the kind-based stub until the backend icon fetch resolves.
+  icon.innerHTML = result.iconSvg
+    || windowsSettingsSvg
+    || (isLinuxSettings ? settingIcon : (fallbacks[result.kind] || appIcon));
+  icon.style.background = 'var(--control-fill)';
+  icon.style.color = 'var(--font-secondary)';
+  row.appendChild(icon);
 
-    // Skip backend icon fetch for ms-settings entries - the Shell PNG would just
-    // be the generic gear and would clobber our category-specific glyph. Same
-    // applies to synthetic discovery rows whose `path` is empty.
-    if (
-        result.kind !== "clipboard" &&
-        !windowsSettingsSvg &&
-        !result.iconSvg &&
-        result.path
-    ) {
-        loadIcon(icon, result.kind, result.path, result.id);
-    }
+  // Skip backend icon fetch for ms-settings entries - the Shell PNG would just
+  // be the generic gear and would clobber our category-specific glyph. Same
+  // applies to synthetic discovery rows whose `path` is empty.
+  if (result.kind !== 'clipboard' && !windowsSettingsSvg && !result.iconSvg && result.path) {
+    loadIcon(icon, result.kind, result.path, result.id);
+  }
 
-    // Text content
-    const text = document.createElement("div");
-    text.className = "result-text";
+  // Text content
+  const text = document.createElement('div');
+  text.className = 'result-text';
 
-    const title = document.createElement("div");
-    title.className = "result-title";
-    title.textContent = result.title;
-    text.appendChild(title);
+  const title = document.createElement('div');
+  title.className = 'result-title';
+  title.textContent = result.title;
+  text.appendChild(title);
 
-    const subtitle = document.createElement("div");
-    subtitle.className = "result-path";
-    subtitle.textContent = displaySubtitle(result);
-    text.appendChild(subtitle);
+  const subtitle = document.createElement('div');
+  subtitle.className = 'result-path';
+  subtitle.textContent = displaySubtitle(result);
+  text.appendChild(subtitle);
 
-    row.appendChild(text);
+  row.appendChild(text);
 
-    // Picked indicator
-    if (pickedMap.has(pickKey(result))) {
-        const el = document.createElement("div");
-        el.className = "pick-check";
-        el.innerHTML = checkIcon;
-        row.appendChild(el);
-    }
+  // Picked indicator
+  if (pickedMap.has(pickKey(result))) {
+    const el = document.createElement('div');
+    el.className = 'pick-check';
+    el.innerHTML = checkIcon;
+    row.appendChild(el);
+  }
 
-    row.addEventListener("click", () => {
-        userNavigated = true;
-        select(index);
-        row.dispatchEvent(new CustomEvent("result-activate", { bubbles: true }));
-    });
+  row.addEventListener('click', () => {
+    userNavigated = true;
+    select(index);
+    row.dispatchEvent(new CustomEvent('result-activate', { bubbles: true }));
+  });
 
-    return row;
+  return row;
 }
 
 function loadIcon(iconEl, kind, path, id) {
-    const cacheKey = `${kind}:${path}`;
+  const cacheKey = `${kind}:${path}`;
 
-    if (iconCache.has(cacheKey)) {
-        const dataUrl = iconCache.get(cacheKey);
-        if (dataUrl) {
-            applyIcon(iconEl, dataUrl);
-        }
-        return;
+  if (iconCache.has(cacheKey)) {
+    const dataUrl = iconCache.get(cacheKey);
+    if (dataUrl) {
+      applyIcon(iconEl, dataUrl);
     }
+    return;
+  }
 
-    getIcon(kind, path, id)
-        .then((result) => {
-            const dataUrl = result?.data_url || null;
-            iconCache.set(cacheKey, dataUrl);
-            if (dataUrl) {
-                applyIcon(iconEl, dataUrl);
-            }
-        })
-        .catch(() => {
-            iconCache.set(cacheKey, null);
-        });
+  getIcon(kind, path, id).then((result) => {
+    const dataUrl = result?.data_url || null;
+    iconCache.set(cacheKey, dataUrl);
+    if (dataUrl) {
+      applyIcon(iconEl, dataUrl);
+    }
+  }).catch(() => {
+    iconCache.set(cacheKey, null);
+  });
 }
 
 function applyIcon(iconEl, dataUrl) {
-    const img = document.createElement("img");
-    img.src = dataUrl;
-    img.alt = "";
-    iconEl.textContent = "";
-    iconEl.style.background = "none";
-    iconEl.appendChild(img);
+  const img = document.createElement('img');
+  img.src = dataUrl;
+  img.alt = '';
+  iconEl.textContent = '';
+  iconEl.style.background = 'none';
+  iconEl.appendChild(img);
 }

--- a/apps/linows/src/js/components/results.js
+++ b/apps/linows/src/js/components/results.js
@@ -1,7 +1,15 @@
-import { getIcon } from '../ipc.js';
-import { clipboard as clipboardIcon, check as checkIcon, appIcon, fileIcon, folderIcon, settingIcon, historyLg } from '../icons.js';
-import { getSettingsIcon as getWindowsSettingsIcon } from '../settings-icons/windows.js';
-import { webSuggestionFromResultId } from '../catalog.js';
+import { getIcon } from "../ipc.js";
+import {
+    clipboard as clipboardIcon,
+    check as checkIcon,
+    appIcon,
+    fileIcon,
+    folderIcon,
+    settingIcon,
+    historyLg,
+} from "../icons.js";
+import { getSettingsIcon as getWindowsSettingsIcon } from "../settings-icons/windows.js";
+import { webSuggestionFromResultId } from "../catalog.js";
 
 const iconCache = new Map();
 const pickedMap = new Map(); // key → result
@@ -11,186 +19,208 @@ let selectedIndex = -1;
 let container = null;
 let onSelectionChange = null;
 let onPickChange = null;
-let emptyState = { mode: 'default' };
+let emptyState = { mode: "default" };
+// True once the user moves the cursor (arrows/Tab/click) within the current
+// query. Gates selection preservation in render(): a cursor the user parked
+// somewhere survives re-renders, but an auto-selected row does not - search
+// publishes progressively (engine, then URL rows, then web suggestions) and
+// a row that painted first may end up mid/bottom of the final order. Without
+// the gate the cursor follows it there instead of resting on the top result.
+let userNavigated = false;
+let lastRenderQuery = null;
 
 export function init(containerEl) {
-  container = containerEl;
+    container = containerEl;
 }
 
 export function setOnSelectionChange(callback) {
-  onSelectionChange = callback;
+    onSelectionChange = callback;
 }
 
 export function setOnPickChange(callback) {
-  onPickChange = callback;
+    onPickChange = callback;
 }
 
 export function setEmptyState(state) {
-  emptyState = state || { mode: 'default' };
-  if (currentResults.length === 0 && container) {
-    container.innerHTML = renderEmptyState();
-  }
+    emptyState = state || { mode: "default" };
+    if (currentResults.length === 0 && container) {
+        container.innerHTML = renderEmptyState();
+    }
 }
 
 function renderEmptyState() {
-  // Left half of the clipboard empty state; the preview column shows the
-  // "How to use" half (macOS ClipboardEmptyInfoView / ClipboardEmptyHelpView).
-  if (emptyState.mode === 'clipboard') {
-    return `
+    // Left half of the clipboard empty state; the preview column shows the
+    // "How to use" half (macOS ClipboardEmptyInfoView / ClipboardEmptyHelpView).
+    if (emptyState.mode === "clipboard") {
+        return `
       <div class="empty-state empty-state-rich">
         <div class="empty-state-icon">${clipboardIcon}</div>
         <div class="empty-state-title">Clipboard History</div>
         <div class="empty-state-body">No clipboard items yet</div>
         <div class="empty-state-help">Copy any text, then search with <kbd>c"word</kbd> to find it here.</div>
       </div>`;
-  }
-  if (emptyState.mode === 'recent') {
-    return `
+    }
+    if (emptyState.mode === "recent") {
+        return `
       <div class="empty-state empty-state-rich">
         <div class="empty-state-icon">${historyLg}</div>
         <div class="empty-state-title">Recent files &amp; folders</div>
         <div class="empty-state-body">Nothing recent yet</div>
         <div class="empty-state-help">Open files/folders through Look, or download/create some - newest activity shows here. Type <kbd>rc"word</kbd> to filter.</div>
       </div>`;
-  }
-  // AI two-col mode: the right column hosts web suggestions, which routinely
-  // return empty (DDG /ac/ rate-limits, transient curl failures). Showing
-  // a stark "No results" there reads as broken when the user can see the
-  // answer card on the left is working fine. Render nothing instead.
-  if (emptyState.mode === 'ai-suggestion') {
-    return '';
-  }
-  return '<div class="empty-state">No results</div>';
+    }
+    // AI two-col mode: the right column hosts web suggestions, which routinely
+    // return empty (DDG /ac/ rate-limits, transient curl failures). Showing
+    // a stark "No results" there reads as broken when the user can see the
+    // answer card on the left is working fine. Render nothing instead.
+    if (emptyState.mode === "ai-suggestion") {
+        return "";
+    }
+    return '<div class="empty-state">No results</div>';
 }
 
-export function render(results) {
-  // Preserve the selected row across re-renders: a file-watcher index refresh
-  // fires `index-ready`, which re-runs the current query and re-publishes the
-  // (often identical) result set. Without this, the cursor snaps back to row 0
-  // mid-scroll a couple seconds after the user picks another row.
-  const prevSelectedId = (selectedIndex >= 0 && selectedIndex < currentResults.length)
-    ? currentResults[selectedIndex].id
-    : null;
+export function render(results, query = null) {
+    // A new query invalidates any manual cursor position.
+    if (query !== lastRenderQuery) {
+        lastRenderQuery = query;
+        userNavigated = false;
+    }
 
-  currentResults = results;
-  container.innerHTML = '';
+    // Preserve the selected row across re-renders, but only when the user put
+    // the cursor there: a file-watcher index refresh fires `index-ready`, which
+    // re-runs the current query and re-publishes the (often identical) result
+    // set. Without this, the cursor snaps back to row 0 mid-scroll a couple
+    // seconds after the user picks another row. Auto-selected rows are exempt
+    // (see userNavigated above) so the cursor lands on row 0 once the full
+    // result order settles.
+    const prevSelectedId =
+        userNavigated &&
+        selectedIndex >= 0 &&
+        selectedIndex < currentResults.length
+            ? currentResults[selectedIndex].id
+            : null;
 
-  if (results.length === 0) {
-    container.innerHTML = renderEmptyState();
-    selectedIndex = -1;
-    return;
-  }
+    currentResults = results;
+    container.innerHTML = "";
 
-  results.forEach((result, index) => {
-    const row = createRow(result, index);
-    container.appendChild(row);
-  });
+    if (results.length === 0) {
+        container.innerHTML = renderEmptyState();
+        selectedIndex = -1;
+        return;
+    }
 
-  let nextIndex = 0;
-  if (prevSelectedId != null) {
-    const idx = results.findIndex((r) => r.id === prevSelectedId);
-    if (idx >= 0) nextIndex = idx;
-  }
-  select(nextIndex);
+    results.forEach((result, index) => {
+        const row = createRow(result, index);
+        container.appendChild(row);
+    });
+
+    let nextIndex = 0;
+    if (prevSelectedId != null) {
+        const idx = results.findIndex((r) => r.id === prevSelectedId);
+        if (idx >= 0) nextIndex = idx;
+    }
+    select(nextIndex);
 }
 
 export function getSelected() {
-  if (selectedIndex >= 0 && selectedIndex < currentResults.length) {
-    return currentResults[selectedIndex];
-  }
-  return null;
+    if (selectedIndex >= 0 && selectedIndex < currentResults.length) {
+        return currentResults[selectedIndex];
+    }
+    return null;
 }
 
 export function getSelectedIndex() {
-  return selectedIndex;
+    return selectedIndex;
 }
 
 export function selectNext() {
-  if (currentResults.length === 0) return;
-  select((selectedIndex + 1) % currentResults.length);
+    if (currentResults.length === 0) return;
+    userNavigated = true;
+    select((selectedIndex + 1) % currentResults.length);
 }
 
 export function selectPrev() {
-  if (currentResults.length === 0) return;
-  select((selectedIndex - 1 + currentResults.length) % currentResults.length);
+    if (currentResults.length === 0) return;
+    userNavigated = true;
+    select((selectedIndex - 1 + currentResults.length) % currentResults.length);
 }
 
 export function select(index) {
-  const prev = container.querySelector('.result-row.selected');
-  if (prev) prev.classList.remove('selected');
+    const prev = container.querySelector(".result-row.selected");
+    if (prev) prev.classList.remove("selected");
 
-  selectedIndex = index;
+    selectedIndex = index;
 
-  const rows = container.querySelectorAll('.result-row');
-  if (rows[index]) {
-    rows[index].classList.add('selected');
-    rows[index].scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-  }
+    const rows = container.querySelectorAll(".result-row");
+    if (rows[index]) {
+        rows[index].classList.add("selected");
+        rows[index].scrollIntoView({ block: "nearest", behavior: "smooth" });
+    }
 
-  if (onSelectionChange) {
-    onSelectionChange(getSelected());
-  }
+    if (onSelectionChange) {
+        onSelectionChange(getSelected());
+    }
 }
 
 // --- Pick management ---
 
 function pickKey(item) {
-  return `${item.kind}|${item.path}`;
+    return `${item.kind}|${item.path}`;
 }
 
 export function togglePick(item) {
-  if (!item) return;
-  const key = pickKey(item);
-  if (pickedMap.has(key)) {
-    pickedMap.delete(key);
-  } else {
-    pickedMap.set(key, item);
-  }
-  updatePickedIndicators();
-  if (onPickChange) onPickChange(getPickedItems());
+    if (!item) return;
+    const key = pickKey(item);
+    if (pickedMap.has(key)) {
+        pickedMap.delete(key);
+    } else {
+        pickedMap.set(key, item);
+    }
+    updatePickedIndicators();
+    if (onPickChange) onPickChange(getPickedItems());
 }
 
 export function removePick(key) {
-  pickedMap.delete(key);
-  updatePickedIndicators();
-  if (onPickChange) onPickChange(getPickedItems());
+    pickedMap.delete(key);
+    updatePickedIndicators();
+    if (onPickChange) onPickChange(getPickedItems());
 }
 
 export function clearPicks() {
-  pickedMap.clear();
-  updatePickedIndicators();
-  if (onPickChange) onPickChange(getPickedItems());
+    pickedMap.clear();
+    updatePickedIndicators();
+    if (onPickChange) onPickChange(getPickedItems());
 }
 
 export function isPicked(item) {
-  return pickedMap.has(pickKey(item));
+    return pickedMap.has(pickKey(item));
 }
 
 export function getPickedItems() {
-  return [...pickedMap.entries()].map(([key, item]) => ({ key, ...item }));
+    return [...pickedMap.entries()].map(([key, item]) => ({ key, ...item }));
 }
 
 export function hasPickedItems() {
-  return pickedMap.size > 0;
+    return pickedMap.size > 0;
 }
 
 function updatePickedIndicators() {
-  const rows = container.querySelectorAll('.result-row');
-  rows.forEach((row, i) => {
-    const result = currentResults[i];
-    if (!result) return;
-    const check = row.querySelector('.pick-check');
-    if (pickedMap.has(pickKey(result))) {
-      if (!check) {
-        const el = document.createElement('div');
-        el.className = 'pick-check';
-        el.innerHTML = checkIcon;
-        row.appendChild(el);
-      }
-    } else if (check) {
-      check.remove();
-    }
-  });
+    const rows = container.querySelectorAll(".result-row");
+    rows.forEach((row, i) => {
+        const result = currentResults[i];
+        if (!result) return;
+        const check = row.querySelector(".pick-check");
+        if (pickedMap.has(pickKey(result))) {
+            if (!check) {
+                const el = document.createElement("div");
+                el.className = "pick-check";
+                el.innerHTML = checkIcon;
+                row.appendChild(el);
+            }
+        } else if (check) {
+            check.remove();
+        }
+    });
 }
 
 // --- Row creation ---
@@ -200,117 +230,133 @@ function updatePickedIndicators() {
 // for search but renders as a long noisy line ("Windows Settings settings
 // wifi wireless network ssid"). Trim the alias tail at render time - engine
 // keeps the full string for scoring.
-const SETTINGS_SUBTITLE_PREFIXES = ['Windows Settings', 'System Settings'];
+const SETTINGS_SUBTITLE_PREFIXES = ["Windows Settings", "System Settings"];
 
 function displaySubtitle(result) {
-  if (result.kind === 'clipboard') return result.subtitle;
-  if (result.subtitle) {
-    for (const prefix of SETTINGS_SUBTITLE_PREFIXES) {
-      if (result.subtitle.startsWith(prefix + ' ')) return prefix;
+    if (result.kind === "clipboard") return result.subtitle;
+    if (result.subtitle) {
+        for (const prefix of SETTINGS_SUBTITLE_PREFIXES) {
+            if (result.subtitle.startsWith(prefix + " ")) return prefix;
+        }
+        return result.subtitle;
     }
-    return result.subtitle;
-  }
-  if (result.kind === 'file' || result.kind === 'folder') return result.path;
-  const kindLabels = { app: 'App', setting: 'Setting' };
-  return kindLabels[result.kind] || result.kind;
+    if (result.kind === "file" || result.kind === "folder") return result.path;
+    const kindLabels = { app: "App", setting: "Setting" };
+    return kindLabels[result.kind] || result.kind;
 }
 
 function createRow(result, index) {
-  const row = document.createElement('div');
-  row.className = 'result-row';
-  row.dataset.index = index;
-  // Web-suggestion rows live in a narrow 320 px column when the AI card is
-  // active; let their title wrap to multiple lines instead of truncating
-  // (matches macOS WebSuggestionPreviewView's 3-line title cap).
-  if (webSuggestionFromResultId(result.id) != null) {
-    row.classList.add('result-row-web-suggest');
-  }
+    const row = document.createElement("div");
+    row.className = "result-row";
+    row.dataset.index = index;
+    // Web-suggestion rows live in a narrow 320 px column when the AI card is
+    // active; let their title wrap to multiple lines instead of truncating
+    // (matches macOS WebSuggestionPreviewView's 3-line title cap).
+    if (webSuggestionFromResultId(result.id) != null) {
+        row.classList.add("result-row-web-suggest");
+    }
 
-  // Icon (kind-based SVG fallback, async-load real icon)
-  const icon = document.createElement('div');
-  icon.className = 'result-icon';
-  const isLinuxSettings = result.path?.startsWith('settings://') || result.subtitle?.toLowerCase().startsWith('settings');
-  // Windows ms-settings: panels share one icon at the OS level (the gear) - we
-  // map each panel to a category-specific Lucide glyph via the catalog so the
-  // list scans visually. Returns null if the path isn't an ms-settings URI.
-  const windowsSettingsSvg = getWindowsSettingsIcon(result.path);
-  const fallbacks = { file: fileIcon, folder: folderIcon, setting: settingIcon, clipboard: clipboardIcon };
-  // Synthetic discovery rows (prefix/command menus) ship their own glyph in
-  // result.iconSvg so the list scans visually; everything else falls back to
-  // the kind-based stub until the backend icon fetch resolves.
-  icon.innerHTML = result.iconSvg
-    || windowsSettingsSvg
-    || (isLinuxSettings ? settingIcon : (fallbacks[result.kind] || appIcon));
-  icon.style.background = 'var(--control-fill)';
-  icon.style.color = 'var(--font-secondary)';
-  row.appendChild(icon);
+    // Icon (kind-based SVG fallback, async-load real icon)
+    const icon = document.createElement("div");
+    icon.className = "result-icon";
+    const isLinuxSettings =
+        result.path?.startsWith("settings://") ||
+        result.subtitle?.toLowerCase().startsWith("settings");
+    // Windows ms-settings: panels share one icon at the OS level (the gear) - we
+    // map each panel to a category-specific Lucide glyph via the catalog so the
+    // list scans visually. Returns null if the path isn't an ms-settings URI.
+    const windowsSettingsSvg = getWindowsSettingsIcon(result.path);
+    const fallbacks = {
+        file: fileIcon,
+        folder: folderIcon,
+        setting: settingIcon,
+        clipboard: clipboardIcon,
+    };
+    // Synthetic discovery rows (prefix/command menus) ship their own glyph in
+    // result.iconSvg so the list scans visually; everything else falls back to
+    // the kind-based stub until the backend icon fetch resolves.
+    icon.innerHTML =
+        result.iconSvg ||
+        windowsSettingsSvg ||
+        (isLinuxSettings ? settingIcon : fallbacks[result.kind] || appIcon);
+    icon.style.background = "var(--control-fill)";
+    icon.style.color = "var(--font-secondary)";
+    row.appendChild(icon);
 
-  // Skip backend icon fetch for ms-settings entries - the Shell PNG would just
-  // be the generic gear and would clobber our category-specific glyph. Same
-  // applies to synthetic discovery rows whose `path` is empty.
-  if (result.kind !== 'clipboard' && !windowsSettingsSvg && !result.iconSvg && result.path) {
-    loadIcon(icon, result.kind, result.path, result.id);
-  }
+    // Skip backend icon fetch for ms-settings entries - the Shell PNG would just
+    // be the generic gear and would clobber our category-specific glyph. Same
+    // applies to synthetic discovery rows whose `path` is empty.
+    if (
+        result.kind !== "clipboard" &&
+        !windowsSettingsSvg &&
+        !result.iconSvg &&
+        result.path
+    ) {
+        loadIcon(icon, result.kind, result.path, result.id);
+    }
 
-  // Text content
-  const text = document.createElement('div');
-  text.className = 'result-text';
+    // Text content
+    const text = document.createElement("div");
+    text.className = "result-text";
 
-  const title = document.createElement('div');
-  title.className = 'result-title';
-  title.textContent = result.title;
-  text.appendChild(title);
+    const title = document.createElement("div");
+    title.className = "result-title";
+    title.textContent = result.title;
+    text.appendChild(title);
 
-  const subtitle = document.createElement('div');
-  subtitle.className = 'result-path';
-  subtitle.textContent = displaySubtitle(result);
-  text.appendChild(subtitle);
+    const subtitle = document.createElement("div");
+    subtitle.className = "result-path";
+    subtitle.textContent = displaySubtitle(result);
+    text.appendChild(subtitle);
 
-  row.appendChild(text);
+    row.appendChild(text);
 
-  // Picked indicator
-  if (pickedMap.has(pickKey(result))) {
-    const el = document.createElement('div');
-    el.className = 'pick-check';
-    el.innerHTML = checkIcon;
-    row.appendChild(el);
-  }
+    // Picked indicator
+    if (pickedMap.has(pickKey(result))) {
+        const el = document.createElement("div");
+        el.className = "pick-check";
+        el.innerHTML = checkIcon;
+        row.appendChild(el);
+    }
 
-  row.addEventListener('click', () => {
-    select(index);
-    row.dispatchEvent(new CustomEvent('result-activate', { bubbles: true }));
-  });
+    row.addEventListener("click", () => {
+        userNavigated = true;
+        select(index);
+        row.dispatchEvent(new CustomEvent("result-activate", { bubbles: true }));
+    });
 
-  return row;
+    return row;
 }
 
 function loadIcon(iconEl, kind, path, id) {
-  const cacheKey = `${kind}:${path}`;
+    const cacheKey = `${kind}:${path}`;
 
-  if (iconCache.has(cacheKey)) {
-    const dataUrl = iconCache.get(cacheKey);
-    if (dataUrl) {
-      applyIcon(iconEl, dataUrl);
+    if (iconCache.has(cacheKey)) {
+        const dataUrl = iconCache.get(cacheKey);
+        if (dataUrl) {
+            applyIcon(iconEl, dataUrl);
+        }
+        return;
     }
-    return;
-  }
 
-  getIcon(kind, path, id).then((result) => {
-    const dataUrl = result?.data_url || null;
-    iconCache.set(cacheKey, dataUrl);
-    if (dataUrl) {
-      applyIcon(iconEl, dataUrl);
-    }
-  }).catch(() => {
-    iconCache.set(cacheKey, null);
-  });
+    getIcon(kind, path, id)
+        .then((result) => {
+            const dataUrl = result?.data_url || null;
+            iconCache.set(cacheKey, dataUrl);
+            if (dataUrl) {
+                applyIcon(iconEl, dataUrl);
+            }
+        })
+        .catch(() => {
+            iconCache.set(cacheKey, null);
+        });
 }
 
 function applyIcon(iconEl, dataUrl) {
-  const img = document.createElement('img');
-  img.src = dataUrl;
-  img.alt = '';
-  iconEl.textContent = '';
-  iconEl.style.background = 'none';
-  iconEl.appendChild(img);
+    const img = document.createElement("img");
+    img.src = dataUrl;
+    img.alt = "";
+    iconEl.textContent = "";
+    iconEl.style.background = "none";
+    iconEl.appendChild(img);
 }

--- a/apps/linows/src/js/ipc.js
+++ b/apps/linows/src/js/ipc.js
@@ -259,3 +259,19 @@ export async function wikipediaAnswer(term) {
 export async function webSuggestions(query, limit) {
   return invoke('web_suggestions', { query, limit });
 }
+
+// URL-like queries + opened-URL history (issue #232 / url-history spec).
+// classifyUrl returns `{ url, tier }` or null; recentUrls returns rows
+// `{ url, title, hit_count, last_used_at_unix_s, score }` in frecency order.
+
+export async function classifyUrl(query) {
+  return invoke('classify_url', { query });
+}
+
+export async function recordUrlHit(url) {
+  return invoke('record_url_hit', { url });
+}
+
+export async function recentUrls(query, limit) {
+  return invoke('recent_urls', { query, limit });
+}

--- a/apps/linows/src/js/keyboard.js
+++ b/apps/linows/src/js/keyboard.js
@@ -1,12 +1,12 @@
 import * as results from './components/results.js';
 import * as search from './search.js';
 import * as translatePanel from './components/translate.js';
-import { openPath, recordUsage, revealPath, hideWindow, copyFilesToClipboard, copyToClipboard, deleteClipboardEntry, trashPaths, countTrashItems, emptyTrash, requestIndexRefresh } from './ipc.js';
+import { openPath, recordUsage, recordUrlHit, revealPath, hideWindow, copyFilesToClipboard, copyToClipboard, deleteClipboardEntry, trashPaths, countTrashItems, emptyTrash, requestIndexRefresh } from './ipc.js';
 import * as banner from './components/banner.js';
 import * as confirm from './components/confirm.js';
 import * as runningApps from './components/running-apps.js';
 import { trash as trashIcon } from './icons.js';
-import { prefixFromResultId, commandIdFromResultId, webSuggestionFromResultId } from './catalog.js';
+import { prefixFromResultId, commandIdFromResultId, webSuggestionFromResultId, webUrlFromResultId } from './catalog.js';
 import * as platform from './platform.js';
 import * as layout from './layout.js';
 
@@ -401,6 +401,15 @@ async function openSelected() {
   if (suggestionText != null) {
     const url = `https://www.google.com/search?q=${encodeURIComponent(suggestionText)}`;
     openPath(url, 'browser', '');
+    return;
+  }
+  // URL row (live or from history) → open the resolved address in the
+  // default browser and remember it for faster re-open later. Recording is
+  // fire-and-forget; a store failure never blocks the open.
+  const urlTarget = webUrlFromResultId(item.id);
+  if (urlTarget != null) {
+    openPath(urlTarget, 'browser', '');
+    recordUrlHit(urlTarget);
     return;
   }
 

--- a/apps/linows/src/js/search.js
+++ b/apps/linows/src/js/search.js
@@ -1,13 +1,18 @@
-import { search as ipcSearch, getClipboardHistory, webSuggestions as ipcWebSuggestions } from './ipc.js';
+import {
+  search as ipcSearch, getClipboardHistory, webSuggestions as ipcWebSuggestions,
+  classifyUrl as ipcClassifyUrl, recentUrls as ipcRecentUrls,
+} from './ipc.js';
 import {
   isPrefixSuggestionQuery, isCommandSuggestionQuery, isPrefixedQuery,
   prefixSuggestionResults, commandSuggestionResults, webSuggestionResults,
+  webUrlResult, WEB_URL_OPEN_SUBTITLE, WEB_URL_RECENT_SUBTITLE,
 } from './catalog.js';
 
 const DEBOUNCE_MS = 70;
 const MIN_QUICK_FOLDER_PREFIX = 2;
 const SEARCH_LIMIT = 40;
 const WEB_SUGGESTIONS_LIMIT = 6;
+const RECENT_URL_LIMIT = 5;
 const MIN_WEB_SUGGESTION_QUERY_LENGTH = 2;
 const CLIPBOARD_TITLE_MAX_CHARS = 80;
 let debounceTimer = null;
@@ -33,6 +38,12 @@ let lastEnginePayload = [];
 let lastWebSuggestions = [];
 let lastQueryString = null;
 let webInFlight = false;
+// URL rows (issue #232 + url-history spec): the live "Open <url>" match for
+// the current query and previously-opened URLs matching it. Reset on every
+// input (both are local and fast, so no cross-query caching like the flaky
+// web suggestions need) and refilled by fetchUrlRows.
+let lastUrlMatch = null;
+let lastRecentUrls = [];
 
 /** Resolved by the backend (Windows: SHGetKnownFolderPath; *nix: $HOME/<name>).
  *  Empty until setQuickFolders is called at boot. */
@@ -90,6 +101,8 @@ export function handleQueryInput(query) {
   // or returns empty (DuckDuckGo /ac/ is occasionally flaky).
   queryVersion += 1;
   lastEnginePayload = [];
+  lastUrlMatch = null;
+  lastRecentUrls = [];
   if (query !== lastQueryString) {
     lastWebSuggestions = [];
   }
@@ -162,7 +175,15 @@ export function handleQueryInput(query) {
   const wantsWeb = aiEnabled && !isPrefixedQuery(query)
     && query.trim().length >= MIN_WEB_SUGGESTION_QUERY_LENGTH;
   webInFlight = wantsWeb;
-  debounceTimer = setTimeout(() => performSearch(query, myVersion), DEBOUNCE_MS);
+  // URL rows share the engine debounce: both are local round-trips, and the
+  // URL leg must not run per keystroke ahead of it (SQLite open per call).
+  // Unlike web suggestions they ignore the AI gate - opening a typed address
+  // is a launcher action, not a web answer.
+  const wantsUrlRows = !isPrefixedQuery(query);
+  debounceTimer = setTimeout(() => {
+    performSearch(query, myVersion);
+    if (wantsUrlRows) fetchUrlRows(query, myVersion);
+  }, DEBOUNCE_MS);
   if (wantsWeb) {
     webSuggestionTimer = setTimeout(() => fetchWebSuggestions(query, myVersion), DEBOUNCE_MS);
   }
@@ -216,12 +237,76 @@ async function fetchWebSuggestions(query, version) {
   }
 }
 
+// Classification + history lookup for the current query. Both run in one leg
+// so a single publish paints them together; each response is version-checked
+// like the other legs. Best-effort: on failure the query simply has no URL
+// rows.
+async function fetchUrlRows(query, version) {
+  try {
+    const [match, recents] = await Promise.all([
+      ipcClassifyUrl(query),
+      ipcRecentUrls(query.trim(), RECENT_URL_LIMIT),
+    ]);
+    if (isStale(version)) return;
+    lastUrlMatch = match || null;
+    lastRecentUrls = Array.isArray(recents) ? recents : [];
+  } catch (err) {
+    console.warn('URL rows failed:', err);
+    if (isStale(version)) return;
+    lastUrlMatch = null;
+    lastRecentUrls = [];
+  }
+  publish(query, version);
+}
+
+// Stable score-descending merge of engine results and recent-URL rows, so a
+// frequently/recently opened URL rises exactly as far as its frecency earns
+// against local matches. Both inputs are already score-sorted; on ties the
+// local result stays ahead, so a URL never displaces an equally-ranked
+// app/file. Mirrors macOS LauncherView+URLResults.mergeByScore.
+function mergeByScore(local, recents) {
+  if (recents.length === 0) return local;
+  const merged = [];
+  let i = 0;
+  let j = 0;
+  while (i < local.length && j < recents.length) {
+    if (recents[j].score > local[i].score) {
+      merged.push(recents[j]);
+      j += 1;
+    } else {
+      merged.push(local[i]);
+      i += 1;
+    }
+  }
+  merged.push(...local.slice(i), ...recents.slice(j));
+  return merged;
+}
+
 function publish(query, version) {
   if (isStale(version) || !onResultsCallback) return;
   const suggestionRows = aiEnabled && lastWebSuggestions.length
     ? webSuggestionResults(lastWebSuggestions)
     : [];
-  const combined = [...lastEnginePayload, ...suggestionRows];
+  // Recent URLs interleave with engine results by frecency, deduped against
+  // the live row so the same address never appears twice. The live row's
+  // placement follows its tier (issue #232): a structural match (scheme,
+  // port, path, localhost/IP) can't be a file or search, so it ranks top; a
+  // bare host.tld must never steal the default slot from a real local
+  // result, so it sits after them. Web-search rows stay last.
+  const liveUrl = lastUrlMatch ? lastUrlMatch.url : null;
+  const recentRows = lastRecentUrls
+    .filter((e) => e.url !== liveUrl)
+    .map((e) => webUrlResult(e.url, WEB_URL_RECENT_SUBTITLE, e.score));
+  const ranked = mergeByScore(lastEnginePayload, recentRows);
+  let combined;
+  if (!lastUrlMatch) {
+    combined = [...ranked, ...suggestionRows];
+  } else {
+    const liveRow = webUrlResult(liveUrl, WEB_URL_OPEN_SUBTITLE, 0);
+    combined = lastUrlMatch.tier === 'structural'
+      ? [liveRow, ...ranked, ...suggestionRows]
+      : [...ranked, liveRow, ...suggestionRows];
+  }
   // Hold an empty render while web suggestions are still loading. The
   // engine returns instantly (~50 ms) but DDG /ac/ takes 500 ms-2 s; on a
   // fresh query we'd otherwise paint "No results" for a couple of seconds

--- a/bridge/ffi/src/url_history_api.rs
+++ b/bridge/ffi/src/url_history_api.rs
@@ -2,66 +2,15 @@
 //! records launcher-opened URLs and queries them back through the same look.db
 //! linows uses. Direct-store access (own connection, own table), mirroring
 //! `todo_api`; both endpoints are best-effort and panic-safe at `lib.rs`.
+//! Frecency ranking lives in `look_engine::url_history`, shared with linows.
 
 use crate::state::{cstr_to_string, default_db_path, store_json_allocation};
-use look_engine::config::SCORE_TITLE_CONTAINS;
-use look_indexing::{Candidate, CandidateKind};
-use look_ranking::rank_score;
-use look_storage::{SqliteStore, UrlHistoryEntry};
-use serde::Serialize;
+use look_engine::url_history::ranked_url_history;
+use look_storage::SqliteStore;
 use std::ffi::CString;
 use std::os::raw::c_char;
 
 const JSON_EMPTY_ARRAY: &str = "[]";
-
-/// Wire shape of a URL-history row. `look_storage::UrlHistoryEntry` is not
-/// `Serialize` (that crate has no serde dep), so map it here. `score` is the
-/// frecency rank so the UI can place recent URLs among local results by the same
-/// math the engine uses for apps/files, not an arbitrary hit-count threshold.
-#[derive(Serialize)]
-struct UrlHistoryDto {
-    url: String,
-    title: Option<String>,
-    hit_count: u64,
-    last_used_at_unix_s: i64,
-    score: i64,
-}
-
-/// Ranks a remembered URL for `query` with the exact `rank_score` the engine
-/// applies to matched candidates: a title-contains base plus log-scaled
-/// frequency (`hit_count`) and a recency bonus. `recent_urls` only returns
-/// substring matches, so the base is always the title-contains score.
-fn score_entry(entry: &UrlHistoryEntry, query: &str) -> i64 {
-    let mut candidate = Candidate::new(&entry.url, CandidateKind::File, &entry.url, &entry.url);
-    candidate.use_count = entry.hit_count;
-    candidate.last_used_at_unix_s = Some(entry.last_used_at_unix_s);
-    let title_lower = entry.url.to_lowercase();
-    rank_score(SCORE_TITLE_CONTAINS, query, &candidate, &title_lower)
-}
-
-/// Scores each entry for `query` and returns the DTOs in frecency order (highest
-/// score first, most-recent breaking ties).
-fn ranked_dtos(entries: Vec<UrlHistoryEntry>, query: &str) -> Vec<UrlHistoryDto> {
-    let mut dtos: Vec<UrlHistoryDto> = entries
-        .into_iter()
-        .map(|e| {
-            let score = score_entry(&e, query);
-            UrlHistoryDto {
-                url: e.url,
-                title: e.title,
-                hit_count: e.hit_count,
-                last_used_at_unix_s: e.last_used_at_unix_s,
-                score,
-            }
-        })
-        .collect();
-    dtos.sort_by(|a, b| {
-        b.score
-            .cmp(&a.score)
-            .then(b.last_used_at_unix_s.cmp(&a.last_used_at_unix_s))
-    });
-    dtos
-}
 
 /// Records that `url` was opened. Returns false on empty input or any store
 /// failure; the caller treats recording as fire-and-forget.
@@ -76,16 +25,15 @@ pub(crate) fn look_record_url_hit_impl(url: *const c_char) -> bool {
     store.record_url_hit(&url).is_ok()
 }
 
-/// JSON array of up to `limit` remembered URLs matching `query` (most-recent
-/// first), or `[]` on any failure.
+/// JSON array of up to `limit` remembered URLs matching `query` (frecency
+/// order), or `[]` on any failure.
 pub(crate) fn look_recent_urls_json_impl(query: *const c_char, limit: u32) -> *mut c_char {
     let query = cstr_to_string(query);
-    let query_norm = query.trim().to_lowercase();
     let json = SqliteStore::open(default_db_path())
         .ok()
         .and_then(|store| store.recent_urls(&query, limit as usize).ok())
-        .map(|entries| ranked_dtos(entries, &query_norm))
-        .and_then(|dtos| serde_json::to_string(&dtos).ok())
+        .map(|entries| ranked_url_history(entries, &query))
+        .and_then(|scored| serde_json::to_string(&scored).ok())
         .unwrap_or_else(|| JSON_EMPTY_ARRAY.to_string());
     let cstring =
         CString::new(json).unwrap_or_else(|_| CString::new(JSON_EMPTY_ARRAY).expect("valid"));

--- a/core/engine/src/lib.rs
+++ b/core/engine/src/lib.rs
@@ -7,6 +7,7 @@ mod query;
 pub mod result;
 mod scoring;
 mod search;
+pub mod url_history;
 
 pub use action::{ActionKind, LaunchAction};
 use config::RuntimeConfig;

--- a/core/engine/src/url_history.rs
+++ b/core/engine/src/url_history.rs
@@ -1,0 +1,103 @@
+//! Frecency ranking for launcher-opened URL history (url-history spec).
+//!
+//! `look_storage::recent_urls` returns raw rows; this module scores them with
+//! the exact `rank_score` the engine applies to matched candidates, so a
+//! remembered URL rises among local results by the same math as apps/files,
+//! not an arbitrary hit-count threshold. Lives in the engine (not per shell)
+//! so macOS (via bridge/ffi) and linows rank identically.
+
+use crate::config::SCORE_TITLE_CONTAINS;
+use look_indexing::{Candidate, CandidateKind};
+use look_ranking::rank_score;
+use look_storage::UrlHistoryEntry;
+use serde::Serialize;
+
+/// Wire shape of a scored URL-history row. `look_storage::UrlHistoryEntry` is
+/// not `Serialize` (that crate has no serde dep), so it is mapped here; both
+/// shells serialise this struct as-is.
+#[derive(Debug, Serialize)]
+pub struct ScoredUrlEntry {
+    pub url: String,
+    pub title: Option<String>,
+    pub hit_count: u64,
+    pub last_used_at_unix_s: i64,
+    pub score: i64,
+}
+
+/// Ranks a remembered URL for `query`: a title-contains base plus log-scaled
+/// frequency (`hit_count`) and a recency bonus. `recent_urls` only returns
+/// substring matches, so the base is always the title-contains score.
+fn score_entry(entry: &UrlHistoryEntry, query: &str) -> i64 {
+    let mut candidate = Candidate::new(&entry.url, CandidateKind::File, &entry.url, &entry.url);
+    candidate.use_count = entry.hit_count;
+    candidate.last_used_at_unix_s = Some(entry.last_used_at_unix_s);
+    let title_lower = entry.url.to_lowercase();
+    rank_score(SCORE_TITLE_CONTAINS, query, &candidate, &title_lower)
+}
+
+/// Scores each entry for `query` (normalised here so callers cannot diverge)
+/// and returns them in frecency order: highest score first, most-recent
+/// breaking ties.
+pub fn ranked_url_history(entries: Vec<UrlHistoryEntry>, query: &str) -> Vec<ScoredUrlEntry> {
+    let query_norm = query.trim().to_lowercase();
+    let mut scored: Vec<ScoredUrlEntry> = entries
+        .into_iter()
+        .map(|e| {
+            let score = score_entry(&e, &query_norm);
+            ScoredUrlEntry {
+                url: e.url,
+                title: e.title,
+                hit_count: e.hit_count,
+                last_used_at_unix_s: e.last_used_at_unix_s,
+                score,
+            }
+        })
+        .collect();
+    scored.sort_by(|a, b| {
+        b.score
+            .cmp(&a.score)
+            .then(b.last_used_at_unix_s.cmp(&a.last_used_at_unix_s))
+    });
+    scored
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(url: &str, hit_count: u64, last_used_at_unix_s: i64) -> UrlHistoryEntry {
+        UrlHistoryEntry {
+            url: url.to_string(),
+            title: None,
+            hit_count,
+            last_used_at_unix_s,
+        }
+    }
+
+    #[test]
+    fn ranks_frequent_and_recent_first() {
+        let now = 1_700_000_000;
+        let ranked = ranked_url_history(
+            vec![
+                entry("https://github.com/old", 1, now - 60 * 60 * 24 * 30),
+                entry("https://github.com", 40, now),
+            ],
+            "GitHub ",
+        );
+        assert_eq!(ranked[0].url, "https://github.com");
+        assert!(ranked[0].score > ranked[1].score);
+    }
+
+    #[test]
+    fn breaks_score_ties_by_recency() {
+        let now = 1_700_000_000;
+        let ranked = ranked_url_history(
+            vec![
+                entry("https://a.com", 2, now - 30),
+                entry("https://b.com", 2, now),
+            ],
+            "com",
+        );
+        assert_eq!(ranked[0].url, "https://b.com");
+    }
+}


### PR DESCRIPTION
## Summary

- Url like queries for linows

## Why

#232 #261

## Changes

-

## Testing

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

<img width="1012" height="693" alt="image" src="https://github.com/user-attachments/assets/04b888d6-8a99-47d8-b765-bb027a552053" />


## Risks / Notes

-

## Checklist

- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered
