### PR TITLE
fix: missing apps

### DIFF
--- a/apps/linows/src-tauri/src/platform/linux/process.rs
+++ b/apps/linows/src-tauri/src/platform/linux/process.rs
@@ -186,26 +186,42 @@ pub(crate) fn list_gui() -> Vec<RunningApp> {
             eprintln!("[list_gui] wlr app_ids: {:?}", app_ids);
         }
         if !app_ids.is_empty() {
+            // StartupWMClass is a third matching axis besides the stem forms:
+            // Wayland Electron apps keep their X11 class as app_id, and variant
+            // packages don't carry it in the stem (discord-ptb.desktop declares
+            // StartupWMClass=discord while the toplevel app_id is "discord").
+            let wm_classes: HashMap<String, String> = scan_desktop_files()
+                .into_iter()
+                .filter_map(|de| {
+                    let wc = de.wm_class?.to_lowercase();
+                    if wc.is_empty() {
+                        None
+                    } else {
+                        Some((de.path, wc))
+                    }
+                })
+                .collect();
             return all
                 .into_iter()
                 .filter(|app| {
+                    let Some(ref id) = app.desktop_id else {
+                        return false;
+                    };
+                    let Some(path) = id.strip_prefix("app:") else {
+                        return false;
+                    };
                     // Match desktop file stem (e.g. "org.mozilla.firefox" or "firefox")
                     // against toplevel app_ids
-                    if let Some(ref id) = app.desktop_id {
-                        let stem = id
-                            .strip_prefix("app:")
-                            .and_then(|p| {
-                                std::path::Path::new(p).file_stem().and_then(|f| f.to_str())
-                            })
-                            .unwrap_or("");
-                        let stem_lower = stem.to_lowercase();
-                        // Try full stem and last segment (for reverse-DNS like org.mozilla.firefox)
-                        let short = stem_lower.rsplit('.').next().unwrap_or("");
-                        app_ids.contains(&stem_lower)
-                            || (!short.is_empty() && app_ids.contains(short))
-                    } else {
-                        false
-                    }
+                    let stem = Path::new(path)
+                        .file_stem()
+                        .and_then(|f| f.to_str())
+                        .unwrap_or("");
+                    let stem_lower = stem.to_lowercase();
+                    // Try full stem and last segment (for reverse-DNS like org.mozilla.firefox)
+                    let short = stem_lower.rsplit('.').next().unwrap_or("");
+                    app_ids.contains(&stem_lower)
+                        || (!short.is_empty() && app_ids.contains(short))
+                        || wm_classes.get(path).is_some_and(|wc| app_ids.contains(wc))
                 })
                 .collect();
         }


### PR DESCRIPTION
## Summary

The desktop file is discord-ptb.desktop, but the app runs as native Wayland with app_id = "discord"
The Wayland strip filter matched app_ids only against the desktop stem and its reverse-DNS tail, so discord vs discord-ptb never matched.


## Changes

- Added StartupWMClass as a third matching axis; the filter now builds a 
desktop-path -> lowercased StartupWMClass map and accepts an app when its declared class matches a toplevel app_id

## Testing

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] Manual verification completed (if UI/behavior changed)
  - [x] Sway

## Screenshots / Recordings (if UI changed)

<img width="1020" height="354" alt="image" src="https://github.com/user-attachments/assets/386d27e2-07f6-4972-af82-4f09eeaae2b5" />

## Checklist

- [x] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered
