### PR TITLE
fix(macos): make Quick Action toggles safe against stale panel state

### DIFF
--- a/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
@@ -46,7 +46,8 @@ final class KeyboardSelectionMonitor {
         onConfirmDelete: (@MainActor () -> Void)? = nil,
         onCancelDelete: (@MainActor () -> Void)? = nil,
         deleteConfirmationActive: @escaping @MainActor () -> Bool = { false },
-        onToggleQuickAction: (@MainActor () -> Void)? = nil
+        onToggleQuickAction: (@MainActor () -> Void)? = nil,
+        hasToggleQuickAction: @escaping @MainActor () -> Bool = { false }
     ) {
         guard monitor == nil else { return }
         self.isKillConfirmationActive = killConfirmationActive
@@ -149,9 +150,14 @@ final class KeyboardSelectionMonitor {
 
             // Cmd+O toggles the selected result's toggle Quick Action (Bluetooth,
             // etc.). Multi-choice controls will use Cmd+J/K in a later pass.
-            if (event.keyCode == 31 || event.charactersIgnoringModifiers?.lowercased() == "o")
+            // Match on the typed character only, not a hardware keyCode: 31 is
+            // the physical ANSI-O position, which types another letter on
+            // Dvorak/Colemak and would hijack that chord. Only swallow the
+            // event when the selection actually has a toggle to act on.
+            if event.charactersIgnoringModifiers?.lowercased() == "o"
                 && flags == [.command]
                 && !inCommandMode()
+                && hasToggleQuickAction()
             {
                 onToggleQuickAction?()
                 return nil

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+QuickActions.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+QuickActions.swift
@@ -81,14 +81,25 @@ extension LauncherView {
             return
         }
 
-        // Flip a toggle immediately for instant feedback; the re-read below
-        // confirms (and corrects it if the change did not take).
+        // A toggle press means "the opposite of the state I am looking at", so
+        // resolve it to an explicit target before it reaches the adapter:
+        // apply(.toggle) flips the LIVE state, which does the opposite of what
+        // the user asked whenever the panel is stale (the system changed while
+        // the launcher was hidden). An unknown displayed state keeps the blind
+        // toggle.
+        var intent = intent
         if intent == .toggle {
             switch quickActionStates[descriptor.actionId] {
-            case .on?: quickActionStates[descriptor.actionId] = .off
-            case .off?: quickActionStates[descriptor.actionId] = .on
+            case .on?: intent = .setOn(false)
+            case .off?: intent = .setOn(true)
             default: break
             }
+        }
+
+        // Show the target immediately for instant feedback; the re-read below
+        // confirms (and corrects it if the change did not take).
+        if case .setOn(let on) = intent {
+            quickActionStates[descriptor.actionId] = on ? .on : .off
         }
 
         Task {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
@@ -228,6 +228,9 @@ extension LauncherView {
             },
             onToggleQuickAction: { [self] in
                 togglePrimaryQuickAction()
+            },
+            hasToggleQuickAction: { [self] in
+                hasToggleQuickAction
             }
         )
     }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -718,6 +718,19 @@ struct LauncherView: View {
             }
             refreshClipboardMonitoringMode()
         }
+        .onReceive(
+            NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)
+        ) { notification in
+            // Quick-action state is cached and otherwise refreshed only when
+            // the selection changes. The window keeps its query and selection
+            // across hide/show, so on re-show the panel would keep states read
+            // before the hide - stale whenever the system changed underneath
+            // (e.g. Bluetooth flipped in Control Center). Re-read on every show.
+            guard let window = notification.object as? NSWindow,
+                window === launcherWindow()
+            else { return }
+            refreshQuickActions()
+        }
         .onReceive(NotificationCenter.default.publisher(for: .lookReloadConfigRequested)) { _ in
             reloadConfig()
         }


### PR DESCRIPTION
## Problem

Quick-action state (the Bluetooth toggle in the info+actions panel) is cached in `quickActionStates` and refreshed only from `.onChange(of: selectedResultID)`. The launcher window keeps its query and selection across hide/show (`orderOut`/`makeKeyAndOrderFront`, the view and its `@State` survive), so re-showing the launcher re-renders states read **before** it was hidden.

That stale display inverts the user's action:

1. Search "bluetooth", select the row → switch shows **On** (correct).
2. Hide the launcher, turn Bluetooth off in Control Center.
3. Re-show the launcher: same query/selection → `onChange` never fires → switch still shows **On**.
4. Click the switch (or press Cmd+O) intending to turn it *off*. `BluetoothControl.apply(.toggle)` computes the target from the **live** state (`!isPoweredOn()` → on), so Bluetooth turns **ON** — the opposite of what the user asked. The optimistic flip then makes the switch animate Off → snap back On with a "Bluetooth on" banner.

Separately, the Cmd+O chord matched hardware `keyCode == 31` (the physical ANSI-O position), which types **r** on Dvorak and **y** on Colemak — so on those layouts a different Cmd+letter chord silently toggled Bluetooth and was swallowed. It was also swallowed even when the selection had no toggle action.

## Fix

- **Refresh on show:** re-read quick-action states from an `NSWindow.didBecomeKeyNotification` observer filtered to the launcher window — one hook covers every show path (hotkey, dock, activation). Same `onReceive` pattern the view already uses.
- **Resolve a toggle press against the displayed state:** in `runQuickAction`, a `.toggle` for a control displaying `.on`/`.off` becomes `.setOn(!displayed)` — "give me the opposite of what I'm looking at". `ActionIntent.setOn` already exists and every adapter handles it; an unknown displayed state keeps the blind toggle. Both entry points (switch click and Cmd+O) already funnel through `runQuickAction`, so one choke point covers both. Even if some other staleness window remains, the action now always matches what the user sees.
- **Cmd+O:** match the typed character only (`charactersIgnoringModifiers`, layout-aware), and only swallow the event when the selection actually has a toggle to act on.

## Testing

- `swiftc -parse` on the four changed files; CI `macos-build` job compiles the app.
- Manual scenario above is the regression check: with the panel deliberately stale, the click now turns Bluetooth off (matching the displayed state) and the switch settles at Off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard support for toggling the primary Quick Action with Command+O when available.
  * Quick Action toggles now reflect the current live state immediately and consistently.

* **Bug Fixes**
  * Refreshed Quick Actions whenever the launcher becomes active, preventing stale states after system-level changes.
  * Improved Command+O detection across keyboard layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->