### PR TITLE
Linows: qactions bluetooth

### DIFF
--- a/apps/linows/src-tauri/Cargo.lock
+++ b/apps/linows/src-tauri/Cargo.lock
@@ -2491,6 +2491,13 @@ name = "look-matching"
 version = "0.1.0"
 
 [[package]]
+name = "look-qactions"
+version = "0.1.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "look-ranking"
 version = "0.1.0"
 dependencies = [
@@ -2523,6 +2530,7 @@ dependencies = [
  "futures-util",
  "look-answers",
  "look-engine",
+ "look-qactions",
  "look-storage",
  "look-todo",
  "notify",

--- a/apps/linows/src-tauri/Cargo.toml
+++ b/apps/linows/src-tauri/Cargo.toml
@@ -27,7 +27,7 @@ trash = "5"
 [target.'cfg(target_os = "linux")'.dependencies]
 x11rb = { version = "0.13", features = ["allow-unsafe-code"] }
 zbus = "5"
-tokio = { version = "1.52.3", features = ["rt"] }
+tokio = { version = "1.52.3", features = ["rt", "time"] }
 # StreamExt for zbus signal streams.
 futures-util = { version = "0.3", default-features = false }
 webkit2gtk = "2.0"

--- a/apps/linows/src-tauri/Cargo.toml
+++ b/apps/linows/src-tauri/Cargo.toml
@@ -10,6 +10,7 @@ tauri-plugin-global-shortcut = "2"
 tauri-plugin-single-instance = "2"
 look-answers = { path = "../../../core/answers" }
 look-engine = { path = "../../../core/engine" }
+look-qactions = { path = "../../../core/qactions" }
 look-storage = { path = "../../../core/storage" }
 look-todo = { path = "../../../core/todo" }
 serde = { version = "1", features = ["derive"] }

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -15,6 +15,7 @@ mod highlight;
 mod music;
 mod platform;
 mod process;
+mod qactions;
 mod shell;
 mod state;
 mod sysinfo;
@@ -679,6 +680,11 @@ fn main() {
             weburl::classify_url,
             weburl::record_url_hit,
             weburl::recent_urls,
+            // Quick Actions (shared look-qactions catalog; adapters live in
+            // qactions/controls, see docs/writing-controls.md)
+            qactions::quick_actions,
+            qactions::quick_action_state,
+            qactions::quick_action_apply,
             // Clipboard
             clipboard::get_clipboard_history,
             clipboard::delete_clipboard_entry,

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -685,6 +685,7 @@ fn main() {
             qactions::quick_actions,
             qactions::quick_action_state,
             qactions::quick_action_apply,
+            qactions::quick_action_apply_item,
             // Clipboard
             clipboard::get_clipboard_history,
             clipboard::delete_clipboard_entry,

--- a/apps/linows/src-tauri/src/platform/linux/dbus.rs
+++ b/apps/linows/src-tauri/src/platform/linux/dbus.rs
@@ -20,3 +20,10 @@ pub fn session() -> Option<&'static zbus::Connection> {
     CONN.get_or_init(|| runtime().block_on(async { zbus::Connection::session().await.ok() }))
         .as_ref()
 }
+
+/// Cached D-Bus system connection (system services like BlueZ).
+pub fn system() -> Option<&'static zbus::Connection> {
+    static CONN: OnceLock<Option<zbus::Connection>> = OnceLock::new();
+    CONN.get_or_init(|| runtime().block_on(async { zbus::Connection::system().await.ok() }))
+        .as_ref()
+}

--- a/apps/linows/src-tauri/src/platform/linux/gnome_ext.rs
+++ b/apps/linows/src-tauri/src/platform/linux/gnome_ext.rs
@@ -32,6 +32,7 @@ const EXTENSIONS_DISABLED_MSG: &str = "GNOME user extensions are turned off, so 
      org.gnome.shell disable-user-extensions false";
 
 /// Install the GNOME Shell extension if not already present, then enable it.
+
 pub fn ensure_installed() {
     let ext_dir = extension_dir();
     let metadata_path = ext_dir.join("metadata.json");
@@ -79,7 +80,10 @@ fn install_current_version(
         return;
     }
     eprintln!("[look] Installed GNOME Shell extension: {EXT_UUID} (manual, needs re-login)");
-    crate::health::report(crate::health::ISSUE_GNOME_EXT, RELOGIN_MSG.to_string());
+    crate::health::report(
+        crate::health::ISSUE_GNOME_EXT,
+        not_loaded_message(user_extensions_disabled()).to_string(),
+    );
     enable_extension();
 }
 
@@ -124,19 +128,26 @@ fn verify_running_later(changed: bool) {
         });
         match err.map(|e| classify_dbus_error(&e)) {
             Some(ExtensionError::NotRunning) => {
-                if user_extensions_disabled() {
+                let disabled = user_extensions_disabled();
+                if disabled || changed {
                     crate::health::report(
                         crate::health::ISSUE_GNOME_EXT,
-                        EXTENSIONS_DISABLED_MSG.to_string(),
+                        not_loaded_message(disabled).to_string(),
                     );
-                } else if changed {
-                    crate::health::report(crate::health::ISSUE_GNOME_EXT, RELOGIN_MSG.to_string());
                 }
             }
             Some(ExtensionError::Stale) => warn_stale_extension_once(),
             _ => {}
         }
     });
+}
+
+fn not_loaded_message(user_extensions_disabled: bool) -> &'static str {
+    if user_extensions_disabled {
+        EXTENSIONS_DISABLED_MSG
+    } else {
+        RELOGIN_MSG
+    }
 }
 
 /// Whether GNOME's global "disable all user extensions" switch is on. When it

--- a/apps/linows/src-tauri/src/platform/linux/gnome_ext.rs
+++ b/apps/linows/src-tauri/src/platform/linux/gnome_ext.rs
@@ -24,6 +24,13 @@ const EXTENSION_JS: &str = include_str!("../../gnome-shell-extension/extension.j
 const RELOGIN_MSG: &str = "Log out and back in to finish enabling Look's GNOME \
      extension (it focuses already-running app windows).";
 
+/// User-facing notice when GNOME's global "disable all user extensions" switch
+/// is on: no re-login helps here, the switch itself has to be cleared, so the
+/// message names the exact command instead of the (useless) re-login advice.
+const EXTENSIONS_DISABLED_MSG: &str = "GNOME user extensions are turned off, so Look \
+     can't focus already-running app windows. Enable them: gsettings set \
+     org.gnome.shell disable-user-extensions false";
+
 /// Install the GNOME Shell extension if not already present, then enable it.
 pub fn ensure_installed() {
     let ext_dir = extension_dir();
@@ -42,7 +49,7 @@ pub fn ensure_installed() {
     if needs_install {
         install_current_version(&ext_dir, &metadata_path, &extension_path);
     }
-    verify_running_later();
+    verify_running_later(needs_install);
 }
 
 fn install_current_version(
@@ -82,11 +89,22 @@ fn install_current_version(
 const VERIFY_DELAY: std::time::Duration = std::time::Duration::from_secs(3);
 
 /// Verify in the background that the running shell actually loaded the
-/// extension, and report a re-login/stale notice when it didn't. Alt+Space
-/// works without the extension, but focus-existing-window and multi-monitor
-/// placement silently degrade - exactly the failures users can't diagnose.
-fn verify_running_later() {
-    std::thread::spawn(|| {
+/// extension, and surface the *right* fix when it didn't:
+///
+/// - GNOME's global user-extensions switch is off: always flag it (a re-login
+///   won't help, only clearing the switch does), regardless of `changed`.
+/// - Otherwise, only nag to re-login when we just wrote a new copy this session
+///   (`changed`): if we did not touch it, its absence is the user's own choice
+///   (they disabled just ours) or a re-login still pending from an earlier
+///   update, and re-reporting it on every launch is noise.
+/// - A stale version already loaded in the shell is always flagged - our newer
+///   on-disk copy needs a re-login to take effect.
+///
+/// Alt+Space works without the extension, but focus-existing-window and
+/// multi-monitor placement silently degrade, so a genuine blocker is worth the
+/// notice.
+fn verify_running_later(changed: bool) {
+    std::thread::spawn(move || {
         std::thread::sleep(VERIFY_DELAY);
         let Some(conn) = dbus_conn() else {
             return;
@@ -106,12 +124,33 @@ fn verify_running_later() {
         });
         match err.map(|e| classify_dbus_error(&e)) {
             Some(ExtensionError::NotRunning) => {
-                crate::health::report(crate::health::ISSUE_GNOME_EXT, RELOGIN_MSG.to_string());
+                if user_extensions_disabled() {
+                    crate::health::report(
+                        crate::health::ISSUE_GNOME_EXT,
+                        EXTENSIONS_DISABLED_MSG.to_string(),
+                    );
+                } else if changed {
+                    crate::health::report(crate::health::ISSUE_GNOME_EXT, RELOGIN_MSG.to_string());
+                }
             }
             Some(ExtensionError::Stale) => warn_stale_extension_once(),
             _ => {}
         }
     });
+}
+
+/// Whether GNOME's global "disable all user extensions" switch is on. When it
+/// is, the shell refuses to load any `~/.local/share` extension no matter what
+/// the enabled list says, so ours can never claim its D-Bus name and a re-login
+/// changes nothing - the switch has to be cleared. Defaults to `false` (not the
+/// blocker) if gsettings is missing or the key can't be read.
+fn user_extensions_disabled() -> bool {
+    super::host_command("gsettings")
+        .args(["get", "org.gnome.shell", "disable-user-extensions"])
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .is_some_and(|out| String::from_utf8_lossy(&out.stdout).trim() == "true")
 }
 
 /// Build a zip of the extension in /tmp and install via `gnome-extensions install --force`.

--- a/apps/linows/src-tauri/src/platform/linux/gnome_ext.rs
+++ b/apps/linows/src-tauri/src/platform/linux/gnome_ext.rs
@@ -32,7 +32,6 @@ const EXTENSIONS_DISABLED_MSG: &str = "GNOME user extensions are turned off, so 
      org.gnome.shell disable-user-extensions false";
 
 /// Install the GNOME Shell extension if not already present, then enable it.
-
 pub fn ensure_installed() {
     let ext_dir = extension_dir();
     let metadata_path = ext_dir.join("metadata.json");

--- a/apps/linows/src-tauri/src/qactions/controls/bluetooth.rs
+++ b/apps/linows/src-tauri/src/qactions/controls/bluetooth.rs
@@ -1,0 +1,220 @@
+//! REFERENCE ADAPTER - copy this file to add a new system control.
+//!
+//! A control implements `SystemControl` and keeps ALL of its OS-specific code
+//! (D-Bus, CLIs, syscalls) inside itself. To add your own:
+//!
+//!   1. Copy this file and rename the type (e.g. `WifiControl`).
+//!   2. Implement `state()` (+ `info()` if the descriptor declares fields).
+//!   3. Implement `apply(_:)` - perform the change, return an `ActionOutcome`.
+//!   4. Register it in `qactions::adapter` under your action id.
+//!   5. Declare the descriptor + result binding in the shared `core/qactions`.
+//!
+//! Nothing else (panel, keyboard, rendering) changes. That is the whole point.
+//!
+//! This adapter talks to BlueZ over the system bus rather than shelling out to
+//! `bluetoothctl`: the CLI is just a client of the same D-Bus API, its output
+//! is not a stable interface, and spawning host tools from the AppImage needs
+//! LD_LIBRARY_PATH scrubbing that an in-process call avoids entirely.
+
+use crate::platform::linux::dbus;
+use crate::qactions::{ActionIntent, ActionOutcome, ActionState, InfoValue, SystemControl};
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use zbus::zvariant::{OwnedObjectPath, OwnedValue};
+
+const BLUEZ_DEST: &str = "org.bluez";
+const OBJECT_MANAGER_IFACE: &str = "org.freedesktop.DBus.ObjectManager";
+const ADAPTER_IFACE: &str = "org.bluez.Adapter1";
+const DEVICE_IFACE: &str = "org.bluez.Device1";
+
+const NO_SERVICE: &str = "Bluetooth service not running";
+const NO_ADAPTER: &str = "Bluetooth hardware not found";
+
+/// How long to wait for the controller to apply a power change, and how often
+/// to re-check while waiting. Mirrors the macOS reference adapter: without the
+/// settle wait, the panel's immediate re-read can still see the old value.
+const SETTLE_TIMEOUT: Duration = Duration::from_millis(1500);
+const POLL_INTERVAL: Duration = Duration::from_millis(80);
+
+/// `a{oa{sa{sv}}}` - the BlueZ object tree from `GetManagedObjects`.
+type ManagedObjects = HashMap<OwnedObjectPath, HashMap<String, HashMap<String, OwnedValue>>>;
+
+/// The BlueZ facts the panel needs, from one `GetManagedObjects` call.
+struct Snapshot {
+    adapter_path: OwnedObjectPath,
+    powered: bool,
+    /// Aliases of currently connected devices.
+    connected: Vec<String>,
+}
+
+/// Toggles and reports Linux system Bluetooth power. Action id: `"bluetooth"`.
+pub struct BluetoothControl;
+
+impl SystemControl for BluetoothControl {
+    fn state(&self) -> ActionState {
+        match snapshot() {
+            Ok(s) if s.powered => ActionState::On,
+            Ok(_) => ActionState::Off,
+            Err(reason) => ActionState::Unavailable { reason },
+        }
+    }
+
+    fn info(&self, keys: &[String]) -> HashMap<String, InfoValue> {
+        let mut values = HashMap::new();
+        if !keys.iter().any(|k| k == "status") {
+            return values;
+        }
+        let value = match snapshot() {
+            Ok(s) if !s.powered => InfoValue::Text {
+                text: "Off".to_string(),
+            },
+            Ok(s) if s.connected.is_empty() => InfoValue::Text {
+                text: "On, not connected".to_string(),
+            },
+            Ok(s) => InfoValue::Text {
+                text: format!("Connected to {}", s.connected.join(", ")),
+            },
+            Err(reason) => InfoValue::Unavailable { reason },
+        };
+        values.insert("status".to_string(), value);
+        values
+    }
+
+    fn apply(&self, intent: ActionIntent) -> ActionOutcome {
+        // Re-read right before acting so a change made elsewhere between show
+        // and press is not clobbered.
+        let snapshot = match snapshot() {
+            Ok(s) => s,
+            Err(reason) => return ActionOutcome::Failed { message: reason },
+        };
+        let target = match intent {
+            ActionIntent::Toggle => !snapshot.powered,
+            ActionIntent::Run => {
+                return ActionOutcome::Failed {
+                    message: "Bluetooth has no run action".to_string(),
+                };
+            }
+        };
+
+        if let Err(message) = set_powered(&snapshot.adapter_path, target) {
+            return ActionOutcome::Failed { message };
+        }
+        // bluetoothd applies the change asynchronously; wait until the power
+        // state reflects the target so the panel's re-read is truthful.
+        if !wait_for_power_state(&snapshot.adapter_path, target) {
+            return ActionOutcome::Failed {
+                message: format!("Could not turn Bluetooth {}", on_off(target)),
+            };
+        }
+        ActionOutcome::Ok {
+            banner: Some(format!("Bluetooth {}", on_off(target))),
+        }
+    }
+}
+
+fn on_off(on: bool) -> &'static str {
+    if on { "on" } else { "off" }
+}
+
+/// One `GetManagedObjects` call -> adapter path, power state, connected
+/// devices. `Err` carries the human reason shown as unavailable.
+fn snapshot() -> Result<Snapshot, String> {
+    let Some(conn) = dbus::system() else {
+        return Err(NO_SERVICE.to_string());
+    };
+    let objects: ManagedObjects = dbus::runtime()
+        .block_on(async {
+            conn.call_method(
+                Some(BLUEZ_DEST),
+                "/",
+                Some(OBJECT_MANAGER_IFACE),
+                "GetManagedObjects",
+                &(),
+            )
+            .await?
+            .body()
+            .deserialize()
+        })
+        .map_err(|_| NO_SERVICE.to_string())?;
+
+    let (adapter_path, adapter_props) = objects
+        .iter()
+        .find_map(|(path, ifaces)| Some((path.clone(), ifaces.get(ADAPTER_IFACE)?)))
+        .ok_or_else(|| NO_ADAPTER.to_string())?;
+    let powered = prop_bool(adapter_props, "Powered").unwrap_or(false);
+
+    let mut connected: Vec<String> = objects
+        .values()
+        .filter_map(|ifaces| ifaces.get(DEVICE_IFACE))
+        .filter(|props| prop_bool(props, "Connected").unwrap_or(false))
+        .filter_map(|props| prop_str(props, "Alias").or_else(|| prop_str(props, "Address")))
+        .collect();
+    connected.sort();
+
+    Ok(Snapshot {
+        adapter_path,
+        powered,
+        connected,
+    })
+}
+
+fn prop_bool(props: &HashMap<String, OwnedValue>, key: &str) -> Option<bool> {
+    props.get(key)?.downcast_ref::<bool>().ok()
+}
+
+fn prop_str(props: &HashMap<String, OwnedValue>, key: &str) -> Option<String> {
+    let value: zbus::zvariant::Str = props.get(key)?.downcast_ref().ok()?;
+    Some(value.to_string())
+}
+
+fn set_powered(adapter_path: &OwnedObjectPath, on: bool) -> Result<(), String> {
+    let Some(conn) = dbus::system() else {
+        return Err(NO_SERVICE.to_string());
+    };
+    dbus::runtime()
+        .block_on(async {
+            zbus::Proxy::new(conn, BLUEZ_DEST, adapter_path.as_str(), ADAPTER_IFACE)
+                .await?
+                .set_property("Powered", on)
+                .await
+        })
+        .map_err(|err| friendly_set_error(&err, on))
+}
+
+fn friendly_set_error(err: &zbus::fdo::Error, target: bool) -> String {
+    // BlueZ rejects the write with org.bluez.Error.Blocked when rfkill has the
+    // radio soft-blocked; that is not an fdo error, so it arrives ZBus-wrapped.
+    if let zbus::fdo::Error::ZBus(zbus::Error::MethodError(name, _, _)) = err
+        && name.as_str() == "org.bluez.Error.Blocked"
+    {
+        return "Bluetooth is blocked by rfkill".to_string();
+    }
+    format!("Could not turn Bluetooth {}", on_off(target))
+}
+
+/// Polls the adapter's `Powered` property until it reaches `target` or the
+/// settle timeout. Runs on the blocking pool, so plain sleeps are fine.
+fn wait_for_power_state(adapter_path: &OwnedObjectPath, target: bool) -> bool {
+    let deadline = Instant::now() + SETTLE_TIMEOUT;
+    loop {
+        if read_powered(adapter_path) == Some(target) {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return read_powered(adapter_path) == Some(target);
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
+fn read_powered(adapter_path: &OwnedObjectPath) -> Option<bool> {
+    let conn = dbus::system()?;
+    dbus::runtime()
+        .block_on(async {
+            zbus::Proxy::new(conn, BLUEZ_DEST, adapter_path.as_str(), ADAPTER_IFACE)
+                .await?
+                .get_property::<bool>("Powered")
+                .await
+        })
+        .ok()
+}

--- a/apps/linows/src-tauri/src/qactions/controls/bluetooth.rs
+++ b/apps/linows/src-tauri/src/qactions/controls/bluetooth.rs
@@ -17,7 +17,9 @@
 //! LD_LIBRARY_PATH scrubbing that an in-process call avoids entirely.
 
 use crate::platform::linux::dbus;
-use crate::qactions::{ActionIntent, ActionOutcome, ActionState, InfoValue, SystemControl};
+use crate::qactions::{
+    ActionIntent, ActionOutcome, ActionState, InfoValue, ListItem, SystemControl,
+};
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 use zbus::zvariant::{OwnedObjectPath, OwnedValue};
@@ -36,15 +38,28 @@ const NO_ADAPTER: &str = "Bluetooth hardware not found";
 const SETTLE_TIMEOUT: Duration = Duration::from_millis(1500);
 const POLL_INTERVAL: Duration = Duration::from_millis(80);
 
+/// How long to wait for a device Connect/Disconnect before reporting failure.
+/// BlueZ's own call can hang up to ~25s when a device is off or out of range;
+/// 6s is plenty for a nearby device and keeps the shared D-Bus runtime from
+/// stalling other calls (e.g. window focus) for long.
+const DEVICE_ACTION_TIMEOUT: Duration = Duration::from_secs(6);
+
 /// `a{oa{sa{sv}}}` - the BlueZ object tree from `GetManagedObjects`.
 type ManagedObjects = HashMap<OwnedObjectPath, HashMap<String, HashMap<String, OwnedValue>>>;
+
+/// A paired device from the BlueZ tree.
+struct Device {
+    path: OwnedObjectPath,
+    alias: String,
+    connected: bool,
+}
 
 /// The BlueZ facts the panel needs, from one `GetManagedObjects` call.
 struct Snapshot {
     adapter_path: OwnedObjectPath,
     powered: bool,
-    /// Aliases of currently connected devices.
-    connected: Vec<String>,
+    /// Paired devices, connected ones first, for the interactive device list.
+    devices: Vec<Device>,
 }
 
 /// Toggles and reports Linux system Bluetooth power. Action id: `"bluetooth"`.
@@ -68,12 +83,22 @@ impl SystemControl for BluetoothControl {
             Ok(s) if !s.powered => InfoValue::Text {
                 text: "Off".to_string(),
             },
-            Ok(s) if s.connected.is_empty() => InfoValue::Text {
-                text: "On, not connected".to_string(),
+            Ok(s) if s.devices.is_empty() => InfoValue::Text {
+                text: "On, no paired devices".to_string(),
             },
-            // One row per connected device: a comma-joined line gets unreadable
-            // (and wraps mid-word) once more than a couple are paired.
-            Ok(s) => InfoValue::List { items: s.connected },
+            // One clickable row per paired device (connect/disconnect); a
+            // comma-joined line gets unreadable once more than a couple pair.
+            Ok(s) => InfoValue::List {
+                items: s
+                    .devices
+                    .into_iter()
+                    .map(|d| ListItem {
+                        id: Some(d.path.to_string()),
+                        label: d.alias,
+                        on: Some(d.connected),
+                    })
+                    .collect(),
+            },
             Err(reason) => InfoValue::Unavailable { reason },
         };
         values.insert("status".to_string(), value);
@@ -110,6 +135,37 @@ impl SystemControl for BluetoothControl {
             banner: Some(format!("Bluetooth {}", on_off(target))),
         }
     }
+
+    fn apply_item(&self, item_id: &str, intent: ActionIntent) -> ActionOutcome {
+        if !matches!(intent, ActionIntent::Toggle) {
+            return ActionOutcome::Failed {
+                message: "Devices can only be connected or disconnected".to_string(),
+            };
+        }
+        // item_id is a BlueZ device object path. Re-read its live connection so
+        // a click flips the real state (not a stale rendered one) and gives us
+        // a name for the banner.
+        let Some((connected, alias)) = device_state(item_id) else {
+            return ActionOutcome::Failed {
+                message: "Device is no longer available".to_string(),
+            };
+        };
+        let connect = !connected;
+        let (verb_ok, verb_fail) = if connect {
+            ("Connected to", "connect to")
+        } else {
+            ("Disconnected from", "disconnect from")
+        };
+        if set_device_connected(item_id, connect) {
+            ActionOutcome::Ok {
+                banner: Some(format!("{verb_ok} {alias}")),
+            }
+        } else {
+            ActionOutcome::Failed {
+                message: format!("Failed to {verb_fail} {alias}"),
+            }
+        }
+    }
 }
 
 fn on_off(on: bool) -> &'static str {
@@ -143,18 +199,66 @@ fn snapshot() -> Result<Snapshot, String> {
         .ok_or_else(|| NO_ADAPTER.to_string())?;
     let powered = prop_bool(adapter_props, "Powered").unwrap_or(false);
 
-    let mut connected: Vec<String> = objects
-        .values()
-        .filter_map(|ifaces| ifaces.get(DEVICE_IFACE))
-        .filter(|props| prop_bool(props, "Connected").unwrap_or(false))
-        .filter_map(|props| prop_str(props, "Alias").or_else(|| prop_str(props, "Address")))
+    let mut devices: Vec<Device> = objects
+        .iter()
+        .filter_map(|(path, ifaces)| {
+            let props = ifaces.get(DEVICE_IFACE)?;
+            // Only devices we have paired with - the ones a user can re-connect.
+            if !prop_bool(props, "Paired").unwrap_or(false) {
+                return None;
+            }
+            Some(Device {
+                path: path.clone(),
+                alias: prop_str(props, "Alias").or_else(|| prop_str(props, "Address"))?,
+                connected: prop_bool(props, "Connected").unwrap_or(false),
+            })
+        })
         .collect();
-    connected.sort();
+    // Connected first, then alphabetical, so the active devices lead the list.
+    devices.sort_by(|a, b| {
+        b.connected
+            .cmp(&a.connected)
+            .then_with(|| a.alias.to_lowercase().cmp(&b.alias.to_lowercase()))
+    });
 
     Ok(Snapshot {
         adapter_path,
         powered,
-        connected,
+        devices,
+    })
+}
+
+/// Read one device's live `Connected` state and display name by object path.
+fn device_state(path: &str) -> Option<(bool, String)> {
+    let conn = dbus::system()?;
+    dbus::runtime().block_on(async {
+        let proxy = zbus::Proxy::new(conn, BLUEZ_DEST, path, DEVICE_IFACE)
+            .await
+            .ok()?;
+        let connected: bool = proxy.get_property("Connected").await.ok()?;
+        let alias = proxy
+            .get_property::<String>("Alias")
+            .await
+            .unwrap_or_else(|_| "device".to_string());
+        Some((connected, alias))
+    })
+}
+
+/// Call `Connect`/`Disconnect` on a device, bounded by `DEVICE_ACTION_TIMEOUT`.
+/// Returns whether it completed within the window.
+fn set_device_connected(path: &str, connect: bool) -> bool {
+    let Some(conn) = dbus::system() else {
+        return false;
+    };
+    let method = if connect { "Connect" } else { "Disconnect" };
+    dbus::runtime().block_on(async {
+        let Ok(proxy) = zbus::Proxy::new(conn, BLUEZ_DEST, path, DEVICE_IFACE).await else {
+            return false;
+        };
+        matches!(
+            tokio::time::timeout(DEVICE_ACTION_TIMEOUT, proxy.call_method(method, &())).await,
+            Ok(Ok(_))
+        )
     })
 }
 

--- a/apps/linows/src-tauri/src/qactions/controls/bluetooth.rs
+++ b/apps/linows/src-tauri/src/qactions/controls/bluetooth.rs
@@ -71,9 +71,9 @@ impl SystemControl for BluetoothControl {
             Ok(s) if s.connected.is_empty() => InfoValue::Text {
                 text: "On, not connected".to_string(),
             },
-            Ok(s) => InfoValue::Text {
-                text: format!("Connected to {}", s.connected.join(", ")),
-            },
+            // One row per connected device: a comma-joined line gets unreadable
+            // (and wraps mid-word) once more than a couple are paired.
+            Ok(s) => InfoValue::List { items: s.connected },
             Err(reason) => InfoValue::Unavailable { reason },
         };
         values.insert("status".to_string(), value);

--- a/apps/linows/src-tauri/src/qactions/controls/mod.rs
+++ b/apps/linows/src-tauri/src/qactions/controls/mod.rs
@@ -1,0 +1,6 @@
+//! Per-control adapters. One file per control, all of its OS-specific code
+//! quarantined inside (see docs/writing-controls.md). `bluetooth` is the
+//! reference implementation to copy.
+
+#[cfg(target_os = "linux")]
+pub mod bluetooth;

--- a/apps/linows/src-tauri/src/qactions/mod.rs
+++ b/apps/linows/src-tauri/src/qactions/mod.rs
@@ -70,14 +70,24 @@ pub enum InfoValue {
     Text {
         text: String,
     },
-    /// A set of items the panel renders one-per-row (e.g. each connected
-    /// Bluetooth device), instead of squeezing them into a single value.
+    /// A set of items the panel renders one-per-row (e.g. each paired Bluetooth
+    /// device), instead of squeezing them into a single value.
     List {
-        items: Vec<String>,
+        items: Vec<ListItem>,
     },
     Unavailable {
         reason: String,
     },
+}
+
+/// One entry in an [`InfoValue::List`]. An `id` makes the row actionable via
+/// [`SystemControl::apply_item`]; `on` drives an on/off marker (e.g. whether a
+/// device is currently connected). Both are optional so a list can be plain.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ListItem {
+    pub id: Option<String>,
+    pub label: String,
+    pub on: Option<bool>,
 }
 
 /// The adapter a contributor implements per control - the one linows file you
@@ -96,6 +106,15 @@ pub trait SystemControl: Send + Sync {
 
     /// Perform `intent` and report the outcome.
     fn apply(&self, intent: ActionIntent) -> ActionOutcome;
+
+    /// Act on one item of a list-valued info field (e.g. connect/disconnect a
+    /// specific device). Defaults to unsupported: most controls have no
+    /// per-item actions.
+    fn apply_item(&self, _item_id: &str, _intent: ActionIntent) -> ActionOutcome {
+        ActionOutcome::Failed {
+            message: "No per-item action".to_string(),
+        }
+    }
 }
 
 /// Resolves an action id to its native adapter - the one-line-per-control
@@ -160,6 +179,26 @@ pub async fn quick_action_state(action_id: String, info_keys: Vec<String>) -> Qu
 pub async fn quick_action_apply(action_id: String, intent: ActionIntent) -> ActionOutcome {
     async_runtime::spawn_blocking(move || match adapter(&action_id) {
         Some(control) => control.apply(intent),
+        None => ActionOutcome::Failed {
+            message: UNAVAILABLE_ON_OS.to_string(),
+        },
+    })
+    .await
+    .unwrap_or_else(|_| ActionOutcome::Failed {
+        message: "Action failed".to_string(),
+    })
+}
+
+/// Run an intent against one list item of an action (e.g. toggle a device's
+/// connection). Like `quick_action_apply`, but targets an item by id.
+#[tauri::command]
+pub async fn quick_action_apply_item(
+    action_id: String,
+    item_id: String,
+    intent: ActionIntent,
+) -> ActionOutcome {
+    async_runtime::spawn_blocking(move || match adapter(&action_id) {
+        Some(control) => control.apply_item(&item_id, intent),
         None => ActionOutcome::Failed {
             message: UNAVAILABLE_ON_OS.to_string(),
         },

--- a/apps/linows/src-tauri/src/qactions/mod.rs
+++ b/apps/linows/src-tauri/src/qactions/mod.rs
@@ -9,6 +9,13 @@
 //! Adapters block (D-Bus, CLIs), so state/apply run on the blocking pool,
 //! mirroring `answers.rs`.
 
+// Every `SystemControl` adapter is Linux-only today (see `controls`), so on
+// other targets nothing constructs the success-path states/outcomes/values of
+// the shared types below - they exist only to serialize back to the frontend.
+// Silence the resulting dead_code lint off Linux; a future non-Linux adapter
+// would use them and this lifts on its own.
+#![cfg_attr(not(target_os = "linux"), allow(dead_code))]
+
 pub mod controls;
 
 use serde::{Deserialize, Serialize};

--- a/apps/linows/src-tauri/src/qactions/mod.rs
+++ b/apps/linows/src-tauri/src/qactions/mod.rs
@@ -67,8 +67,17 @@ pub enum ActionOutcome {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum InfoValue {
-    Text { text: String },
-    Unavailable { reason: String },
+    Text {
+        text: String,
+    },
+    /// A set of items the panel renders one-per-row (e.g. each connected
+    /// Bluetooth device), instead of squeezing them into a single value.
+    List {
+        items: Vec<String>,
+    },
+    Unavailable {
+        reason: String,
+    },
 }
 
 /// The adapter a contributor implements per control - the one linows file you

--- a/apps/linows/src-tauri/src/qactions/mod.rs
+++ b/apps/linows/src-tauri/src/qactions/mod.rs
@@ -1,0 +1,162 @@
+//! Quick Actions - the linows half of the shared framework (see
+//! docs/writing-controls.md and the macOS peer in
+//! apps/macos/.../Support/QuickActions/).
+//!
+//! Descriptors (which actions exist, their labels, control kind, info fields)
+//! come from the shared `look-qactions` catalog; this module supplies the
+//! native side: the `SystemControl` adapter contract, the registry resolving
+//! an `action_id` to its adapter, and the Tauri commands the frontend calls.
+//! Adapters block (D-Bus, CLIs), so state/apply run on the blocking pool,
+//! mirroring `answers.rs`.
+
+pub mod controls;
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use tauri::async_runtime;
+
+/// Current state of a control's value, read for display in the panel.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "state", rename_all = "lowercase")]
+pub enum ActionState {
+    On,
+    Off,
+    /// A non-boolean value shown as-is (e.g. a level or a mode name). Part of
+    /// the shared adapter contract; no linows control returns it yet.
+    #[allow(dead_code)]
+    Value {
+        value: String,
+    },
+    /// The control cannot act here: no hardware, no service, unsupported OS.
+    Unavailable {
+        reason: String,
+    },
+}
+
+/// What the user asked a control to do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ActionIntent {
+    /// Flip a boolean control (on <-> off).
+    Toggle,
+    /// Trigger a non-toggle action (a plain button).
+    Run,
+}
+
+/// Result of applying an intent, surfaced to the user as a banner.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum ActionOutcome {
+    /// Success. `banner` overrides the default confirmation text.
+    Ok {
+        banner: Option<String>,
+    },
+    Failed {
+        message: String,
+    },
+    /// Part of the shared adapter contract; no linows control needs an OS
+    /// permission yet.
+    #[allow(dead_code)]
+    NeedsPermission {
+        message: String,
+    },
+}
+
+/// A resolved info-field value. The shared descriptor declares `label` +
+/// `value_key`; the adapter resolves the key to what to display.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum InfoValue {
+    Text { text: String },
+    Unavailable { reason: String },
+}
+
+/// The adapter a contributor implements per control - the one linows file you
+/// write when adding one (see docs/writing-controls.md). Methods may block;
+/// they always run off the UI thread. Best-effort: never panic, surface
+/// problems as `Unavailable` / `Failed` / `NeedsPermission`.
+pub trait SystemControl: Send + Sync {
+    /// Read the current state for display.
+    fn state(&self) -> ActionState;
+
+    /// Resolve the descriptor's info `value_key`s to display values. Controls
+    /// without info fields keep the default.
+    fn info(&self, _keys: &[String]) -> HashMap<String, InfoValue> {
+        HashMap::new()
+    }
+
+    /// Perform `intent` and report the outcome.
+    fn apply(&self, intent: ActionIntent) -> ActionOutcome;
+}
+
+/// Resolves an action id to its native adapter - the one-line-per-control
+/// registry. An id with a shared descriptor but no adapter here renders as
+/// unavailable (declaration is shared across OSes; execution is not).
+#[cfg(target_os = "linux")]
+fn adapter(action_id: &str) -> Option<&'static dyn SystemControl> {
+    match action_id {
+        "bluetooth" => Some(&controls::bluetooth::BluetoothControl),
+        _ => None,
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn adapter(_action_id: &str) -> Option<&'static dyn SystemControl> {
+    None
+}
+
+const UNAVAILABLE_ON_OS: &str = "Not supported on this system";
+
+/// One action's live state plus its resolved info values, fetched together so
+/// a selection costs a single IPC round trip.
+#[derive(Serialize)]
+pub struct QuickActionStatus {
+    pub state: ActionState,
+    pub info: HashMap<String, InfoValue>,
+}
+
+fn unavailable_status() -> QuickActionStatus {
+    QuickActionStatus {
+        state: ActionState::Unavailable {
+            reason: UNAVAILABLE_ON_OS.to_string(),
+        },
+        info: HashMap::new(),
+    }
+}
+
+/// Quick Action descriptors for a selected result, from the shared catalog.
+/// Empty for results with no actions (the common case).
+#[tauri::command]
+pub fn quick_actions(result_id: String, kind: String) -> Vec<look_qactions::ActionDescriptor> {
+    look_qactions::descriptors_for(&result_id, &kind)
+}
+
+/// Live state + info values for an action. `info_keys` are the descriptor's
+/// `value_key`s the frontend wants resolved.
+#[tauri::command]
+pub async fn quick_action_state(action_id: String, info_keys: Vec<String>) -> QuickActionStatus {
+    async_runtime::spawn_blocking(move || match adapter(&action_id) {
+        Some(control) => QuickActionStatus {
+            state: control.state(),
+            info: control.info(&info_keys),
+        },
+        None => unavailable_status(),
+    })
+    .await
+    .unwrap_or_else(|_| unavailable_status())
+}
+
+/// Run an action's intent; the outcome feeds the banner.
+#[tauri::command]
+pub async fn quick_action_apply(action_id: String, intent: ActionIntent) -> ActionOutcome {
+    async_runtime::spawn_blocking(move || match adapter(&action_id) {
+        Some(control) => control.apply(intent),
+        None => ActionOutcome::Failed {
+            message: UNAVAILABLE_ON_OS.to_string(),
+        },
+    })
+    .await
+    .unwrap_or_else(|_| ActionOutcome::Failed {
+        message: "Action failed".to_string(),
+    })
+}

--- a/apps/linows/src/css/components/preview.css
+++ b/apps/linows/src/css/components/preview.css
@@ -525,3 +525,41 @@
     background: var(--accent-color);
     color: var(--on-accent-color);
 }
+
+/* Connected-device list: one row per device under the status header, so many
+   paired devices stay readable instead of a comma-run that wraps mid-word. */
+.qaction-info-field {
+    display: flex;
+    flex-direction: column;
+}
+
+.qaction-device-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    margin: 2px 0 2px 2px;
+}
+
+.qaction-device-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    padding: 2px 0;
+}
+
+.qaction-device-dot {
+    width: 6px;
+    height: 6px;
+    flex-shrink: 0;
+    border-radius: 50%;
+    background: var(--accent-color);
+}
+
+.qaction-device-name {
+    font-size: calc(var(--font-size) - 1px);
+    color: var(--font-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/apps/linows/src/css/components/preview.css
+++ b/apps/linows/src/css/components/preview.css
@@ -536,23 +536,45 @@
 .qaction-device-list {
     display: flex;
     flex-direction: column;
-    gap: 2px;
+    gap: 1px;
     margin: 2px 0 2px 2px;
 }
 
+/* Clickable row: connects if the device is off, disconnects if it is on. */
 .qaction-device-row {
     display: flex;
     align-items: center;
     gap: 8px;
     min-width: 0;
-    padding: 2px 0;
+    width: 100%;
+    padding: 4px 6px;
+    border: none;
+    border-radius: 6px;
+    background: none;
+    color: inherit;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+    outline: none;
 }
 
+.qaction-device-row:hover {
+    background: var(--control-fill);
+}
+
+/* Hollow dot = paired but disconnected; filled accent = connected. */
 .qaction-device-dot {
-    width: 6px;
-    height: 6px;
+    width: 7px;
+    height: 7px;
     flex-shrink: 0;
+    box-sizing: border-box;
     border-radius: 50%;
+    border: 1.5px solid var(--font-muted);
+    background: transparent;
+}
+
+.qaction-device-row.is-connected .qaction-device-dot {
+    border-color: var(--accent-color);
     background: var(--accent-color);
 }
 

--- a/apps/linows/src/css/components/preview.css
+++ b/apps/linows/src/css/components/preview.css
@@ -430,3 +430,98 @@
     background: rgba(255, 255, 255, 0.12);
     border-radius: 4px;
 }
+
+/* ============ Quick Actions ============ */
+/* The interactive section beneath the metadata rows (components/qactions.js).
+   Row layout mirrors macOS QuickActionsSection: title left, control + key
+   hint right, on a subtly filled rounded row. */
+
+.preview-qactions {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    flex-shrink: 0;
+    /* Sits directly under the header (which owns the gap above); this spaces it
+       from the Version/Kind rows below, matching macOS stack spacing. */
+    margin-bottom: 12px;
+}
+
+.qaction-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 8px 10px;
+    background: var(--control-fill);
+    border-radius: 8px;
+}
+
+.qaction-title {
+    font-size: var(--font-size);
+    font-weight: 500;
+    color: var(--font-color);
+}
+
+.qaction-control {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.qaction-hint {
+    font-size: calc(var(--font-size) - 3px);
+    font-weight: 600;
+    color: var(--font-muted);
+}
+
+.qaction-unavailable,
+.qaction-info-unavailable {
+    font-size: calc(var(--font-size) - 3px);
+    color: var(--font-muted);
+}
+
+.qaction-toggle {
+    position: relative;
+    width: 34px;
+    height: 20px;
+    padding: 0;
+    border: none;
+    border-radius: 10px;
+    background: var(--selection-fill);
+    cursor: pointer;
+    transition: background 0.15s ease;
+}
+
+.qaction-toggle.is-on {
+    background: var(--accent-color);
+}
+
+.qaction-toggle-knob {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--on-accent-color);
+    transition: transform 0.15s ease;
+}
+
+.qaction-toggle.is-on .qaction-toggle-knob {
+    transform: translateX(14px);
+}
+
+.qaction-button {
+    padding: 4px 10px;
+    border: none;
+    border-radius: 6px;
+    background: var(--selection-fill);
+    color: var(--font-color);
+    font-size: calc(var(--font-size) - 1px);
+    cursor: pointer;
+}
+
+.qaction-button:hover {
+    background: var(--accent-color);
+    color: var(--on-accent-color);
+}

--- a/apps/linows/src/css/layout.css
+++ b/apps/linows/src/css/layout.css
@@ -489,6 +489,17 @@ html[data-os="windows"] .launcher-window {
     margin: 0 var(--content-padding);
 }
 
+/* Floating/resting: the transient banner floats as an inset, rounded pill
+ * aligned with the tiles, instead of a full-width bar that overhangs the
+ * (invisible) window edges. The bottom margin keeps it off the results tiles
+ * with the same inner-gap rhythm; the top bar already spaces it from above. */
+.bar-free #banner {
+    margin: 0 var(--content-padding) var(--inner-gap);
+    border-radius: 10px;
+    border-bottom: none;
+    box-shadow: 0 3px 7px rgba(0, 0, 0, 0.25);
+}
+
 /* Empty-query resting state: just the frosted top bar on the desktop -
  * no columns, no hint bar, no copyright. Applies at gap 0 too. */
 .resting .results-row,

--- a/apps/linows/src/html/screens/help.html
+++ b/apps/linows/src/html/screens/help.html
@@ -43,6 +43,10 @@
                 <kbd>Ctrl+F</kbd><span>Reveal selected item in file manager</span>
             </div>
             <div class="help-item">
+                <kbd>Ctrl+O</kbd
+                ><span>Toggle the selected result's quick action (e.g. Bluetooth on/off)</span>
+            </div>
+            <div class="help-item">
                 <kbd>Ctrl+Enter</kbd><span>Search current query on Google</span>
             </div>
             <div class="help-item"><kbd>Ctrl+/</kbd><span>Enter command mode</span></div>

--- a/apps/linows/src/html/screens/settings.html
+++ b/apps/linows/src/html/screens/settings.html
@@ -390,6 +390,10 @@
                         <kbd>Ctrl+F</kbd><span>Reveal selected item in file manager</span>
                     </div>
                     <div class="settings-shortcut">
+                        <kbd>Ctrl+O</kbd
+                        ><span>Toggle the selected result's quick action (e.g. Bluetooth)</span>
+                    </div>
+                    <div class="settings-shortcut">
                         <kbd>Ctrl+Enter</kbd><span>Search query on Google</span>
                     </div>
                     <div class="settings-shortcut">

--- a/apps/linows/src/js/components/preview.js
+++ b/apps/linows/src/js/components/preview.js
@@ -21,6 +21,7 @@ import {
     webUrlFromResultId,
     WEB_URL_OPEN_SUBTITLE,
 } from '../catalog.js';
+import * as qactions from './qactions.js';
 
 let panel = null;
 let currentPath = null;
@@ -39,6 +40,7 @@ export function update(result) {
     if (!result) {
         panel.hidden = true;
         currentPath = null;
+        qactions.clear();
         return;
     }
 
@@ -53,6 +55,9 @@ export function update(result) {
     }
     panel.hidden = false;
     panel.innerHTML = '';
+    // The panel was wiped: invalidate any in-flight Quick Actions render so a
+    // late response can't append a stale section for the previous result.
+    qactions.clear();
 
     if (result.kind === 'clipboard') {
         renderClipboardPreview(result);
@@ -126,6 +131,13 @@ export function update(result) {
     header.appendChild(headerText);
     panel.appendChild(header);
 
+    // Quick Actions slot - directly beneath the header, above the preview and
+    // metadata rows, matching macOS ResultPreviewView (QuickActionsSection
+    // renders right after the header). A fixed slot keeps the position stable
+    // while the section fills in asynchronously.
+    const qactionsSlot = document.createElement('div');
+    panel.appendChild(qactionsSlot);
+
     // Preview placeholder - sits between header and metadata (matches macOS order)
     const previewSlot = document.createElement('div');
     previewSlot.className = 'preview-slot';
@@ -141,6 +153,11 @@ export function update(result) {
     } else {
         renderFileMeta(metaWrap, previewSlot, result, headerSub);
     }
+
+    // Quick Actions - interactive controls for results the shared catalog
+    // marks actionable (settings toggles). Fills the slot beneath the header;
+    // appends nothing for the rest.
+    qactions.render(qactionsSlot, result);
 }
 
 function renderClipboardPreview(result) {
@@ -394,6 +411,7 @@ export function clear() {
         panel.hidden = true;
         panel.innerHTML = '';
         currentPath = null;
+        qactions.clear();
     }
 }
 
@@ -403,6 +421,7 @@ export function clear() {
 export function showClipboardHelp() {
     if (!panel) return;
     currentPath = null;
+    qactions.clear();
     panel.hidden = false;
     panel.innerHTML = `
     <div class="preview-clip-help">

--- a/apps/linows/src/js/components/qactions.js
+++ b/apps/linows/src/js/components/qactions.js
@@ -1,0 +1,210 @@
+// Quick Actions - the interactive part of the right panel (see
+// docs/writing-controls.md). Descriptors for the selected result come from
+// the shared core catalog; each action's live state/info and its execution go
+// through the native adapter behind the qactions IPC commands. Mirrors macOS
+// LauncherView+QuickActions: Ctrl+O flips the primary toggle, clicking the
+// switch does the same, the outcome shows as a banner and state is re-read
+// after apply. A stale-token guard drops late reads when the selection moves.
+
+import { quickActions, quickActionState, quickActionApply } from '../ipc.js';
+import * as banner from './banner.js';
+
+// Banner durations (seconds), matching macOS Banner constants.
+const BANNER_SUCCESS = 1.2;
+const BANNER_ERROR = 1.6;
+const BANNER_PERMISSION = 2.2;
+
+const VALUE_PLACEHOLDER = '…';
+const TOGGLE_HINT = 'Ctrl+O';
+
+let token = 0; // bumped on every render/clear; async work checks it
+let primary = null; // handle of the first toggle action (drives Ctrl+O)
+let inFlight = false; // debounce: one apply at a time
+
+export function clear() {
+    token += 1;
+    primary = null;
+    inFlight = false;
+}
+
+/**
+ * Fetch the result's Quick Actions and append the section to `container`.
+ * No-op for results the catalog declares nothing for (the common case).
+ */
+export async function render(container, result) {
+    clear();
+    const myToken = token;
+
+    const descriptors = await quickActions(result.id, result.kind);
+    if (token !== myToken || !descriptors?.length) return;
+
+    const section = document.createElement('div');
+    section.className = 'preview-qactions';
+
+    for (const descriptor of descriptors) {
+        const handle = buildAction(section, descriptor);
+        if (descriptor.control === 'toggle' && !primary) primary = handle;
+        loadStatus(handle, myToken);
+    }
+
+    container.appendChild(section);
+}
+
+/** Flip the selected result's primary toggle (Ctrl+O). */
+export function togglePrimary() {
+    if (primary?.available) run(primary, 'toggle');
+}
+
+// One action row: title, the control for its kind, key hint, plus the
+// descriptor's info rows above it. Returns a handle used to feed async
+// state/info updates into the DOM.
+function buildAction(section, descriptor) {
+    const infoValues = new Map();
+    if (descriptor.info.length > 0) {
+        const meta = document.createElement('div');
+        meta.className = 'preview-meta';
+        for (const field of descriptor.info) {
+            const row = document.createElement('div');
+            row.className = 'preview-info-row';
+            const label = document.createElement('span');
+            label.className = 'preview-info-label';
+            label.textContent = field.label;
+            row.appendChild(label);
+            const value = document.createElement('span');
+            value.className = 'preview-info-value';
+            value.textContent = VALUE_PLACEHOLDER;
+            row.appendChild(value);
+            meta.appendChild(row);
+            infoValues.set(field.value_key, value);
+        }
+        section.appendChild(meta);
+    }
+
+    const row = document.createElement('div');
+    row.className = 'qaction-row';
+
+    const title = document.createElement('span');
+    title.className = 'qaction-title';
+    title.textContent = descriptor.title;
+    row.appendChild(title);
+
+    const controlWrap = document.createElement('span');
+    controlWrap.className = 'qaction-control';
+    row.appendChild(controlWrap);
+    section.appendChild(row);
+
+    const handle = {
+        descriptor,
+        available: false,
+        isOn: null,
+        switchEl: null,
+        controlWrap,
+        infoValues,
+    };
+
+    if (descriptor.control === 'toggle') {
+        const switchEl = document.createElement('button');
+        switchEl.type = 'button';
+        switchEl.className = 'qaction-toggle';
+        switchEl.setAttribute('role', 'switch');
+        switchEl.appendChild(document.createElement('span')).className = 'qaction-toggle-knob';
+        switchEl.addEventListener('click', () => {
+            if (handle.available) run(handle, 'toggle');
+        });
+        controlWrap.appendChild(switchEl);
+
+        const hint = document.createElement('span');
+        hint.className = 'qaction-hint';
+        hint.textContent = TOGGLE_HINT;
+        controlWrap.appendChild(hint);
+        handle.switchEl = switchEl;
+    } else {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'qaction-button';
+        button.textContent = descriptor.title;
+        button.addEventListener('click', () => {
+            if (handle.available) run(handle, 'run');
+        });
+        controlWrap.appendChild(button);
+    }
+
+    return handle;
+}
+
+async function loadStatus(handle, myToken) {
+    const keys = handle.descriptor.info.map((f) => f.value_key);
+    const status = await quickActionState(handle.descriptor.action_id, keys);
+    if (token !== myToken) return;
+    applyStatus(handle, status);
+}
+
+function applyStatus(handle, status) {
+    const { state } = status;
+    if (state.state === 'unavailable') {
+        handle.available = false;
+        handle.controlWrap.innerHTML = '';
+        const reason = document.createElement('span');
+        reason.className = 'qaction-unavailable';
+        reason.textContent = state.reason;
+        handle.controlWrap.appendChild(reason);
+    } else {
+        handle.available = true;
+        if (handle.switchEl && (state.state === 'on' || state.state === 'off')) {
+            setSwitch(handle, state.state === 'on');
+        }
+    }
+
+    for (const [key, el] of handle.infoValues) {
+        const value = status.info[key];
+        if (value?.kind === 'text') {
+            el.textContent = value.text;
+        } else {
+            el.textContent = value?.reason || 'Unavailable';
+            el.classList.add('qaction-info-unavailable');
+        }
+    }
+}
+
+function setSwitch(handle, on) {
+    handle.isOn = on;
+    handle.switchEl.setAttribute('aria-checked', String(on));
+    handle.switchEl.classList.toggle('is-on', on);
+}
+
+// Run an action's intent (switch click, button click, or Ctrl+O), show the
+// outcome, and re-read the state so the panel reflects what really happened.
+async function run(handle, intent) {
+    if (inFlight) return;
+    inFlight = true;
+    const myToken = token;
+
+    // Flip a toggle immediately for instant feedback; the re-read below
+    // confirms (and corrects it if the change did not take).
+    if (intent === 'toggle' && handle.isOn != null) {
+        setSwitch(handle, !handle.isOn);
+    }
+
+    const outcome = await quickActionApply(handle.descriptor.action_id, intent);
+    if (token !== myToken) return;
+    showOutcome(handle.descriptor, outcome);
+
+    const keys = handle.descriptor.info.map((f) => f.value_key);
+    const status = await quickActionState(handle.descriptor.action_id, keys);
+    if (token !== myToken) return;
+    applyStatus(handle, status);
+    inFlight = false;
+}
+
+function showOutcome(descriptor, outcome) {
+    switch (outcome?.outcome) {
+        case 'ok':
+            banner.show(outcome.banner || `${descriptor.title} done`, 'success', BANNER_SUCCESS);
+            break;
+        case 'needs_permission':
+            banner.show(outcome.message, 'info', BANNER_PERMISSION);
+            break;
+        default:
+            banner.show(outcome?.message || `${descriptor.title} failed`, 'error', BANNER_ERROR);
+    }
+}

--- a/apps/linows/src/js/components/qactions.js
+++ b/apps/linows/src/js/components/qactions.js
@@ -14,7 +14,6 @@ const BANNER_SUCCESS = 1.2;
 const BANNER_ERROR = 1.6;
 const BANNER_PERMISSION = 2.2;
 
-const VALUE_PLACEHOLDER = '…';
 const TOGGLE_HINT = 'Ctrl+O';
 
 let token = 0; // bumped on every render/clear; async work checks it
@@ -56,30 +55,11 @@ export function togglePrimary() {
 }
 
 // One action row: title, the control for its kind, key hint, plus the
-// descriptor's info rows above it. Returns a handle used to feed async
+// descriptor's info rows below it. Returns a handle used to feed async
 // state/info updates into the DOM.
 function buildAction(section, descriptor) {
-    const infoValues = new Map();
-    if (descriptor.info.length > 0) {
-        const meta = document.createElement('div');
-        meta.className = 'preview-meta';
-        for (const field of descriptor.info) {
-            const row = document.createElement('div');
-            row.className = 'preview-info-row';
-            const label = document.createElement('span');
-            label.className = 'preview-info-label';
-            label.textContent = field.label;
-            row.appendChild(label);
-            const value = document.createElement('span');
-            value.className = 'preview-info-value';
-            value.textContent = VALUE_PLACEHOLDER;
-            row.appendChild(value);
-            meta.appendChild(row);
-            infoValues.set(field.value_key, value);
-        }
-        section.appendChild(meta);
-    }
-
+    // Control row first, so the toggle sits directly under the header and the
+    // status (with its per-device rows) reads beneath it.
     const row = document.createElement('div');
     row.className = 'qaction-row';
 
@@ -93,13 +73,29 @@ function buildAction(section, descriptor) {
     row.appendChild(controlWrap);
     section.appendChild(row);
 
+    // Info fields (e.g. Status + connected devices) render below the control.
+    // Each field owns a container the async status fills, so a value can render
+    // as a single row (text) or a header plus one row per item (list).
+    const infoFields = new Map();
+    if (descriptor.info.length > 0) {
+        const meta = document.createElement('div');
+        meta.className = 'preview-meta';
+        for (const field of descriptor.info) {
+            const container = document.createElement('div');
+            container.className = 'qaction-info-field';
+            meta.appendChild(container);
+            infoFields.set(field.value_key, { container, label: field.label });
+        }
+        section.appendChild(meta);
+    }
+
     const handle = {
         descriptor,
         available: false,
         isOn: null,
         switchEl: null,
         controlWrap,
-        infoValues,
+        infoFields,
     };
 
     if (descriptor.control === 'toggle') {
@@ -155,15 +151,55 @@ function applyStatus(handle, status) {
         }
     }
 
-    for (const [key, el] of handle.infoValues) {
-        const value = status.info[key];
-        if (value?.kind === 'text') {
-            el.textContent = value.text;
-        } else {
-            el.textContent = value?.reason || 'Unavailable';
-            el.classList.add('qaction-info-unavailable');
-        }
+    for (const [key, field] of handle.infoFields) {
+        renderInfoField(field, status.info[key]);
     }
+}
+
+// Fill one info field's container from its resolved value: a plain label/value
+// row for text, or a labelled header plus one row per item for a list (e.g.
+// each connected Bluetooth device), mirroring the folder listing.
+function renderInfoField({ container, label }, value) {
+    container.innerHTML = '';
+    if (value?.kind === 'list') {
+        container.appendChild(infoRow(label, `${value.items.length} connected`));
+        const list = document.createElement('div');
+        list.className = 'qaction-device-list';
+        for (const name of value.items) {
+            const row = document.createElement('div');
+            row.className = 'qaction-device-row';
+            row.appendChild(document.createElement('span')).className = 'qaction-device-dot';
+            const nameEl = document.createElement('span');
+            nameEl.className = 'qaction-device-name';
+            nameEl.textContent = name;
+            nameEl.title = name;
+            row.appendChild(nameEl);
+            list.appendChild(row);
+        }
+        container.appendChild(list);
+        return;
+    }
+    const text = value?.kind === 'text' ? value.text : value?.reason || 'Unavailable';
+    const row = infoRow(label, text);
+    if (value?.kind !== 'text') {
+        row.querySelector('.preview-info-value').classList.add('qaction-info-unavailable');
+    }
+    container.appendChild(row);
+}
+
+// A label/value row matching the panel's other metadata rows.
+function infoRow(label, value) {
+    const row = document.createElement('div');
+    row.className = 'preview-info-row';
+    const labelEl = document.createElement('span');
+    labelEl.className = 'preview-info-label';
+    labelEl.textContent = label;
+    row.appendChild(labelEl);
+    const valueEl = document.createElement('span');
+    valueEl.className = 'preview-info-value';
+    valueEl.textContent = value;
+    row.appendChild(valueEl);
+    return row;
 }
 
 function setSwitch(handle, on) {

--- a/apps/linows/src/js/components/qactions.js
+++ b/apps/linows/src/js/components/qactions.js
@@ -6,13 +6,16 @@
 // switch does the same, the outcome shows as a banner and state is re-read
 // after apply. A stale-token guard drops late reads when the selection moves.
 
-import { quickActions, quickActionState, quickActionApply } from '../ipc.js';
+import { quickActions, quickActionState, quickActionApply, quickActionApplyItem } from '../ipc.js';
 import * as banner from './banner.js';
 
 // Banner durations (seconds), matching macOS Banner constants.
 const BANNER_SUCCESS = 1.2;
 const BANNER_ERROR = 1.6;
 const BANNER_PERMISSION = 2.2;
+// Matches the backend device-action timeout, so the "Connecting…" toast stays
+// up for the whole wait and the outcome banner takes over when it lands.
+const DEVICE_PENDING = 6;
 
 const TOGGLE_HINT = 'Ctrl+O';
 
@@ -152,29 +155,25 @@ function applyStatus(handle, status) {
     }
 
     for (const [key, field] of handle.infoFields) {
-        renderInfoField(field, status.info[key]);
+        renderInfoField(handle, field, status.info[key]);
     }
 }
 
 // Fill one info field's container from its resolved value: a plain label/value
 // row for text, or a labelled header plus one row per item for a list (e.g.
-// each connected Bluetooth device), mirroring the folder listing.
-function renderInfoField({ container, label }, value) {
+// each paired Bluetooth device), mirroring the folder listing. List items with
+// an `id` are clickable and toggle that item (connect/disconnect a device).
+function renderInfoField(handle, { container, label }, value) {
     container.innerHTML = '';
     if (value?.kind === 'list') {
-        container.appendChild(infoRow(label, `${value.items.length} connected`));
+        const connected = value.items.filter((it) => it.on === true).length;
+        container.appendChild(
+            infoRow(label, connected === 0 ? 'None connected' : `${connected} connected`),
+        );
         const list = document.createElement('div');
         list.className = 'qaction-device-list';
-        for (const name of value.items) {
-            const row = document.createElement('div');
-            row.className = 'qaction-device-row';
-            row.appendChild(document.createElement('span')).className = 'qaction-device-dot';
-            const nameEl = document.createElement('span');
-            nameEl.className = 'qaction-device-name';
-            nameEl.textContent = name;
-            nameEl.title = name;
-            row.appendChild(nameEl);
-            list.appendChild(row);
+        for (const item of value.items) {
+            list.appendChild(deviceRow(handle, item));
         }
         container.appendChild(list);
         return;
@@ -185,6 +184,27 @@ function renderInfoField({ container, label }, value) {
         row.querySelector('.preview-info-value').classList.add('qaction-info-unavailable');
     }
     container.appendChild(row);
+}
+
+// One device row: a connection dot + name. When the item carries an `id` it is
+// a clickable button that toggles that device's connection.
+function deviceRow(handle, item) {
+    const actionable = item.id != null;
+    const row = document.createElement(actionable ? 'button' : 'div');
+    row.className = 'qaction-device-row';
+    row.classList.toggle('is-connected', item.on === true);
+    if (actionable) {
+        row.type = 'button';
+        row.tabIndex = -1;
+        row.addEventListener('click', () => runItem(handle, item));
+    }
+    row.appendChild(document.createElement('span')).className = 'qaction-device-dot';
+    const nameEl = document.createElement('span');
+    nameEl.className = 'qaction-device-name';
+    nameEl.textContent = item.label;
+    nameEl.title = item.label;
+    row.appendChild(nameEl);
+    return row;
 }
 
 // A label/value row matching the panel's other metadata rows.
@@ -222,6 +242,30 @@ async function run(handle, intent) {
     }
 
     const outcome = await quickActionApply(handle.descriptor.action_id, intent);
+    finishAction(handle, outcome, myToken);
+}
+
+// Toggle one list item (connect/disconnect a device), then reconcile as `run`.
+async function runItem(handle, item) {
+    if (inFlight) return;
+    inFlight = true;
+    const myToken = token;
+    // Connecting can take a few seconds; show immediate feedback so the click
+    // doesn't feel dead. The outcome banner replaces this when it lands.
+    const connecting = item.on !== true;
+    banner.show(
+        `${connecting ? 'Connecting to' : 'Disconnecting'} ${item.label}…`,
+        'info',
+        DEVICE_PENDING,
+    );
+    const outcome = await quickActionApplyItem(handle.descriptor.action_id, item.id, 'toggle');
+    finishAction(handle, outcome, myToken);
+}
+
+// Shared tail for run/runItem: show the outcome banner and re-read state so the
+// panel reflects reality. Late responses (selection moved) drop on the token;
+// clear() resets `inFlight` in that case, so we needn't reset it here.
+async function finishAction(handle, outcome, myToken) {
     if (token !== myToken) return;
     showOutcome(handle.descriptor, outcome);
 

--- a/apps/linows/src/js/components/qactions.js
+++ b/apps/linows/src/js/components/qactions.js
@@ -241,8 +241,9 @@ async function run(handle, intent) {
         setSwitch(handle, !handle.isOn);
     }
 
-    const outcome = await quickActionApply(handle.descriptor.action_id, intent);
-    finishAction(handle, outcome, myToken);
+    await applyAndReconcile(handle, myToken, () =>
+        quickActionApply(handle.descriptor.action_id, intent),
+    );
 }
 
 // Toggle one list item (connect/disconnect a device), then reconcile as `run`.
@@ -258,22 +259,33 @@ async function runItem(handle, item) {
         'info',
         DEVICE_PENDING,
     );
-    const outcome = await quickActionApplyItem(handle.descriptor.action_id, item.id, 'toggle');
-    finishAction(handle, outcome, myToken);
+    await applyAndReconcile(handle, myToken, () =>
+        quickActionApplyItem(handle.descriptor.action_id, item.id, 'toggle'),
+    );
 }
 
-// Shared tail for run/runItem: show the outcome banner and re-read state so the
-// panel reflects reality. Late responses (selection moved) drop on the token;
-// clear() resets `inFlight` in that case, so we needn't reset it here.
-async function finishAction(handle, outcome, myToken) {
-    if (token !== myToken) return;
-    showOutcome(handle.descriptor, outcome);
+// Shared body for run/runItem: apply, show the outcome, and re-read state so the
+// panel reflects reality. Everything is wrapped so a rejected IPC (backend
+// error/panic, Tauri failure) still releases `inFlight` - otherwise the control
+// wedges until the selection changes. Late responses (selection moved) drop on
+// the token guard; `finally` only releases `inFlight` while we still own the
+// current token (clear() already reset it for a newer run otherwise).
+async function applyAndReconcile(handle, myToken, apply) {
+    try {
+        const outcome = await apply();
+        if (token !== myToken) return;
+        showOutcome(handle.descriptor, outcome);
 
-    const keys = handle.descriptor.info.map((f) => f.value_key);
-    const status = await quickActionState(handle.descriptor.action_id, keys);
-    if (token !== myToken) return;
-    applyStatus(handle, status);
-    inFlight = false;
+        const keys = handle.descriptor.info.map((f) => f.value_key);
+        const status = await quickActionState(handle.descriptor.action_id, keys);
+        if (token !== myToken) return;
+        applyStatus(handle, status);
+    } catch (err) {
+        console.error('quick action failed', err);
+        if (token === myToken) showOutcome(handle.descriptor, null);
+    } finally {
+        if (token === myToken) inFlight = false;
+    }
 }
 
 function showOutcome(descriptor, outcome) {

--- a/apps/linows/src/js/ipc.js
+++ b/apps/linows/src/js/ipc.js
@@ -153,6 +153,22 @@ export async function translate(text, targetLang) {
     return invoke('translate', { text, targetLang });
 }
 
+// Quick Actions: descriptors come from the shared look-qactions catalog;
+// state/apply go through the native adapter for the action id
+// (see docs/writing-controls.md).
+
+export async function quickActions(resultId, kind) {
+    return invoke('quick_actions', { resultId, kind });
+}
+
+export async function quickActionState(actionId, infoKeys) {
+    return invoke('quick_action_state', { actionId, infoKeys });
+}
+
+export async function quickActionApply(actionId, intent) {
+    return invoke('quick_action_apply', { actionId, intent });
+}
+
 // Todo: full-set load/save against the shared look-todo store. Tasks are
 // `{ id, name, done, due_date, created_at_unix_s }` (same JSON contract as
 // the macOS FFI bridge).

--- a/apps/linows/src/js/ipc.js
+++ b/apps/linows/src/js/ipc.js
@@ -169,6 +169,10 @@ export async function quickActionApply(actionId, intent) {
     return invoke('quick_action_apply', { actionId, intent });
 }
 
+export async function quickActionApplyItem(actionId, itemId, intent) {
+    return invoke('quick_action_apply_item', { actionId, itemId, intent });
+}
+
 // Todo: full-set load/save against the shared look-todo store. Tasks are
 // `{ id, name, done, due_date, created_at_unix_s }` (same JSON contract as
 // the macOS FFI bridge).

--- a/apps/linows/src/js/keyboard.js
+++ b/apps/linows/src/js/keyboard.js
@@ -17,6 +17,7 @@ import {
 } from './ipc.js';
 import * as banner from './components/banner.js';
 import * as confirm from './components/confirm.js';
+import * as qactions from './components/qactions.js';
 import * as runningApps from './components/running-apps.js';
 import { trash as trashIcon } from './icons.js';
 import {
@@ -310,6 +311,16 @@ function handleKeyDown(e) {
                 e.preventDefault();
                 if (isDiscoveryMode()) break;
                 handleTrashShortcut();
+            }
+            break;
+
+        case 'o':
+            // Ctrl+O flips the selected result's toggle Quick Action
+            // (Bluetooth, ...). Mirrors Cmd+O on macOS; no-op when the
+            // selection has none.
+            if (e.ctrlKey && !e.shiftKey && !e.altKey) {
+                e.preventDefault();
+                qactions.togglePrimary();
             }
             break;
     }

--- a/core/engine/src/index/settings.rs
+++ b/core/engine/src/index/settings.rs
@@ -5,28 +5,45 @@ use look_indexing::{Candidate, CandidateKind};
 use std::sync::mpsc;
 
 pub fn discover_system_settings_entries(tx: mpsc::SyncSender<Candidate>) {
-    // Only emit settings if the settings app is available on this system.
-    // e.g. gnome-control-center on GNOME, skip on i3/sway/minimal distros.
-    if !platform::has_settings_app() {
+    // With a settings app (gnome-control-center family), emit the whole catalog.
+    // e.g. gnome-control-center on GNOME, skipped on i3/sway/minimal distros.
+    if platform::has_settings_app() {
+        for entry in platform::settings_catalog() {
+            emit_entry(&tx, entry);
+        }
+
+        // Windows extras: classic .cpl / .msc / .exe applets that Settings
+        // doesn't cover (env vars, Device Manager, Services, Registry, Task
+        // Manager, …). Paths use the `look-cmd://` scheme so the Tauri launcher
+        // knows to spawn them via Command::new rather than ShellExecute.
+        #[cfg(target_os = "windows")]
+        emit_windows_control_panel_entries(&tx);
         return;
     }
-    for entry in platform::settings_catalog() {
-        let mut candidate = Candidate::new(
-            &candidate_id(entry),
-            CandidateKind::App,
-            entry.title,
-            &target_path(entry),
-        );
-        candidate.subtitle = Some(subtitle(entry).into());
-        let _ = tx.send(candidate);
-    }
 
-    // Windows extras: classic .cpl / .msc / .exe applets that Settings doesn't
-    // cover (env vars, Device Manager, Services, Registry, Task Manager, …).
-    // Paths use the `look-cmd://` scheme so the Tauri launcher knows to spawn
-    // them via Command::new rather than ShellExecute.
-    #[cfg(target_os = "windows")]
-    emit_windows_control_panel_entries(&tx);
+    // No settings app (KDE, sway, i3, minimal): the panel targets are
+    // gnome-control-center URLs that won't open here, so we skip them - except
+    // Bluetooth, whose quick action toggles and lists devices over BlueZ, which
+    // is desktop-agnostic. Surface just that one when a controller is present.
+    #[cfg(target_os = "linux")]
+    if platform::bluetooth_present()
+        && let Some(entry) = platform::settings_catalog()
+            .iter()
+            .find(|e| e.target == "bluetooth")
+    {
+        emit_entry(&tx, entry);
+    }
+}
+
+fn emit_entry(tx: &mpsc::SyncSender<Candidate>, entry: &SettingsCatalogEntry) {
+    let mut candidate = Candidate::new(
+        &candidate_id(entry),
+        CandidateKind::App,
+        entry.title,
+        &target_path(entry),
+    );
+    candidate.subtitle = Some(subtitle(entry).into());
+    let _ = tx.send(candidate);
 }
 
 #[cfg(target_os = "windows")]
@@ -162,7 +179,16 @@ mod tests {
             }
             total
         } else {
-            0
+            // The only no-settings-app case is Linux, which still surfaces the
+            // Bluetooth entry alone when a controller is present.
+            #[cfg(target_os = "linux")]
+            {
+                usize::from(platform::bluetooth_present())
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                0
+            }
         };
         assert_eq!(discovered.len(), expected_len);
 

--- a/core/engine/src/platform/mod.rs
+++ b/core/engine/src/platform/mod.rs
@@ -118,3 +118,14 @@ pub(crate) fn has_settings_app() -> bool {
             .unwrap_or(false)
     }
 }
+
+/// Whether a Bluetooth controller is present. Cheap filesystem probe, no D-Bus:
+/// BlueZ exposes each controller as `/sys/class/bluetooth/hciN`. Lets us surface
+/// the Bluetooth control on desktops without a settings app (KDE, sway, i3, ...),
+/// where its BlueZ-backed toggle and device list still work.
+#[cfg(target_os = "linux")]
+pub(crate) fn bluetooth_present() -> bool {
+    std::fs::read_dir("/sys/class/bluetooth")
+        .map(|mut entries| entries.any(|e| e.is_ok()))
+        .unwrap_or(false)
+}

--- a/core/qactions/src/lib.rs
+++ b/core/qactions/src/lib.rs
@@ -81,7 +81,16 @@ fn binding_for(result_id: &str, _kind: &str) -> Option<&'static str> {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
+fn binding_for(result_id: &str, _kind: &str) -> Option<&'static str> {
+    // Ids come from core/engine/src/platform/linux/settings_catalog.rs.
+    match result_id {
+        "setting:bluetooth" => Some("bluetooth"),
+        _ => None,
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
 fn binding_for(_result_id: &str, _kind: &str) -> Option<&'static str> {
     None
 }
@@ -102,6 +111,16 @@ mod tests {
     #[test]
     fn unknown_action_is_none() {
         assert!(descriptor("nope").is_none());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_bluetooth_setting_resolves_to_the_toggle() {
+        let found = descriptors_for("setting:bluetooth", "app");
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].action_id, "bluetooth");
+        // A non-actionable result yields nothing.
+        assert!(descriptors_for("setting:sound", "app").is_empty());
     }
 
     #[cfg(target_os = "macos")]

--- a/docs/writing-controls.md
+++ b/docs/writing-controls.md
@@ -18,8 +18,8 @@ has no cross-platform implementation, so we share the *declaration* and keep the
 | Piece | Location | Scope |
 |-------|----------|-------|
 | **Descriptor** — what it is: id, match, control kind, on/off labels, info fields | `core/qactions` catalog | shared, all OSes |
-| **Adapter** — how it runs: read + set the OS state (`state()` / `apply()`) | `apps/<platform>/…/QuickActions/Controls/<Name>Control.swift` | native, per OS |
-| **Registration** — wire the adapter to its action id | `…/QuickActions/ActionAdapterRegistry.swift` | native, one line |
+| **Adapter** — how it runs: read + set the OS state (`state()` / `apply()`) | macOS: `…/QuickActions/Controls/<Name>Control.swift`; linows: `…/src-tauri/src/qactions/controls/<name>.rs` | native, per OS |
+| **Registration** — wire the adapter to its action id | macOS: `…/QuickActions/ActionAdapterRegistry.swift`; linows: `qactions/mod.rs` `adapter()` | native, one line |
 
 A control is searchable **and** actionable from its single descriptor; you do not
 separately register it with the search engine. If an OS has no adapter for a
@@ -35,10 +35,13 @@ pieces sit with their peers rather than in one feature folder.)
 You edit:
 
 ```
-core/qactions/src/lib.rs                                  declare the descriptor
+core/qactions/src/lib.rs                                  declare the descriptor + per-OS result binding
 apps/macos/…/Support/QuickActions/
-  Controls/<Name>Control.swift                            your adapter (copy Bluetooth)
+  Controls/<Name>Control.swift                            macOS adapter (copy Bluetooth)
   ActionAdapterRegistry.swift                             one line: "id": Control()
+apps/linows/src-tauri/src/qactions/
+  controls/<name>.rs                                      linows adapter (copy bluetooth.rs)
+  mod.rs                                                  one line in adapter()
 ```
 
 Framework, for reference only, do not edit:
@@ -50,19 +53,28 @@ apps/macos/…/Support/UI/ToggleSwitch.swift                reusable switch comp
 apps/macos/…/Views/Launcher/QuickActionsSection.swift     renders the controls
 apps/macos/…/Views/Launcher/LauncherView+QuickActions.swift  loads state, runs actions
 bridge/ffi/src/qactions_api.rs                            exposes the catalog to Swift
+apps/linows/src-tauri/src/qactions/mod.rs                 contract + Tauri commands (edit only adapter())
+apps/linows/src/js/components/qactions.js                 renders controls, loads state, runs actions
 ```
 
 ## Steps
 
 1. **Declare** the descriptor once in the shared `core/qactions` catalog: id,
-   what result it matches (`setting:<x>`, an app kind, a bundle id), the control
-   kind (toggle/button), on/off labels, and any info fields. The key hint is
-   derived from the control kind (a toggle shows `⌘O`), so you do not set it.
-2. **Implement** the adapter. Copy the reference (`BluetoothControl.swift`),
-   rename the type, and fill in `state()` and `apply(_:)`. Keep **all**
-   OS-specific and private-API code inside this one file.
-3. **Register** it: add one line to `ActionAdapterRegistry.adapters`, e.g.
-   `"wifi": WiFiControl()`.
+   the control kind (toggle/button), on/off labels, and any info fields. Then
+   bind the result id(s) that trigger it in the per-OS `binding_for` arms
+   (result ids differ per OS: `setting:com.apple.bluetoothsettings` on macOS,
+   `setting:bluetooth` on Linux). The key hint is derived from the control kind
+   (a toggle shows `⌘O` / `Ctrl+O`), so you do not set it.
+2. **Implement** the adapter for each OS you support. Copy the reference
+   (`BluetoothControl.swift` on macOS, `controls/bluetooth.rs` on linows),
+   rename the type, and fill in `state()` and `apply(_:)` (plus `info()` on
+   linows if the descriptor declares info fields). Keep **all** OS-specific
+   and private-API code inside this one file. An OS without an adapter shows
+   the action as unavailable there; that is fine.
+3. **Register** it: one line per OS - `ActionAdapterRegistry.adapters`
+   (`"wifi": WiFiControl()`) on macOS, the `adapter()` match in
+   `qactions/mod.rs` (`"wifi" => Some(&controls::wifi::WifiControl)`) on
+   linows.
 
 ## Adapter contract
 
@@ -101,8 +113,16 @@ struct <Name>Control: SystemControl {
 }
 ```
 
+The linows contract is the Rust mirror of the same shape (see
+`apps/linows/src-tauri/src/qactions/mod.rs`): `state()`, `apply(intent)`, and an
+optional `info(keys)` that resolves the descriptor's info `value_key`s to
+display values. Adapters may block (D-Bus, CLIs); the commands run them on the
+blocking pool.
+
 ## Reference
 
 Read [`BluetoothControl.swift`](../apps/macos/LauncherApp/look-app/Support/QuickActions/Controls/BluetoothControl.swift)
-first: it is a complete, commented adapter (including how it quarantines a private
-macOS API) and the template every other control follows.
+(macOS, quarantines a private API) or
+[`bluetooth.rs`](../apps/linows/src-tauri/src/qactions/controls/bluetooth.rs)
+(linows, talks to BlueZ over D-Bus) first: each is a complete, commented
+adapter and the template every other control follows.


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added Linux Quick Actions for Bluetooth: power toggle plus paired-device connect/disconnect.
  * Introduced a Quick Actions panel with live state, device info, and execution feedback.
  * Added **Ctrl+O** shortcut to toggle the selected result’s primary Quick Action (also documented in help/settings).
* **Bug Fixes**
  * Improved GNOME extension messaging to distinguish “extensions disabled” from “re-login required.”
  * Updated settings discovery to show Bluetooth settings on Linux only when a controller is present (when the settings app isn’t available).
* **Documentation**
  * Expanded the Quick Action authoring guide with cross-OS adapter mapping.
* **Style**
  * Refined Quick Actions preview and banner UI styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Why

- #263 

## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [x] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

[Screencast From 2026-07-13 18-28-37.webm](https://github.com/user-attachments/assets/e76c3c16-7d3d-437a-b563-3b190e1b73f2)

## Checklist

- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


