### PR TITLE
fix(macos): make Quick Action toggles safe against stale panel state

### DIFF
--- a/apps/linows/src-tauri/src/qactions/controls/bluetooth.rs
+++ b/apps/linows/src-tauri/src/qactions/controls/bluetooth.rs
@@ -114,6 +114,7 @@ impl SystemControl for BluetoothControl {
         };
         let target = match intent {
             ActionIntent::Toggle => !snapshot.powered,
+            ActionIntent::SetOn(on) => on,
             ActionIntent::Run => {
                 return ActionOutcome::Failed {
                     message: "Bluetooth has no run action".to_string(),

--- a/apps/linows/src-tauri/src/qactions/mod.rs
+++ b/apps/linows/src-tauri/src/qactions/mod.rs
@@ -42,10 +42,16 @@ pub enum ActionState {
 
 /// What the user asked a control to do.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum ActionIntent {
-    /// Flip a boolean control (on <-> off).
+    /// Flip a boolean control against its live state (on <-> off).
     Toggle,
+    /// Drive a boolean control to an explicit target. The panel resolves a
+    /// toggle press to this against the state it is showing, so a press does
+    /// what the user sees even when the panel is stale (the system changed
+    /// while the window was hidden); a blind `Toggle` would flip the live state
+    /// and do the opposite. Wire form: `{ "set_on": true }`.
+    SetOn(bool),
     /// Trigger a non-toggle action (a plain button).
     Run,
 }

--- a/apps/linows/src/css/components/preview.css
+++ b/apps/linows/src/css/components/preview.css
@@ -562,6 +562,16 @@
     background: var(--control-fill);
 }
 
+/* Busy while a connect/disconnect is applying: dimmed and non-interactive. */
+.qaction-device-row.is-pending {
+    opacity: 0.5;
+    cursor: default;
+}
+
+.qaction-device-row.is-pending:hover {
+    background: none;
+}
+
 /* Hollow dot = paired but disconnected; filled accent = connected. */
 .qaction-device-dot {
     width: 7px;

--- a/apps/linows/src/css/components/preview.css
+++ b/apps/linows/src/css/components/preview.css
@@ -572,6 +572,17 @@
     background: none;
 }
 
+/* One action at a time: while any control is applying, the others (the toggle,
+   a plain button, every non-pending device row) go inert so nothing looks
+   clickable that the in-flight guard would silently swallow. The applying row
+   keeps its own .is-pending styling. */
+.preview-qactions.is-busy .qaction-toggle,
+.preview-qactions.is-busy .qaction-button,
+.preview-qactions.is-busy .qaction-device-row:not(.is-pending) {
+    opacity: 0.5;
+    pointer-events: none;
+}
+
 /* Hollow dot = paired but disconnected; filled accent = connected. */
 .qaction-device-dot {
     width: 7px;

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -552,6 +552,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         queryInput.select();
         requestIndexRefresh();
         runningApps.refresh();
+        // Quick-action state is cached from the last render; the system may have
+        // changed while hidden (Bluetooth flipped elsewhere), so re-read it.
+        preview.refreshQuickActions();
         // Re-read todos when nothing would be lost, so the quick view stays
         // fresh across day rollovers and edits from other Look clients.
         todoCmd.reloadIfClean();

--- a/apps/linows/src/js/components/preview.js
+++ b/apps/linows/src/js/components/preview.js
@@ -415,6 +415,13 @@ export function clear() {
     }
 }
 
+// Re-read the current result's Quick Action states in place. Called when the
+// window is re-shown: the selection survives hide/show, so a cached state can
+// be stale if the system changed while hidden (e.g. Bluetooth flipped).
+export function refreshQuickActions() {
+    qactions.refresh();
+}
+
 // Right half of the clipboard empty state - the "How to use" tips card that
 // pairs with the results list's "Clipboard History" info (macOS
 // ClipboardEmptyHelpView). Static content, safe as innerHTML.

--- a/apps/linows/src/js/components/qactions.js
+++ b/apps/linows/src/js/components/qactions.js
@@ -22,6 +22,7 @@ const TOGGLE_HINT = 'Ctrl+O';
 let token = 0; // bumped on every render/clear; async work checks it
 let primary = null; // handle of the first toggle action (drives Ctrl+O)
 let handles = []; // every rendered action, so a re-show can re-read their state
+let sectionEl = null; // current section, to reflect the in-flight lock in the UI
 let inFlight = false; // debounce: one apply at a time
 // Item ids currently applying (connecting/disconnecting), rendered as busy so a
 // re-click is ignored and the row reads as in-progress. Mirrors macOS pendingItems.
@@ -31,8 +32,18 @@ export function clear() {
     token += 1;
     primary = null;
     handles = [];
+    sectionEl = null;
     inFlight = false;
     pendingItems.clear();
+}
+
+// Single source of truth for the "one action at a time" lock. Flagging the
+// section busy lets CSS render every other control (the toggle, non-pending
+// device rows) inert while an action applies, so nothing looks clickable that
+// the inFlight guard would silently swallow.
+function setBusy(busy) {
+    inFlight = busy;
+    sectionEl?.classList.toggle('is-busy', busy);
 }
 
 /**
@@ -48,6 +59,7 @@ export async function render(container, result) {
 
     const section = document.createElement('div');
     section.className = 'preview-qactions';
+    sectionEl = section;
 
     for (const descriptor of descriptors) {
         const handle = buildAction(section, descriptor);
@@ -257,7 +269,7 @@ function setSwitch(handle, on) {
 // outcome, and re-read the state so the panel reflects what really happened.
 async function run(handle, intent) {
     if (inFlight) return;
-    inFlight = true;
+    setBusy(true);
     const myToken = token;
 
     // A toggle press means "the opposite of the state I am looking at", so
@@ -279,7 +291,7 @@ async function run(handle, intent) {
 // Toggle one list item (connect/disconnect a device), then reconcile as `run`.
 async function runItem(handle, item, row) {
     if (inFlight || pendingItems.has(item.id)) return;
-    inFlight = true;
+    setBusy(true);
     const myToken = token;
     // Mark the row busy so it dims and stops taking clicks while it applies.
     pendingItems.add(item.id);
@@ -327,7 +339,7 @@ async function applyAndReconcile(handle, myToken, apply, onApplied) {
         onApplied?.();
         if (token === myToken) showOutcome(handle.descriptor, null);
     } finally {
-        if (token === myToken) inFlight = false;
+        if (token === myToken) setBusy(false);
     }
 }
 

--- a/apps/linows/src/js/components/qactions.js
+++ b/apps/linows/src/js/components/qactions.js
@@ -21,12 +21,18 @@ const TOGGLE_HINT = 'Ctrl+O';
 
 let token = 0; // bumped on every render/clear; async work checks it
 let primary = null; // handle of the first toggle action (drives Ctrl+O)
+let handles = []; // every rendered action, so a re-show can re-read their state
 let inFlight = false; // debounce: one apply at a time
+// Item ids currently applying (connecting/disconnecting), rendered as busy so a
+// re-click is ignored and the row reads as in-progress. Mirrors macOS pendingItems.
+const pendingItems = new Set();
 
 export function clear() {
     token += 1;
     primary = null;
+    handles = [];
     inFlight = false;
+    pendingItems.clear();
 }
 
 /**
@@ -45,11 +51,26 @@ export async function render(container, result) {
 
     for (const descriptor of descriptors) {
         const handle = buildAction(section, descriptor);
+        handles.push(handle);
         if (descriptor.control === 'toggle' && !primary) primary = handle;
         loadStatus(handle, myToken);
     }
 
     container.appendChild(section);
+}
+
+/**
+ * Re-read every rendered action's state/info in place (no DOM rebuild). Called
+ * when the window is re-shown: it keeps its query and selection across
+ * hide/show, so the panel would otherwise render states read before the hide,
+ * stale whenever the system changed underneath (e.g. Bluetooth flipped
+ * elsewhere). Mirrors macOS refreshQuickActions on the window becoming key.
+ * Skipped mid-apply so it can't clobber the optimistic state a press just set.
+ */
+export function refresh() {
+    if (inFlight) return;
+    const myToken = token;
+    for (const handle of handles) loadStatus(handle, myToken);
 }
 
 /** Flip the selected result's primary toggle (Ctrl+O). */
@@ -187,16 +208,20 @@ function renderInfoField(handle, { container, label }, value) {
 }
 
 // One device row: a connection dot + name. When the item carries an `id` it is
-// a clickable button that toggles that device's connection.
+// a clickable button that toggles that device's connection. A row whose id is
+// still applying renders busy (dimmed, non-interactive) until the outcome lands.
 function deviceRow(handle, item) {
     const actionable = item.id != null;
+    const pending = actionable && pendingItems.has(item.id);
     const row = document.createElement(actionable ? 'button' : 'div');
     row.className = 'qaction-device-row';
     row.classList.toggle('is-connected', item.on === true);
+    row.classList.toggle('is-pending', pending);
     if (actionable) {
         row.type = 'button';
         row.tabIndex = -1;
-        row.addEventListener('click', () => runItem(handle, item));
+        row.disabled = pending;
+        row.addEventListener('click', () => runItem(handle, item, row));
     }
     row.appendChild(document.createElement('span')).className = 'qaction-device-dot';
     const nameEl = document.createElement('span');
@@ -235,22 +260,31 @@ async function run(handle, intent) {
     inFlight = true;
     const myToken = token;
 
-    // Flip a toggle immediately for instant feedback; the re-read below
-    // confirms (and corrects it if the change did not take).
+    // A toggle press means "the opposite of the state I am looking at", so
+    // resolve it to an explicit target before it reaches the adapter: a blind
+    // toggle flips the LIVE state, doing the opposite of what the user asked
+    // whenever the panel is stale. An unknown displayed state keeps the blind
+    // toggle. Flip immediately for instant feedback; the re-read below confirms.
+    let payload = intent;
     if (intent === 'toggle' && handle.isOn != null) {
+        payload = { set_on: !handle.isOn };
         setSwitch(handle, !handle.isOn);
     }
 
     await applyAndReconcile(handle, myToken, () =>
-        quickActionApply(handle.descriptor.action_id, intent),
+        quickActionApply(handle.descriptor.action_id, payload),
     );
 }
 
 // Toggle one list item (connect/disconnect a device), then reconcile as `run`.
-async function runItem(handle, item) {
-    if (inFlight) return;
+async function runItem(handle, item, row) {
+    if (inFlight || pendingItems.has(item.id)) return;
     inFlight = true;
     const myToken = token;
+    // Mark the row busy so it dims and stops taking clicks while it applies.
+    pendingItems.add(item.id);
+    row.classList.add('is-pending');
+    row.disabled = true;
     // Connecting can take a few seconds; show immediate feedback so the click
     // doesn't feel dead. The outcome banner replaces this when it lands.
     const connecting = item.on !== true;
@@ -259,8 +293,13 @@ async function runItem(handle, item) {
         'info',
         DEVICE_PENDING,
     );
-    await applyAndReconcile(handle, myToken, () =>
-        quickActionApplyItem(handle.descriptor.action_id, item.id, 'toggle'),
+    await applyAndReconcile(
+        handle,
+        myToken,
+        () => quickActionApplyItem(handle.descriptor.action_id, item.id, 'toggle'),
+        // Clear pending before the reconcile re-renders the list, so the fresh
+        // rows read from the real state instead of inheriting the busy marker.
+        () => pendingItems.delete(item.id),
     );
 }
 
@@ -270,9 +309,12 @@ async function runItem(handle, item) {
 // wedges until the selection changes. Late responses (selection moved) drop on
 // the token guard; `finally` only releases `inFlight` while we still own the
 // current token (clear() already reset it for a newer run otherwise).
-async function applyAndReconcile(handle, myToken, apply) {
+// `onApplied` (optional) runs the moment apply() resolves, before the re-read,
+// so per-item pending state clears ahead of the list rebuild.
+async function applyAndReconcile(handle, myToken, apply, onApplied) {
     try {
         const outcome = await apply();
+        onApplied?.();
         if (token !== myToken) return;
         showOutcome(handle.descriptor, outcome);
 
@@ -282,6 +324,7 @@ async function applyAndReconcile(handle, myToken, apply) {
         applyStatus(handle, status);
     } catch (err) {
         console.error('quick action failed', err);
+        onApplied?.();
         if (token === myToken) showOutcome(handle.descriptor, null);
     } finally {
         if (token === myToken) inFlight = false;

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
@@ -46,7 +46,8 @@ final class KeyboardSelectionMonitor {
         onConfirmDelete: (@MainActor () -> Void)? = nil,
         onCancelDelete: (@MainActor () -> Void)? = nil,
         deleteConfirmationActive: @escaping @MainActor () -> Bool = { false },
-        onToggleQuickAction: (@MainActor () -> Void)? = nil
+        onToggleQuickAction: (@MainActor () -> Void)? = nil,
+        hasToggleQuickAction: @escaping @MainActor () -> Bool = { false }
     ) {
         guard monitor == nil else { return }
         self.isKillConfirmationActive = killConfirmationActive
@@ -149,9 +150,14 @@ final class KeyboardSelectionMonitor {
 
             // Cmd+O toggles the selected result's toggle Quick Action (Bluetooth,
             // etc.). Multi-choice controls will use Cmd+J/K in a later pass.
-            if (event.keyCode == 31 || event.charactersIgnoringModifiers?.lowercased() == "o")
+            // Match on the typed character only, not a hardware keyCode: 31 is
+            // the physical ANSI-O position, which types another letter on
+            // Dvorak/Colemak and would hijack that chord. Only swallow the
+            // event when the selection actually has a toggle to act on.
+            if event.charactersIgnoringModifiers?.lowercased() == "o"
                 && flags == [.command]
                 && !inCommandMode()
+                && hasToggleQuickAction()
             {
                 onToggleQuickAction?()
                 return nil

--- a/apps/macos/LauncherApp/look-app/Support/QuickActions/Controls/BluetoothControl.swift
+++ b/apps/macos/LauncherApp/look-app/Support/QuickActions/Controls/BluetoothControl.swift
@@ -36,6 +36,9 @@ struct BluetoothControl: SystemControl {
     /// to re-check while waiting. The controller applies asynchronously (~100ms).
     private static let settleTimeout: TimeInterval = 1.5
     private static let pollInterval: UInt64 = 80_000_000  // 80ms in nanoseconds
+    /// Give a device connection this long before reporting failure. Matches the
+    /// linows adapter's device-action timeout.
+    static let deviceActionTimeout: TimeInterval = 6
 
     private func isPoweredOn() -> Bool {
         IOBluetoothPreferenceGetControllerPowerState() == 1
@@ -60,28 +63,38 @@ struct BluetoothControl: SystemControl {
     }
 
     /// Connects/disconnects a paired device. `itemId` is its Bluetooth address.
+    /// Connecting uses IOBluetooth's async API so the UI never blocks on the
+    /// handshake; disconnecting is quick and done inline.
     func applyItem(_ itemId: String, intent: ActionIntent) async -> ActionOutcome {
         guard intent == .toggle else {
             return .failed("Devices can only be connected or disconnected")
         }
-        // The whole lookup + connect stays on the main actor (IOBluetoothDevice
-        // is @MainActor); only the Sendable outcome crosses back.
-        return await MainActor.run {
+        let found = await MainActor.run { () -> (name: String, connected: Bool)? in
             guard let device = Self.pairedDevices().first(where: { $0.addressString == itemId }) else {
-                return .failed("Device is no longer available")
+                return nil
             }
-            let name = device.name ?? itemId
-            let connect = !device.isConnected()
-            let result: IOReturn = connect ? device.openConnection() : device.closeConnection()
-            guard result == kIOReturnSuccess else {
-                return .failed(connect ? "Failed to connect to \(name)" : "Failed to disconnect from \(name)")
-            }
-            return .ok(banner: connect ? "Connected to \(name)" : "Disconnected from \(name)")
+            return (device.name ?? itemId, device.isConnected())
         }
+        guard let found else { return .failed("Device is no longer available") }
+
+        if found.connected {
+            let result = await MainActor.run { () -> IOReturn in
+                Self.pairedDevices().first(where: { $0.addressString == itemId })?.closeConnection() ?? kIOReturnNoDevice
+            }
+            return result == kIOReturnSuccess
+                ? .ok(banner: "Disconnected from \(found.name)")
+                : .failed("Failed to disconnect from \(found.name)")
+        }
+
+        let connector = await BluetoothConnector()
+        let status = await connector.connect(address: itemId, timeout: Self.deviceActionTimeout)
+        return status == kIOReturnSuccess
+            ? .ok(banner: "Connected to \(found.name)")
+            : .failed("Failed to connect to \(found.name)")
     }
 
     @MainActor
-    private static func pairedDevices() -> [IOBluetoothDevice] {
+    fileprivate static func pairedDevices() -> [IOBluetoothDevice] {
         (IOBluetoothDevice.pairedDevices() as? [IOBluetoothDevice]) ?? []
     }
 
@@ -133,5 +146,46 @@ struct BluetoothControl: SystemControl {
             try? await Task.sleep(nanoseconds: Self.pollInterval)
         }
         return isPoweredOn() == target
+    }
+}
+
+/// Bridges `IOBluetoothDevice`'s async connection callback to Swift concurrency,
+/// so a connect never blocks the UI thread. `openConnection(_:)` returns
+/// immediately and `connectionComplete(_:status:)` fires on the run loop; a
+/// timeout guards a device that never answers. Retained by the awaiting task
+/// until the continuation resumes.
+@MainActor
+private final class BluetoothConnector: NSObject {
+    private var continuation: CheckedContinuation<IOReturn, Never>?
+    private var timeoutTask: Task<Void, Never>?
+
+    func connect(address: String, timeout: TimeInterval) async -> IOReturn {
+        guard let device = BluetoothControl.pairedDevices().first(where: { $0.addressString == address }) else {
+            return kIOReturnNoDevice
+        }
+        return await withCheckedContinuation { continuation in
+            self.continuation = continuation
+            let initiated = device.openConnection(self)
+            if initiated != kIOReturnSuccess {
+                finish(initiated)
+                return
+            }
+            timeoutTask = Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                guard !Task.isCancelled else { return }
+                self?.finish(kIOReturnTimeout)
+            }
+        }
+    }
+
+    @objc func connectionComplete(_ device: IOBluetoothDevice!, status: IOReturn) {
+        finish(status)
+    }
+
+    private func finish(_ status: IOReturn) {
+        timeoutTask?.cancel()
+        timeoutTask = nil
+        continuation?.resume(returning: status)
+        continuation = nil
     }
 }

--- a/apps/macos/LauncherApp/look-app/Support/QuickActions/Controls/BluetoothControl.swift
+++ b/apps/macos/LauncherApp/look-app/Support/QuickActions/Controls/BluetoothControl.swift
@@ -46,6 +46,61 @@ struct BluetoothControl: SystemControl {
         isPoweredOn() ? .on : .off
     }
 
+    /// Resolves "status" to the paired-device list (connected first), so the
+    /// panel can connect/disconnect each one. Falls back to a plain line when
+    /// Bluetooth is off or nothing is paired.
+    func info(keys: [String]) async -> [String: InfoValue] {
+        guard keys.contains("status") else { return [:] }
+        guard isPoweredOn() else { return ["status": .text("Off")] }
+        // IOBluetoothDevice APIs are @MainActor in the SDK; hop there. The read
+        // is cheap and returns only Sendable list items.
+        let items = await MainActor.run { Self.pairedDeviceItems() }
+        if items.isEmpty { return ["status": .text("On, no paired devices")] }
+        return ["status": .list(items)]
+    }
+
+    /// Connects/disconnects a paired device. `itemId` is its Bluetooth address.
+    func applyItem(_ itemId: String, intent: ActionIntent) async -> ActionOutcome {
+        guard intent == .toggle else {
+            return .failed("Devices can only be connected or disconnected")
+        }
+        // The whole lookup + connect stays on the main actor (IOBluetoothDevice
+        // is @MainActor); only the Sendable outcome crosses back.
+        return await MainActor.run {
+            guard let device = Self.pairedDevices().first(where: { $0.addressString == itemId }) else {
+                return .failed("Device is no longer available")
+            }
+            let name = device.name ?? itemId
+            let connect = !device.isConnected()
+            let result: IOReturn = connect ? device.openConnection() : device.closeConnection()
+            guard result == kIOReturnSuccess else {
+                return .failed(connect ? "Failed to connect to \(name)" : "Failed to disconnect from \(name)")
+            }
+            return .ok(banner: connect ? "Connected to \(name)" : "Disconnected from \(name)")
+        }
+    }
+
+    @MainActor
+    private static func pairedDevices() -> [IOBluetoothDevice] {
+        (IOBluetoothDevice.pairedDevices() as? [IOBluetoothDevice]) ?? []
+    }
+
+    /// Paired devices as list items, connected first then alphabetical.
+    @MainActor
+    private static func pairedDeviceItems() -> [QuickActionListItem] {
+        pairedDevices()
+            .compactMap { device -> QuickActionListItem? in
+                guard let address = device.addressString else { return nil }
+                return QuickActionListItem(id: address, label: device.name ?? address, on: device.isConnected())
+            }
+            .sorted { lhs, rhs in
+                let lhsOn = lhs.on ?? false
+                let rhsOn = rhs.on ?? false
+                if lhsOn != rhsOn { return lhsOn }
+                return lhs.label.localizedCaseInsensitiveCompare(rhs.label) == .orderedAscending
+            }
+    }
+
     func apply(_ intent: ActionIntent) async -> ActionOutcome {
         let target: Bool
         switch intent {

--- a/apps/macos/LauncherApp/look-app/Support/QuickActions/SystemControl.swift
+++ b/apps/macos/LauncherApp/look-app/Support/QuickActions/SystemControl.swift
@@ -41,6 +41,25 @@ enum ActionOutcome: Equatable {
     case needsPermission(String)
 }
 
+/// One entry in an `InfoValue.list`. An `id` makes the row actionable via
+/// `SystemControl.applyItem` (e.g. connect/disconnect a device); `on` drives an
+/// on/off marker (e.g. whether a device is connected). Both optional so a list
+/// can be plain, read-only rows.
+struct QuickActionListItem: Equatable, Hashable {
+    let id: String?
+    let label: String
+    let on: Bool?
+}
+
+/// A resolved info-field value. The shared descriptor declares `label` +
+/// `valueKey`; the adapter resolves the key to what to display: a single line
+/// (`text`), one row per item (`list`, e.g. paired devices), or `unavailable`.
+enum InfoValue: Equatable {
+    case text(String)
+    case list([QuickActionListItem])
+    case unavailable(String)
+}
+
 /// The adapter a contributor implements per control. Keep it small and pure:
 /// read state, apply an intent, return an outcome. Async so controls backed by
 /// AppleScript, a CLI, or the network can await without blocking the UI; simple
@@ -50,7 +69,24 @@ protocol SystemControl: Sendable {
     /// control does not apply on this machine.
     func state() async -> ActionState
 
+    /// Resolve the descriptor's info `valueKey`s to display values. Controls
+    /// without info fields keep the default (no info shown).
+    func info(keys: [String]) async -> [String: InfoValue]
+
     /// Perform `intent` and report the outcome. Best-effort: never throw, never
     /// block; surface problems as `.failed` / `.needsPermission`.
     func apply(_ intent: ActionIntent) async -> ActionOutcome
+
+    /// Act on one item of a list-valued info field (e.g. connect/disconnect a
+    /// specific device). Defaults to unsupported: most controls have no per-item
+    /// actions.
+    func applyItem(_ itemId: String, intent: ActionIntent) async -> ActionOutcome
+}
+
+extension SystemControl {
+    func info(keys: [String]) async -> [String: InfoValue] { [:] }
+
+    func applyItem(_ itemId: String, intent: ActionIntent) async -> ActionOutcome {
+        .failed("This action has no per-item actions")
+    }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+QuickActions.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+QuickActions.swift
@@ -2,11 +2,11 @@ import Foundation
 
 /// Quick Actions - data loading and execution for the info+actions panel (see
 /// docs/writing-controls.md). Descriptors come from the shared `look_qactions`
-/// catalog; each action's live state and its execution come from a native
-/// `SystemControl` adapter resolved by `actionId`.
+/// catalog; each action's live state, info (e.g. paired devices), and execution
+/// come from a native `SystemControl` adapter resolved by `actionId`.
 ///
-/// Interaction: a `.toggle` control is flipped with Cmd+O (no navigation).
-/// Multi-choice controls (future) will move between options with Cmd+J/K.
+/// Interaction: a `.toggle` control is flipped with Cmd+O; a list item (e.g. a
+/// paired device) is connected/disconnected by clicking its row.
 extension LauncherView {
     /// Banner durations (seconds) for action outcomes.
     private enum Banner {
@@ -31,37 +31,37 @@ extension LauncherView {
     var hasToggleQuickAction: Bool { toggleQuickAction != nil }
 
     /// Loads the selected result's Quick Actions and reads each one's live state
-    /// off the main thread. Cancels any in-flight read so a stale result never
-    /// populates the panel. Called on selection/query change.
+    /// and info off the main thread. Cancels any in-flight read so a stale result
+    /// never populates the panel. Called on selection/query change.
     func refreshQuickActions() {
         quickActionTask?.cancel()
 
         guard let result = selectedResultForActions else {
             if !quickActionDescriptors.isEmpty { quickActionDescriptors = [] }
             if !quickActionStates.isEmpty { quickActionStates = [:] }
+            if !quickActionInfo.isEmpty { quickActionInfo = [:] }
             return
         }
 
         let descriptors = bridge.quickActions(forResultID: result.id, kind: result.kind.rawValue)
         quickActionDescriptors = descriptors
         quickActionStates = [:]
+        quickActionInfo = [:]
         guard !descriptors.isEmpty else { return }
 
         let resultID = result.id
         quickActionTask = Task {
             for descriptor in descriptors {
                 guard !Task.isCancelled else { return }
-                let state: ActionState
-                if let adapter = ActionAdapterRegistry.adapter(for: descriptor.actionId) {
-                    state = await adapter.state()
-                } else {
-                    state = .unavailable("Not supported on this Mac")
-                }
+                let adapter = ActionAdapterRegistry.adapter(for: descriptor.actionId)
+                let state = await adapter?.state() ?? .unavailable("Not supported on this Mac")
+                let info = await adapter?.info(keys: descriptor.info.map(\.valueKey)) ?? [:]
                 guard !Task.isCancelled else { return }
                 await MainActor.run {
                     // Drop the read if the selection moved on while we awaited.
                     guard selectedResultID == resultID else { return }
                     quickActionStates[descriptor.actionId] = state
+                    quickActionInfo[descriptor.actionId] = info
                 }
             }
         }
@@ -74,7 +74,7 @@ extension LauncherView {
     }
 
     /// Runs a specific action's intent (from a click or a key), shows the
-    /// outcome, and refreshes its state. Shared by the toggle switch and Cmd+O.
+    /// outcome, and reloads its state + info. Shared by the toggle and Cmd+O.
     func runQuickAction(_ descriptor: QuickActionDescriptor, intent: ActionIntent) {
         guard let adapter = ActionAdapterRegistry.adapter(for: descriptor.actionId) else {
             showBanner("\(descriptor.title) is not available", style: .info, duration: Banner.unavailable)
@@ -104,20 +104,42 @@ extension LauncherView {
 
         Task {
             let outcome = await adapter.apply(intent)
-            await MainActor.run {
-                switch outcome {
-                case .ok(let banner):
-                    showBanner(banner ?? "\(descriptor.title) done", style: .success, duration: Banner.success)
-                case .failed(let message):
-                    showBanner(message, style: .error, duration: Banner.error)
-                case .needsPermission(let message):
-                    showBanner(message, style: .info, duration: Banner.needsPermission)
-                }
-            }
-            let state = await adapter.state()
-            await MainActor.run {
-                quickActionStates[descriptor.actionId] = state
-            }
+            await MainActor.run { showOutcomeBanner(outcome, fallback: "\(descriptor.title) done") }
+            await reloadQuickAction(descriptor)
+        }
+    }
+
+    /// Connects/disconnects a list item (a paired device) when its row is
+    /// clicked in the panel.
+    func activateQuickActionItem(_ descriptor: QuickActionDescriptor, itemId: String) {
+        guard let adapter = ActionAdapterRegistry.adapter(for: descriptor.actionId) else { return }
+        Task {
+            let outcome = await adapter.applyItem(itemId, intent: .toggle)
+            await MainActor.run { showOutcomeBanner(outcome, fallback: "Done") }
+            await reloadQuickAction(descriptor)
+        }
+    }
+
+    /// Re-reads one action's live state + info after an apply, so the toggle and
+    /// device list stay truthful without a full refresh.
+    private func reloadQuickAction(_ descriptor: QuickActionDescriptor) async {
+        guard let adapter = ActionAdapterRegistry.adapter(for: descriptor.actionId) else { return }
+        let state = await adapter.state()
+        let info = await adapter.info(keys: descriptor.info.map(\.valueKey))
+        await MainActor.run {
+            quickActionStates[descriptor.actionId] = state
+            quickActionInfo[descriptor.actionId] = info
+        }
+    }
+
+    private func showOutcomeBanner(_ outcome: ActionOutcome, fallback: String) {
+        switch outcome {
+        case .ok(let banner):
+            showBanner(banner ?? fallback, style: .success, duration: Banner.success)
+        case .failed(let message):
+            showBanner(message, style: .error, duration: Banner.error)
+        case .needsPermission(let message):
+            showBanner(message, style: .info, duration: Banner.needsPermission)
         }
     }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+QuickActions.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+QuickActions.swift
@@ -33,6 +33,37 @@ extension LauncherView {
     /// Whether Cmd+O has a toggle to act on for the current selection.
     var hasToggleQuickAction: Bool { toggleQuickAction != nil }
 
+    /// The actions with something applying right now: the action itself (a toggle
+    /// mid-flip) or one of its list items (a device connecting). One action at a time.
+    ///
+    /// Scoped to the action, not the whole panel. Powering the controller down while one
+    /// of its devices is still connecting is a real race, so a busy action must not take
+    /// another press. But a Bluetooth connect can take seconds, and freezing every other
+    /// control for its duration would be wrong the moment a second adapter exists. linows
+    /// locks globally; with Bluetooth as the only action today the two are
+    /// indistinguishable, and this one stays right when that stops being true.
+    ///
+    /// Derived once here and handed to the view, so the guard and what the panel draws
+    /// can never disagree about which controls are live.
+    var busyQuickActionIds: Set<String> {
+        Set(
+            quickActionDescriptors
+                .filter { descriptor in
+                    pendingQuickActions.contains(descriptor.actionId)
+                        || quickActionItemIds(descriptor).contains(where: pendingQuickActions.contains)
+                }
+                .map(\.actionId)
+        )
+    }
+
+    /// Every list-item id this action currently shows (e.g. its paired devices).
+    private func quickActionItemIds(_ descriptor: QuickActionDescriptor) -> [String] {
+        (quickActionInfo[descriptor.actionId] ?? [:]).values.flatMap { value -> [String] in
+            guard case .list(let items) = value else { return [] }
+            return items.compactMap(\.id)
+        }
+    }
+
     /// Loads the selected result's Quick Actions and reads each one's live state
     /// and info off the main thread. Cancels any in-flight read so a stale result
     /// never populates the panel. Called on selection/query change.
@@ -43,13 +74,27 @@ extension LauncherView {
             if !quickActionDescriptors.isEmpty { quickActionDescriptors = [] }
             if !quickActionStates.isEmpty { quickActionStates = [:] }
             if !quickActionInfo.isEmpty { quickActionInfo = [:] }
+            quickActionsLoadedResultID = nil
             return
         }
 
         let descriptors = bridge.quickActions(forResultID: result.id, kind: result.kind.rawValue)
         quickActionDescriptors = descriptors
-        quickActionStates = [:]
-        quickActionInfo = [:]
+
+        // Only a *different* result invalidates what the panel is showing. Re-reading
+        // the same one (a window show, a re-render) keeps its resolved state until the
+        // fresh values land, so the toggle does not blink back to its dimmed loading
+        // look every time, and the unresolved-state window that `togglePrimaryQuickAction`
+        // has to refuse to act in stays as narrow as possible.
+        //
+        // Carrying state across a selection change would be the worse bug: the new
+        // result's panel would show the previous result's toggle.
+        if quickActionsLoadedResultID != result.id {
+            quickActionStates = [:]
+            quickActionInfo = [:]
+            quickActionsLoadedResultID = result.id
+        }
+
         guard !descriptors.isEmpty else { return }
 
         let resultID = result.id
@@ -67,7 +112,9 @@ extension LauncherView {
         }
     }
 
-    /// Flips the selected result's primary toggle (Cmd+O).
+    /// Flips the selected result's primary toggle (Cmd+O). A toggle whose state has not
+    /// resolved yet is refused by `runQuickAction`, the same way `ToggleSwitch` renders
+    /// it dimmed and `.disabled` to a click.
     func togglePrimaryQuickAction() {
         guard let descriptor = toggleQuickAction else { return }
         runQuickAction(descriptor, intent: .toggle)
@@ -80,23 +127,29 @@ extension LauncherView {
             showBanner("\(descriptor.title) is not available", style: .info, duration: Banner.unavailable)
             return
         }
-        // Ignore a re-press while this action is still applying.
+        // Ignore a press while anything under this action is still applying, including
+        // one of its devices connecting: flipping the controller off mid-connect races
+        // the apply and the re-read that follows it.
         let key = descriptor.actionId
-        guard !pendingQuickActions.contains(key) else { return }
+        guard !busyQuickActionIds.contains(key) else { return }
         let resultID = selectedResultID
 
-        // A toggle press means "the opposite of the state I am looking at", so
-        // resolve it to an explicit target before it reaches the adapter:
-        // apply(.toggle) flips the LIVE state, which does the opposite of what
-        // the user asked whenever the panel is stale (the system changed while
-        // the launcher was hidden). An unknown displayed state keeps the blind
-        // toggle.
+        // A toggle press means "the opposite of the state I am looking at", so resolve
+        // it to an explicit target before it reaches the adapter: apply(.toggle) flips
+        // the LIVE state, which does the opposite of what the user asked whenever the
+        // panel is stale (the system changed while the launcher was hidden).
+        //
+        // With no displayed state there is nothing to take the opposite of, so refuse
+        // rather than fall back to that blind flip. Enforced here, at the one point every
+        // caller passes through, so no future entry point can reintroduce it: the click
+        // is already blocked upstream by `ToggleSwitch` rendering an unresolved state as
+        // dimmed and `.disabled`, but Cmd+O reaches this function directly.
         var intent = intent
         if intent == .toggle {
             switch quickActionStates[descriptor.actionId] {
             case .on?: intent = .setOn(false)
             case .off?: intent = .setOn(true)
-            default: break
+            default: return
             }
         }
 
@@ -123,7 +176,9 @@ extension LauncherView {
     func activateQuickActionItem(_ descriptor: QuickActionDescriptor, item: QuickActionListItem) {
         guard let itemId = item.id,
             let adapter = ActionAdapterRegistry.adapter(for: descriptor.actionId),
-            !pendingQuickActions.contains(itemId)  // ignore a re-click while in flight
+            // Ignore a re-click on this row, and a click on a sibling row or the toggle,
+            // while anything under this action is applying.
+            !busyQuickActionIds.contains(descriptor.actionId)
         else { return }
         let resultID = selectedResultID
 

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+QuickActions.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+QuickActions.swift
@@ -80,6 +80,10 @@ extension LauncherView {
             showBanner("\(descriptor.title) is not available", style: .info, duration: Banner.unavailable)
             return
         }
+        // Ignore a re-press while this action is still applying.
+        let key = descriptor.actionId
+        guard !pendingQuickActions.contains(key) else { return }
+        let resultID = selectedResultID
 
         // A toggle press means "the opposite of the state I am looking at", so
         // resolve it to an explicit target before it reaches the adapter:
@@ -102,10 +106,14 @@ extension LauncherView {
             quickActionStates[descriptor.actionId] = on ? .on : .off
         }
 
+        pendingQuickActions.insert(key)
         Task {
             let outcome = await adapter.apply(intent)
-            await MainActor.run { showOutcomeBanner(outcome, fallback: "\(descriptor.title) done") }
-            await reloadQuickAction(descriptor)
+            await MainActor.run {
+                pendingQuickActions.remove(key)
+                showOutcomeBanner(outcome, fallback: "\(descriptor.title) done")
+            }
+            await reloadQuickAction(descriptor, resultID: resultID)
         }
     }
 
@@ -114,25 +122,35 @@ extension LauncherView {
     /// can take a moment; the outcome banner replaces it when it finishes.
     func activateQuickActionItem(_ descriptor: QuickActionDescriptor, item: QuickActionListItem) {
         guard let itemId = item.id,
-            let adapter = ActionAdapterRegistry.adapter(for: descriptor.actionId)
+            let adapter = ActionAdapterRegistry.adapter(for: descriptor.actionId),
+            !pendingQuickActions.contains(itemId)  // ignore a re-click while in flight
         else { return }
+        let resultID = selectedResultID
 
         let disconnecting = item.on == true
         let progress = disconnecting ? "Disconnecting from \(item.label)…" : "Connecting to \(item.label)…"
         showBanner(progress, style: .info, duration: Banner.inProgress)
 
+        pendingQuickActions.insert(itemId)
         Task {
             let outcome = await adapter.applyItem(itemId, intent: .toggle)
-            await MainActor.run { showOutcomeBanner(outcome, fallback: "Done") }
-            await reloadQuickAction(descriptor)
+            await MainActor.run {
+                pendingQuickActions.remove(itemId)
+                showOutcomeBanner(outcome, fallback: "Done")
+            }
+            await reloadQuickAction(descriptor, resultID: resultID)
         }
     }
 
     /// Re-reads one action's live state + info after an apply, so the toggle and
-    /// device list stay truthful without a full refresh.
-    private func reloadQuickAction(_ descriptor: QuickActionDescriptor) async {
+    /// device list stay truthful without a full refresh. Drops the write if the
+    /// selection changed while the (slow) apply was in flight.
+    private func reloadQuickAction(_ descriptor: QuickActionDescriptor, resultID: String?) async {
         let (state, info) = await readQuickAction(descriptor)
-        await MainActor.run { apply(state: state, info: info, for: descriptor) }
+        await MainActor.run {
+            guard selectedResultID == resultID else { return }
+            apply(state: state, info: info, for: descriptor)
+        }
     }
 
     /// Reads an action's live state and info from its adapter (or `.unavailable`

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+QuickActions.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+QuickActions.swift
@@ -81,14 +81,25 @@ extension LauncherView {
             return
         }
 
-        // Flip a toggle immediately for instant feedback; the re-read below
-        // confirms (and corrects it if the change did not take).
+        // A toggle press means "the opposite of the state I am looking at", so
+        // resolve it to an explicit target before it reaches the adapter:
+        // apply(.toggle) flips the LIVE state, which does the opposite of what
+        // the user asked whenever the panel is stale (the system changed while
+        // the launcher was hidden). An unknown displayed state keeps the blind
+        // toggle.
+        var intent = intent
         if intent == .toggle {
             switch quickActionStates[descriptor.actionId] {
-            case .on?: quickActionStates[descriptor.actionId] = .off
-            case .off?: quickActionStates[descriptor.actionId] = .on
+            case .on?: intent = .setOn(false)
+            case .off?: intent = .setOn(true)
             default: break
             }
+        }
+
+        // Show the target immediately for instant feedback; the re-read below
+        // confirms (and corrects it if the change did not take).
+        if case .setOn(let on) = intent {
+            quickActionStates[descriptor.actionId] = on ? .on : .off
         }
 
         Task {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+QuickActions.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+QuickActions.swift
@@ -56,15 +56,12 @@ extension LauncherView {
         quickActionTask = Task {
             for descriptor in descriptors {
                 guard !Task.isCancelled else { return }
-                let adapter = ActionAdapterRegistry.adapter(for: descriptor.actionId)
-                let state = await adapter?.state() ?? .unavailable("Not supported on this Mac")
-                let info = await adapter?.info(keys: descriptor.info.map(\.valueKey)) ?? [:]
+                let (state, info) = await readQuickAction(descriptor)
                 guard !Task.isCancelled else { return }
                 await MainActor.run {
                     // Drop the read if the selection moved on while we awaited.
                     guard selectedResultID == resultID else { return }
-                    quickActionStates[descriptor.actionId] = state
-                    quickActionInfo[descriptor.actionId] = info
+                    apply(state: state, info: info, for: descriptor)
                 }
             }
         }
@@ -134,13 +131,26 @@ extension LauncherView {
     /// Re-reads one action's live state + info after an apply, so the toggle and
     /// device list stay truthful without a full refresh.
     private func reloadQuickAction(_ descriptor: QuickActionDescriptor) async {
-        guard let adapter = ActionAdapterRegistry.adapter(for: descriptor.actionId) else { return }
+        let (state, info) = await readQuickAction(descriptor)
+        await MainActor.run { apply(state: state, info: info, for: descriptor) }
+    }
+
+    /// Reads an action's live state and info from its adapter (or `.unavailable`
+    /// when no adapter is registered on this OS). Shared by the initial load and
+    /// the post-apply reload.
+    private func readQuickAction(_ descriptor: QuickActionDescriptor) async -> (ActionState, [String: InfoValue]) {
+        guard let adapter = ActionAdapterRegistry.adapter(for: descriptor.actionId) else {
+            return (.unavailable("Not supported on this Mac"), [:])
+        }
         let state = await adapter.state()
         let info = await adapter.info(keys: descriptor.info.map(\.valueKey))
-        await MainActor.run {
-            quickActionStates[descriptor.actionId] = state
-            quickActionInfo[descriptor.actionId] = info
-        }
+        return (state, info)
+    }
+
+    /// Stores a read result into the panel state. Main-actor only.
+    private func apply(state: ActionState, info: [String: InfoValue], for descriptor: QuickActionDescriptor) {
+        quickActionStates[descriptor.actionId] = state
+        quickActionInfo[descriptor.actionId] = info
     }
 
     private func showOutcomeBanner(_ outcome: ActionOutcome, fallback: String) {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+QuickActions.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+QuickActions.swift
@@ -14,6 +14,9 @@ extension LauncherView {
         static let error: TimeInterval = 1.6
         static let needsPermission: TimeInterval = 2.2
         static let unavailable: TimeInterval = 1.4
+        /// "Connecting to…" stays until the outcome replaces it; long enough to
+        /// outlast a device connect that times out (deviceActionTimeout + buffer).
+        static let inProgress: TimeInterval = 8
     }
 
     /// The selected result, if it is a real candidate (not a synthesized row).
@@ -110,9 +113,17 @@ extension LauncherView {
     }
 
     /// Connects/disconnects a list item (a paired device) when its row is
-    /// clicked in the panel.
-    func activateQuickActionItem(_ descriptor: QuickActionDescriptor, itemId: String) {
-        guard let adapter = ActionAdapterRegistry.adapter(for: descriptor.actionId) else { return }
+    /// clicked. Shows an immediate "Connecting to…" banner because the operation
+    /// can take a moment; the outcome banner replaces it when it finishes.
+    func activateQuickActionItem(_ descriptor: QuickActionDescriptor, item: QuickActionListItem) {
+        guard let itemId = item.id,
+            let adapter = ActionAdapterRegistry.adapter(for: descriptor.actionId)
+        else { return }
+
+        let disconnecting = item.on == true
+        let progress = disconnecting ? "Disconnecting from \(item.label)…" : "Connecting to \(item.label)…"
+        showBanner(progress, style: .info, duration: Banner.inProgress)
+
         Task {
             let outcome = await adapter.applyItem(itemId, intent: .toggle)
             await MainActor.run { showOutcomeBanner(outcome, fallback: "Done") }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
@@ -228,6 +228,9 @@ extension LauncherView {
             },
             onToggleQuickAction: { [self] in
                 togglePrimaryQuickAction()
+            },
+            hasToggleQuickAction: { [self] in
+                hasToggleQuickAction
             }
         )
     }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -1048,8 +1048,8 @@ struct LauncherView: View {
                     onRunQuickAction: { descriptor, intent in
                         runQuickAction(descriptor, intent: intent)
                     },
-                    onActivateQuickActionItem: { descriptor, itemId in
-                        activateQuickActionItem(descriptor, itemId: itemId)
+                    onActivateQuickActionItem: { descriptor, item in
+                        activateQuickActionItem(descriptor, item: item)
                     },
                     onDeleteClipboard: selectedResult.kind == .clipboard
                         ? { deleteClipboardResult(resultID: selectedResult.id) }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -50,6 +50,10 @@ struct LauncherView: View {
     // Resolved info values per action (actionId -> valueKey -> value), e.g. the
     // Bluetooth "status" key resolving to the paired-device list.
     @State var quickActionInfo: [String: [String: InfoValue]] = [:]
+    // In-flight action keys (an action id for a toggle, an item id for a list
+    // row), so a second press can't race a running connect/toggle. Keys don't
+    // collide: action ids are short slugs, item ids are device addresses.
+    @State var pendingQuickActions: Set<String> = []
     @State var quickActionTask: Task<Void, Never>?
     @State var selectedResultID: String?
     @State var pickedKeys: [String] = []
@@ -1045,6 +1049,7 @@ struct LauncherView: View {
                     quickActions: quickActionDescriptors,
                     quickActionStates: quickActionStates,
                     quickActionInfo: quickActionInfo,
+                    pendingQuickActionItems: pendingQuickActions,
                     onRunQuickAction: { descriptor, intent in
                         runQuickAction(descriptor, intent: intent)
                     },

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -47,6 +47,10 @@ struct LauncherView: View {
     // Quick Actions for the selected result (see docs/writing-controls.md).
     @State var quickActionDescriptors: [QuickActionDescriptor] = []
     @State var quickActionStates: [String: ActionState] = [:]
+    // The result `quickActionStates`/`quickActionInfo` were read for. Lets a refresh
+    // of the SAME result keep showing what it already resolved, instead of blanking
+    // the panel back to "loading" on every window show and re-render.
+    @State var quickActionsLoadedResultID: String?
     // Resolved info values per action (actionId -> valueKey -> value), e.g. the
     // Bluetooth "status" key resolving to the paired-device list.
     @State var quickActionInfo: [String: [String: InfoValue]] = [:]
@@ -1050,6 +1054,7 @@ struct LauncherView: View {
                     quickActionStates: quickActionStates,
                     quickActionInfo: quickActionInfo,
                     pendingQuickActionItems: pendingQuickActions,
+                    busyQuickActionIds: busyQuickActionIds,
                     onRunQuickAction: { descriptor, intent in
                         runQuickAction(descriptor, intent: intent)
                     },

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -718,6 +718,19 @@ struct LauncherView: View {
             }
             refreshClipboardMonitoringMode()
         }
+        .onReceive(
+            NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)
+        ) { notification in
+            // Quick-action state is cached and otherwise refreshed only when
+            // the selection changes. The window keeps its query and selection
+            // across hide/show, so on re-show the panel would keep states read
+            // before the hide - stale whenever the system changed underneath
+            // (e.g. Bluetooth flipped in Control Center). Re-read on every show.
+            guard let window = notification.object as? NSWindow,
+                window === launcherWindow()
+            else { return }
+            refreshQuickActions()
+        }
         .onReceive(NotificationCenter.default.publisher(for: .lookReloadConfigRequested)) { _ in
             reloadConfig()
         }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -47,6 +47,9 @@ struct LauncherView: View {
     // Quick Actions for the selected result (see docs/writing-controls.md).
     @State var quickActionDescriptors: [QuickActionDescriptor] = []
     @State var quickActionStates: [String: ActionState] = [:]
+    // Resolved info values per action (actionId -> valueKey -> value), e.g. the
+    // Bluetooth "status" key resolving to the paired-device list.
+    @State var quickActionInfo: [String: [String: InfoValue]] = [:]
     @State var quickActionTask: Task<Void, Never>?
     @State var selectedResultID: String?
     @State var pickedKeys: [String] = []
@@ -1041,8 +1044,12 @@ struct LauncherView: View {
                     result: selectedResult,
                     quickActions: quickActionDescriptors,
                     quickActionStates: quickActionStates,
+                    quickActionInfo: quickActionInfo,
                     onRunQuickAction: { descriptor, intent in
                         runQuickAction(descriptor, intent: intent)
+                    },
+                    onActivateQuickActionItem: { descriptor, itemId in
+                        activateQuickActionItem(descriptor, itemId: itemId)
                     },
                     onDeleteClipboard: selectedResult.kind == .clipboard
                         ? { deleteClipboardResult(resultID: selectedResult.id) }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/QuickActionsSection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/QuickActionsSection.swift
@@ -16,7 +16,7 @@ struct QuickActionsSection: View {
     /// A control was activated by click (Cmd+O runs the same path).
     var onRun: (QuickActionDescriptor, ActionIntent) -> Void = { _, _ in }
     /// A list item (e.g. a device row) was clicked to connect/disconnect.
-    var onActivateItem: (QuickActionDescriptor, String) -> Void = { _, _ in }
+    var onActivateItem: (QuickActionDescriptor, QuickActionListItem) -> Void = { _, _ in }
 
     private enum Layout {
         static let rowSpacing: CGFloat = 6
@@ -31,7 +31,7 @@ struct QuickActionsSection: View {
                     info: info[descriptor.actionId] ?? [:],
                     themeStore: themeStore,
                     onRun: { intent in onRun(descriptor, intent) },
-                    onActivateItem: { itemId in onActivateItem(descriptor, itemId) }
+                    onActivateItem: { item in onActivateItem(descriptor, item) }
                 )
             }
         }
@@ -45,7 +45,7 @@ private struct QuickActionControl: View {
     let info: [String: InfoValue]
     let themeStore: ThemeStore
     let onRun: (ActionIntent) -> Void
-    let onActivateItem: (String) -> Void
+    let onActivateItem: (QuickActionListItem) -> Void
 
     private enum Layout {
         static let sectionSpacing: CGFloat = 4
@@ -55,11 +55,9 @@ private struct QuickActionControl: View {
         static let verticalPadding: CGFloat = 8
         static let cornerRadius: CGFloat = 8
         static let rowBackgroundOpacity = 0.18
-        static let itemBackgroundOpacity = 0.10
         static let toggleKeyHint = "⌘O"
         static let hintFontSizeDelta: CGFloat = 3
         static let minHintFontSize: CGFloat = 10
-        static let dotSize: CGFloat = 7
         static let itemSpacing: CGFloat = 3
         static let listTopPadding: CGFloat = 2
     }
@@ -136,42 +134,13 @@ private struct QuickActionControl: View {
         case .list(let items):
             VStack(spacing: Layout.itemSpacing) {
                 ForEach(items, id: \.self) { item in
-                    deviceRow(item)
+                    DeviceRow(item: item, hintFont: hintFont, themeStore: themeStore) {
+                        onActivateItem(item)
+                    }
                 }
             }
             .padding(.top, Layout.listTopPadding)
         }
-    }
-
-    private func deviceRow(_ item: QuickActionListItem) -> some View {
-        Button {
-            if let id = item.id { onActivateItem(id) }
-        } label: {
-            HStack(spacing: Layout.controlSpacing) {
-                Circle()
-                    .fill(item.on == true ? Color.green : Color.clear)
-                    .overlay(Circle().strokeBorder(themeStore.mutedTextColor(), lineWidth: item.on == true ? 0 : 1))
-                    .frame(width: Layout.dotSize, height: Layout.dotSize)
-                Text(item.label)
-                    .font(hintFont)
-                    .foregroundStyle(themeStore.fontColor())
-                    .lineLimit(1)
-                Spacer(minLength: 0)
-                if item.on == true {
-                    Text("Connected")
-                        .font(hintFont)
-                        .foregroundStyle(themeStore.mutedTextColor())
-                }
-            }
-            .padding(.horizontal, Layout.horizontalPadding)
-            .padding(.vertical, Layout.verticalPadding / 2)
-            .background(
-                themeStore.dividerColor().opacity(Layout.itemBackgroundOpacity),
-                in: RoundedRectangle(cornerRadius: Layout.cornerRadius, style: .continuous)
-            )
-        }
-        .buttonStyle(.plain)
-        .disabled(item.id == nil)
     }
 
     // MARK: - Helpers
@@ -201,5 +170,62 @@ private struct QuickActionControl: View {
         Text(text)
             .font(themeStore.uiFont(size: hintFontSize, weight: .semibold))
             .foregroundStyle(themeStore.mutedTextColor())
+    }
+}
+
+/// One paired-device row: a connection dot, the name, and a "Connected" marker.
+/// Clickable to connect/disconnect, with a hover highlight so it reads as active.
+private struct DeviceRow: View {
+    let item: QuickActionListItem
+    let hintFont: Font
+    let themeStore: ThemeStore
+    let onActivate: () -> Void
+
+    @State private var hovering = false
+
+    private enum Layout {
+        static let spacing: CGFloat = 8
+        static let horizontalPadding: CGFloat = 10
+        static let verticalPadding: CGFloat = 4
+        static let cornerRadius: CGFloat = 8
+        static let dotSize: CGFloat = 7
+        static let restOpacity = 0.10
+        static let hoverOpacity = 0.28
+    }
+
+    var body: some View {
+        Button(action: onActivate) {
+            HStack(spacing: Layout.spacing) {
+                Circle()
+                    .fill(item.on == true ? Color.green : Color.clear)
+                    .overlay(Circle().strokeBorder(themeStore.mutedTextColor(), lineWidth: item.on == true ? 0 : 1))
+                    .frame(width: Layout.dotSize, height: Layout.dotSize)
+                Text(item.label)
+                    .font(hintFont)
+                    .foregroundStyle(themeStore.fontColor())
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+                if item.on == true {
+                    Text("Connected")
+                        .font(hintFont)
+                        .foregroundStyle(themeStore.mutedTextColor())
+                }
+            }
+            .padding(.horizontal, Layout.horizontalPadding)
+            .padding(.vertical, Layout.verticalPadding)
+            .background(
+                themeStore.dividerColor().opacity(hovering ? Layout.hoverOpacity : Layout.restOpacity),
+                in: RoundedRectangle(cornerRadius: Layout.cornerRadius, style: .continuous)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(item.id == nil)
+        .onHover { inside in
+            hovering = inside
+            if item.id != nil {
+                inside ? NSCursor.pointingHand.push() : NSCursor.pop()
+            }
+        }
     }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/QuickActionsSection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/QuickActionsSection.swift
@@ -129,7 +129,7 @@ private struct QuickActionControl: View {
         case .list(let items):
             // A summary line (e.g. "Status: N connected"), then one row per item.
             VStack(alignment: .leading, spacing: Layout.itemSpacing) {
-                statusRow(label: field.label, value: connectedSummary(items))
+                statusRow(label: field.label, value: listSummary(items))
                 ForEach(items, id: \.self) { item in
                     ListItemRow(
                         item: item,
@@ -160,7 +160,12 @@ private struct QuickActionControl: View {
         .padding(.horizontal, Layout.horizontalPadding)
     }
 
-    private func connectedSummary(_ items: [QuickActionListItem]) -> String {
+    /// Summary shown next to a list's label. A connectivity list (items carry an
+    /// on/off marker) reports how many are on; a plain list just reports its size.
+    private func listSummary(_ items: [QuickActionListItem]) -> String {
+        guard items.contains(where: { $0.on != nil }) else {
+            return "\(items.count)"
+        }
         let connected = items.filter { $0.on == true }.count
         return "\(connected) connected"
     }
@@ -229,10 +234,11 @@ private struct ListItemRow: View {
     var body: some View {
         Button(action: onActivate) {
             HStack(spacing: Layout.spacing) {
-                // Filled dot = connected, hollow = paired but not connected.
+                // Filled = on, hollow = off, invisible = no on/off (plain item).
+                // The clear placeholder keeps labels aligned across a mixed list.
                 Circle()
                     .fill(item.on == true ? themeStore.fontColor() : Color.clear)
-                    .overlay(Circle().strokeBorder(themeStore.mutedTextColor(), lineWidth: item.on == true ? 0 : 1))
+                    .overlay(Circle().strokeBorder(themeStore.mutedTextColor(), lineWidth: item.on == false ? 1 : 0))
                     .frame(width: Layout.dotSize, height: Layout.dotSize)
                 Text(item.label)
                     .font(hintFont)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/QuickActionsSection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/QuickActionsSection.swift
@@ -110,29 +110,22 @@ private struct QuickActionControl: View {
     private var infoFields: some View {
         ForEach(descriptor.info, id: \.valueKey) { field in
             if let value = info[field.valueKey] {
-                infoField(value)
+                infoField(field, value)
             }
         }
     }
 
     @ViewBuilder
-    private func infoField(_ value: InfoValue) -> some View {
+    private func infoField(_ field: QuickActionInfoField, _ value: InfoValue) -> some View {
         switch value {
         case .text(let text):
-            // The toggle already conveys plain On/Off; only show extra detail.
-            if text != "On" && text != "Off" {
-                Text(text)
-                    .font(hintFont)
-                    .foregroundStyle(themeStore.mutedTextColor())
-                    .padding(.horizontal, Layout.horizontalPadding)
-            }
+            statusRow(label: field.label, value: text)
         case .unavailable(let reason):
-            Text(reason)
-                .font(hintFont)
-                .foregroundStyle(themeStore.mutedTextColor())
-                .padding(.horizontal, Layout.horizontalPadding)
+            statusRow(label: field.label, value: reason)
         case .list(let items):
-            VStack(spacing: Layout.itemSpacing) {
+            // A "Status: N connected" summary line, then one row per device.
+            VStack(alignment: .leading, spacing: Layout.itemSpacing) {
+                statusRow(label: field.label, value: connectedSummary(items))
                 ForEach(items, id: \.self) { item in
                     DeviceRow(item: item, hintFont: hintFont, themeStore: themeStore) {
                         onActivateItem(item)
@@ -141,6 +134,26 @@ private struct QuickActionControl: View {
             }
             .padding(.top, Layout.listTopPadding)
         }
+    }
+
+    /// A label/value line matching `InfoRow` (Kind, Path), used for the status.
+    private func statusRow(label: String, value: String) -> some View {
+        HStack {
+            Text(label)
+                .font(infoFont)
+                .foregroundStyle(themeStore.mutedTextColor())
+            Spacer(minLength: 0)
+            Text(value)
+                .font(infoFont)
+                .foregroundStyle(themeStore.secondaryTextColor())
+                .lineLimit(1)
+        }
+        .padding(.horizontal, Layout.horizontalPadding)
+    }
+
+    private func connectedSummary(_ items: [QuickActionListItem]) -> String {
+        let connected = items.filter { $0.on == true }.count
+        return "\(connected) connected"
     }
 
     // MARK: - Helpers
@@ -164,6 +177,11 @@ private struct QuickActionControl: View {
 
     private var hintFont: Font {
         themeStore.uiFont(size: hintFontSize, weight: .regular)
+    }
+
+    /// Label/value font for info rows, matching `InfoRow` (Kind, Path, Status).
+    private var infoFont: Font {
+        themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular)
     }
 
     private func keyHint(_ text: String) -> some View {
@@ -196,8 +214,9 @@ private struct DeviceRow: View {
     var body: some View {
         Button(action: onActivate) {
             HStack(spacing: Layout.spacing) {
+                // Filled dot = connected, hollow = paired but not connected.
                 Circle()
-                    .fill(item.on == true ? Color.green : Color.clear)
+                    .fill(item.on == true ? themeStore.fontColor() : Color.clear)
                     .overlay(Circle().strokeBorder(themeStore.mutedTextColor(), lineWidth: item.on == true ? 0 : 1))
                     .frame(width: Layout.dotSize, height: Layout.dotSize)
                 Text(item.label)
@@ -205,11 +224,6 @@ private struct DeviceRow: View {
                     .foregroundStyle(themeStore.fontColor())
                     .lineLimit(1)
                 Spacer(minLength: 0)
-                if item.on == true {
-                    Text("Connected")
-                        .font(hintFont)
-                        .foregroundStyle(themeStore.mutedTextColor())
-                }
             }
             .padding(.horizontal, Layout.horizontalPadding)
             .padding(.vertical, Layout.verticalPadding)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/QuickActionsSection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/QuickActionsSection.swift
@@ -123,11 +123,11 @@ private struct QuickActionControl: View {
         case .unavailable(let reason):
             statusRow(label: field.label, value: reason)
         case .list(let items):
-            // A "Status: N connected" summary line, then one row per device.
+            // A summary line (e.g. "Status: N connected"), then one row per item.
             VStack(alignment: .leading, spacing: Layout.itemSpacing) {
                 statusRow(label: field.label, value: connectedSummary(items))
                 ForEach(items, id: \.self) { item in
-                    DeviceRow(item: item, hintFont: hintFont, themeStore: themeStore) {
+                    ListItemRow(item: item, hintFont: hintFont, themeStore: themeStore) {
                         onActivateItem(item)
                     }
                 }
@@ -191,9 +191,10 @@ private struct QuickActionControl: View {
     }
 }
 
-/// One paired-device row: a connection dot, the name, and a "Connected" marker.
-/// Clickable to connect/disconnect, with a hover highlight so it reads as active.
-private struct DeviceRow: View {
+/// One actionable list item: a state dot, its label, clickable to act on it
+/// (e.g. connect/disconnect a paired device), with a hover highlight. Generic -
+/// any control whose info resolves to a `.list` renders its items through this.
+private struct ListItemRow: View {
     let item: QuickActionListItem
     let hintFont: Font
     let themeStore: ThemeStore

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/QuickActionsSection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/QuickActionsSection.swift
@@ -12,6 +12,8 @@ struct QuickActionsSection: View {
     let states: [String: ActionState]
     /// actionId -> valueKey -> resolved info value (device list, status, ...).
     let info: [String: [String: InfoValue]]
+    /// Item ids currently applying (connecting/disconnecting), rendered as busy.
+    let pendingItems: Set<String>
     let themeStore: ThemeStore
     /// A control was activated by click (Cmd+O runs the same path).
     var onRun: (QuickActionDescriptor, ActionIntent) -> Void = { _, _ in }
@@ -29,6 +31,7 @@ struct QuickActionsSection: View {
                     descriptor: descriptor,
                     state: states[descriptor.actionId],
                     info: info[descriptor.actionId] ?? [:],
+                    pendingItems: pendingItems,
                     themeStore: themeStore,
                     onRun: { intent in onRun(descriptor, intent) },
                     onActivateItem: { item in onActivateItem(descriptor, item) }
@@ -43,6 +46,7 @@ private struct QuickActionControl: View {
     let descriptor: QuickActionDescriptor
     let state: ActionState?
     let info: [String: InfoValue]
+    let pendingItems: Set<String>
     let themeStore: ThemeStore
     let onRun: (ActionIntent) -> Void
     let onActivateItem: (QuickActionListItem) -> Void
@@ -127,7 +131,12 @@ private struct QuickActionControl: View {
             VStack(alignment: .leading, spacing: Layout.itemSpacing) {
                 statusRow(label: field.label, value: connectedSummary(items))
                 ForEach(items, id: \.self) { item in
-                    ListItemRow(item: item, hintFont: hintFont, themeStore: themeStore) {
+                    ListItemRow(
+                        item: item,
+                        isPending: item.id.map(pendingItems.contains) ?? false,
+                        hintFont: hintFont,
+                        themeStore: themeStore
+                    ) {
                         onActivateItem(item)
                     }
                 }
@@ -196,6 +205,7 @@ private struct QuickActionControl: View {
 /// any control whose info resolves to a `.list` renders its items through this.
 private struct ListItemRow: View {
     let item: QuickActionListItem
+    let isPending: Bool
     let hintFont: Font
     let themeStore: ThemeStore
     let onActivate: () -> Void
@@ -210,7 +220,11 @@ private struct ListItemRow: View {
         static let dotSize: CGFloat = 7
         static let restOpacity = 0.10
         static let hoverOpacity = 0.28
+        static let pendingOpacity = 0.5
     }
+
+    /// Clickable only when it has an id and isn't already applying.
+    private var isActionable: Bool { item.id != nil && !isPending }
 
     var body: some View {
         Button(action: onActivate) {
@@ -229,18 +243,17 @@ private struct ListItemRow: View {
             .padding(.horizontal, Layout.horizontalPadding)
             .padding(.vertical, Layout.verticalPadding)
             .background(
-                themeStore.dividerColor().opacity(hovering ? Layout.hoverOpacity : Layout.restOpacity),
+                themeStore.dividerColor().opacity(hovering && isActionable ? Layout.hoverOpacity : Layout.restOpacity),
                 in: RoundedRectangle(cornerRadius: Layout.cornerRadius, style: .continuous)
             )
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .disabled(item.id == nil)
-        .onHover { inside in
-            hovering = inside
-            if item.id != nil {
-                inside ? NSCursor.pointingHand.push() : NSCursor.pop()
-            }
-        }
+        .disabled(!isActionable)
+        .opacity(isPending ? Layout.pendingOpacity : 1)
+        // Native pointer (macOS 15+) avoids the unbalanced NSCursor push/pop
+        // stack that would leave a stuck cursor when a row is removed on reload.
+        .pointerStyle(isActionable ? .link : nil)
+        .onHover { hovering = $0 }
     }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/QuickActionsSection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/QuickActionsSection.swift
@@ -3,15 +3,20 @@ import SwiftUI
 /// The actions portion of the info+actions panel (see docs/writing-controls.md).
 /// A vertical stack of control components, one per declared action, rendered
 /// beneath the result's info in `ResultPreviewView`. Each `ControlKind` maps to
-/// its own building block (toggle switch, button, ...), so supporting a new
-/// control type is adding a case in `QuickActionControl` - the rest of the panel
-/// stays the same. This is the reusable template contributors compose against.
+/// its own building block (toggle switch, button, ...), and an action's info
+/// fields render below it: a single line (`.text`) or one clickable row per item
+/// (`.list`, e.g. paired Bluetooth devices). Supporting a new control type is
+/// adding a case in `QuickActionControl` - the rest of the panel stays the same.
 struct QuickActionsSection: View {
     let descriptors: [QuickActionDescriptor]
     let states: [String: ActionState]
+    /// actionId -> valueKey -> resolved info value (device list, status, ...).
+    let info: [String: [String: InfoValue]]
     let themeStore: ThemeStore
-    /// Called when a control is activated by click (Cmd+O runs the same path).
+    /// A control was activated by click (Cmd+O runs the same path).
     var onRun: (QuickActionDescriptor, ActionIntent) -> Void = { _, _ in }
+    /// A list item (e.g. a device row) was clicked to connect/disconnect.
+    var onActivateItem: (QuickActionDescriptor, String) -> Void = { _, _ in }
 
     private enum Layout {
         static let rowSpacing: CGFloat = 6
@@ -23,34 +28,50 @@ struct QuickActionsSection: View {
                 QuickActionControl(
                     descriptor: descriptor,
                     state: states[descriptor.actionId],
+                    info: info[descriptor.actionId] ?? [:],
                     themeStore: themeStore,
-                    onRun: { intent in onRun(descriptor, intent) }
+                    onRun: { intent in onRun(descriptor, intent) },
+                    onActivateItem: { itemId in onActivateItem(descriptor, itemId) }
                 )
             }
         }
     }
 }
 
-/// One action row: the title, the control for its kind, and its key hint.
+/// One action: the control row (title + control + key hint) plus its info fields.
 private struct QuickActionControl: View {
     let descriptor: QuickActionDescriptor
     let state: ActionState?
+    let info: [String: InfoValue]
     let themeStore: ThemeStore
     let onRun: (ActionIntent) -> Void
+    let onActivateItem: (String) -> Void
 
     private enum Layout {
+        static let sectionSpacing: CGFloat = 4
         static let contentSpacing: CGFloat = 10
         static let controlSpacing: CGFloat = 8
         static let horizontalPadding: CGFloat = 10
         static let verticalPadding: CGFloat = 8
         static let cornerRadius: CGFloat = 8
         static let rowBackgroundOpacity = 0.18
+        static let itemBackgroundOpacity = 0.10
         static let toggleKeyHint = "⌘O"
         static let hintFontSizeDelta: CGFloat = 3
         static let minHintFontSize: CGFloat = 10
+        static let dotSize: CGFloat = 7
+        static let itemSpacing: CGFloat = 3
+        static let listTopPadding: CGFloat = 2
     }
 
     var body: some View {
+        VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
+            controlRow
+            infoFields
+        }
+    }
+
+    private var controlRow: some View {
         HStack(spacing: Layout.contentSpacing) {
             Text(descriptor.title)
                 .font(titleFont)
@@ -84,6 +105,76 @@ private struct QuickActionControl: View {
             }
         }
     }
+
+    // MARK: - Info fields
+
+    @ViewBuilder
+    private var infoFields: some View {
+        ForEach(descriptor.info, id: \.valueKey) { field in
+            if let value = info[field.valueKey] {
+                infoField(value)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func infoField(_ value: InfoValue) -> some View {
+        switch value {
+        case .text(let text):
+            // The toggle already conveys plain On/Off; only show extra detail.
+            if text != "On" && text != "Off" {
+                Text(text)
+                    .font(hintFont)
+                    .foregroundStyle(themeStore.mutedTextColor())
+                    .padding(.horizontal, Layout.horizontalPadding)
+            }
+        case .unavailable(let reason):
+            Text(reason)
+                .font(hintFont)
+                .foregroundStyle(themeStore.mutedTextColor())
+                .padding(.horizontal, Layout.horizontalPadding)
+        case .list(let items):
+            VStack(spacing: Layout.itemSpacing) {
+                ForEach(items, id: \.self) { item in
+                    deviceRow(item)
+                }
+            }
+            .padding(.top, Layout.listTopPadding)
+        }
+    }
+
+    private func deviceRow(_ item: QuickActionListItem) -> some View {
+        Button {
+            if let id = item.id { onActivateItem(id) }
+        } label: {
+            HStack(spacing: Layout.controlSpacing) {
+                Circle()
+                    .fill(item.on == true ? Color.green : Color.clear)
+                    .overlay(Circle().strokeBorder(themeStore.mutedTextColor(), lineWidth: item.on == true ? 0 : 1))
+                    .frame(width: Layout.dotSize, height: Layout.dotSize)
+                Text(item.label)
+                    .font(hintFont)
+                    .foregroundStyle(themeStore.fontColor())
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+                if item.on == true {
+                    Text("Connected")
+                        .font(hintFont)
+                        .foregroundStyle(themeStore.mutedTextColor())
+                }
+            }
+            .padding(.horizontal, Layout.horizontalPadding)
+            .padding(.vertical, Layout.verticalPadding / 2)
+            .background(
+                themeStore.dividerColor().opacity(Layout.itemBackgroundOpacity),
+                in: RoundedRectangle(cornerRadius: Layout.cornerRadius, style: .continuous)
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(item.id == nil)
+    }
+
+    // MARK: - Helpers
 
     private var isOn: Bool? {
         switch state {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/QuickActionsSection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/QuickActionsSection.swift
@@ -14,6 +14,9 @@ struct QuickActionsSection: View {
     let info: [String: [String: InfoValue]]
     /// Item ids currently applying (connecting/disconnecting), rendered as busy.
     let pendingItems: Set<String>
+    /// Actions with something applying. Their other controls go inert, so nothing looks
+    /// clickable that the guard in `runQuickAction` would silently swallow.
+    let busyActionIds: Set<String>
     let themeStore: ThemeStore
     /// A control was activated by click (Cmd+O runs the same path).
     var onRun: (QuickActionDescriptor, ActionIntent) -> Void = { _, _ in }
@@ -32,6 +35,7 @@ struct QuickActionsSection: View {
                     state: states[descriptor.actionId],
                     info: info[descriptor.actionId] ?? [:],
                     pendingItems: pendingItems,
+                    isBusy: busyActionIds.contains(descriptor.actionId),
                     themeStore: themeStore,
                     onRun: { intent in onRun(descriptor, intent) },
                     onActivateItem: { item in onActivateItem(descriptor, item) }
@@ -47,6 +51,8 @@ private struct QuickActionControl: View {
     let state: ActionState?
     let info: [String: InfoValue]
     let pendingItems: Set<String>
+    /// Something under this action is applying, so its controls stop taking input.
+    let isBusy: Bool
     let themeStore: ThemeStore
     let onRun: (ActionIntent) -> Void
     let onActivateItem: (QuickActionListItem) -> Void
@@ -59,6 +65,8 @@ private struct QuickActionControl: View {
         static let verticalPadding: CGFloat = 8
         static let cornerRadius: CGFloat = 8
         static let rowBackgroundOpacity = 0.18
+        /// Matches the pending row's dim, and the linows `.is-busy` rule.
+        static let busyOpacity = 0.5
         static let toggleKeyHint = "⌘O"
         static let hintFontSizeDelta: CGFloat = 3
         static let minHintFontSize: CGFloat = 10
@@ -94,17 +102,25 @@ private struct QuickActionControl: View {
         if case .unavailable(let reason)? = state {
             Text(reason).font(hintFont).foregroundStyle(themeStore.mutedTextColor())
         } else {
-            switch descriptor.control {
-            case .toggle:
-                HStack(spacing: Layout.controlSpacing) {
-                    ToggleSwitch(isOn: isOn, themeStore: themeStore) { onRun(.toggle) }
-                    keyHint(Layout.toggleKeyHint)
+            Group {
+                switch descriptor.control {
+                case .toggle:
+                    HStack(spacing: Layout.controlSpacing) {
+                        ToggleSwitch(isOn: isOn, themeStore: themeStore) { onRun(.toggle) }
+                        keyHint(Layout.toggleKeyHint)
+                    }
+                case .button:
+                    Button(descriptor.title) { onRun(.run) }
+                        .buttonStyle(.borderless)
+                        .font(hintFont)
                 }
-            case .button:
-                Button(descriptor.title) { onRun(.run) }
-                    .buttonStyle(.borderless)
-                    .font(hintFont)
             }
+            // While one of this action's devices is connecting, its own control stops
+            // taking input rather than looking live and being swallowed by the guard.
+            // `ToggleSwitch` already dims itself for an unresolved state, so only dim
+            // here when there is a resolved state to dim.
+            .disabled(isBusy)
+            .opacity(isBusy && isOn != nil ? Layout.busyOpacity : 1)
         }
     }
 
@@ -131,9 +147,13 @@ private struct QuickActionControl: View {
             VStack(alignment: .leading, spacing: Layout.itemSpacing) {
                 statusRow(label: field.label, value: listSummary(items))
                 ForEach(items, id: \.self) { item in
+                    let isPending = item.id.map(pendingItems.contains) ?? false
                     ListItemRow(
                         item: item,
-                        isPending: item.id.map(pendingItems.contains) ?? false,
+                        isPending: isPending,
+                        // A sibling row is inert while another device applies. The
+                        // applying row keeps its own pending styling.
+                        isBusy: isBusy && !isPending,
                         hintFont: hintFont,
                         themeStore: themeStore
                     ) {
@@ -211,6 +231,8 @@ private struct QuickActionControl: View {
 private struct ListItemRow: View {
     let item: QuickActionListItem
     let isPending: Bool
+    /// Another control under the same action is applying, so this row goes inert.
+    let isBusy: Bool
     let hintFont: Font
     let themeStore: ThemeStore
     let onActivate: () -> Void
@@ -228,8 +250,9 @@ private struct ListItemRow: View {
         static let pendingOpacity = 0.5
     }
 
-    /// Clickable only when it has an id and isn't already applying.
-    private var isActionable: Bool { item.id != nil && !isPending }
+    /// Clickable only when it has an id, isn't already applying, and no sibling control
+    /// under the same action is applying either.
+    private var isActionable: Bool { item.id != nil && !isPending && !isBusy }
 
     var body: some View {
         Button(action: onActivate) {
@@ -256,7 +279,7 @@ private struct ListItemRow: View {
         }
         .buttonStyle(.plain)
         .disabled(!isActionable)
-        .opacity(isPending ? Layout.pendingOpacity : 1)
+        .opacity(isPending || isBusy ? Layout.pendingOpacity : 1)
         // Native pointer (macOS 15+) avoids the unbalanced NSCursor push/pop
         // stack that would leave a stuck cursor when a row is removed on reload.
         .pointerStyle(isActionable ? .link : nil)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
@@ -9,7 +9,9 @@ struct ResultPreviewView: View {
     /// panel). Empty for results with no actions.
     var quickActions: [QuickActionDescriptor] = []
     var quickActionStates: [String: ActionState] = [:]
+    var quickActionInfo: [String: [String: InfoValue]] = [:]
     var onRunQuickAction: (QuickActionDescriptor, ActionIntent) -> Void = { _, _ in }
+    var onActivateQuickActionItem: (QuickActionDescriptor, String) -> Void = { _, _ in }
     var onDeleteClipboard: (() -> Void)? = nil
 
     @State private var folderListing: FolderListing?
@@ -161,8 +163,10 @@ struct ResultPreviewView: View {
                     QuickActionsSection(
                         descriptors: quickActions,
                         states: quickActionStates,
+                        info: quickActionInfo,
                         themeStore: themeStore,
-                        onRun: onRunQuickAction
+                        onRun: onRunQuickAction,
+                        onActivateItem: onActivateQuickActionItem
                     )
                 }
 

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
@@ -10,6 +10,7 @@ struct ResultPreviewView: View {
     var quickActions: [QuickActionDescriptor] = []
     var quickActionStates: [String: ActionState] = [:]
     var quickActionInfo: [String: [String: InfoValue]] = [:]
+    var pendingQuickActionItems: Set<String> = []
     var onRunQuickAction: (QuickActionDescriptor, ActionIntent) -> Void = { _, _ in }
     var onActivateQuickActionItem: (QuickActionDescriptor, QuickActionListItem) -> Void = { _, _ in }
     var onDeleteClipboard: (() -> Void)? = nil
@@ -164,6 +165,7 @@ struct ResultPreviewView: View {
                         descriptors: quickActions,
                         states: quickActionStates,
                         info: quickActionInfo,
+                        pendingItems: pendingQuickActionItems,
                         themeStore: themeStore,
                         onRun: onRunQuickAction,
                         onActivateItem: onActivateQuickActionItem

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
@@ -11,7 +11,7 @@ struct ResultPreviewView: View {
     var quickActionStates: [String: ActionState] = [:]
     var quickActionInfo: [String: [String: InfoValue]] = [:]
     var onRunQuickAction: (QuickActionDescriptor, ActionIntent) -> Void = { _, _ in }
-    var onActivateQuickActionItem: (QuickActionDescriptor, String) -> Void = { _, _ in }
+    var onActivateQuickActionItem: (QuickActionDescriptor, QuickActionListItem) -> Void = { _, _ in }
     var onDeleteClipboard: (() -> Void)? = nil
 
     @State private var folderListing: FolderListing?

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
@@ -11,6 +11,9 @@ struct ResultPreviewView: View {
     var quickActionStates: [String: ActionState] = [:]
     var quickActionInfo: [String: [String: InfoValue]] = [:]
     var pendingQuickActionItems: Set<String> = []
+    /// Actions with something applying: their controls render inert (see
+    /// `LauncherView.busyQuickActionIds`).
+    var busyQuickActionIds: Set<String> = []
     var onRunQuickAction: (QuickActionDescriptor, ActionIntent) -> Void = { _, _ in }
     var onActivateQuickActionItem: (QuickActionDescriptor, QuickActionListItem) -> Void = { _, _ in }
     var onDeleteClipboard: (() -> Void)? = nil
@@ -166,6 +169,7 @@ struct ResultPreviewView: View {
                         states: quickActionStates,
                         info: quickActionInfo,
                         pendingItems: pendingQuickActionItems,
+                        busyActionIds: busyQuickActionIds,
                         themeStore: themeStore,
                         onRun: onRunQuickAction,
                         onActivateItem: onActivateQuickActionItem


### PR DESCRIPTION
## Summary from code_rabbit

- Refresh quick-action states whenever the launcher window becomes key: the window keeps its query and selection across hide/show, so on re-show the panel could render states read before the hide (e.g. Bluetooth flipped in Control Center while hidden still showed "On").
- Resolve a toggle press against the displayed state (`.setOn`) before it reaches the adapter: `apply(.toggle)` flips the live state, which does the opposite of what the user asked whenever the panel is stale.
- Cmd+O: match the typed character instead of hardware keyCode 31 (the ANSI-O position types another letter on Dvorak/Colemak), and only swallow the chord when the selection actually has a toggle to act on.
- Add a list of previously connected devices (e.g. Bluetooth) with direct connect/disconnect actions, similar to the approach used in the Linows PR (`#274`), instead of live-monitoring external state changes.

## Why

Toggling a feature like Bluetooth from Control Center while Look's panel was hidden left the panel showing stale state on re-show, so pressing the toggle could invert the user's intent. Rather than adding real-time monitoring of external feature changes (added complexity/resource usage), Look now refreshes on window activation and exposes a device list for direct connect/disconnect actions.

## Changes

- `KeyboardSelectionMonitor`: Cmd+O now matches typed character `"o"` instead of keyCode 31; shortcut is only swallowed when the selected item has a toggle.
- `LauncherView+QuickActions`: `.toggle` intents are resolved into explicit `.setOn(true/false)` based on currently displayed cached state before being applied.
- `LauncherView+Selection`: keyboard monitor now reports `hasToggleQuickAction` availability.
- `LauncherView`: listens for `NSWindow.didBecomeKeyNotification` to refresh quick-action states when the launcher window becomes key.
- Added previously-connected devices list feature (connect/disconnect actions, hover state, status line).

## Testing

- Manual verification: toggled Bluetooth via Control Center while Look panel hidden, re-opened panel, confirmed state reflects reality and toggle acts on displayed state.
- Manual verification: Cmd+O behaves correctly on non-ANSI keyboard layouts and doesn't swallow the shortcut when no toggle is available.
- Manual verification: device list connect/disconnect actions.

## Risks / Notes

- No real-time monitoring of external feature/device state changes is implemented by design (per discussion in this PR) — state reflects reality after a search/window activation, not instantly on external change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added richer Quick Action details with info fields and interactive list rows (including per-item/per-device actions).
  - Added Bluetooth Quick Actions with live status and connect/disconnect controls for paired devices.
- **Improvements**
  - Quick Actions now reliably refresh when the launcher window regains focus and when the preview is shown again.
  - Toggle Quick Actions now use the currently known on/off state for more accurate updates, with clearer progress and outcome feedback (including pending/busy behavior).
- **Bug Fixes**
  - Corrected Cmd+O toggle Quick Action keyboard handling to match the intended shortcut behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->