### PR TITLE
Chore: configurable number of clipboad history items

### DIFF
--- a/apps/linows/src-tauri/src/clipboard.rs
+++ b/apps/linows/src-tauri/src/clipboard.rs
@@ -4,7 +4,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
-const MAX_ENTRIES: usize = 10;
 const MAX_ENTRY_BYTES: usize = 30_000;
 const POLL_MS: u64 = 500;
 
@@ -19,6 +18,7 @@ pub struct ClipboardEntry {
 struct ClipboardState {
     entries: Vec<ClipboardEntry>,
     last_text: String,
+    max_entries: usize,
 }
 
 static STATE: Mutex<Option<ClipboardState>> = Mutex::new(None);
@@ -63,9 +63,15 @@ pub fn mark_self_write() {
 
 /// Start background clipboard polling thread.
 pub fn start_monitor() {
-    let entries = load_entries();
+    let max_entries = crate::config::clipboard_history_limit();
+    let mut entries = load_entries();
+    entries.truncate(max_entries);
     let last_text = entries.first().map(|e| e.text.clone()).unwrap_or_default();
-    *STATE.lock().unwrap() = Some(ClipboardState { entries, last_text });
+    *STATE.lock().unwrap() = Some(ClipboardState {
+        entries,
+        last_text,
+        max_entries,
+    });
 
     std::thread::spawn(|| {
         let mut clipboard = match arboard::Clipboard::new() {
@@ -116,7 +122,7 @@ pub fn start_monitor() {
             };
 
             state.entries.insert(0, entry);
-            state.entries.truncate(MAX_ENTRIES);
+            state.entries.truncate(state.max_entries);
             save_entries(&state.entries);
         }
     });

--- a/apps/linows/src-tauri/src/clipboard.rs
+++ b/apps/linows/src-tauri/src/clipboard.rs
@@ -128,6 +128,22 @@ pub fn start_monitor() {
     });
 }
 
+/// Re-reads the clipboard section of `~/.look.config` and applies it to the running
+/// monitor (trimming and persisting any entries beyond a lowered limit), so file-only
+/// clipboard settings take effect on config reload without a restart. One reload entry
+/// point for the whole subsystem: adding a clipboard key means another apply line here,
+/// not a new function wired into `reload_config`.
+pub fn reload_from_config() {
+    let mut lock = STATE.lock().unwrap();
+    if let Some(state) = lock.as_mut() {
+        state.max_entries = crate::config::clipboard_history_limit();
+        if state.entries.len() > state.max_entries {
+            state.entries.truncate(state.max_entries);
+            save_entries(&state.entries);
+        }
+    }
+}
+
 #[tauri::command]
 pub fn get_clipboard_history(query: String) -> Vec<ClipboardEntry> {
     let lock = STATE.lock().unwrap();

--- a/apps/linows/src-tauri/src/commands.rs
+++ b/apps/linows/src-tauri/src/commands.rs
@@ -315,6 +315,7 @@ pub fn reload_config(state: State<'_, AppState>) -> bool {
     // read on every refresh). When the user explicitly reloads, drop the cache
     // so the next bootstrap picks up their edits.
     RuntimeConfig::invalidate_cache();
+    crate::clipboard::reload_from_config();
     state.request_index_refresh()
 }
 

--- a/apps/linows/src-tauri/src/config.rs
+++ b/apps/linows/src-tauri/src/config.rs
@@ -127,6 +127,9 @@ fn default_config_contents() -> String {
         "# Running apps switcher: none, right\n\
          running_apps_placement=right\n\
          \n\
+         # Clipboard history size (10-100). Out-of-range values fall back to 10.\n\
+         clipboard_history_limit=10\n\
+         \n\
          # Home-screen inner gap in px (0-24). 0 keeps the classic framed panel;\n\
          # above 0 the home screen splits into floating tiles separated by this gap.\n\
          inner_gap=0\n\
@@ -144,6 +147,41 @@ fn default_config_contents() -> String {
 
 pub const ENV_CONFIG_PATH: &str = "LOOK_CONFIG_PATH";
 const CONFIG_FILE: &str = ".look.config";
+
+const CLIPBOARD_HISTORY_LIMIT_KEY: &str = "clipboard_history_limit";
+pub const CLIPBOARD_HISTORY_LIMIT_DEFAULT: usize = 10;
+pub const CLIPBOARD_HISTORY_LIMIT_MIN: usize = 10;
+pub const CLIPBOARD_HISTORY_LIMIT_MAX: usize = 100;
+
+/// How many clipboard clips to keep, read from `clipboard_history_limit` in the
+/// config file. Returns the default (10) when the key is absent, unparseable, or
+/// outside the accepted [10, 100] range.
+pub fn clipboard_history_limit() -> usize {
+    let path = config_file_path();
+    let Ok(contents) = std::fs::read_to_string(&path) else {
+        return CLIPBOARD_HISTORY_LIMIT_DEFAULT;
+    };
+    for line in contents.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        if let Some((key, value)) = line.split_once('=')
+            && key.trim() == CLIPBOARD_HISTORY_LIMIT_KEY
+        {
+            return match value.trim().parse::<usize>() {
+                Ok(parsed)
+                    if (CLIPBOARD_HISTORY_LIMIT_MIN..=CLIPBOARD_HISTORY_LIMIT_MAX)
+                        .contains(&parsed) =>
+                {
+                    parsed
+                }
+                _ => CLIPBOARD_HISTORY_LIMIT_DEFAULT,
+            };
+        }
+    }
+    CLIPBOARD_HISTORY_LIMIT_DEFAULT
+}
 
 pub fn config_file_path() -> std::path::PathBuf {
     if let Ok(custom) = std::env::var(ENV_CONFIG_PATH) {

--- a/apps/linows/src-tauri/src/config.rs
+++ b/apps/linows/src-tauri/src/config.rs
@@ -231,7 +231,10 @@ mod tests {
 
     #[test]
     fn missing_key_falls_back_to_default() {
-        assert_eq!(parse_clipboard_history_limit(""), CLIPBOARD_HISTORY_LIMIT_DEFAULT);
+        assert_eq!(
+            parse_clipboard_history_limit(""),
+            CLIPBOARD_HISTORY_LIMIT_DEFAULT
+        );
         assert_eq!(
             parse_clipboard_history_limit("file_scan_limit=8000\nai_enabled=true\n"),
             CLIPBOARD_HISTORY_LIMIT_DEFAULT
@@ -240,13 +243,22 @@ mod tests {
 
     #[test]
     fn valid_in_range_value_is_used() {
-        assert_eq!(parse_clipboard_history_limit("clipboard_history_limit=50\n"), 50);
+        assert_eq!(
+            parse_clipboard_history_limit("clipboard_history_limit=50\n"),
+            50
+        );
     }
 
     #[test]
     fn boundary_values_are_accepted() {
-        assert_eq!(parse_clipboard_history_limit("clipboard_history_limit=10\n"), 10);
-        assert_eq!(parse_clipboard_history_limit("clipboard_history_limit=100\n"), 100);
+        assert_eq!(
+            parse_clipboard_history_limit("clipboard_history_limit=10\n"),
+            10
+        );
+        assert_eq!(
+            parse_clipboard_history_limit("clipboard_history_limit=100\n"),
+            100
+        );
     }
 
     #[test]
@@ -285,13 +297,18 @@ mod tests {
 
     #[test]
     fn surrounding_whitespace_is_ignored() {
-        assert_eq!(parse_clipboard_history_limit("  clipboard_history_limit = 42 \n"), 42);
+        assert_eq!(
+            parse_clipboard_history_limit("  clipboard_history_limit = 42 \n"),
+            42
+        );
     }
 
     #[test]
     fn trailing_inline_comment_is_stripped() {
         assert_eq!(
-            parse_clipboard_history_limit("clipboard_history_limit=50   # bumped for my workflow\n"),
+            parse_clipboard_history_limit(
+                "clipboard_history_limit=50   # bumped for my workflow\n"
+            ),
             50
         );
         // The comment must not smuggle an out-of-range value past the range check.

--- a/apps/linows/src-tauri/src/config.rs
+++ b/apps/linows/src-tauri/src/config.rs
@@ -153,6 +153,22 @@ pub const CLIPBOARD_HISTORY_LIMIT_DEFAULT: usize = 10;
 pub const CLIPBOARD_HISTORY_LIMIT_MIN: usize = 10;
 pub const CLIPBOARD_HISTORY_LIMIT_MAX: usize = 100;
 
+/// Drops a trailing comment. `#` only starts one at the beginning of the line or after
+/// whitespace, so it survives inside a value: cutting at the first `#` anywhere would
+/// truncate a path like `/Users/me/pic#1.png` down to `/Users/me/pic`, silently
+/// corrupting the setting. Must stay in step with the cross-platform reader
+/// in `core/engine/src/config.rs` (`strip_comments`), since both parse the same file.
+fn strip_inline_comment(value: &str) -> &str {
+    let mut previous_is_whitespace = true;
+    for (index, character) in value.char_indices() {
+        if character == '#' && previous_is_whitespace {
+            return &value[..index];
+        }
+        previous_is_whitespace = character.is_whitespace();
+    }
+    value
+}
+
 /// How many clipboard clips to keep, read from `clipboard_history_limit` in the
 /// config file. Returns the default (10) when the key is absent, unparseable, or
 /// outside the accepted [10, 100] range.
@@ -161,23 +177,27 @@ pub fn clipboard_history_limit() -> usize {
     let Ok(contents) = std::fs::read_to_string(&path) else {
         return CLIPBOARD_HISTORY_LIMIT_DEFAULT;
     };
-    for line in contents.lines() {
-        let line = line.trim();
+    let mut last_value: Option<&str> = None;
+    for raw_line in contents.lines() {
+        let line = strip_inline_comment(raw_line).trim();
         if line.is_empty() || line.starts_with('#') {
             continue;
         }
         if let Some((key, value)) = line.split_once('=')
             && key.trim() == CLIPBOARD_HISTORY_LIMIT_KEY
         {
-            return match value.trim().parse::<usize>() {
-                Ok(parsed)
-                    if (CLIPBOARD_HISTORY_LIMIT_MIN..=CLIPBOARD_HISTORY_LIMIT_MAX)
-                        .contains(&parsed) =>
-                {
-                    parsed
-                }
-                _ => CLIPBOARD_HISTORY_LIMIT_DEFAULT,
-            };
+            last_value = Some(value.trim());
+        }
+    }
+    if let Some(value) = last_value {
+        match value.parse::<usize>() {
+            Ok(parsed)
+                if (CLIPBOARD_HISTORY_LIMIT_MIN..=CLIPBOARD_HISTORY_LIMIT_MAX)
+                    .contains(&parsed) =>
+            {
+                return parsed;
+            }
+            _ => {}
         }
     }
     CLIPBOARD_HISTORY_LIMIT_DEFAULT

--- a/apps/linows/src-tauri/src/config.rs
+++ b/apps/linows/src-tauri/src/config.rs
@@ -177,6 +177,15 @@ pub fn clipboard_history_limit() -> usize {
     let Ok(contents) = std::fs::read_to_string(&path) else {
         return CLIPBOARD_HISTORY_LIMIT_DEFAULT;
     };
+    parse_clipboard_history_limit(&contents)
+}
+
+/// Parses `clipboard_history_limit` out of raw config file contents. Split from
+/// `clipboard_history_limit` so the parsing rules can be unit-tested without touching
+/// the filesystem or the shared `LOOK_CONFIG_PATH` env var. The last assignment wins
+/// (matching how the file is applied line by line); returns the default when the key is
+/// absent, unparseable, or outside [10, 100].
+fn parse_clipboard_history_limit(contents: &str) -> usize {
     let mut last_value: Option<&str> = None;
     for raw_line in contents.lines() {
         let line = strip_inline_comment(raw_line).trim();
@@ -214,4 +223,116 @@ pub fn config_file_path() -> std::path::PathBuf {
         .or_else(|_| std::env::var("USERPROFILE"))
         .unwrap_or_else(|_| ".".to_string());
     std::path::PathBuf::from(home).join(CONFIG_FILE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_key_falls_back_to_default() {
+        assert_eq!(parse_clipboard_history_limit(""), CLIPBOARD_HISTORY_LIMIT_DEFAULT);
+        assert_eq!(
+            parse_clipboard_history_limit("file_scan_limit=8000\nai_enabled=true\n"),
+            CLIPBOARD_HISTORY_LIMIT_DEFAULT
+        );
+    }
+
+    #[test]
+    fn valid_in_range_value_is_used() {
+        assert_eq!(parse_clipboard_history_limit("clipboard_history_limit=50\n"), 50);
+    }
+
+    #[test]
+    fn boundary_values_are_accepted() {
+        assert_eq!(parse_clipboard_history_limit("clipboard_history_limit=10\n"), 10);
+        assert_eq!(parse_clipboard_history_limit("clipboard_history_limit=100\n"), 100);
+    }
+
+    #[test]
+    fn out_of_range_values_fall_back_to_default() {
+        // Below min, above max, and zero all revert to the default rather than clamp.
+        assert_eq!(
+            parse_clipboard_history_limit("clipboard_history_limit=9\n"),
+            CLIPBOARD_HISTORY_LIMIT_DEFAULT
+        );
+        assert_eq!(
+            parse_clipboard_history_limit("clipboard_history_limit=101\n"),
+            CLIPBOARD_HISTORY_LIMIT_DEFAULT
+        );
+        assert_eq!(
+            parse_clipboard_history_limit("clipboard_history_limit=0\n"),
+            CLIPBOARD_HISTORY_LIMIT_DEFAULT
+        );
+    }
+
+    #[test]
+    fn non_numeric_and_negative_values_fall_back_to_default() {
+        assert_eq!(
+            parse_clipboard_history_limit("clipboard_history_limit=abc\n"),
+            CLIPBOARD_HISTORY_LIMIT_DEFAULT
+        );
+        // `-5` is not a valid usize, so parsing fails and we fall back.
+        assert_eq!(
+            parse_clipboard_history_limit("clipboard_history_limit=-5\n"),
+            CLIPBOARD_HISTORY_LIMIT_DEFAULT
+        );
+        assert_eq!(
+            parse_clipboard_history_limit("clipboard_history_limit=\n"),
+            CLIPBOARD_HISTORY_LIMIT_DEFAULT
+        );
+    }
+
+    #[test]
+    fn surrounding_whitespace_is_ignored() {
+        assert_eq!(parse_clipboard_history_limit("  clipboard_history_limit = 42 \n"), 42);
+    }
+
+    #[test]
+    fn trailing_inline_comment_is_stripped() {
+        assert_eq!(
+            parse_clipboard_history_limit("clipboard_history_limit=50   # bumped for my workflow\n"),
+            50
+        );
+        // The comment must not smuggle an out-of-range value past the range check.
+        assert_eq!(
+            parse_clipboard_history_limit("clipboard_history_limit=999 # too big\n"),
+            CLIPBOARD_HISTORY_LIMIT_DEFAULT
+        );
+    }
+
+    #[test]
+    fn commented_out_line_is_not_read() {
+        assert_eq!(
+            parse_clipboard_history_limit("# clipboard_history_limit=50\n"),
+            CLIPBOARD_HISTORY_LIMIT_DEFAULT
+        );
+    }
+
+    #[test]
+    fn key_must_match_exactly_not_as_a_suffix() {
+        // A different key that merely ends with the name must not match.
+        assert_eq!(
+            parse_clipboard_history_limit("my_clipboard_history_limit=50\n"),
+            CLIPBOARD_HISTORY_LIMIT_DEFAULT
+        );
+    }
+
+    #[test]
+    fn last_assignment_wins() {
+        assert_eq!(
+            parse_clipboard_history_limit(
+                "clipboard_history_limit=20\nclipboard_history_limit=80\n"
+            ),
+            80
+        );
+        // When the last duplicate is invalid the whole lookup falls back to the default,
+        // even though an earlier line held a valid value.
+        assert_eq!(
+            parse_clipboard_history_limit(
+                "clipboard_history_limit=50\nclipboard_history_limit=oops\n"
+            ),
+            CLIPBOARD_HISTORY_LIMIT_DEFAULT
+        );
+    }
 }

--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -146,7 +146,7 @@ enum AppConstants {
                 Entry(prefix: QueryPrefix.regex, argHint: "pattern", description: "Regex search"),
                 Entry(
                     prefix: QueryPrefix.clipboard, argHint: "word",
-                    description: "Clipboard history search (latest 10 text clips)"),
+                    description: "Clipboard history search (recent text clips)"),
                 Entry(prefix: QueryPrefix.translate, argHint: "word", description: "Web translate (VI/EN/JA)"),
                 Entry(
                     prefix: QueryPrefix.translateWord, argHint: "word",
@@ -241,7 +241,13 @@ enum AppConstants {
         enum Clipboard {
             static let resultIDPrefix = "clipboard:"
             static let resultPath = "clipboard://history"
+            // How many clips history keeps. `maxEntries` is the default/fallback used
+            // when `clipboard_history_limit` in ~/.look.config is absent or out of the
+            // [minEntries, maxEntriesLimit] range. See ClipboardHistoryStore.
             static let maxEntries = 10
+            static let minEntries = 10
+            static let maxEntriesLimit = 100
+            static let historyLimitConfigKey = "clipboard_history_limit"
             static let maxStoredCharacters = 30_000
             static let foregroundPollInterval: TimeInterval = 0.35
             static let backgroundPollInterval: TimeInterval = 0.9

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/ClipboardHistoryStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/ClipboardHistoryStore.swift
@@ -53,20 +53,46 @@ final class ClipboardHistoryStore: ObservableObject {
 
     @Published private(set) var entries: [ClipboardHistoryEntry] = []
 
-    private let maxEntries = ClipboardHistoryStore.resolveMaxEntries()
+    private var maxEntries = ClipboardHistoryStore.resolveMaxEntries()
     private let maxStoredCharacters = AppConstants.Launcher.Clipboard.maxStoredCharacters
 
-    /// Reads `clipboard_history_limit` from `~/.look.config`, falling back to the
-    /// default (10) when the key is missing, unparseable, or outside the accepted
-    /// [10, 100] range. Read once at init: changing the limit takes effect on relaunch,
-    /// matching how the rest of the config is loaded.
-    private static func resolveMaxEntries() -> Int {
-        let fallback = AppConstants.Launcher.Clipboard.maxEntries
+    /// Re-reads the clipboard section of `~/.look.config` and applies it live, so file-only
+    /// clipboard settings take effect on config reload (`Cmd+Shift+;`) without a restart.
+    /// Matches the `reloadFromConfig()` convention used by ThemeStore. Every clipboard key
+    /// is applied from a single parse here, so adding a key is one more `apply` line below,
+    /// not a new reload method.
+    func reloadFromConfig() {
+        let values = ClipboardHistoryStore.loadConfigValues()
+        applyMaxEntries(ClipboardHistoryStore.resolveMaxEntries(from: values))
+    }
+
+    private func applyMaxEntries(_ newValue: Int) {
+        guard newValue != maxEntries else { return }
+        maxEntries = newValue
+        if entries.count > maxEntries {
+            entries.removeLast(entries.count - maxEntries)
+        }
+    }
+
+    /// Reads every `key=value` pair from the active config file once, or an empty map when
+    /// the file is missing/unreadable. One parse feeds all clipboard settings.
+    private static func loadConfigValues() -> [String: String] {
         let path = ConfigPathResolver.resolvedPath()
         guard let raw = try? String(contentsOfFile: path, encoding: .utf8) else {
-            return fallback
+            return [:]
         }
-        let values = ConfigFileLines.keyValues(raw)
+        return ConfigFileLines.keyValues(raw)
+    }
+
+    private static func resolveMaxEntries() -> Int {
+        resolveMaxEntries(from: loadConfigValues())
+    }
+
+    /// Resolves `clipboard_history_limit` from already-parsed config values, falling back to
+    /// the default (10) when the key is missing, unparseable, or outside the accepted
+    /// [10, 100] range.
+    private static func resolveMaxEntries(from values: [String: String]) -> Int {
+        let fallback = AppConstants.Launcher.Clipboard.maxEntries
         guard let rawValue = values[AppConstants.Launcher.Clipboard.historyLimitConfigKey],
               let parsed = Int(rawValue.trimmingCharacters(in: .whitespacesAndNewlines)) else {
             return fallback

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/ClipboardHistoryStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/ClipboardHistoryStore.swift
@@ -53,8 +53,28 @@ final class ClipboardHistoryStore: ObservableObject {
 
     @Published private(set) var entries: [ClipboardHistoryEntry] = []
 
-    private let maxEntries = AppConstants.Launcher.Clipboard.maxEntries
+    private let maxEntries = ClipboardHistoryStore.resolveMaxEntries()
     private let maxStoredCharacters = AppConstants.Launcher.Clipboard.maxStoredCharacters
+
+    /// Reads `clipboard_history_limit` from `~/.look.config`, falling back to the
+    /// default (10) when the key is missing, unparseable, or outside the accepted
+    /// [10, 100] range. Read once at init: changing the limit takes effect on relaunch,
+    /// matching how the rest of the config is loaded.
+    private static func resolveMaxEntries() -> Int {
+        let fallback = AppConstants.Launcher.Clipboard.maxEntries
+        let path = ConfigPathResolver.resolvedPath()
+        guard let raw = try? String(contentsOfFile: path, encoding: .utf8) else {
+            return fallback
+        }
+        let values = ConfigFileLines.keyValues(raw)
+        guard let rawValue = values[AppConstants.Launcher.Clipboard.historyLimitConfigKey],
+              let parsed = Int(rawValue.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+            return fallback
+        }
+        let lower = AppConstants.Launcher.Clipboard.minEntries
+        let upper = AppConstants.Launcher.Clipboard.maxEntriesLimit
+        return (lower...upper).contains(parsed) ? parsed : fallback
+    }
     private var monitoringMode: MonitoringMode = .foreground
     // nonisolated(unsafe) so the nonisolated deinit can call invalidate()
     // on these without going through the actor.

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Search.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Search.swift
@@ -186,6 +186,7 @@ extension LauncherView {
     func reloadConfig() {
         let result = themeStore.reloadFromConfig()
         let backendReloaded = bridge.reloadConfig()
+        clipboardStore.reloadFromConfig()
 
         // Sync settings blur multiplier to AppUIState
         if let blurMultiplier = result.settingsBlurMultiplier {

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -397,6 +397,9 @@ file_exclude_paths=\n\
 lazy_indexing_enabled=true\n\
 skip_dir_names=node_modules,target,build,dist,library,applications,old firefox data,deriveddata,pods,vendor,out,coverage,tmp,cache,venv\n\
 \n\
+# Clipboard history size (10-100). Out-of-range values fall back to 10.\n\
+clipboard_history_limit=10\n\
+\n\
 # UI theme\n\
 ui_tint_red=0.08\n\
 ui_tint_green=0.10\n\

--- a/docs/features.md
+++ b/docs/features.md
@@ -27,7 +27,7 @@ This document tracks what `look` supports today and what is planned next.
 ### Clipboard and translation
 
 - clipboard history mode with `c"` prefix
-- in-memory clipboard history (latest text clips); file/folder copies are excluded
+- in-memory clipboard history (recent text clips, size set by `clipboard_history_limit`, default 10, range 10 to 100); file/folder copies are excluded
 - quick translation with `t"...`
 - dictionary lookup panel with `tw"...`
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -247,7 +247,7 @@ Backend-related keys:
 
 File-only settings (no Settings UI):
 
-These keys have no control in the Settings screens. Edit `~/.look.config` directly, then reload with `Cmd+Shift+;` or restart Look. Out-of-range or unparseable values fall back to the listed default. More keys will be added here over time.
+These keys have no control in the Settings screens. Edit `~/.look.config` directly, then reload with `Cmd+Shift+;` (macOS) or `Ctrl+Shift+;` (Linux/Windows), or restart Look. Out-of-range or unparseable values fall back to the listed default. More keys will be added here over time.
 
 - `clipboard_history_limit` (clipboard history size, range 10 to 100, default 10)
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -100,7 +100,7 @@ Path-like queries (for example `git/project/readme`) are also supported and bias
 
 Clipboard mode (`c"`):
 
-- stores recent text clips for the running app session,
+- stores recent text clips for the running app session (history size is configurable via `clipboard_history_limit`, see File-only settings below),
 - `Enter` on a clipboard row copies that content back to clipboard.
 
 Translation mode (`t"`/`tw"`):
@@ -244,6 +244,12 @@ Backend-related keys:
 - `skip_dir_names`
 - `alias_<keyword>` (for app + System Settings query aliases, for example `alias_note=Notion|Obsidian|Notes|Apple Notes|Bear|Logseq`)
 - `backend_log_level`, `launch_at_login`
+
+File-only settings (no Settings UI):
+
+These keys have no control in the Settings screens. Edit `~/.look.config` directly, then reload with `Cmd+Shift+;` or restart Look. Out-of-range or unparseable values fall back to the listed default. More keys will be added here over time.
+
+- `clipboard_history_limit` (clipboard history size, range 10 to 100, default 10)
 
 Alias note:
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable clipboard history limit for recent text clips on Linux and macOS (`clipboard_history_limit`, default 10; allowed range 10–100), applied at runtime and reloaded without restarting.
* **Bug Fixes**
  * Clipboard history sizing and truncation now consistently follow the configured limit (including recomputing as needed) and fall back to defaults when missing/invalid.
  * Reloading configuration now also refreshes clipboard-related settings.
* **Documentation**
  * Updated clipboard help text and user guide to describe “recent text clips” and the new setting.
* **Tests**
  * Added unit tests for config parsing, validation, whitespace/comment handling, and “last assignment wins.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



## Why

#190

## Testing

- `core`
  - [ ] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [ ] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [ ] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [ ] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [ ] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [ ] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [ ] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [ ] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered
