### PR TITLE
feat: Ignored file patterns

### DIFF
--- a/apps/linows/src-tauri/Cargo.lock
+++ b/apps/linows/src-tauri/Cargo.lock
@@ -2467,6 +2467,7 @@ dependencies = [
 name = "look-engine"
 version = "0.1.0"
 dependencies = [
+ "globset",
  "ignore",
  "look-indexing",
  "look-matching",

--- a/apps/linows/src-tauri/src/config.rs
+++ b/apps/linows/src-tauri/src/config.rs
@@ -105,6 +105,10 @@ fn default_config_contents() -> String {
          file_scan_depth=4\n\
          file_scan_limit=8000\n\
          file_exclude_paths=\n\
+         ignored_patterns_sample=\n\
+         # File ignore patterns. Format: ignored_patterns_<group>=Pattern1|Pattern2|Pattern3\n\
+         # ignored_patterns_browser=~/AppData/Local/BraveSoftware/**/*.log|~/AppData/Local/Google/Chrome/**/*.tmp\n\
+         # ignored_patterns_sqlite=~/Documents/git/project/**/*.db-wal|~/Documents/git/project/**/*.db-shm\n\
          lazy_indexing_enabled=true\n\
          skip_dir_names=node_modules,target,build,dist,.git,vendor,out,coverage,tmp,cache,venv\n\
          \n",

--- a/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
@@ -820,7 +820,7 @@ file_exclude_paths=
 ignored_patterns_sample=
 # File ignore patterns. Gitignore-style path globs: *, **, ?, [abc].
 # Format: ignored_patterns_<group>=Pattern1|Pattern2|Pattern3
-# macOS/Linux usually use ~/... or /... ; on Windows, C:\... is the safest documented form and ~ expands to your home dir.
+# macOS/Linux usually use ~/... or /... ; on Windows, C:\\... is the safest documented form and ~ expands to your home dir.
 # ignored_patterns_browser=~/AppData/Local/BraveSoftware/**/*.log|~/AppData/Local/Google/Chrome/**/*.tmp
 # ignored_patterns_sqlite=~/Documents/git/project/**/*.db-wal|~/Documents/git/project/**/*.db-shm
 # ignored_patterns_temp=~/Downloads/*.tmp|~/Downloads/**/*.part

--- a/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
@@ -816,8 +816,15 @@ file_scan_roots=Desktop,Documents,Downloads
 file_scan_extra_roots=
 file_scan_depth=4
 file_scan_limit=8000
-lazy_indexing_enabled=true
 file_exclude_paths=
+ignored_patterns_sample=
+# File ignore patterns. Gitignore-style path globs: *, **, ?, [abc].
+# Format: ignored_patterns_<group>=Pattern1|Pattern2|Pattern3
+# macOS/Linux usually use ~/... or /... ; on Windows, C:\... is the safest documented form and ~ expands to your home dir.
+# ignored_patterns_browser=~/AppData/Local/BraveSoftware/**/*.log|~/AppData/Local/Google/Chrome/**/*.tmp
+# ignored_patterns_sqlite=~/Documents/git/project/**/*.db-wal|~/Documents/git/project/**/*.db-shm
+# ignored_patterns_temp=~/Downloads/*.tmp|~/Downloads/**/*.part
+lazy_indexing_enabled=true
 backend_log_level=error
 launch_at_login=true
 skip_dir_names=node_modules,target,build,dist,library,applications,old firefox data,deriveddata,pods,vendor,out,coverage,tmp,cache,venv

--- a/bridge/ffi/Cargo.lock
+++ b/bridge/ffi/Cargo.lock
@@ -261,6 +261,7 @@ dependencies = [
 name = "look-engine"
 version = "0.1.0"
 dependencies = [
+ "globset",
  "ignore",
  "look-indexing",
  "look-matching",

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -200,6 +200,7 @@ dependencies = [
 name = "look-engine"
 version = "0.1.0"
 dependencies = [
+ "globset",
  "ignore",
  "look-indexing",
  "look-matching",

--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -14,6 +14,7 @@ regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 unicode-normalization = "0.1"
+globset = "0.4.18"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.62", features = [

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -418,9 +418,12 @@ file_scan_depth=4\n\
 file_scan_limit=8000\n\
 file_exclude_paths=\n\
 ignored_patterns_sample=\n\
-# File ignore patterns. Format: ignored_patterns_<group>=Pattern1|Pattern2|Pattern3\n\
+# File ignore patterns. Gitignore-style path globs: *, **, ?, [abc].\n\
+# Format: ignored_patterns_<group>=Pattern1|Pattern2|Pattern3\n\
+# macOS/Linux usually use ~/... or /... ; on Windows, C:\\... is the safest documented form and ~ expands to your home dir.\n\
 # ignored_patterns_browser=~/AppData/Local/BraveSoftware/**/*.log|~/AppData/Local/Google/Chrome/**/*.tmp\n\
 # ignored_patterns_sqlite=~/Documents/git/project/**/*.db-wal|~/Documents/git/project/**/*.db-shm\n\
+# ignored_patterns_temp=~/Downloads/*.tmp|~/Downloads/**/*.part\n\
 lazy_indexing_enabled=true\n\
 skip_dir_names=node_modules,target,build,dist,library,applications,old firefox data,deriveddata,pods,vendor,out,coverage,tmp,cache,venv\n\
 \n\

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -1,6 +1,7 @@
+use globset::Glob;
 use crate::normalize::normalize_for_search;
 use crate::platform;
-use crate::platform::paths::expand_with_home;
+use crate::platform::paths::{PathPolicy, expand_with_home};
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::path::{Path, PathBuf};
@@ -81,6 +82,7 @@ pub struct RuntimeConfig {
     pub file_scan_limit: usize,
     pub file_exclude_paths: Vec<String>,
     pub skip_dir_names: Vec<String>,
+    pub ignored_file_patterns: Vec<String>,
     pub lazy_indexing_enabled: bool,
     pub search_aliases: HashMap<String, Vec<String>>,
 }
@@ -110,6 +112,7 @@ impl Default for RuntimeConfig {
                 .iter()
                 .map(|value| value.to_string())
                 .collect(),
+            ignored_file_patterns: Vec::new(),
             lazy_indexing_enabled: LAZY_INDEXING_ENABLED,
             search_aliases: default_search_aliases(),
         }
@@ -285,6 +288,24 @@ impl RuntimeConfig {
                 "lazy_indexing_enabled" => {
                     if let Some(parsed) = parse_bool(value) {
                         self.lazy_indexing_enabled = parsed;
+                    }
+                }
+                _ if key.strip_prefix("ignored_patterns_").is_some() => {
+                    let parsed = parse_pattern_values(value);
+                    for pattern in parsed {
+                        let expanded = expand_path(&pattern, home.as_deref());
+                        let normalized = PathPolicy::for_base(&expanded)
+                            .normalize_for_matching(&expanded);
+                        if Glob::new(&normalized).is_err() {
+                            continue;
+                        }
+                        if !self
+                            .ignored_file_patterns
+                            .iter()
+                            .any(|existing| existing == &normalized)
+                        {
+                            self.ignored_file_patterns.push(normalized);
+                        }
                     }
                 }
                 _ if key.strip_prefix("alias_").is_some() => {
@@ -719,6 +740,17 @@ fn parse_alias_values(value: &str) -> Vec<String> {
         let normalized = normalize_for_search(raw.trim());
         if !normalized.is_empty() && !values.iter().any(|entry| entry == &normalized) {
             values.push(normalized);
+        }
+    }
+    values
+}
+
+fn parse_pattern_values(value: &str) -> Vec<String> {
+    let mut values = Vec::new();
+    for raw in value.split('|') {
+        let trimmed = raw.trim();
+        if !trimmed.is_empty() && !values.iter().any(|entry| entry == trimmed) {
+            values.push(trimmed.to_string());
         }
     }
     values

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -1162,7 +1162,7 @@ mod tests {
         // backslashes, on-disk casing.
         let candidate = r"C:\Users\Me\Temp\nested\trace.etl";
         let ignored = matchers.iter().any(|(policy, glob_matcher)| {
-            glob_matcher.is_match(policy.normalize_for_matching(candidate))
+            glob_matcher.is_match(&*policy.normalize_for_matching(candidate))
         });
 
         assert!(

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -1120,7 +1120,7 @@ mod tests {
 
         assert_eq!(
             config.ignored_file_patterns,
-            vec!["c:/users/me/appdata/local/temp/**/*.etl".to_string()]
+            vec![r"C:\Users\me\AppData\Local\Temp\**\*.etl".to_string()]
         );
 
         let _ = std::fs::remove_file(&tmp);

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -1112,7 +1112,10 @@ mod tests {
         let mut config = RuntimeConfig::default();
         config.apply_from_file(&tmp);
 
-        assert_eq!(config.ignored_file_patterns.len(), 1);
+        assert_eq!(
+            config.ignored_file_patterns,
+            vec!["c:/users/me/appdata/local/temp/**/*.etl".to_string()]
+        );
 
         let _ = std::fs::remove_file(&tmp);
     }

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -415,6 +415,10 @@ file_scan_extra_roots=\n\
 file_scan_depth=4\n\
 file_scan_limit=8000\n\
 file_exclude_paths=\n\
+ignored_patterns_sample=\n\
+# File ignore patterns. Format: ignored_patterns_<group>=Pattern1|Pattern2|Pattern3\n\
+# ignored_patterns_browser=~/AppData/Local/BraveSoftware/**/*.log|~/AppData/Local/Google/Chrome/**/*.tmp\n\
+# ignored_patterns_sqlite=~/Documents/git/project/**/*.db-wal|~/Documents/git/project/**/*.db-shm\n\
 lazy_indexing_enabled=true\n\
 skip_dir_names=node_modules,target,build,dist,library,applications,old firefox data,deriveddata,pods,vendor,out,coverage,tmp,cache,venv\n\
 \n\

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -1126,6 +1126,60 @@ mod tests {
         let _ = std::fs::remove_file(&tmp);
     }
 
+    // End-to-end across the seam the other tests skip: a Windows pattern goes
+    // through the real config parse-and-store step, then is matched the exact
+    // way `walk_files` (index/files.rs) does. The Windows tests elsewhere build
+    // matchers from the raw pattern and never feed config's STORED output back
+    // into the walk matcher, which is where the Windows path breaks.
+    #[test]
+    fn windows_pattern_from_config_ignores_backslash_candidate() {
+        let tmp = std::env::temp_dir().join(format!(
+            "look-config-test-ignored-patterns-walk-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time should be after epoch")
+                .as_nanos()
+        ));
+        std::fs::write(
+            &tmp,
+            "ignored_patterns_win=C:\\Users\\me\\Temp\\**\\*.etl\n",
+        )
+        .expect("should write temporary config");
+
+        let mut config = RuntimeConfig::default();
+        config.apply_from_file(&tmp);
+        let _ = std::fs::remove_file(&tmp);
+
+        // Rebuild matchers exactly like `walk_files`, from the STORED patterns.
+        let matchers = config
+            .ignored_file_patterns
+            .iter()
+            .filter_map(|pattern| {
+                let policy = PathPolicy::for_base(pattern);
+                let normalized_pattern = policy.normalize_for_matching(pattern);
+                let mut builder = GlobBuilder::new(&normalized_pattern);
+                builder.literal_separator(true);
+                builder
+                    .build()
+                    .ok()
+                    .map(|glob| (policy, glob.compile_matcher()))
+            })
+            .collect::<Vec<_>>();
+
+        // Candidate as the `ignore` walker emits it on Windows: native
+        // backslashes, on-disk casing.
+        let candidate = r"C:\Users\Me\Temp\nested\trace.etl";
+        let ignored = matchers.iter().any(|(policy, glob_matcher)| {
+            glob_matcher.is_match(policy.normalize_for_matching(candidate))
+        });
+
+        assert!(
+            ignored,
+            "a Windows pattern loaded from config should ignore the matching backslash candidate"
+        );
+    }
+
     #[test]
     fn default_config_contents_include_alias_entries() {
         let contents = default_config_contents();

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -1,7 +1,7 @@
 use crate::normalize::normalize_for_search;
 use crate::platform;
 #[cfg(test)]
-use crate::platform::paths::PathPolicy;
+use crate::platform::paths::compile_ignore_matcher;
 use crate::platform::paths::expand_with_home;
 use globset::GlobBuilder;
 use std::collections::{HashMap, HashSet};
@@ -1155,16 +1155,7 @@ mod tests {
         let matchers = config
             .ignored_file_patterns
             .iter()
-            .filter_map(|pattern| {
-                let policy = PathPolicy::for_base(pattern);
-                let normalized_pattern = policy.normalize_for_matching(pattern);
-                let mut builder = GlobBuilder::new(&normalized_pattern);
-                builder.literal_separator(true);
-                builder
-                    .build()
-                    .ok()
-                    .map(|glob| (policy, glob.compile_matcher()))
-            })
+            .filter_map(|pattern| compile_ignore_matcher(pattern))
             .collect::<Vec<_>>();
 
         // Candidate as the `ignore` walker emits it on Windows: native

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -824,6 +824,15 @@ mod tests {
     }
 
     #[test]
+    fn parse_pattern_values_trims_and_deduplicates_entries() {
+        // Case: " ~/Project/**/*.log | | ~/Project/**/*.tmp | ~/Project/**/*.log "
+        let parsed = parse_pattern_values(
+            " ~/Project/**/*.log | | ~/Project/**/*.tmp | ~/Project/**/*.log ",
+        );
+        assert_eq!(parsed, vec!["~/Project/**/*.log", "~/Project/**/*.tmp"]);
+    }
+
+    #[test]
     fn expand_path_supports_home_tokens() {
         let home = Some("/Users/demo");
         assert_eq!(expand_path("~/Projects", home), "/Users/demo/Projects");
@@ -1009,6 +1018,99 @@ mod tests {
 
         config.apply_from_file(&tmp);
         assert!(!config.search_aliases.contains_key("note"));
+
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn ignored_pattern_entries_are_loaded_from_config() {
+        // Case:
+        // ignored_patterns_logs=/Users/demo/Project/**/*.log | /Users/demo/Project/**/*.tmp
+        // ignored_patterns_more=/Users/demo/Project/**/*.tmp|[invalid
+        // lazy_indexing_enabled=false
+        let tmp = std::env::temp_dir().join(format!(
+            "look-config-test-ignored-patterns-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time should be after epoch")
+                .as_nanos()
+        ));
+
+        std::fs::write(
+            &tmp,
+            "ignored_patterns_logs=/Users/demo/Project/**/*.log | /Users/demo/Project/**/*.tmp\nignored_patterns_more=/Users/demo/Project/**/*.tmp|[invalid\nlazy_indexing_enabled=false\n",
+        )
+        .expect("should write temporary config");
+
+        let mut config = RuntimeConfig::default();
+        config.apply_from_file(&tmp);
+
+        assert_eq!(
+            config.ignored_file_patterns,
+            vec![
+                "/Users/demo/Project/**/*.log".to_string(),
+                "/Users/demo/Project/**/*.tmp".to_string()
+            ]
+        );
+        assert!(!config.lazy_indexing_enabled);
+
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn ignored_pattern_empty_values_do_not_fail_parsing() {
+        // Case:
+        // ignored_patterns_empty=
+        // ignored_patterns_spaces= |  |
+        // lazy_indexing_enabled=false
+        let tmp = std::env::temp_dir().join(format!(
+            "look-config-test-ignored-patterns-empty-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time should be after epoch")
+                .as_nanos()
+        ));
+
+        std::fs::write(
+            &tmp,
+            "ignored_patterns_empty=\nignored_patterns_spaces= |  |\nlazy_indexing_enabled=false\n",
+        )
+        .expect("should write temporary config");
+
+        let mut config = RuntimeConfig::default();
+        config.apply_from_file(&tmp);
+
+        assert!(config.ignored_file_patterns.is_empty());
+        assert!(!config.lazy_indexing_enabled);
+
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn ignored_pattern_windows_style_path_is_accepted() {
+        // Case: ignored_patterns_windows=C:\Users\me\AppData\Local\Temp\**\*.etl
+        let tmp = std::env::temp_dir().join(format!(
+            "look-config-test-ignored-patterns-windows-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time should be after epoch")
+                .as_nanos()
+        ));
+
+        std::fs::write(
+            &tmp,
+            r"ignored_patterns_windows=C:\Users\me\AppData\Local\Temp\**\*.etl
+",
+        )
+        .expect("should write temporary config");
+
+        let mut config = RuntimeConfig::default();
+        config.apply_from_file(&tmp);
+
+        assert_eq!(config.ignored_file_patterns.len(), 1);
 
         let _ = std::fs::remove_file(&tmp);
     }

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -1,8 +1,8 @@
 use crate::normalize::normalize_for_search;
 use crate::platform;
-use crate::platform::paths::expand_with_home;
 #[cfg(test)]
 use crate::platform::paths::PathPolicy;
+use crate::platform::paths::expand_with_home;
 use globset::GlobBuilder;
 use std::collections::{HashMap, HashSet};
 use std::env;

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -1,4 +1,4 @@
-use globset::Glob;
+use globset::GlobBuilder;
 use crate::normalize::normalize_for_search;
 use crate::platform;
 use crate::platform::paths::{PathPolicy, expand_with_home};
@@ -296,7 +296,9 @@ impl RuntimeConfig {
                         let expanded = expand_path(&pattern, home.as_deref());
                         let normalized = PathPolicy::for_base(&expanded)
                             .normalize_for_matching(&expanded);
-                        if Glob::new(&normalized).is_err() {
+                        let mut builder = GlobBuilder::new(&normalized);
+                        builder.literal_separator(true);
+                        if builder.build().is_err() {
                             continue;
                         }
                         if !self

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -1171,6 +1171,41 @@ mod tests {
         );
     }
 
+    // Full flow for the Windows home form `~\`, across both steps the other
+    // tests split: config.rs splits + dedups the raw values and stores each one
+    // home-expanded (raw, not policy-normalized); files.rs builds the matcher
+    // from that stored string. Uses an explicit Windows home so the assertion is
+    // deterministic regardless of the machine's real HOME.
+    #[test]
+    fn home_tilde_pattern_from_config_ignores_backslash_candidate() {
+        let home = Some("C:\\Users\\me");
+
+        // Step 1 (config.rs): split on `|`, trim, drop the duplicate.
+        let raw = parse_pattern_values(r" ~\Temp\**\*.log | ~\Temp\**\*.log | ~\Temp\**\*.log ");
+        assert_eq!(raw, vec![r"~\Temp\**\*.log".to_string()]);
+
+        // Step 2 (config.rs): store each home-expanded, still raw (un-normalized).
+        let stored: Vec<String> = raw
+            .iter()
+            .map(|pattern| expand_path(pattern, home))
+            .collect();
+        assert_eq!(stored, vec![r"C:\Users\me\Temp\**\*.log".to_string()]);
+
+        // Step 3 (files.rs): build the matcher from the stored pattern and match
+        // a candidate as the walker emits it on Windows (backslashes, on-disk
+        // casing).
+        let (policy, matcher) = compile_ignore_matcher(&stored[0]).expect("pattern should compile");
+        assert!(
+            matcher.is_match(&*policy.normalize_for_matching(r"C:\Users\Me\Temp\nested\trace.log")),
+            "a ~\\ home pattern from config should ignore the matching candidate"
+        );
+        // A different extension under the same dir stays visible.
+        assert!(
+            !matcher
+                .is_match(&*policy.normalize_for_matching(r"C:\Users\Me\Temp\nested\trace.txt"))
+        );
+    }
+
     #[test]
     fn default_config_contents_include_alias_entries() {
         let contents = default_config_contents();

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -1,7 +1,7 @@
-use globset::GlobBuilder;
 use crate::normalize::normalize_for_search;
 use crate::platform;
 use crate::platform::paths::{PathPolicy, expand_with_home};
+use globset::GlobBuilder;
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::path::{Path, PathBuf};
@@ -294,8 +294,8 @@ impl RuntimeConfig {
                     let parsed = parse_pattern_values(value);
                     for pattern in parsed {
                         let expanded = expand_path(&pattern, home.as_deref());
-                        let normalized = PathPolicy::for_base(&expanded)
-                            .normalize_for_matching(&expanded);
+                        let normalized =
+                            PathPolicy::for_base(&expanded).normalize_for_matching(&expanded);
                         let mut builder = GlobBuilder::new(&normalized);
                         builder.literal_separator(true);
                         if builder.build().is_err() {

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -1,6 +1,8 @@
 use crate::normalize::normalize_for_search;
 use crate::platform;
-use crate::platform::paths::{PathPolicy, expand_with_home};
+use crate::platform::paths::expand_with_home;
+#[cfg(test)]
+use crate::platform::paths::PathPolicy;
 use globset::GlobBuilder;
 use std::collections::{HashMap, HashSet};
 use std::env;
@@ -294,9 +296,7 @@ impl RuntimeConfig {
                     let parsed = parse_pattern_values(value);
                     for pattern in parsed {
                         let expanded = expand_path(&pattern, home.as_deref());
-                        let normalized =
-                            PathPolicy::for_base(&expanded).normalize_for_matching(&expanded);
-                        let mut builder = GlobBuilder::new(&normalized);
+                        let mut builder = GlobBuilder::new(&expanded);
                         builder.literal_separator(true);
                         if builder.build().is_err() {
                             continue;
@@ -304,9 +304,9 @@ impl RuntimeConfig {
                         if !self
                             .ignored_file_patterns
                             .iter()
-                            .any(|existing| existing == &normalized)
+                            .any(|existing| existing == &expanded)
                         {
-                            self.ignored_file_patterns.push(normalized);
+                            self.ignored_file_patterns.push(expanded);
                         }
                     }
                 }

--- a/core/engine/src/index/files.rs
+++ b/core/engine/src/index/files.rs
@@ -1,7 +1,8 @@
 use crate::config::RuntimeConfig;
 use crate::index::{FILE_CANDIDATE_ID_PREFIX, FOLDER_CANDIDATE_ID_PREFIX};
-use crate::platform::paths::{PathPolicy, candidate_id_path_component, path_is_same_or_child};
-use globset::GlobBuilder;
+use crate::platform::paths::{
+    PathPolicy, candidate_id_path_component, compile_ignore_matcher, path_is_same_or_child,
+};
 use globset::GlobMatcher;
 use ignore::WalkBuilder;
 use look_indexing::{Candidate, CandidateKind};
@@ -51,16 +52,7 @@ fn walk_files(
     let ignored_file_matchers = config
         .ignored_file_patterns
         .iter()
-        .filter_map(|pattern| {
-            let policy = PathPolicy::for_base(pattern);
-            let normalized_pattern = policy.normalize_for_matching(pattern);
-            let mut builder = GlobBuilder::new(&normalized_pattern);
-            builder.literal_separator(true);
-            builder
-                .build()
-                .ok()
-                .map(|glob| (policy, glob.compile_matcher()))
-        })
+        .filter_map(|pattern| compile_ignore_matcher(pattern))
         .collect::<Vec<IgnoredFileMatcher>>();
     walker
         .hidden(false)
@@ -176,8 +168,7 @@ fn should_exclude_path(path: &str, file_exclude_paths: &[String]) -> bool {
 mod tests {
     use super::{discover_local_files_and_folders, should_exclude_path};
     use crate::config::RuntimeConfig;
-    use crate::platform::paths::PathPolicy;
-    use globset::GlobBuilder;
+    use crate::platform::paths::{PathPolicy, compile_ignore_matcher};
     use look_indexing::CandidateKind;
     use std::sync::mpsc;
 
@@ -193,16 +184,11 @@ mod tests {
     }
 
     fn windows_style_ignored_pattern_matches(pattern: &str, path: &str) -> bool {
-        let policy = PathPolicy::for_base(pattern);
-        let normalized_pattern = policy.normalize_for_matching(pattern);
+        let Some((policy, matcher)) = compile_ignore_matcher(pattern) else {
+            return false;
+        };
         let normalized_path = policy.normalize_for_matching(path);
-        let mut builder = GlobBuilder::new(&normalized_pattern);
-        builder.literal_separator(true);
-        builder
-            .build()
-            .expect("pattern should compile")
-            .compile_matcher()
-            .is_match(&normalized_path)
+        matcher.is_match(&normalized_path)
     }
 
     #[test]
@@ -384,14 +370,7 @@ mod tests {
     #[test]
     fn ignored_patterns_match_windows_backslash_pattern_against_slash_candidate() {
         let pattern = r"C:\Users\me\Temp\*.log";
-        let policy = PathPolicy::for_base(pattern);
-        let normalized_pattern = policy.normalize_for_matching(pattern);
-        let mut builder = GlobBuilder::new(&normalized_pattern);
-        builder.literal_separator(true);
-        let matcher = builder
-            .build()
-            .expect("pattern should compile")
-            .compile_matcher();
+        let (policy, matcher) = compile_ignore_matcher(pattern).expect("pattern should compile");
 
         assert!(matcher.is_match(policy.normalize_for_matching("C:/Users/me/Temp/debug.log")));
         assert!(!matcher.is_match(policy.normalize_for_matching("C:/Users/me/Temp/debug.txt")));

--- a/core/engine/src/index/files.rs
+++ b/core/engine/src/index/files.rs
@@ -100,9 +100,6 @@ fn walk_files(
             break;
         }
 
-        // Read mtime from the walker's entry metadata before consuming `entry`,
-        // so the recent view can rank by when files appeared/changed on disk.
-        let modified_at = modified_unix_s(entry.metadata().ok().as_ref());
         let path_buf = entry.into_path();
         let Some(path_str) = path_buf.to_str() else {
             continue;
@@ -114,7 +111,16 @@ fn walk_files(
         let Some(name) = path_buf.file_name().and_then(|s| s.to_str()) else {
             continue;
         };
-        if path_buf.is_dir() {
+
+        // One stat per entry, reused for both kind and mtime. `fs::metadata`
+        // follows symlinks, matching the old `Path::is_dir`/`is_file` calls,
+        // which each did their own separate stat on top of the mtime read.
+        let Ok(metadata) = std::fs::metadata(&path_buf) else {
+            continue;
+        };
+        let modified_at = modified_unix_s(Some(&metadata));
+
+        if metadata.is_dir() {
             let key = format!(
                 "{FOLDER_CANDIDATE_ID_PREFIX}{}",
                 candidate_id_path_component(path_str)
@@ -126,7 +132,7 @@ fn walk_files(
             continue;
         }
 
-        if path_buf.is_file() {
+        if metadata.is_file() {
             // Normalize the candidate with the same policy used for the
             // pattern. Without this, a Windows pattern like `C:\tmp\*.log`
             // becomes lowercase `c:/...`, while walker output like

--- a/core/engine/src/index/files.rs
+++ b/core/engine/src/index/files.rs
@@ -1,17 +1,17 @@
 use crate::config::RuntimeConfig;
 use crate::index::{FILE_CANDIDATE_ID_PREFIX, FOLDER_CANDIDATE_ID_PREFIX};
 use crate::platform::paths::{
-    PathPolicy, candidate_id_path_component, compile_ignore_matcher, path_is_same_or_child,
+    PathPolicy, candidate_id_path_component, compile_ignore_glob, path_is_same_or_child,
 };
-use globset::GlobMatcher;
+use globset::{GlobSet, GlobSetBuilder};
 use ignore::WalkBuilder;
 use look_indexing::{Candidate, CandidateKind};
 use std::sync::mpsc;
 use std::time::UNIX_EPOCH;
 
-// Matchers grouped by their path policy so a candidate is normalized once per
-// distinct policy per file, instead of once per pattern in the match closure.
-type IgnoredFileMatchers = Vec<(PathPolicy, Vec<GlobMatcher>)>;
+// One `GlobSet` per path policy: a candidate is normalized once per distinct
+// policy and matched against all patterns of that policy in a single pass.
+type IgnoredFileMatchers = Vec<(PathPolicy, GlobSet)>;
 
 fn modified_unix_s(metadata: Option<&std::fs::Metadata>) -> Option<i64> {
     metadata?
@@ -28,9 +28,12 @@ pub fn discover_local_files_and_folders(config: &RuntimeConfig, tx: mpsc::SyncSe
     roots.sort();
     roots.dedup();
 
+    // Compile the ignore matchers once, not once per root.
+    let ignored_file_matchers = build_ignored_matchers(&config.ignored_file_patterns);
+
     let mut file_count = 0usize;
     for root in &roots {
-        walk_files(root, config, &tx, &mut file_count);
+        walk_files(root, config, &ignored_file_matchers, &tx, &mut file_count);
         if file_count >= config.file_scan_limit {
             break;
         }
@@ -40,6 +43,7 @@ pub fn discover_local_files_and_folders(config: &RuntimeConfig, tx: mpsc::SyncSe
 fn walk_files(
     path: &str,
     config: &RuntimeConfig,
+    ignored_file_matchers: &IgnoredFileMatchers,
     tx: &mpsc::SyncSender<Candidate>,
     file_count: &mut usize,
 ) {
@@ -51,7 +55,6 @@ fn walk_files(
     let root_path = path.to_string();
     let exclude_paths = config.file_exclude_paths.clone();
     let skip_dir_names = config.skip_dir_names.clone();
-    let ignored_file_matchers = group_ignored_matchers_by_policy(&config.ignored_file_patterns);
     walker
         .hidden(false)
         .git_ignore(false)
@@ -128,11 +131,8 @@ fn walk_files(
             // pattern. Without this, a Windows pattern like `C:\tmp\*.log`
             // becomes lowercase `c:/...`, while walker output like
             // `C:/tmp/debug.log` can keep its original case and miss the glob.
-            if ignored_file_matchers.iter().any(|(policy, glob_matchers)| {
-                let normalized = policy.normalize_for_matching(path_str);
-                glob_matchers
-                    .iter()
-                    .any(|matcher| matcher.is_match(&normalized))
+            if ignored_file_matchers.iter().any(|(policy, glob_set)| {
+                glob_set.is_match(&*policy.normalize_for_matching(path_str))
             }) {
                 continue;
             }
@@ -150,18 +150,27 @@ fn walk_files(
     }
 }
 
-fn group_ignored_matchers_by_policy(patterns: &[String]) -> IgnoredFileMatchers {
-    let mut groups: IgnoredFileMatchers = Vec::new();
-    for (policy, matcher) in patterns
+fn build_ignored_matchers(patterns: &[String]) -> IgnoredFileMatchers {
+    let mut groups: Vec<(PathPolicy, GlobSetBuilder)> = Vec::new();
+    for (policy, glob) in patterns
         .iter()
-        .filter_map(|pattern| compile_ignore_matcher(pattern))
+        .filter_map(|pattern| compile_ignore_glob(pattern))
     {
         match groups.iter_mut().find(|(existing, _)| *existing == policy) {
-            Some((_, matchers)) => matchers.push(matcher),
-            None => groups.push((policy, vec![matcher])),
+            Some((_, builder)) => {
+                builder.add(glob);
+            }
+            None => {
+                let mut builder = GlobSetBuilder::new();
+                builder.add(glob);
+                groups.push((policy, builder));
+            }
         }
     }
     groups
+        .into_iter()
+        .filter_map(|(policy, builder)| builder.build().ok().map(|set| (policy, set)))
+        .collect()
 }
 
 fn should_skip_dir(name: &str, skip_dir_names: &[String]) -> bool {
@@ -203,7 +212,7 @@ mod tests {
             return false;
         };
         let normalized_path = policy.normalize_for_matching(path);
-        matcher.is_match(&normalized_path)
+        matcher.is_match(&*normalized_path)
     }
 
     #[test]
@@ -390,7 +399,7 @@ mod tests {
         let pattern = r"C:\Users\me\Temp\*.log";
         let (policy, matcher) = compile_ignore_matcher(pattern).expect("pattern should compile");
 
-        assert!(matcher.is_match(policy.normalize_for_matching("C:/Users/me/Temp/debug.log")));
-        assert!(!matcher.is_match(policy.normalize_for_matching("C:/Users/me/Temp/debug.txt")));
+        assert!(matcher.is_match(&*policy.normalize_for_matching("C:/Users/me/Temp/debug.log")));
+        assert!(!matcher.is_match(&*policy.normalize_for_matching("C:/Users/me/Temp/debug.txt")));
     }
 }

--- a/core/engine/src/index/files.rs
+++ b/core/engine/src/index/files.rs
@@ -161,7 +161,21 @@ fn should_exclude_path(path: &str, file_exclude_paths: &[String]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::should_exclude_path;
+    use super::{discover_local_files_and_folders, should_exclude_path};
+    use crate::config::RuntimeConfig;
+    use look_indexing::CandidateKind;
+    use std::sync::mpsc;
+
+    fn temp_path(prefix: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "look-files-test-{prefix}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time should be after epoch")
+                .as_nanos()
+        ))
+    }
 
     #[test]
     fn excludes_nested_paths_and_exact_matches() {
@@ -210,5 +224,116 @@ mod tests {
             "C:/Users/demo/Downloads/cache/a.txt",
             &excludes
         ));
+    }
+
+    #[test]
+    fn ignored_patterns_skip_matching_files_but_keep_other_entries() {
+        let root = temp_path("ignored-patterns");
+        let nested = root.join("nested");
+        std::fs::create_dir_all(&nested).expect("should create test directories");
+        std::fs::write(root.join("debug.log"), "log").expect("should write log file");
+        std::fs::write(root.join("notes.md"), "notes").expect("should write notes file");
+        std::fs::write(nested.join("state.db-wal"), "wal").expect("should write wal file");
+
+        let mut config = RuntimeConfig::default();
+        config.file_scan_roots = vec![root.to_string_lossy().into_owned()];
+        config.file_scan_extra_roots.clear();
+        config.file_scan_depth = 4;
+        config.file_scan_limit = 100;
+        let root_str = root.to_string_lossy().into_owned();
+        config.ignored_file_patterns = vec![
+            format!("{root_str}/*.log"),
+            format!("{root_str}/**/*.db-wal"),
+        ];
+
+        let (tx, rx) = mpsc::sync_channel(128);
+        discover_local_files_and_folders(&config, tx);
+        let candidates = rx.try_iter().collect::<Vec<_>>();
+
+        assert!(candidates.iter().any(|candidate| {
+            candidate.kind == CandidateKind::File && candidate.title.as_ref() == "notes.md"
+        }));
+        assert!(candidates.iter().any(|candidate| {
+            candidate.kind == CandidateKind::Folder && candidate.title.as_ref() == "nested"
+        }));
+        assert!(
+            !candidates
+                .iter()
+                .any(|candidate| candidate.title.as_ref() == "debug.log")
+        );
+        assert!(
+            !candidates
+                .iter()
+                .any(|candidate| candidate.title.as_ref() == "state.db-wal")
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn ignored_patterns_do_not_consume_file_scan_limit() {
+        let root = temp_path("ignored-pattern-limit");
+        std::fs::create_dir_all(&root).expect("should create test directory");
+        std::fs::write(root.join("debug.log"), "log").expect("should write ignored file");
+        std::fs::write(root.join("notes.md"), "notes").expect("should write kept file");
+
+        let mut config = RuntimeConfig::default();
+        config.file_scan_roots = vec![root.to_string_lossy().into_owned()];
+        config.file_scan_extra_roots.clear();
+        config.file_scan_depth = 2;
+        config.file_scan_limit = 1;
+        let root_str = root.to_string_lossy().into_owned();
+        config.ignored_file_patterns = vec![format!("{root_str}/*.log")];
+
+        let (tx, rx) = mpsc::sync_channel(32);
+        discover_local_files_and_folders(&config, tx);
+        let candidates = rx.try_iter().collect::<Vec<_>>();
+
+        let file_titles = candidates
+            .iter()
+            .filter(|candidate| candidate.kind == CandidateKind::File)
+            .map(|candidate| candidate.title.as_ref())
+            .collect::<Vec<_>>();
+        assert_eq!(file_titles, vec!["notes.md"]);
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn ignored_patterns_folder_scoped_glob_only_matches_direct_children() {
+        // Case:
+        // - root/direct.tmp
+        // - root/nested/child.tmp
+        // - ignored_file_patterns = [root/*.tmp]
+        let root = temp_path("ignored-pattern-direct-children");
+        let nested = root.join("nested");
+        std::fs::create_dir_all(&nested).expect("should create test directories");
+        std::fs::write(root.join("direct.tmp"), "tmp").expect("should write direct file");
+        std::fs::write(nested.join("child.tmp"), "tmp").expect("should write nested file");
+
+        let mut config = RuntimeConfig::default();
+        config.file_scan_roots = vec![root.to_string_lossy().into_owned()];
+        config.file_scan_extra_roots.clear();
+        config.file_scan_depth = 4;
+        config.file_scan_limit = 10;
+        let root_str = root.to_string_lossy().into_owned();
+        config.ignored_file_patterns = vec![format!("{root_str}/*.tmp")];
+
+        let (tx, rx) = mpsc::sync_channel(32);
+        discover_local_files_and_folders(&config, tx);
+        let candidates = rx.try_iter().collect::<Vec<_>>();
+
+        assert!(
+            !candidates
+                .iter()
+                .any(|candidate| candidate.title.as_ref() == "direct.tmp")
+        );
+        assert!(
+            candidates
+                .iter()
+                .any(|candidate| candidate.title.as_ref() == "child.tmp")
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/core/engine/src/index/files.rs
+++ b/core/engine/src/index/files.rs
@@ -49,7 +49,8 @@ fn walk_files(
         .ignored_file_patterns
         .iter()
         .filter_map(|pattern| {
-            let mut builder = GlobBuilder::new(pattern);
+            let normalized_pattern = PathPolicy::for_base(pattern).normalize_for_matching(pattern);
+            let mut builder = GlobBuilder::new(&normalized_pattern);
             builder.literal_separator(true);
             builder.build().ok()
         })

--- a/core/engine/src/index/files.rs
+++ b/core/engine/src/index/files.rs
@@ -9,7 +9,9 @@ use look_indexing::{Candidate, CandidateKind};
 use std::sync::mpsc;
 use std::time::UNIX_EPOCH;
 
-type IgnoredFileMatcher = (PathPolicy, GlobMatcher);
+// Matchers grouped by their path policy so a candidate is normalized once per
+// distinct policy per file, instead of once per pattern in the match closure.
+type IgnoredFileMatchers = Vec<(PathPolicy, Vec<GlobMatcher>)>;
 
 fn modified_unix_s(metadata: Option<&std::fs::Metadata>) -> Option<i64> {
     metadata?
@@ -49,11 +51,7 @@ fn walk_files(
     let root_path = path.to_string();
     let exclude_paths = config.file_exclude_paths.clone();
     let skip_dir_names = config.skip_dir_names.clone();
-    let ignored_file_matchers = config
-        .ignored_file_patterns
-        .iter()
-        .filter_map(|pattern| compile_ignore_matcher(pattern))
-        .collect::<Vec<IgnoredFileMatcher>>();
+    let ignored_file_matchers = group_ignored_matchers_by_policy(&config.ignored_file_patterns);
     walker
         .hidden(false)
         .git_ignore(false)
@@ -130,8 +128,11 @@ fn walk_files(
             // pattern. Without this, a Windows pattern like `C:\tmp\*.log`
             // becomes lowercase `c:/...`, while walker output like
             // `C:/tmp/debug.log` can keep its original case and miss the glob.
-            if ignored_file_matchers.iter().any(|(policy, glob_matcher)| {
-                glob_matcher.is_match(policy.normalize_for_matching(path_str))
+            if ignored_file_matchers.iter().any(|(policy, glob_matchers)| {
+                let normalized = policy.normalize_for_matching(path_str);
+                glob_matchers
+                    .iter()
+                    .any(|matcher| matcher.is_match(&normalized))
             }) {
                 continue;
             }
@@ -147,6 +148,20 @@ fn walk_files(
             let _ = tx.send(candidate);
         }
     }
+}
+
+fn group_ignored_matchers_by_policy(patterns: &[String]) -> IgnoredFileMatchers {
+    let mut groups: IgnoredFileMatchers = Vec::new();
+    for (policy, matcher) in patterns
+        .iter()
+        .filter_map(|pattern| compile_ignore_matcher(pattern))
+    {
+        match groups.iter_mut().find(|(existing, _)| *existing == policy) {
+            Some((_, matchers)) => matchers.push(matcher),
+            None => groups.push((policy, vec![matcher])),
+        }
+    }
+    groups
 }
 
 fn should_skip_dir(name: &str, skip_dir_names: &[String]) -> bool {
@@ -168,7 +183,7 @@ fn should_exclude_path(path: &str, file_exclude_paths: &[String]) -> bool {
 mod tests {
     use super::{discover_local_files_and_folders, should_exclude_path};
     use crate::config::RuntimeConfig;
-    use crate::platform::paths::{PathPolicy, compile_ignore_matcher};
+    use crate::platform::paths::compile_ignore_matcher;
     use look_indexing::CandidateKind;
     use std::sync::mpsc;
 
@@ -249,18 +264,19 @@ mod tests {
         std::fs::write(root.join("notes.md"), "notes").expect("should write notes file");
         std::fs::write(nested.join("state.db-wal"), "wal").expect("should write wal file");
 
-        let mut config = RuntimeConfig::default();
-        config.file_scan_roots = vec![root.to_string_lossy().into_owned()];
-        config.file_scan_extra_roots.clear();
-        config.file_scan_depth = 4;
-        config.file_scan_limit = 100;
-        config.ignored_file_patterns = vec![
-            root.join("*.log").to_string_lossy().into_owned(),
-            root.join("**")
-                .join("*.db-wal")
-                .to_string_lossy()
-                .into_owned(),
-        ];
+        let config = RuntimeConfig {
+            file_scan_roots: vec![root.to_string_lossy().into_owned()],
+            file_scan_depth: 4,
+            file_scan_limit: 100,
+            ignored_file_patterns: vec![
+                root.join("*.log").to_string_lossy().into_owned(),
+                root.join("**")
+                    .join("*.db-wal")
+                    .to_string_lossy()
+                    .into_owned(),
+            ],
+            ..Default::default()
+        };
 
         let (tx, rx) = mpsc::sync_channel(128);
         discover_local_files_and_folders(&config, tx);
@@ -293,12 +309,13 @@ mod tests {
         std::fs::write(root.join("debug.log"), "log").expect("should write ignored file");
         std::fs::write(root.join("notes.md"), "notes").expect("should write kept file");
 
-        let mut config = RuntimeConfig::default();
-        config.file_scan_roots = vec![root.to_string_lossy().into_owned()];
-        config.file_scan_extra_roots.clear();
-        config.file_scan_depth = 2;
-        config.file_scan_limit = 1;
-        config.ignored_file_patterns = vec![root.join("*.log").to_string_lossy().into_owned()];
+        let config = RuntimeConfig {
+            file_scan_roots: vec![root.to_string_lossy().into_owned()],
+            file_scan_depth: 2,
+            file_scan_limit: 1,
+            ignored_file_patterns: vec![root.join("*.log").to_string_lossy().into_owned()],
+            ..Default::default()
+        };
 
         let (tx, rx) = mpsc::sync_channel(32);
         discover_local_files_and_folders(&config, tx);
@@ -326,12 +343,13 @@ mod tests {
         std::fs::write(root.join("direct.tmp"), "tmp").expect("should write direct file");
         std::fs::write(nested.join("child.tmp"), "tmp").expect("should write nested file");
 
-        let mut config = RuntimeConfig::default();
-        config.file_scan_roots = vec![root.to_string_lossy().into_owned()];
-        config.file_scan_extra_roots.clear();
-        config.file_scan_depth = 4;
-        config.file_scan_limit = 10;
-        config.ignored_file_patterns = vec![root.join("*.tmp").to_string_lossy().into_owned()];
+        let config = RuntimeConfig {
+            file_scan_roots: vec![root.to_string_lossy().into_owned()],
+            file_scan_depth: 4,
+            file_scan_limit: 10,
+            ignored_file_patterns: vec![root.join("*.tmp").to_string_lossy().into_owned()],
+            ..Default::default()
+        };
 
         let (tx, rx) = mpsc::sync_channel(32);
         discover_local_files_and_folders(&config, tx);

--- a/core/engine/src/index/files.rs
+++ b/core/engine/src/index/files.rs
@@ -1,7 +1,7 @@
 use crate::config::RuntimeConfig;
 use crate::index::{FILE_CANDIDATE_ID_PREFIX, FOLDER_CANDIDATE_ID_PREFIX};
 use crate::platform::paths::{PathPolicy, candidate_id_path_component, path_is_same_or_child};
-use globset::Glob;
+use globset::GlobBuilder;
 use ignore::WalkBuilder;
 use look_indexing::{Candidate, CandidateKind};
 use std::sync::mpsc;
@@ -48,7 +48,11 @@ fn walk_files(
     let ignored_file_matchers = config
         .ignored_file_patterns
         .iter()
-        .filter_map(|pattern| Glob::new(pattern).ok())
+        .filter_map(|pattern| {
+            let mut builder = GlobBuilder::new(pattern);
+            builder.literal_separator(true);
+            builder.build().ok()
+        })
         .map(|glob| glob.compile_matcher())
         .collect::<Vec<_>>();
     walker

--- a/core/engine/src/index/files.rs
+++ b/core/engine/src/index/files.rs
@@ -262,7 +262,10 @@ mod tests {
         config.file_scan_limit = 100;
         config.ignored_file_patterns = vec![
             root.join("*.log").to_string_lossy().into_owned(),
-            root.join("**").join("*.db-wal").to_string_lossy().into_owned(),
+            root.join("**")
+                .join("*.db-wal")
+                .to_string_lossy()
+                .into_owned(),
         ];
 
         let (tx, rx) = mpsc::sync_channel(128);

--- a/core/engine/src/index/files.rs
+++ b/core/engine/src/index/files.rs
@@ -166,9 +166,9 @@ fn should_exclude_path(path: &str, file_exclude_paths: &[String]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{discover_local_files_and_folders, should_exclude_path};
+    use crate::config::RuntimeConfig;
     use crate::platform::paths::PathPolicy;
     use globset::GlobBuilder;
-    use crate::config::RuntimeConfig;
     use look_indexing::CandidateKind;
     use std::sync::mpsc;
 

--- a/core/engine/src/index/files.rs
+++ b/core/engine/src/index/files.rs
@@ -260,10 +260,9 @@ mod tests {
         config.file_scan_extra_roots.clear();
         config.file_scan_depth = 4;
         config.file_scan_limit = 100;
-        let root_str = root.to_string_lossy().into_owned();
         config.ignored_file_patterns = vec![
-            format!("{root_str}/*.log"),
-            format!("{root_str}/**/*.db-wal"),
+            root.join("*.log").to_string_lossy().into_owned(),
+            root.join("**").join("*.db-wal").to_string_lossy().into_owned(),
         ];
 
         let (tx, rx) = mpsc::sync_channel(128);
@@ -302,8 +301,7 @@ mod tests {
         config.file_scan_extra_roots.clear();
         config.file_scan_depth = 2;
         config.file_scan_limit = 1;
-        let root_str = root.to_string_lossy().into_owned();
-        config.ignored_file_patterns = vec![format!("{root_str}/*.log")];
+        config.ignored_file_patterns = vec![root.join("*.log").to_string_lossy().into_owned()];
 
         let (tx, rx) = mpsc::sync_channel(32);
         discover_local_files_and_folders(&config, tx);
@@ -336,8 +334,7 @@ mod tests {
         config.file_scan_extra_roots.clear();
         config.file_scan_depth = 4;
         config.file_scan_limit = 10;
-        let root_str = root.to_string_lossy().into_owned();
-        config.ignored_file_patterns = vec![format!("{root_str}/*.tmp")];
+        config.ignored_file_patterns = vec![root.join("*.tmp").to_string_lossy().into_owned()];
 
         let (tx, rx) = mpsc::sync_channel(32);
         discover_local_files_and_folders(&config, tx);

--- a/core/engine/src/index/files.rs
+++ b/core/engine/src/index/files.rs
@@ -2,10 +2,13 @@ use crate::config::RuntimeConfig;
 use crate::index::{FILE_CANDIDATE_ID_PREFIX, FOLDER_CANDIDATE_ID_PREFIX};
 use crate::platform::paths::{PathPolicy, candidate_id_path_component, path_is_same_or_child};
 use globset::GlobBuilder;
+use globset::GlobMatcher;
 use ignore::WalkBuilder;
 use look_indexing::{Candidate, CandidateKind};
 use std::sync::mpsc;
 use std::time::UNIX_EPOCH;
+
+type IgnoredFileMatcher = (PathPolicy, GlobMatcher);
 
 fn modified_unix_s(metadata: Option<&std::fs::Metadata>) -> Option<i64> {
     metadata?
@@ -49,13 +52,16 @@ fn walk_files(
         .ignored_file_patterns
         .iter()
         .filter_map(|pattern| {
-            let normalized_pattern = PathPolicy::for_base(pattern).normalize_for_matching(pattern);
+            let policy = PathPolicy::for_base(pattern);
+            let normalized_pattern = policy.normalize_for_matching(pattern);
             let mut builder = GlobBuilder::new(&normalized_pattern);
             builder.literal_separator(true);
-            builder.build().ok()
+            builder
+                .build()
+                .ok()
+                .map(|glob| (policy, glob.compile_matcher()))
         })
-        .map(|glob| glob.compile_matcher())
-        .collect::<Vec<_>>();
+        .collect::<Vec<IgnoredFileMatcher>>();
     walker
         .hidden(false)
         .git_ignore(false)
@@ -128,11 +134,13 @@ fn walk_files(
         }
 
         if path_buf.is_file() {
-            let normalized_path = PathPolicy::for_base(path_str).normalize_for_matching(path_str);
-            if ignored_file_matchers
-                .iter()
-                .any(|matcher| matcher.is_match(&normalized_path))
-            {
+            // Normalize the candidate with the same policy used for the
+            // pattern. Without this, a Windows pattern like `C:\tmp\*.log`
+            // becomes lowercase `c:/...`, while walker output like
+            // `C:/tmp/debug.log` can keep its original case and miss the glob.
+            if ignored_file_matchers.iter().any(|(policy, glob_matcher)| {
+                glob_matcher.is_match(policy.normalize_for_matching(path_str))
+            }) {
                 continue;
             }
 
@@ -371,5 +379,21 @@ mod tests {
             r"C:\Users\me\AppData\Local\Temp\**\*.etl",
             "C:/Users/me/AppData/Local/Temp/nested/trace.log"
         ));
+    }
+
+    #[test]
+    fn ignored_patterns_match_windows_backslash_pattern_against_slash_candidate() {
+        let pattern = r"C:\Users\me\Temp\*.log";
+        let policy = PathPolicy::for_base(pattern);
+        let normalized_pattern = policy.normalize_for_matching(pattern);
+        let mut builder = GlobBuilder::new(&normalized_pattern);
+        builder.literal_separator(true);
+        let matcher = builder
+            .build()
+            .expect("pattern should compile")
+            .compile_matcher();
+
+        assert!(matcher.is_match(policy.normalize_for_matching("C:/Users/me/Temp/debug.log")));
+        assert!(!matcher.is_match(policy.normalize_for_matching("C:/Users/me/Temp/debug.txt")));
     }
 }

--- a/core/engine/src/index/files.rs
+++ b/core/engine/src/index/files.rs
@@ -1,6 +1,7 @@
 use crate::config::RuntimeConfig;
 use crate::index::{FILE_CANDIDATE_ID_PREFIX, FOLDER_CANDIDATE_ID_PREFIX};
-use crate::platform::paths::{candidate_id_path_component, path_is_same_or_child};
+use crate::platform::paths::{PathPolicy, candidate_id_path_component, path_is_same_or_child};
+use globset::Glob;
 use ignore::WalkBuilder;
 use look_indexing::{Candidate, CandidateKind};
 use std::sync::mpsc;
@@ -44,6 +45,12 @@ fn walk_files(
     let root_path = path.to_string();
     let exclude_paths = config.file_exclude_paths.clone();
     let skip_dir_names = config.skip_dir_names.clone();
+    let ignored_file_matchers = config
+        .ignored_file_patterns
+        .iter()
+        .filter_map(|pattern| Glob::new(pattern).ok())
+        .map(|glob| glob.compile_matcher())
+        .collect::<Vec<_>>();
     walker
         .hidden(false)
         .git_ignore(false)
@@ -116,6 +123,14 @@ fn walk_files(
         }
 
         if path_buf.is_file() {
+            let normalized_path = PathPolicy::for_base(path_str).normalize_for_matching(path_str);
+            if ignored_file_matchers
+                .iter()
+                .any(|matcher| matcher.is_match(&normalized_path))
+            {
+                continue;
+            }
+
             *file_count += 1;
             let key = format!(
                 "{FILE_CANDIDATE_ID_PREFIX}{}",

--- a/core/engine/src/index/files.rs
+++ b/core/engine/src/index/files.rs
@@ -166,6 +166,8 @@ fn should_exclude_path(path: &str, file_exclude_paths: &[String]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{discover_local_files_and_folders, should_exclude_path};
+    use crate::platform::paths::PathPolicy;
+    use globset::GlobBuilder;
     use crate::config::RuntimeConfig;
     use look_indexing::CandidateKind;
     use std::sync::mpsc;
@@ -179,6 +181,19 @@ mod tests {
                 .expect("system time should be after epoch")
                 .as_nanos()
         ))
+    }
+
+    fn windows_style_ignored_pattern_matches(pattern: &str, path: &str) -> bool {
+        let policy = PathPolicy::for_base(pattern);
+        let normalized_pattern = policy.normalize_for_matching(pattern);
+        let normalized_path = policy.normalize_for_matching(path);
+        let mut builder = GlobBuilder::new(&normalized_pattern);
+        builder.literal_separator(true);
+        builder
+            .build()
+            .expect("pattern should compile")
+            .compile_matcher()
+            .is_match(&normalized_path)
     }
 
     #[test]
@@ -339,5 +354,21 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn ignored_patterns_windows_style_paths_match_consistently() {
+        // Case:
+        // - pattern = C:\Users\me\AppData\Local\Temp\**\*.etl
+        // - path = C:/Users/me/AppData/Local/Temp/nested/trace.etl
+        // - unrelated = C:/Users/me/AppData/Local/Temp/nested/trace.log
+        assert!(windows_style_ignored_pattern_matches(
+            r"C:\Users\me\AppData\Local\Temp\**\*.etl",
+            "C:/Users/me/AppData/Local/Temp/nested/trace.etl"
+        ));
+        assert!(!windows_style_ignored_pattern_matches(
+            r"C:\Users\me\AppData\Local\Temp\**\*.etl",
+            "C:/Users/me/AppData/Local/Temp/nested/trace.log"
+        ));
     }
 }

--- a/core/engine/src/platform/paths.rs
+++ b/core/engine/src/platform/paths.rs
@@ -1,3 +1,4 @@
+use globset::{GlobBuilder, GlobMatcher};
 use std::path::Path;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -109,6 +110,17 @@ impl PathPolicy {
     pub(crate) fn id_component(&self, path: &str) -> String {
         self.normalize_for_matching(path).to_lowercase()
     }
+}
+
+pub(crate) fn compile_ignore_matcher(pattern: &str) -> Option<(PathPolicy, GlobMatcher)> {
+    let policy = PathPolicy::for_base(pattern);
+    let normalized_pattern = policy.normalize_for_matching(pattern);
+    let mut builder = GlobBuilder::new(&normalized_pattern);
+    builder.literal_separator(true);
+    builder
+        .build()
+        .ok()
+        .map(|glob| (policy, glob.compile_matcher()))
 }
 
 fn separator_for_style(style: PathStyle) -> char {

--- a/core/engine/src/platform/paths.rs
+++ b/core/engine/src/platform/paths.rs
@@ -211,9 +211,14 @@ pub(crate) fn looks_like_absolute_path(path: &str) -> bool {
 }
 
 pub(crate) fn expand_with_home(value: &str, home: Option<&str>) -> String {
-    if value.starts_with("~/") {
+    // Accept both `~/` and the Windows-native `~\` home prefix. `join_path`
+    // then re-emits the tail with the separator that matches `home`.
+    if let Some(rest) = value
+        .strip_prefix("~/")
+        .or_else(|| value.strip_prefix("~\\"))
+    {
         return home
-            .map(|prefix| join_path(prefix, value.trim_start_matches("~/")))
+            .map(|prefix| join_path(prefix, rest))
             .unwrap_or_else(|| value.to_string());
     }
 
@@ -296,6 +301,21 @@ mod tests {
         );
         assert_eq!(expand_with_home("/tmp", Some("/Users/demo")), "/tmp");
         assert_eq!(expand_with_home("~/Desktop", Some("/")), "/Desktop");
+    }
+
+    #[test]
+    fn expand_with_home_handles_windows_backslash_tilde() {
+        // `~\` is the native Windows home form; it must expand against a Windows
+        // home the same way `~/` does, keeping the tail intact.
+        let home = Some("C:\\Users\\demo");
+        assert_eq!(
+            expand_with_home("~\\AppData\\Local\\Temp\\*.etl", home),
+            "C:\\Users\\demo\\AppData\\Local\\Temp\\*.etl"
+        );
+        assert_eq!(
+            expand_with_home("~\\Downloads\\*.tmp", Some("/Users/demo")),
+            "/Users/demo/Downloads\\*.tmp"
+        );
     }
 
     #[test]

--- a/core/engine/src/platform/paths.rs
+++ b/core/engine/src/platform/paths.rs
@@ -1,4 +1,5 @@
-use globset::{GlobBuilder, GlobMatcher};
+use globset::{Glob, GlobBuilder};
+use std::borrow::Cow;
 use std::path::Path;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -46,20 +47,17 @@ impl PathPolicy {
         Self::current()
     }
 
-    pub(crate) fn normalize_for_matching(&self, path: &str) -> String {
-        let mut normalized = match self.style {
-            PathStyle::Windows => path.replace('\\', "/"),
-            PathStyle::Posix => path.to_string(),
-        };
-        while normalized.len() > 1 && normalized.ends_with('/') {
-            normalized.pop();
+    pub(crate) fn normalize_for_matching<'a>(&self, path: &'a str) -> Cow<'a, str> {
+        match self.style {
+            // Posix candidates already use `/` and the right case, so the
+            // common Linux path only trims trailing slashes and borrows.
+            PathStyle::Posix => Cow::Borrowed(trim_trailing_slashes(path)),
+            PathStyle::Windows => {
+                let mut normalized = path.replace('\\', "/");
+                normalized.truncate(trim_trailing_slashes(&normalized).len());
+                Cow::Owned(normalized.to_lowercase())
+            }
         }
-
-        if matches!(self.style, PathStyle::Windows) {
-            return normalized.to_lowercase();
-        }
-
-        normalized
     }
 
     pub(crate) fn is_same_or_child(&self, path: &str, parent: &str) -> bool {
@@ -69,8 +67,8 @@ impl PathPolicy {
             return false;
         }
 
-        normalized_path == normalized_parent
-            || normalized_path.starts_with(&(normalized_parent + "/"))
+        let parent_prefix = format!("{normalized_parent}/");
+        normalized_path == normalized_parent || normalized_path.starts_with(parent_prefix.as_str())
     }
 
     pub(crate) fn join(&self, base: &str, child: &str) -> String {
@@ -112,15 +110,28 @@ impl PathPolicy {
     }
 }
 
-pub(crate) fn compile_ignore_matcher(pattern: &str) -> Option<(PathPolicy, GlobMatcher)> {
+/// Compile one ignore pattern into its path policy and glob. The caller groups
+/// globs by policy into a `GlobSet` so every candidate is matched against all
+/// patterns of a policy in a single pass.
+pub(crate) fn compile_ignore_glob(pattern: &str) -> Option<(PathPolicy, Glob)> {
     let policy = PathPolicy::for_base(pattern);
     let normalized_pattern = policy.normalize_for_matching(pattern);
     let mut builder = GlobBuilder::new(&normalized_pattern);
     builder.literal_separator(true);
-    builder
-        .build()
-        .ok()
-        .map(|glob| (policy, glob.compile_matcher()))
+    builder.build().ok().map(|glob| (policy, glob))
+}
+
+#[cfg(test)]
+pub(crate) fn compile_ignore_matcher(pattern: &str) -> Option<(PathPolicy, globset::GlobMatcher)> {
+    compile_ignore_glob(pattern).map(|(policy, glob)| (policy, glob.compile_matcher()))
+}
+
+fn trim_trailing_slashes(path: &str) -> &str {
+    let mut end = path.len();
+    while end > 1 && path.as_bytes()[end - 1] == b'/' {
+        end -= 1;
+    }
+    &path[..end]
 }
 
 fn separator_for_style(style: PathStyle) -> char {
@@ -260,7 +271,7 @@ mod tests {
             style: PathStyle::Posix,
         };
 
-        assert_eq!(policy.normalize_for_matching("/tmp/a\\b "), "/tmp/a\\b ");
+        assert_eq!(&*policy.normalize_for_matching("/tmp/a\\b "), "/tmp/a\\b ");
     }
 
     #[test]

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -240,6 +240,7 @@ Backend-related keys:
 
 - `app_scan_roots`, `app_scan_depth`, `app_exclude_paths`, `app_exclude_names`
 - `file_scan_roots`, `file_scan_extra_roots`, `file_scan_depth`, `file_scan_limit`, `file_exclude_paths`
+- `ignored_patterns_<group>` (path-aware file ignore globs, merged across all groups)
 - `lazy_indexing_enabled`
 - `skip_dir_names`
 - `alias_<keyword>` (for app + System Settings query aliases, for example `alias_note=Notion|Obsidian|Notes|Apple Notes|Bear|Logseq`)
@@ -250,6 +251,29 @@ File-only settings (no Settings UI):
 These keys have no control in the Settings screens. Edit `~/.look.config` directly, then reload with `Cmd+Shift+;` (macOS) or `Ctrl+Shift+;` (Linux/Windows), or restart Look. Out-of-range or unparseable values fall back to the listed default. More keys will be added here over time.
 
 - `clipboard_history_limit` (clipboard history size, range 10 to 100, default 10)
+
+Ignore-pattern note:
+
+- `ignored_patterns_<group>` uses gitignore-style path glob syntax: `*`, `**`, `?`, `[abc]`
+- macOS/Linux normally use `/` paths like `~/Library/...` or `/home/name/...`
+- Windows is verified with native absolute paths like `C:\Users\me\...`; `~` is expanded against your home directory before matching
+- macOS works the same way; common roots are `~/Library/...`, `~/Documents/...`, `~/Downloads/...`
+- values are separated with `|`, and all `ignored_patterns_*` entries are merged together
+- patterns apply to files only; they do not exclude folders from traversal
+
+Examples:
+
+- `ignored_patterns_macos=~/Library/Application Support/Code/logs/**/*.log|~/Library/Caches/**/*.tmp`
+- `ignored_patterns_windows=C:\Users\me\AppData\Local\Temp\**\*.etl|C:\Users\me\Downloads\**\*.tmp`
+- `ignored_patterns_browser=~/AppData/Local/BraveSoftware/**/*.log|~/AppData/Local/Google/Chrome/**/*.tmp`
+- `ignored_patterns_sqlite=~/Documents/git/project/**/*.db-wal|~/Documents/git/project/**/*.db-shm`
+- `ignored_patterns_temp=~/Downloads/*.tmp|~/Downloads/**/*.part`
+
+Quick matching guide:
+
+- `*` matches within one path segment: `~/Downloads/*.tmp`
+- `**` matches across nested folders: `~/Downloads/**/*.tmp`
+- keep patterns path-scoped when possible; `*.log` works but is usually too broad
 
 Alias note:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -252,28 +252,26 @@ These keys have no control in the Settings screens. Edit `~/.look.config` direct
 
 - `clipboard_history_limit` (clipboard history size, range 10 to 100, default 10)
 
-Ignore-pattern note:
-
 - `ignored_patterns_<group>` uses gitignore-style path glob syntax: `*`, `**`, `?`, `[abc]`
-- macOS/Linux normally use `/` paths like `~/Library/...` or `/home/name/...`
-- Windows is verified with native absolute paths like `C:\Users\me\...`; `~` is expanded against your home directory before matching
-- macOS works the same way; common roots are `~/Library/...`, `~/Documents/...`, `~/Downloads/...`
-- values are separated with `|`, and all `ignored_patterns_*` entries are merged together
-- patterns apply to files only; they do not exclude folders from traversal
+    - macOS/Linux normally use `/` paths like `~/Library/...` or `/home/name/...`
+    - Windows is verified with native absolute paths like `C:\Users\me\...`; `~` is expanded against your home directory before matching
+    - macOS works the same way; common roots are `~/Library/...`, `~/Documents/...`, `~/Downloads/...`
+    - values are separated with `|`, and all `ignored_patterns_*` entries are merged together
+    - patterns apply to files only; they do not exclude folders from traversal
 
-Examples:
+    Examples:
 
-- `ignored_patterns_macos=~/Library/Application Support/Code/logs/**/*.log|~/Library/Caches/**/*.tmp`
-- `ignored_patterns_windows=C:\Users\me\AppData\Local\Temp\**\*.etl|C:\Users\me\Downloads\**\*.tmp`
-- `ignored_patterns_browser=~/AppData/Local/BraveSoftware/**/*.log|~/AppData/Local/Google/Chrome/**/*.tmp`
-- `ignored_patterns_sqlite=~/Documents/git/project/**/*.db-wal|~/Documents/git/project/**/*.db-shm`
-- `ignored_patterns_temp=~/Downloads/*.tmp|~/Downloads/**/*.part`
+    - `ignored_patterns_macos=~/Library/Application Support/Code/logs/**/*.log|~/Library/Caches/**/*.tmp`
+    - `ignored_patterns_windows=C:\Users\me\AppData\Local\Temp\**\*.etl|C:\Users\me\Downloads\**\*.tmp`
+    - `ignored_patterns_browser=~/AppData/Local/BraveSoftware/**/*.log|~/AppData/Local/Google/Chrome/**/*.tmp`
+    - `ignored_patterns_sqlite=~/Documents/git/project/**/*.db-wal|~/Documents/git/project/**/*.db-shm`
+    - `ignored_patterns_temp=~/Downloads/*.tmp|~/Downloads/**/*.part`
 
-Quick matching guide:
+    Quick matching guide:
 
-- `*` matches within one path segment: `~/Downloads/*.tmp`
-- `**` matches across nested folders: `~/Downloads/**/*.tmp`
-- keep patterns path-scoped when possible; `*.log` works but is usually too broad
+    - `*` matches within one path segment: `~/Downloads/*.tmp`
+    - `**` matches across nested folders: `~/Downloads/**/*.tmp`
+    - keep patterns path-scoped when possible; `*.log` works but is usually too broad
 
 Alias note:
 


### PR DESCRIPTION
## Summary

- Add `ignored_patterns_*` config support for file indexing
- Skip matching files without excluding parent folders

## Why

- https://github.com/kunkka19xx/look/issues/269

## Changes

- add `ignored_file_patterns` to `RuntimeConfig`
- parse and merge `ignored_patterns_*` values from config
- normalize and validate patterns, skipping invalid entries
- apply ignored pattern checks only to file candidates during indexing
- ensure ignored files do not consume `file_scan_limit`
- document `ignored_patterns_*` in generated default configs

## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [x] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

- pattern matching is file-only; directory traversal behavior is unchanged

## Checklist

- [x] Unit test
- [x] i3/x11
- [x] Gnome 
- [ ] Win11
- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable glob-based “ignored patterns” via `ignored_patterns_<group>=Pattern1|Pattern2|...`, including `~` expansion, Windows path normalization, and de-duplication.
  * File scanning now skips files matching these patterns, while folder discovery and existing exclusions remain unchanged.
* **Documentation**
  * Updated default config templates and the user guide with the new syntax, merge behavior, file-only scope, and examples.
* **Tests**
  * Expanded unit and matcher tests to cover valid/invalid patterns, empty/whitespace values, normalization, and Windows matching consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->