### PR TITLE
feat: remove clipboard entries with Cmd/Ctrl+D

### DIFF
--- a/apps/linows/src-tauri/src/clipboard.rs
+++ b/apps/linows/src-tauri/src/clipboard.rs
@@ -162,16 +162,26 @@ pub fn get_clipboard_history(query: String) -> Vec<ClipboardEntry> {
         .collect()
 }
 
+fn remove_clipboard_entry(entries: &mut Vec<ClipboardEntry>, timestamp: u64, text: &str) -> bool {
+    let Some(index) = entries
+        .iter()
+        .position(|entry| entry.timestamp == timestamp && entry.text == text)
+    else {
+        return false;
+    };
+    entries.remove(index);
+    true
+}
+
 #[tauri::command]
-pub fn delete_clipboard_entry(index: usize) -> bool {
+pub fn delete_clipboard_entry(timestamp: u64, text: String) -> bool {
     let mut lock = STATE.lock().unwrap();
     let Some(state) = lock.as_mut() else {
         return false;
     };
-    if index >= state.entries.len() {
+    if !remove_clipboard_entry(&mut state.entries, timestamp, &text) {
         return false;
     }
-    state.entries.remove(index);
     save_entries(&state.entries);
     true
 }
@@ -182,4 +192,35 @@ pub fn copy_to_clipboard(text: String) -> Result<(), String> {
     let mut clipboard = arboard::Clipboard::new().map_err(|e| e.to_string())?;
     clipboard.set_text(&text).map_err(|e| e.to_string())?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ClipboardEntry, remove_clipboard_entry};
+
+    fn entry(text: &str, timestamp: u64) -> ClipboardEntry {
+        ClipboardEntry {
+            text: text.to_owned(),
+            timestamp,
+            char_count: text.chars().count(),
+            line_count: text.lines().count(),
+        }
+    }
+
+    #[test]
+    fn removes_the_matching_entry_instead_of_a_filtered_position() {
+        let mut entries = vec![entry("unrelated", 10), entry("needle", 20)];
+
+        assert!(remove_clipboard_entry(&mut entries, 20, "needle"));
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].text, "unrelated");
+    }
+
+    #[test]
+    fn keeps_history_unchanged_when_identity_does_not_match() {
+        let mut entries = vec![entry("same timestamp", 10)];
+
+        assert!(!remove_clipboard_entry(&mut entries, 10, "different text"));
+        assert_eq!(entries.len(), 1);
+    }
 }

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -57,7 +57,7 @@ import {
 const HINT_MAIN = 'Enter: Open \u2022 Ctrl+H: Help \u2022 Ctrl+/: Command mode';
 const HINT_TRANSLATE =
     'Enter: Translate \u2022 Copy per result \u2022 Ctrl+H: Help \u2022 Ctrl+/: Command mode';
-const HINT_CLIPBOARD = 'Enter: Copy clip \u2022 Delete: Remove clip';
+const HINT_CLIPBOARD = 'Enter: Copy clip \u2022 Ctrl+D: Remove clip';
 // Discovery-menu hints \u2014 mirror macOS prefixSuggestion / commandSuggestion
 // hint bars (LauncherView.swift hintItems).
 const HINT_PREFIX_DISCOVERY =

--- a/apps/linows/src/js/components/preview.js
+++ b/apps/linows/src/js/components/preview.js
@@ -192,7 +192,7 @@ function renderClipboardPreview(result) {
     delBtn.className = 'preview-clip-delete';
     delBtn.innerHTML = trashIcon + ' Delete';
     delBtn.addEventListener('click', async () => {
-        await deleteClipboardEntry(result.clipIndex);
+        await deleteClipboardEntry(result.clipTimestamp, result.clipText);
         if (onClipDelete) onClipDelete();
     });
     header.appendChild(delBtn);

--- a/apps/linows/src/js/ipc.js
+++ b/apps/linows/src/js/ipc.js
@@ -113,8 +113,8 @@ export async function getClipboardHistory(query = '') {
     return invoke('get_clipboard_history', { query });
 }
 
-export async function deleteClipboardEntry(index) {
-    return invoke('delete_clipboard_entry', { index });
+export async function deleteClipboardEntry(timestamp, text) {
+    return invoke('delete_clipboard_entry', { timestamp, text });
 }
 
 export async function copyToClipboard(text) {

--- a/apps/linows/src/js/keyboard.js
+++ b/apps/linows/src/js/keyboard.js
@@ -567,7 +567,7 @@ async function removeClipboardEntry() {
     const item = results.getSelected();
     if (!item || item.kind !== 'clipboard') return;
     try {
-        await deleteClipboardEntry(item.clipIndex);
+        await deleteClipboardEntry(item.clipTimestamp, item.clipText);
         // Re-trigger search to refresh the list
         search.handleQueryInput(queryInput.value);
     } catch (err) {

--- a/apps/linows/src/js/keyboard.js
+++ b/apps/linows/src/js/keyboard.js
@@ -272,14 +272,6 @@ function handleKeyDown(e) {
             }
             break;
 
-        case 'Delete':
-        case 'Backspace':
-            if (search.isClipboardMode() && e.key === 'Delete') {
-                e.preventDefault();
-                removeClipboardEntry();
-            }
-            break;
-
         case 'Escape':
             e.preventDefault();
             if (
@@ -336,7 +328,7 @@ function handleKeyDown(e) {
 
         case 'd':
         case 'D':
-            if (e.ctrlKey && !e.shiftKey && !e.altKey) {
+            if (e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey) {
                 e.preventDefault();
                 if (isDiscoveryMode()) break;
                 if (search.isClipboardMode()) {

--- a/apps/linows/src/js/keyboard.js
+++ b/apps/linows/src/js/keyboard.js
@@ -339,7 +339,11 @@ function handleKeyDown(e) {
             if (e.ctrlKey && !e.shiftKey && !e.altKey) {
                 e.preventDefault();
                 if (isDiscoveryMode()) break;
-                handleTrashShortcut();
+                if (search.isClipboardMode()) {
+                    removeClipboardEntry();
+                } else {
+                    handleTrashShortcut();
+                }
             }
             break;
 

--- a/apps/linows/src/js/search.js
+++ b/apps/linows/src/js/search.js
@@ -375,13 +375,12 @@ async function performClipboardSearch(filter) {
             const shortDate = formatShortDate(e.timestamp);
             const subtitle = `Clipboard  \u2022  ${e.char_count} chars  \u2022  ${e.line_count} lines  \u2022  ${shortDate}`;
             return {
-                id: `clip:${i}`,
+                id: `clip:${e.timestamp}:${i}`,
                 kind: 'clipboard',
                 title,
                 subtitle,
                 path: 'clipboard://history',
                 score: 0,
-                clipIndex: i,
                 clipText: e.text,
                 clipTimestamp: e.timestamp,
                 clipCharCount: e.char_count,

--- a/apps/macos/LauncherApp/LauncherLogicTests/DeleteTargetLogicTests.swift
+++ b/apps/macos/LauncherApp/LauncherLogicTests/DeleteTargetLogicTests.swift
@@ -6,6 +6,19 @@ final class DeleteTargetLogicTests: XCTestCase {
         LauncherResult(id: id, kind: kind, title: id, subtitle: nil, path: path, score: 0)
     }
 
+    // MARK: - shortcut routing
+
+    func testCmdDRemovesClipboardHistoryRows() {
+        let clip = result("clipboard:42", .clipboard, path: "clipboard://history")
+        XCTAssertTrue(DeleteTargetLogic.removesClipboardHistory(clip))
+    }
+
+    func testCmdDKeepsFilesAndMissingSelectionsInTrashFlow() {
+        let file = result("file", .file, path: "/tmp/file.txt")
+        XCTAssertFalse(DeleteTargetLogic.removesClipboardHistory(file))
+        XCTAssertFalse(DeleteTargetLogic.removesClipboardHistory(nil))
+    }
+
     // MARK: - eligible(from:fileExists:)
 
     func testKeepsFilesAndFoldersThatExist() {

--- a/apps/macos/LauncherApp/LauncherLogicTests/DeleteTargetLogicTests.swift
+++ b/apps/macos/LauncherApp/LauncherLogicTests/DeleteTargetLogicTests.swift
@@ -8,6 +8,40 @@ final class DeleteTargetLogicTests: XCTestCase {
 
     // MARK: - shortcut routing
 
+    func testCmdDIsDisabledWhileAnotherLauncherSurfaceIsVisible() {
+        XCTAssertFalse(
+            DeleteTargetLogic.allowsKeyboardDelete(
+                isCommandMode: true,
+                showsThemeSettings: false,
+                showsHelpScreen: false
+            )
+        )
+        XCTAssertFalse(
+            DeleteTargetLogic.allowsKeyboardDelete(
+                isCommandMode: false,
+                showsThemeSettings: true,
+                showsHelpScreen: false
+            )
+        )
+        XCTAssertFalse(
+            DeleteTargetLogic.allowsKeyboardDelete(
+                isCommandMode: false,
+                showsThemeSettings: false,
+                showsHelpScreen: true
+            )
+        )
+    }
+
+    func testCmdDIsEnabledForTheNormalResultsSurface() {
+        XCTAssertTrue(
+            DeleteTargetLogic.allowsKeyboardDelete(
+                isCommandMode: false,
+                showsThemeSettings: false,
+                showsHelpScreen: false
+            )
+        )
+    }
+
     func testCmdDRemovesClipboardHistoryRows() {
         let clip = result("clipboard:42", .clipboard, path: "clipboard://history")
         XCTAssertTrue(DeleteTargetLogic.removesClipboardHistory(clip))

--- a/apps/macos/LauncherApp/LauncherLogicTests/DeleteTargetLogicTests.swift
+++ b/apps/macos/LauncherApp/LauncherLogicTests/DeleteTargetLogicTests.swift
@@ -11,21 +11,12 @@ final class DeleteTargetLogicTests: XCTestCase {
     func testCmdDIsDisabledWhileAnotherLauncherSurfaceIsVisible() {
         XCTAssertFalse(
             DeleteTargetLogic.allowsKeyboardDelete(
-                isCommandMode: true,
-                showsThemeSettings: false,
-                showsHelpScreen: false
-            )
-        )
-        XCTAssertFalse(
-            DeleteTargetLogic.allowsKeyboardDelete(
-                isCommandMode: false,
                 showsThemeSettings: true,
                 showsHelpScreen: false
             )
         )
         XCTAssertFalse(
             DeleteTargetLogic.allowsKeyboardDelete(
-                isCommandMode: false,
                 showsThemeSettings: false,
                 showsHelpScreen: true
             )
@@ -35,7 +26,6 @@ final class DeleteTargetLogicTests: XCTestCase {
     func testCmdDIsEnabledForTheNormalResultsSurface() {
         XCTAssertTrue(
             DeleteTargetLogic.allowsKeyboardDelete(
-                isCommandMode: false,
                 showsThemeSettings: false,
                 showsHelpScreen: false
             )

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/DeleteTargetLogic.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/DeleteTargetLogic.swift
@@ -7,6 +7,12 @@ import Foundation
 /// `NSWorkspace.recycle` call, icons, and state; everything here is data-in /
 /// data-out so it's deterministic under test.
 enum DeleteTargetLogic {
+    /// Clipboard rows reuse Cmd+D for history removal instead of entering the
+    /// file/folder Trash flow.
+    static func removesClipboardHistory(_ result: LauncherResult?) -> Bool {
+        result?.kind == .clipboard
+    }
+
     /// Filters a set of candidate results down to those that can be trashed:
     /// only `.file`/`.folder` kinds, excluding URL-scheme "paths" (settings
     /// panes, custom schemes) and anything no longer present on disk.

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/DeleteTargetLogic.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/DeleteTargetLogic.swift
@@ -9,12 +9,13 @@ import Foundation
 enum DeleteTargetLogic {
     /// Keyboard deletion is disabled while another launcher surface owns the
     /// window, so a selection hidden behind an overlay cannot be mutated.
+    /// Command mode is already excluded upstream by `KeyboardSelectionMonitor`,
+    /// which never forwards Cmd+D while the command input has focus.
     static func allowsKeyboardDelete(
-        isCommandMode: Bool,
         showsThemeSettings: Bool,
         showsHelpScreen: Bool
     ) -> Bool {
-        !isCommandMode && !showsThemeSettings && !showsHelpScreen
+        !showsThemeSettings && !showsHelpScreen
     }
 
     /// Clipboard rows reuse Cmd+D for history removal instead of entering the

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/DeleteTargetLogic.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/DeleteTargetLogic.swift
@@ -7,6 +7,16 @@ import Foundation
 /// `NSWorkspace.recycle` call, icons, and state; everything here is data-in /
 /// data-out so it's deterministic under test.
 enum DeleteTargetLogic {
+    /// Keyboard deletion is disabled while another launcher surface owns the
+    /// window, so a selection hidden behind an overlay cannot be mutated.
+    static func allowsKeyboardDelete(
+        isCommandMode: Bool,
+        showsThemeSettings: Bool,
+        showsHelpScreen: Bool
+    ) -> Bool {
+        !isCommandMode && !showsThemeSettings && !showsHelpScreen
+    }
+
     /// Clipboard rows reuse Cmd+D for history removal instead of entering the
     /// file/folder Trash flow.
     static func removesClipboardHistory(_ result: LauncherResult?) -> Bool {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
@@ -498,7 +498,7 @@ private enum LauncherHelpContent {
         ("Cmd+P", "Toggle pick on selected file/folder (multi-select copy)"),
         ("Shift+Enter", "Open all picked files/folders at once"),
         ("Cmd+Shift+P", "Clear all picked items"),
-        ("Cmd+D", "Move selected file/folder to Trash (on the Trash folder: empty Trash)"),
+        ("Cmd+D", "Move files to Trash or remove the selected clipboard item"),
         ("Tab / Shift+Tab", "Move selection"),
         ("Up / Down", "Move selection"),
         ("Cmd+F", "Reveal selected app/file/folder in Finder"),

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
@@ -220,6 +220,11 @@ extension LauncherView {
                 pendingKillCandidate != nil
             },
             onRequestDelete: { [self] in
+                guard DeleteTargetLogic.allowsKeyboardDelete(
+                    isCommandMode: isCommandMode,
+                    showsThemeSettings: appUIState.showsThemeSettings,
+                    showsHelpScreen: showsHelpScreen
+                ) else { return }
                 let selected = displayedResults.first { $0.id == selectedResultID }
                 if DeleteTargetLogic.removesClipboardHistory(selected), let selected {
                     deleteClipboardResult(resultID: selected.id)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
@@ -220,6 +220,11 @@ extension LauncherView {
                 pendingKillCandidate != nil
             },
             onRequestDelete: { [self] in
+                let selected = displayedResults.first { $0.id == selectedResultID }
+                if DeleteTargetLogic.removesClipboardHistory(selected), let selected {
+                    deleteClipboardResult(resultID: selected.id)
+                    return
+                }
                 requestDeleteSelection()
             },
             onConfirmDelete: { [self] in

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
@@ -221,7 +221,6 @@ extension LauncherView {
             },
             onRequestDelete: { [self] in
                 guard DeleteTargetLogic.allowsKeyboardDelete(
-                    isCommandMode: isCommandMode,
                     showsThemeSettings: appUIState.showsThemeSettings,
                     showsHelpScreen: showsHelpScreen
                 ) else { return }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -498,7 +498,7 @@ struct LauncherView: View {
         }
 
         if isClipboardQuery {
-            return ["Enter copy clip", "Delete remove clip"]
+            return ["Enter copy clip", "Cmd+D remove clip"]
         }
 
         // The home screen replaces the "Cmd+/ command mode" hint with a

--- a/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Shortcuts.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Shortcuts.swift
@@ -67,7 +67,7 @@ enum ShortcutDocs {
             title: "Clipboard history",
             items: [
                 ShortcutItem(keys: "Enter", action: "Copy selected history item back to clipboard"),
-                ShortcutItem(keys: "Delete button", action: "Remove selected clipboard item from look history"),
+                ShortcutItem(keys: "Cmd+D", action: "Remove selected clipboard item from look history"),
             ]
         ),
         ShortcutSectionData(

--- a/docs/features.md
+++ b/docs/features.md
@@ -29,6 +29,7 @@ This document tracks what `look` supports today and what is planned next.
 
 - clipboard history mode with `c"` prefix
 - in-memory clipboard history (recent text clips, size set by `clipboard_history_limit`, default 10, range 10 to 100); file/folder copies are excluded
+- remove the selected clipboard history item with `Cmd+D` / `Ctrl+D`
 - quick translation with `t"...`
 - dictionary lookup panel with `tw"...`
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -103,7 +103,8 @@ URL-like queries are detected automatically (no prefix). Type a URL and Look off
 Clipboard mode (`c"`):
 
 - stores recent text clips for the running app session (history size is configurable via `clipboard_history_limit`, see File-only settings below),
-- `Enter` on a clipboard row copies that content back to clipboard.
+- `Enter` on a clipboard row copies that content back to clipboard,
+- `Cmd+D` (`Ctrl+D` on Linux/Windows) removes the selected row from Look's clipboard history.
 
 Translation mode (`t"`/`tw"`):
 
@@ -322,7 +323,7 @@ Note: `Settings Blur` is stored as local app UI state (UserDefaults) and is not 
 - `Cmd+F`: reveal in Finder
 - `Cmd+C`: copy selected file/folder
 - `Cmd+P` / `Cmd+Shift+P`: toggle pick / clear picked set
-- `Cmd+D`: move selected file/folder (or picked items) to Trash; on the pinned Trash folder, empty the Trash (macOS only for now)
+- `Cmd+D`: remove the selected clipboard history item; otherwise move selected file/folder (or picked items) to Trash, or empty the pinned Trash folder
 - `Cmd+Shift+,`: toggle settings panel
 - `Cmd+Shift+;`: reload config
 - `Cmd+-`, `Cmd+=`, `Cmd+0`: temporary UI zoom out/in/reset


### PR DESCRIPTION
## Summary

- route Cmd+D on macOS clipboard results to the existing history deletion action
- route Ctrl+D in linows clipboard mode to the same deletion path while preserving file/folder trash behavior elsewhere
- update clipboard hints, shortcut docs, and user documentation
- add focused macOS logic coverage for clipboard-vs-trash shortcut routing

## Why

Clipboard history already supports removal from the preview and with the Delete key, but it did not share the Cmd/Ctrl+D removal shortcut used by file and folder results.

Closes #287.

## Testing

- `cargo check --workspace --manifest-path core/Cargo.toml`
- `cargo test --workspace --manifest-path core/Cargo.toml`
- `cargo check --manifest-path bridge/ffi/Cargo.toml`
- `cargo test --manifest-path bridge/ffi/Cargo.toml`
- `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
- `node --input-type=module --check < apps/linows/src/js/keyboard.js`
- `node --input-type=module --check < apps/linows/src/js/app.js`
- `swiftc -frontend -parse` on all changed Swift sources

Not runnable on this host:

- `swift test`: the active Apple Command Line Tools installation cannot load `XCTest`
- Xcode app build: full Xcode is not installed
- `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`: the current linows crate references Linux-only platform and trash APIs when compiled on macOS

## Risks / Notes

- The physical Delete-key shortcut and preview delete controls remain unchanged.
- Cmd/Ctrl+D still uses the existing Trash flow for non-clipboard results.
