### PR TITLE
feat: add fuzzy process search

### DIFF
--- a/apps/linows/src/js/screens/commands/kill.js
+++ b/apps/linows/src/js/screens/commands/kill.js
@@ -1,3 +1,5 @@
+import { rankProcesses } from './process-search.mjs';
+
 const MAX_PORT = 65535;
 const PORT_DEBOUNCE_MS = 200;
 
@@ -143,8 +145,7 @@ function filterProcesses(query) {
         }
         return;
     } else {
-        const q = query.toLowerCase();
-        filteredProcesses = baseProcessList.filter((p) => p.name.toLowerCase().includes(q));
+        filteredProcesses = rankProcesses(query, baseProcessList);
     }
     selectedIndex = Math.min(selectedIndex, Math.max(0, filteredProcesses.length - 1));
 }

--- a/apps/linows/src/js/screens/commands/process-search.mjs
+++ b/apps/linows/src/js/screens/commands/process-search.mjs
@@ -1,0 +1,64 @@
+function normalize(value) {
+    return String(value || '')
+        .normalize('NFD')
+        .replace(/\p{Diacritic}/gu, '')
+        .toLowerCase()
+        .replaceAll('đ', 'd');
+}
+
+function textScore(needle, haystack) {
+    if (haystack === needle) return 7000;
+    if (haystack.startsWith(needle)) return 6000 - (haystack.length - needle.length);
+
+    const substringIndex = haystack.indexOf(needle);
+    if (substringIndex >= 0) return 5000 - substringIndex;
+
+    let needleIndex = 0;
+    let previousOffset = -1;
+    let firstOffset = -1;
+    let totalGap = 0;
+    let consecutive = 0;
+
+    for (let offset = 0; offset < haystack.length && needleIndex < needle.length; offset++) {
+        if (haystack[offset] !== needle[needleIndex]) continue;
+        if (firstOffset < 0) firstOffset = offset;
+        if (previousOffset >= 0) {
+            const gap = offset - previousOffset - 1;
+            totalGap += gap;
+            if (gap === 0) consecutive += 1;
+        }
+        previousOffset = offset;
+        needleIndex += 1;
+    }
+
+    if (needleIndex !== needle.length) return null;
+    return 3000 + needle.length * 20 + consecutive * 10 - totalGap - firstOffset;
+}
+
+export function processSearchScore(query, process) {
+    const needle = normalize(query).trim();
+    if (!needle) return 0;
+
+    const pid = String(process.pid ?? '');
+    if (pid === needle) return 10000;
+    if (pid.startsWith(needle)) return 9000 - (pid.length - needle.length);
+    if (pid.includes(needle)) return 8000 - (pid.length - needle.length);
+
+    const scores = [process.name, process.exec]
+        .filter(Boolean)
+        .map((value) => textScore(needle, normalize(value)))
+        .filter((score) => score !== null);
+    return scores.length ? Math.max(...scores) : null;
+}
+
+export function rankProcesses(query, processes) {
+    return processes
+        .map((process, index) => ({
+            process,
+            index,
+            score: processSearchScore(query, process),
+        }))
+        .filter((entry) => entry.score !== null)
+        .sort((left, right) => right.score - left.score || left.index - right.index)
+        .map((entry) => entry.process);
+}

--- a/apps/linows/tests/process-search.test.mjs
+++ b/apps/linows/tests/process-search.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+    processSearchScore,
+    rankProcesses,
+} from '../src/js/screens/commands/process-search.mjs';
+
+test('matches process names by fuzzy subsequence', () => {
+    assert.notEqual(
+        processSearchScore('vsc', { name: 'Visual Studio Code', pid: 42 }),
+        null,
+    );
+    assert.notEqual(
+        processSearchScore('visual studio', { name: 'Visual Studio Code', pid: 42 }),
+        null,
+    );
+});
+
+test('matches process ids and executable paths', () => {
+    assert.notEqual(processSearchScore('424', { name: 'Terminal', pid: 4242 }), null);
+    assert.notEqual(
+        processSearchScore('firefx', {
+            name: 'Web Browser',
+            pid: 7,
+            exec: '/usr/bin/firefox',
+        }),
+        null,
+    );
+});
+
+test('ranks exact matches above fuzzy matches while preserving stable ties', () => {
+    const exact = { name: 'Code', pid: 1 };
+    const fuzzy = { name: 'Visual Studio Code', pid: 2 };
+    const results = rankProcesses('code', [fuzzy, exact]);
+    assert.deepEqual(results, [exact, fuzzy]);
+});
+
+test('rejects unrelated processes', () => {
+    assert.equal(processSearchScore('xyz', { name: 'Terminal', pid: 42 }), null);
+});

--- a/apps/macos/LauncherApp/LauncherLogicTests/ProcessSearchLogicTests.swift
+++ b/apps/macos/LauncherApp/LauncherLogicTests/ProcessSearchLogicTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import LauncherLogic
+
+final class ProcessSearchLogicTests: XCTestCase {
+    func testFuzzySubsequenceMatchesProcessName() {
+        XCTAssertNotNil(
+            ProcessSearchLogic.score(query: "vsc", name: "Visual Studio Code", pid: 42)
+        )
+        XCTAssertNotNil(
+            ProcessSearchLogic.score(query: "visual studio", name: "Visual Studio Code", pid: 42)
+        )
+    }
+
+    func testSearchIsCaseAndDiacriticInsensitive() {
+        XCTAssertNotNil(
+            ProcessSearchLogic.score(query: "dien", name: "Điện thoại", pid: 42)
+        )
+    }
+
+    func testPIDCanBeSearchedDirectly() {
+        XCTAssertNotNil(ProcessSearchLogic.score(query: "424", name: "Terminal", pid: 4_242))
+        XCTAssertNil(ProcessSearchLogic.score(query: "999", name: "Terminal", pid: 4_242))
+    }
+
+    func testExactNameOutranksFuzzyName() {
+        let exact = ProcessSearchLogic.score(query: "code", name: "Code", pid: 10)
+        let fuzzy = ProcessSearchLogic.score(query: "code", name: "Visual Code", pid: 11)
+        XCTAssertGreaterThan(exact!, fuzzy!)
+    }
+}

--- a/apps/macos/LauncherApp/Package.swift
+++ b/apps/macos/LauncherApp/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
                 "Support/AppConstants.swift",
                 "Support/ConfigFileLines.swift",
                 "Support/Launcher/LauncherSearchLogic.swift",
+                "Support/Launcher/ProcessSearchLogic.swift",
                 "Support/Launcher/DeleteTargetLogic.swift",
                 "Support/Launcher/BridgeErrorMapping.swift",
                 "Support/SingleInstanceLock.swift",

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/ProcessSearchLogic.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/ProcessSearchLogic.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+enum ProcessSearchLogic {
+    static func score(query: String, name: String, pid: Int32) -> Int? {
+        let needle = normalize(query).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !needle.isEmpty else { return 0 }
+
+        let pidText = String(pid)
+        if pidText == needle { return 10_000 }
+        if pidText.hasPrefix(needle) { return 9_000 - (pidText.count - needle.count) }
+        if pidText.contains(needle) { return 8_000 - (pidText.count - needle.count) }
+
+        return textScore(needle: needle, haystack: normalize(name))
+    }
+
+    private static func textScore(needle: String, haystack: String) -> Int? {
+        if haystack == needle { return 7_000 }
+        if haystack.hasPrefix(needle) { return 6_000 - (haystack.count - needle.count) }
+        if let range = haystack.range(of: needle) {
+            return 5_000 - haystack.distance(from: haystack.startIndex, to: range.lowerBound)
+        }
+
+        var needleIndex = needle.startIndex
+        var previousOffset: Int?
+        var firstOffset: Int?
+        var totalGap = 0
+        var consecutive = 0
+
+        for (offset, character) in haystack.enumerated() where character == needle[needleIndex] {
+            firstOffset = firstOffset ?? offset
+            if let previousOffset {
+                let gap = offset - previousOffset - 1
+                totalGap += gap
+                if gap == 0 { consecutive += 1 }
+            }
+            previousOffset = offset
+            needleIndex = needle.index(after: needleIndex)
+            if needleIndex == needle.endIndex {
+                return 3_000
+                    + needle.count * 20
+                    + consecutive * 10
+                    - totalGap
+                    - (firstOffset ?? 0)
+            }
+        }
+
+        return nil
+    }
+
+    private static func normalize(_ text: String) -> String {
+        text.folding(
+            options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive],
+            locale: nil
+        )
+        .replacingOccurrences(of: "đ", with: "d")
+        .replacingOccurrences(of: "Đ", with: "d")
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Commands/KillCommand.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/KillCommand.swift
@@ -123,7 +123,34 @@ struct KillCommand {
             return [candidates[num - 1]]
         }
 
-        return candidates.filter { $0.displayName.lowercased().contains(searchTerm.lowercased()) }
+        return candidates
+            .compactMap { candidate -> (Candidate, Int)? in
+                guard let score = ProcessSearchLogic.score(
+                    query: searchTerm,
+                    name: candidate.displayName,
+                    pid: candidate.pid
+                ) else {
+                    return nil
+                }
+                return (candidate, score)
+            }
+            .sorted { lhs, rhs in
+                if lhs.1 != rhs.1 { return lhs.1 > rhs.1 }
+                return lhs.0.displayName.localizedCaseInsensitiveCompare(rhs.0.displayName)
+                    == .orderedAscending
+            }
+            .enumerated()
+            .map { index, match in
+                let candidate = match.0
+                return Candidate(
+                    id: candidate.id,
+                    displayName: candidate.displayName,
+                    pid: candidate.pid,
+                    icon: candidate.icon,
+                    number: index + 1,
+                    detail: candidate.detail
+                )
+            }
     }
 
     static func kill(pid: Int32, name: String, completion: @escaping (String) -> Void) {

--- a/docs/features.md
+++ b/docs/features.md
@@ -48,7 +48,8 @@ This document tracks what `look` supports today and what is planned next.
 - `pomo`: pomodoro focus timer with editable session list, three timer styles (Modern Ring / Vintage Dial / Minimal Text), shuffled background-music folder, menu-bar mini-timer, 5s standby fade, "ending soon" alert at 10s remaining
 - `todo`: daily tasks grouped by date (3 unfinished per day, 3 upcoming groups, OVERDUE badges on past days, fuzzy search over tasks and dates, manual save) plus a Stats page: weekly/monthly completion donuts, streak, 30-day trend, GitHub-style year heatmap. Today's done/total shows as a clickable stat in the home hint bar. Stored in the shared `look.db` (`core/todo`), one-year retention
 - calc parser supports exponent (`^`), factorial (`!`), constants (`pi`, `e`), math functions (`sqrt`, `abs`, `round`, `floor`, `ceil`), and `%` shorthand while keeping modulo
-- kill flow with explicit confirmation and process-by-port lookup (`:3000` / `port 3000`)
+- kill flow with explicit confirmation, fuzzy process name/PID search, and process-by-port lookup
+  (`:3000` / `port 3000`)
 - warning cue when shell input contains `sudo`
 
 ### Running apps switcher


### PR DESCRIPTION
Closes #193.

## What changed

- add ranked fuzzy matching for process names on macOS and Linux/Windows
- allow direct PID lookup; Linux/Windows also searches the executable path
- preserve the existing numeric shortcut and port-query flows
- normalize case and Vietnamese diacritics, with exact/prefix/substring matches ranked above subsequences
- add focused Swift and Node regression tests and document the behavior

## Why

The kill command previously required a literal substring match. Queries such as `vsc` for “Visual Studio Code” returned no result, and PID/executable lookup was inconsistent across platforms.

## Validation

- `node --test apps/linows/tests/process-search.test.mjs` — 4 passed
- `swift test` in `apps/macos/LauncherApp` — 51 passed
- `cargo test --workspace` in `core` — 179 passed
- `cargo test` in `bridge/ffi` — 13 passed
- `git diff --check` — passed

The Swift package still reports its existing “92 unhandled files” warning; all tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fuzzy process search in the `kill` command.
  * Search now supports process names, PIDs, and executable paths, with the most relevant matches shown first.
  * Matching is case- and diacritic-insensitive.
  * Existing process-by-port search remains supported.

* **Documentation**
  * Updated command mode documentation to describe fuzzy process and PID search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->