### PR TITLE
feat: Empty state super actions

### DIFF
--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -358,6 +358,8 @@ enum AppConstants {
             /// system reads wired up (see docs; controls land per follow-up PR).
             static let mockBatteryValue = "84%"
             static let mockNowPlayingTitle = "Not playing"
+            /// Placeholder shown in the Weather tile until the live source lands.
+            static let weatherPlaceholderValue = "--°"
         }
 
         static let commandCatalog: [AppCommand] = [

--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -330,6 +330,36 @@ enum AppConstants {
             }
         }
 
+        /// Empty-state launchpad: a 6-column bento of L/M/S tiles shown below the
+        /// search bar when the query is empty. Sizing/timing only; the tile order,
+        /// labels, and mnemonics come from the shared `look_qactions` catalog.
+        enum Launchpad {
+            static let columns = 6
+            static let rowHeight: CGFloat = 76
+            static let gap: CGFloat = 8
+            static let cornerRadius: CGFloat = 12
+            static let outerTopPadding: CGFloat = 8
+
+            /// The L slot rotates Todo <-> Pomo every this often when both apply.
+            static let lSlotRotateSeconds: TimeInterval = 5
+            /// The Todo tile cycles its next-task name at this cadence.
+            static let todoTaskRotateSeconds: TimeInterval = 2.6
+            /// The Clock tile only needs minute resolution; refresh coarsely.
+            static let clockTickSeconds: TimeInterval = 20
+            /// Crossfade duration for the L slot swap.
+            static let rotateFadeSeconds: TimeInterval = 0.45
+
+            static let titleFontSize: CGFloat = 12.5
+            static let valueFontSize: CGFloat = 22
+            static let captionFontSize: CGFloat = 10.5
+            static let smallLabelFontSize: CGFloat = 10.5
+
+            /// Placeholder values used while the layout-only pass has no live
+            /// system reads wired up (see docs; controls land per follow-up PR).
+            static let mockBatteryValue = "84%"
+            static let mockNowPlayingTitle = "Not playing"
+        }
+
         static let commandCatalog: [AppCommand] = [
             AppCommand(id: Command.calc, title: "calc (⌘1)", detail: "Evaluate math expression", placeholder: "Type math expression"),
             AppCommand(id: Command.pomo, title: "pomo (⌘2)", detail: "Pomodoro focus timer", placeholder: "Manage focus sessions"),

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
@@ -64,6 +64,10 @@ private func look_recent_urls_json(_ query: UnsafePointer<CChar>?, _ limit: UInt
 nonisolated
 private func look_qactions_json(_ resultID: UnsafePointer<CChar>?, _ kind: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
 
+@_silgen_name("look_quick_actions_launchpad_json")
+nonisolated
+private func look_quick_actions_launchpad_json() -> UnsafeMutablePointer<CChar>?
+
 @_silgen_name("look_definitional_entity_json")
 nonisolated
 private func look_definitional_entity_json(_ query: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
@@ -290,6 +294,18 @@ final class EngineBridge: @unchecked Sendable {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         return (try? decoder.decode([QuickActionDescriptor].self, from: data)) ?? []
+    }
+
+    /// The empty-state launchpad layout from the shared `look_qactions` catalog:
+    /// fixed tile order, sizes, and mnemonics. Pure catalog lookup, cheap. Empty
+    /// only on an unexpected decode failure.
+    nonisolated func launchpadLayout() -> [LaunchpadTileModel] {
+        guard let ptr = look_quick_actions_launchpad_json() else { return [] }
+        defer { look_free_cstring(ptr) }
+        guard let data = String(cString: ptr).data(using: .utf8) else { return [] }
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return (try? decoder.decode([LaunchpadTileModel].self, from: data)) ?? []
     }
 
     /// The entity from a definitional query ("what is vim" -> "vim"), or nil.

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
@@ -47,7 +47,10 @@ final class KeyboardSelectionMonitor {
         onCancelDelete: (@MainActor () -> Void)? = nil,
         deleteConfirmationActive: @escaping @MainActor () -> Bool = { false },
         onToggleQuickAction: (@MainActor () -> Void)? = nil,
-        hasToggleQuickAction: @escaping @MainActor () -> Bool = { false }
+        hasToggleQuickAction: @escaping @MainActor () -> Bool = { false },
+        isLaunchpadActive: @escaping @MainActor () -> Bool = { false },
+        onLaunchpadMnemonic: (@MainActor (Character) -> Bool)? = nil,
+        onLaunchpadEscape: (@MainActor () -> Bool)? = nil
     ) {
         guard monitor == nil else { return }
         self.isKillConfirmationActive = killConfirmationActive
@@ -68,6 +71,20 @@ final class KeyboardSelectionMonitor {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
                     onEnterCommandMode()
                 }
+                return nil
+            }
+
+            // Empty-state launchpad mnemonics (⌘B/⌘W/⌘T/...). Only fires when the
+            // launchpad is on screen, so it never shadows the result-oriented
+            // chords below (Cmd+F reveal, Cmd+P pick, etc.) once the user types.
+            // Match on the typed character, not a keyCode, so it holds on
+            // non-QWERTY layouts (same rationale as the Cmd+O handler).
+            if flags == [.command],
+                isLaunchpadActive(),
+                let handler = onLaunchpadMnemonic,
+                let character = event.charactersIgnoringModifiers?.first,
+                handler(character)
+            {
                 return nil
             }
 
@@ -212,6 +229,12 @@ final class KeyboardSelectionMonitor {
             }
 
             if event.keyCode == 53 {
+                // A pending launchpad Restart / Shut Down confirm swallows Escape
+                // to dismiss the prompt rather than hiding the launcher.
+                if let onLaunchpadEscape, onLaunchpadEscape() {
+                    return nil
+                }
+
                 if onDismissHelpIfVisible() {
                     return nil
                 }

--- a/apps/macos/LauncherApp/look-app/Support/QuickActions/LaunchpadTileModel.swift
+++ b/apps/macos/LauncherApp/look-app/Support/QuickActions/LaunchpadTileModel.swift
@@ -18,6 +18,7 @@ enum LaunchpadActionID {
     static let restart = "restart"
     static let shutdown = "shutdown"
     static let battery = "battery"
+    static let weather = "weather"
     static let nowPlaying = "nowplaying"
 }
 
@@ -50,6 +51,7 @@ enum LaunchpadTileRole: String, Decodable {
     case info
     case action
     case media
+    case weather
     case slot
 }
 
@@ -64,6 +66,8 @@ struct LaunchpadTileModel: Decodable, Identifiable, Equatable {
     let mnemonic: Character?
     /// Column-span override (Now Playing spans 3). Nil uses `size.columns`.
     let span: Int?
+    /// Row-span override (Weather stands 2 rows tall). Nil uses `size.rows`.
+    let rowSpan: Int?
     /// On/off captions for toggle tiles (e.g. Theme's Dark/Light). Nil for
     /// non-toggle tiles, which fall back to a generic On/Off.
     let onLabel: String?
@@ -75,8 +79,12 @@ struct LaunchpadTileModel: Decodable, Identifiable, Equatable {
     /// natural width of the tile size.
     var columnSpan: Int { span ?? size.columns }
 
+    /// Effective row span: the per-tile override when present, else the natural
+    /// height of the tile size.
+    var rowSpanCount: Int { rowSpan ?? size.rows }
+
     private enum CodingKeys: String, CodingKey {
-        case actionId, title, size, role, mnemonic, span, onLabel, offLabel
+        case actionId, title, size, role, mnemonic, span, rowSpan, onLabel, offLabel
     }
 
     init(from decoder: Decoder) throws {
@@ -86,6 +94,7 @@ struct LaunchpadTileModel: Decodable, Identifiable, Equatable {
         size = try container.decode(LaunchpadTileSize.self, forKey: .size)
         role = try container.decode(LaunchpadTileRole.self, forKey: .role)
         span = try container.decodeIfPresent(Int.self, forKey: .span)
+        rowSpan = try container.decodeIfPresent(Int.self, forKey: .rowSpan)
         onLabel = try container.decodeIfPresent(String.self, forKey: .onLabel)
         offLabel = try container.decodeIfPresent(String.self, forKey: .offLabel)
         // serde serializes a `char` as a single-character string; take its first

--- a/apps/macos/LauncherApp/look-app/Support/QuickActions/LaunchpadTileModel.swift
+++ b/apps/macos/LauncherApp/look-app/Support/QuickActions/LaunchpadTileModel.swift
@@ -76,12 +76,14 @@ struct LaunchpadTileModel: Decodable, Identifiable, Equatable {
     var id: String { actionId }
 
     /// Effective column span: the per-tile override when present, else the
-    /// natural width of the tile size.
-    var columnSpan: Int { span ?? size.columns }
+    /// natural width of the tile size. Clamped to at least 1 so a malformed
+    /// catalog value can never produce a zero/negative tile width.
+    var columnSpan: Int { max(1, span ?? size.columns) }
 
     /// Effective row span: the per-tile override when present, else the natural
-    /// height of the tile size.
-    var rowSpanCount: Int { rowSpan ?? size.rows }
+    /// height of the tile size. Clamped to at least 1 for the same reason as
+    /// `columnSpan`.
+    var rowSpanCount: Int { max(1, rowSpan ?? size.rows) }
 
     private enum CodingKeys: String, CodingKey {
         case actionId, title, size, role, mnemonic, span, rowSpan, onLabel, offLabel

--- a/apps/macos/LauncherApp/look-app/Support/QuickActions/LaunchpadTileModel.swift
+++ b/apps/macos/LauncherApp/look-app/Support/QuickActions/LaunchpadTileModel.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// Swift mirror of the shared `look_qactions::LaunchpadTile`. Decoded from the
+/// FFI JSON with `.convertFromSnakeCase`, so `action_id` -> `actionId`. The
+/// order, sizes, and mnemonics come from the shared core catalog; this app only
+/// renders them and resolves live state natively.
+
+/// The shared `action_id` strings from `look_qactions::action_id`, mirrored here
+/// so the launchpad UI never hard-codes bare literals.
+enum LaunchpadActionID {
+    static let lSlot = "lslot"
+    static let bluetooth = "bluetooth"
+    static let wifi = "wifi"
+    static let theme = "theme"
+    static let focus = "focus"
+    static let saver = "saver"
+    static let mic = "mic"
+    static let restart = "restart"
+    static let shutdown = "shutdown"
+    static let battery = "battery"
+    static let nowPlaying = "nowplaying"
+}
+
+/// A launchpad tile's footprint in the 6-column bento grid.
+enum LaunchpadTileSize: String, Decodable {
+    case l
+    case m
+    case s
+
+    /// Natural column span for this size before any per-tile `span` override.
+    var columns: Int {
+        switch self {
+        case .l, .m: return 2
+        case .s: return 1
+        }
+    }
+
+    /// Row span for this size.
+    var rows: Int {
+        switch self {
+        case .l: return 2
+        case .m, .s: return 1
+        }
+    }
+}
+
+/// How a launchpad tile is drawn (see the Rust `TileRole`).
+enum LaunchpadTileRole: String, Decodable {
+    case toggle
+    case info
+    case action
+    case media
+    case slot
+}
+
+/// A single launchpad tile, decoded from the shared catalog.
+struct LaunchpadTileModel: Decodable, Identifiable, Equatable {
+    let actionId: String
+    let title: String
+    let size: LaunchpadTileSize
+    let role: LaunchpadTileRole
+    /// The mnemonic character (triggered with Command). Nil for the L slot and
+    /// Battery. Decoded from a one-character JSON string.
+    let mnemonic: Character?
+    /// Column-span override (Now Playing spans 3). Nil uses `size.columns`.
+    let span: Int?
+    /// On/off captions for toggle tiles (e.g. Theme's Dark/Light). Nil for
+    /// non-toggle tiles, which fall back to a generic On/Off.
+    let onLabel: String?
+    let offLabel: String?
+
+    var id: String { actionId }
+
+    /// Effective column span: the per-tile override when present, else the
+    /// natural width of the tile size.
+    var columnSpan: Int { span ?? size.columns }
+
+    private enum CodingKeys: String, CodingKey {
+        case actionId, title, size, role, mnemonic, span, onLabel, offLabel
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        actionId = try container.decode(String.self, forKey: .actionId)
+        title = try container.decode(String.self, forKey: .title)
+        size = try container.decode(LaunchpadTileSize.self, forKey: .size)
+        role = try container.decode(LaunchpadTileRole.self, forKey: .role)
+        span = try container.decodeIfPresent(Int.self, forKey: .span)
+        onLabel = try container.decodeIfPresent(String.self, forKey: .onLabel)
+        offLabel = try container.decodeIfPresent(String.self, forKey: .offLabel)
+        // serde serializes a `char` as a single-character string; take its first
+        // character (nil when absent or empty).
+        mnemonic = try container.decodeIfPresent(String.self, forKey: .mnemonic)?.first
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/QuickActions/WeatherService.swift
+++ b/apps/macos/LauncherApp/look-app/Support/QuickActions/WeatherService.swift
@@ -1,0 +1,274 @@
+import Foundation
+import OSLog
+
+/// A resolved weather reading ready for display in the launchpad tile.
+struct WeatherSnapshot: Equatable {
+    /// Formatted temperature including the degree sign, e.g. "18°".
+    let temperature: String
+    /// SF Symbol name for the current condition.
+    let symbolName: String
+    /// Short human-readable condition, e.g. "Partly Cloudy".
+    let condition: String
+    /// Today's formatted high and low temperatures, e.g. "24°" / "13°".
+    let high: String
+    let low: String
+    /// Today's chance of precipitation as a formatted percent (e.g. "60%"), or
+    /// nil when the source didn't report it.
+    let rainChance: String?
+    /// City name from the IP lookup, or nil when it wasn't reported. Not shown in
+    /// the tile (location is kept private); retained for potential future use.
+    let city: String?
+}
+
+/// Fetches current weather for the user's approximate location and caches it.
+///
+/// Location comes from a keyless IP lookup (no permission prompt, city-level),
+/// weather from Open-Meteo (keyless, free). Both responses are cached in
+/// `UserDefaults`, so reopening the launcher shows the last reading instantly and
+/// the network is hit at most once per refresh interval. This is the native
+/// per-shell state read the shared catalog declares for the Weather tile; other
+/// platforms resolve it their own way.
+final class WeatherService {
+    static let shared = WeatherService()
+
+    private enum Endpoint {
+        /// Keyless HTTPS IP geolocation (ipwho.is); returns numeric
+        /// `latitude`/`longitude` and a `success` flag. Free tier is generous
+        /// enough for a per-user tile given the day-long location cache.
+        static let ipGeolocation = "https://ipwho.is/"
+        /// Open-Meteo current-conditions, parameterized by coordinates and unit.
+        static let openMeteo = "https://api.open-meteo.com/v1/forecast"
+    }
+
+    /// Skip the network when the cached reading is younger than this.
+    private static let weatherMaxAge: TimeInterval = 30 * 60  // 30 minutes
+    /// Location changes rarely; reuse the cached coordinates for this long.
+    private static let locationMaxAge: TimeInterval = 24 * 60 * 60  // 1 day
+    /// Cap each request so a hung network never stalls the refresh.
+    private static let requestTimeout: TimeInterval = 8
+
+    private static let cachedWeatherKey = "look.weather.cachedReading"
+    private static let cachedLocationKey = "look.weather.cachedLocation"
+
+    private let session: URLSession
+    private let defaults: UserDefaults
+    private let log = Logger(subsystem: "noah-code.Look", category: "WeatherService")
+
+    init(session: URLSession = .shared, defaults: UserDefaults = .standard) {
+        self.session = session
+        self.defaults = defaults
+    }
+
+    /// Returns the current weather, using the cache when it is still fresh and
+    /// otherwise fetching from the network. Returns the last cached reading (or
+    /// nil) when the network is unavailable, so the tile degrades gracefully.
+    func currentWeather() async -> WeatherSnapshot? {
+        if let cached = cachedWeather(), age(of: cached.fetchedAt) < Self.weatherMaxAge {
+            return snapshot(from: cached)
+        }
+
+        do {
+            let coordinates = try await coordinates()
+            let reading = try await fetchWeather(at: coordinates)
+            store(reading, forKey: Self.cachedWeatherKey)
+            return snapshot(from: reading)
+        } catch {
+            log.error("Weather refresh failed: \(error.localizedDescription, privacy: .public)")
+            return cachedWeather().map(snapshot(from:))
+        }
+    }
+
+    // MARK: - Location
+
+    private func coordinates() async throws -> Coordinates {
+        if let cached = cached(Coordinates.self, forKey: Self.cachedLocationKey),
+           age(of: cached.fetchedAt) < Self.locationMaxAge {
+            return cached
+        }
+        let fresh = try await fetchCoordinates()
+        store(fresh, forKey: Self.cachedLocationKey)
+        return fresh
+    }
+
+    private func fetchCoordinates() async throws -> Coordinates {
+        guard let url = URL(string: Endpoint.ipGeolocation) else { throw WeatherError.badURL }
+        let response: IPGeoResponse = try await get(url)
+        guard response.success, let latitude = response.latitude, let longitude = response.longitude else {
+            throw WeatherError.badResponse
+        }
+        return Coordinates(
+            latitude: latitude,
+            longitude: longitude,
+            city: response.city,
+            fetchedAt: Date().timeIntervalSince1970
+        )
+    }
+
+    // MARK: - Weather
+
+    private func fetchWeather(at coordinates: Coordinates) async throws -> CachedWeather {
+        let fahrenheit = usesFahrenheit
+        var components = URLComponents(string: Endpoint.openMeteo)
+        components?.queryItems = [
+            URLQueryItem(name: "latitude", value: String(coordinates.latitude)),
+            URLQueryItem(name: "longitude", value: String(coordinates.longitude)),
+            URLQueryItem(name: "current", value: "temperature_2m,weather_code"),
+            URLQueryItem(name: "daily", value: "temperature_2m_max,temperature_2m_min,precipitation_probability_max"),
+            URLQueryItem(name: "temperature_unit", value: fahrenheit ? "fahrenheit" : "celsius"),
+            URLQueryItem(name: "timezone", value: "auto"),
+            URLQueryItem(name: "forecast_days", value: "1"),
+        ]
+        guard let url = components?.url else { throw WeatherError.badURL }
+        let response: OpenMeteoResponse = try await get(url)
+        guard let high = response.daily.high.first, let low = response.daily.low.first else {
+            throw WeatherError.badResponse
+        }
+        return CachedWeather(
+            temperature: response.current.temperature,
+            weatherCode: response.current.weatherCode,
+            high: high,
+            low: low,
+            rainChance: response.daily.rainChance.first.flatMap { $0 },
+            isFahrenheit: fahrenheit,
+            city: coordinates.city,
+            fetchedAt: Date().timeIntervalSince1970
+        )
+    }
+
+    /// Fahrenheit for US-style locales, Celsius everywhere else.
+    private var usesFahrenheit: Bool {
+        Locale.current.measurementSystem == .us
+    }
+
+    // MARK: - Networking
+
+    private func get<T: Decodable>(_ url: URL) async throws -> T {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = Self.requestTimeout
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw WeatherError.badResponse
+        }
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    // MARK: - Presentation
+
+    private func snapshot(from reading: CachedWeather) -> WeatherSnapshot {
+        let condition = Self.condition(for: reading.weatherCode)
+        return WeatherSnapshot(
+            temperature: Self.formatTemperature(reading.temperature),
+            symbolName: condition.symbol,
+            condition: condition.label,
+            high: Self.formatTemperature(reading.high),
+            low: Self.formatTemperature(reading.low),
+            rainChance: reading.rainChance.map { "\($0)%" },
+            city: reading.city
+        )
+    }
+
+    private static func formatTemperature(_ value: Double) -> String {
+        "\(Int(value.rounded()))°"
+    }
+
+    /// Maps a WMO weather-interpretation code to an SF Symbol and short label.
+    /// Codes are grouped per the Open-Meteo documentation.
+    private static func condition(for code: Int) -> (symbol: String, label: String) {
+        switch code {
+        case 0: return ("sun.max.fill", "Clear")
+        case 1, 2: return ("cloud.sun.fill", "Partly Cloudy")
+        case 3: return ("cloud.fill", "Cloudy")
+        case 45, 48: return ("cloud.fog.fill", "Fog")
+        case 51, 53, 55, 56, 57: return ("cloud.drizzle.fill", "Drizzle")
+        case 61, 63, 65, 66, 67: return ("cloud.rain.fill", "Rain")
+        case 71, 73, 75, 77: return ("cloud.snow.fill", "Snow")
+        case 80, 81, 82: return ("cloud.heavyrain.fill", "Showers")
+        case 85, 86: return ("cloud.snow.fill", "Snow Showers")
+        case 95, 96, 99: return ("cloud.bolt.rain.fill", "Thunderstorm")
+        default: return ("cloud.fill", "Cloudy")
+        }
+    }
+
+    // MARK: - Cache
+
+    private func cachedWeather() -> CachedWeather? {
+        cached(CachedWeather.self, forKey: Self.cachedWeatherKey)
+    }
+
+    private func cached<T: Decodable>(_ type: T.Type, forKey key: String) -> T? {
+        guard let data = defaults.data(forKey: key) else { return nil }
+        return try? JSONDecoder().decode(T.self, from: data)
+    }
+
+    private func store<T: Encodable>(_ value: T, forKey key: String) {
+        guard let data = try? JSONEncoder().encode(value) else { return }
+        defaults.set(data, forKey: key)
+    }
+
+    private func age(of epoch: TimeInterval) -> TimeInterval {
+        Date().timeIntervalSince1970 - epoch
+    }
+}
+
+// MARK: - Wire models
+
+private enum WeatherError: Error {
+    case badURL
+    case badResponse
+}
+
+private struct Coordinates: Codable {
+    let latitude: Double
+    let longitude: Double
+    let city: String?
+    let fetchedAt: TimeInterval
+}
+
+private struct CachedWeather: Codable {
+    let temperature: Double
+    let weatherCode: Int
+    let high: Double
+    let low: Double
+    let rainChance: Int?
+    let isFahrenheit: Bool
+    let city: String?
+    let fetchedAt: TimeInterval
+}
+
+private struct IPGeoResponse: Decodable {
+    /// ipwho.is reports `success: false` with a message on failure (e.g. an
+    /// unroutable IP), and omits coordinates, so both are optional and gated.
+    let success: Bool
+    let latitude: Double?
+    let longitude: Double?
+    let city: String?
+}
+
+private struct OpenMeteoResponse: Decodable {
+    struct Current: Decodable {
+        let temperature: Double
+        let weatherCode: Int
+
+        private enum CodingKeys: String, CodingKey {
+            case temperature = "temperature_2m"
+            case weatherCode = "weather_code"
+        }
+    }
+
+    struct Daily: Decodable {
+        /// Single-element arrays (the request asks for one forecast day). Rain
+        /// probability can be null for a slot, hence the optional element.
+        let high: [Double]
+        let low: [Double]
+        let rainChance: [Int?]
+
+        private enum CodingKeys: String, CodingKey {
+            case high = "temperature_2m_max"
+            case low = "temperature_2m_min"
+            case rainChance = "precipitation_probability_max"
+        }
+    }
+
+    let current: Current
+    let daily: Daily
+}

--- a/apps/macos/LauncherApp/look-app/Support/QuickActions/WeatherService.swift
+++ b/apps/macos/LauncherApp/look-app/Support/QuickActions/WeatherService.swift
@@ -63,7 +63,7 @@ final class WeatherService {
     /// otherwise fetching from the network. Returns the last cached reading (or
     /// nil) when the network is unavailable, so the tile degrades gracefully.
     func currentWeather() async -> WeatherSnapshot? {
-        if let cached = cachedWeather(), age(of: cached.fetchedAt) < Self.weatherMaxAge {
+        if let cached = usableCachedWeather(), age(of: cached.fetchedAt) < Self.weatherMaxAge {
             return snapshot(from: cached)
         }
 
@@ -74,7 +74,7 @@ final class WeatherService {
             return snapshot(from: reading)
         } catch {
             log.error("Weather refresh failed: \(error.localizedDescription, privacy: .public)")
-            return cachedWeather().map(snapshot(from:))
+            return usableCachedWeather().map(snapshot(from:))
         }
     }
 
@@ -193,6 +193,16 @@ final class WeatherService {
 
     private func cachedWeather() -> CachedWeather? {
         cached(CachedWeather.self, forKey: Self.cachedWeatherKey)
+    }
+
+    /// The cached reading, but only when it was captured in the unit the current
+    /// locale wants. After a region change the old value is in the wrong unit, so
+    /// it is discarded to force a refetch rather than shown as a bare degree.
+    private func usableCachedWeather() -> CachedWeather? {
+        guard let cached = cachedWeather(), cached.isFahrenheit == usesFahrenheit else {
+            return nil
+        }
+        return cached
     }
 
     private func cached<T: Decodable>(_ type: T.Type, forKey key: String) -> T? {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
@@ -295,17 +295,23 @@ private struct LaunchpadActionTile: View {
                     tintOpacity: (confirming || micMuted) ? launchpadAlertTintOpacity : 0
                 )
             )
-            .overlay(
-                RoundedRectangle(cornerRadius: Const.cornerRadius, style: .continuous)
-                    .strokeBorder(
-                        (confirming || micMuted)
-                            ? tint.opacity(launchpadAlertBorderOpacity)
-                            : themeStore.dividerColor().opacity(launchpadRestingBorderOpacity),
-                        lineWidth: launchpadBorderWidth
-                    )
-            )
+            .overlay(border)
         }
         .buttonStyle(.plain)
+    }
+
+    /// An armed confirm or a muted mic always draws its coloured state border, so
+    /// it stays visible even under a borderless (0-thickness) theme. A resting
+    /// tile defers to the theme border, matching the panel and search-result
+    /// tiles, and disappears with them when the border is turned off.
+    @ViewBuilder
+    private var border: some View {
+        let shape = RoundedRectangle(cornerRadius: Const.cornerRadius, style: .continuous)
+        if confirming || micMuted {
+            shape.strokeBorder(tint.opacity(launchpadAlertBorderOpacity), lineWidth: launchpadStateBorderWidth)
+        } else if themeStore.borderLineWidth() > 0 {
+            shape.strokeBorder(themeStore.borderColor(), lineWidth: themeStore.borderLineWidth())
+        }
     }
 
     private var iconName: String {
@@ -383,11 +389,11 @@ private let launchpadOnTintOpacity = 0.22
 /// takes its hue from `tint` rather than baking one in here.
 private let launchpadAlertTintOpacity = 0.16
 
-/// Tile borders. Every tile rests on the same neutral divider so the strip reads
-/// as one surface; colour is reserved for a state the user just entered, an
-/// on-state toggle or an armed confirm, never for a tile sitting idle.
-private let launchpadBorderWidth: CGFloat = 1
-private let launchpadRestingBorderOpacity = 0.4
+/// State-border chrome. A resting tile takes the user's theme border (see
+/// `tileBorder` / `LaunchpadActionTile.border`); these values govern only the
+/// coloured overlays a tile draws for a state the user just entered, an on-state
+/// toggle or an armed confirm, which stay visible even under a borderless theme.
+private let launchpadStateBorderWidth: CGFloat = 1
 private let launchpadOnBorderOpacity = 0.35
 private let launchpadAlertBorderOpacity = 0.3
 
@@ -409,13 +415,16 @@ func frostedTile(themeStore: ThemeStore, tint: Color? = nil, tintOpacity: Double
     .clipShape(RoundedRectangle(cornerRadius: radius, style: .continuous))
 }
 
+/// The border for a toggle or slot tile. An on-state toggle always draws its
+/// accent outline so the active state stays legible under any theme; a resting
+/// tile defers to the theme border (panel + search-result parity) and vanishes
+/// with it when the border is turned off.
+@ViewBuilder
 private func tileBorder(isOn: Bool, themeStore: ThemeStore) -> some View {
-    let radius = AppConstants.Launcher.Launchpad.cornerRadius
-    return RoundedRectangle(cornerRadius: radius, style: .continuous)
-        .strokeBorder(
-            isOn
-                ? themeStore.accentColor().opacity(launchpadOnBorderOpacity)
-                : themeStore.dividerColor().opacity(launchpadRestingBorderOpacity),
-            lineWidth: launchpadBorderWidth
-        )
+    let shape = RoundedRectangle(cornerRadius: AppConstants.Launcher.Launchpad.cornerRadius, style: .continuous)
+    if isOn {
+        shape.strokeBorder(themeStore.accentColor().opacity(launchpadOnBorderOpacity), lineWidth: launchpadStateBorderWidth)
+    } else if themeStore.borderLineWidth() > 0 {
+        shape.strokeBorder(themeStore.borderColor(), lineWidth: themeStore.borderLineWidth())
+    }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
@@ -45,8 +45,9 @@ struct EmptyStateLaunchpadView: View {
     // MARK: Layout
     //
     // The spec's fixed order tiles a 6-column grid as three rows:
-    //   row 0/1 cols 0-1: L slot (2x2)   | cols 2-5: BT, Wi-Fi, Battery(2)
-    //                                     |           Theme(2), Focus, Saver
+    //   row 0/1 cols 0-1: L slot (2x2) | cols 2-4: BT, Wi-Fi, Battery
+    //                                   |          Theme, Focus, Saver
+    //                                   | col 5:   Weather (1x2)
     //   row 2 cols 0-5: Mic, Restart, Shut Down, Now Playing(3)
     // SwiftUI has no cell spanning, so the arrangement is composed explicitly
     // from the known order rather than auto-packed.
@@ -70,6 +71,8 @@ struct EmptyStateLaunchpadView: View {
                         tileView(LaunchpadActionID.saver, cell: cell)
                     }
                 }
+
+                tileView(LaunchpadActionID.weather, cell: cell)
             }
 
             HStack(spacing: Const.gap) {
@@ -92,7 +95,7 @@ struct EmptyStateLaunchpadView: View {
     private func tileView(_ actionID: String, cell: CGFloat) -> some View {
         if let model = byID[actionID] {
             let w = width(columns: model.columnSpan, cell: cell)
-            let h = height(rows: model.size.rows)
+            let h = height(rows: model.rowSpanCount)
             tileContent(model)
                 .frame(width: w, height: h)
         }
@@ -122,6 +125,12 @@ struct EmptyStateLaunchpadView: View {
                 isPlaying: controller.isPlaying,
                 themeStore: themeStore
             ) { controller.activate(model) }
+        case .weather:
+            LaunchpadWeatherTile(
+                model: model,
+                weather: controller.weather,
+                themeStore: themeStore
+            )
         case .slot:
             EmptyView()
         }
@@ -247,6 +256,65 @@ private struct LaunchpadInfoTile: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         .background(frostedTile(themeStore: themeStore))
         .overlay(tileBorder(isOn: false, themeStore: themeStore))
+    }
+}
+
+/// A read-only weather tile: a tall single-column tile stacking a condition
+/// icon, the temperature, the condition, and today's high/low and rain chance.
+/// Shows a placeholder icon and value until the first reading resolves.
+private struct LaunchpadWeatherTile: View {
+    let model: LaunchpadTileModel
+    let weather: WeatherSnapshot?
+    var themeStore: ThemeStore
+
+    private typealias Const = AppConstants.Launcher.Launchpad
+
+    /// The caption under the temperature: the live condition once known, else
+    /// the tile title while the placeholder shows.
+    private var caption: String {
+        (weather?.condition ?? model.title).uppercased()
+    }
+
+    var body: some View {
+        VStack(spacing: 5) {
+            Image(systemName: weather?.symbolName ?? "cloud.sun.fill")
+                .font(.system(size: 20, weight: .medium))
+                .foregroundColor(themeStore.accentColor())
+            Text(weather?.temperature ?? Const.weatherPlaceholderValue)
+                .font(themeStore.uiFont(size: Const.valueFontSize - 4, weight: .bold))
+                .foregroundColor(themeStore.fontColor())
+            Text(caption)
+                .font(themeStore.uiFont(size: Const.captionFontSize - 1, weight: .medium))
+                .foregroundColor(themeStore.mutedTextColor())
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+            if let weather {
+                details(weather)
+            }
+        }
+        .padding(.horizontal, 6)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(frostedTile(themeStore: themeStore))
+        .overlay(tileBorder(isOn: false, themeStore: themeStore))
+    }
+
+    /// Today's high/low and, when reported, the chance of rain.
+    @ViewBuilder
+    private func details(_ weather: WeatherSnapshot) -> some View {
+        VStack(spacing: 2) {
+            Text("H \(weather.high)   L \(weather.low)")
+                .foregroundColor(themeStore.secondaryTextColor())
+            if let rainChance = weather.rainChance {
+                HStack(spacing: 3) {
+                    Image(systemName: "drop.fill")
+                    Text(rainChance)
+                }
+                .foregroundColor(themeStore.mutedTextColor())
+            }
+        }
+        .font(themeStore.uiFont(size: Const.captionFontSize - 1.5))
+        .lineLimit(1)
+        .minimumScaleFactor(0.7)
     }
 }
 

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
@@ -291,17 +291,17 @@ private struct LaunchpadActionTile: View {
             .background(
                 frostedTile(
                     themeStore: themeStore,
-                    tint: (confirming || micMuted) ? themeStore.dangerColor() : nil,
-                    tintOpacity: (confirming || micMuted) ? launchpadDangerTintOpacity : 0
+                    tint: (confirming || micMuted) ? tint : nil,
+                    tintOpacity: (confirming || micMuted) ? launchpadAlertTintOpacity : 0
                 )
             )
             .overlay(
                 RoundedRectangle(cornerRadius: Const.cornerRadius, style: .continuous)
                     .strokeBorder(
-                        (confirming || micMuted || isDanger)
-                            ? tint.opacity(0.3)
-                            : themeStore.dividerColor().opacity(0.4),
-                        lineWidth: 1
+                        (confirming || micMuted)
+                            ? tint.opacity(launchpadAlertBorderOpacity)
+                            : themeStore.dividerColor().opacity(launchpadRestingBorderOpacity),
+                        lineWidth: launchpadBorderWidth
                     )
             )
         }
@@ -379,7 +379,17 @@ private struct LaunchpadMediaTile: View {
 /// so launchpad tiles read with the same depth as the rest of the floating UI.
 private let launchpadTileScrimOpacity = 0.30
 private let launchpadOnTintOpacity = 0.22
-private let launchpadDangerTintOpacity = 0.16
+/// Backs both the red confirm state and the amber muted-mic state, so the tile
+/// takes its hue from `tint` rather than baking one in here.
+private let launchpadAlertTintOpacity = 0.16
+
+/// Tile borders. Every tile rests on the same neutral divider so the strip reads
+/// as one surface; colour is reserved for a state the user just entered, an
+/// on-state toggle or an armed confirm, never for a tile sitting idle.
+private let launchpadBorderWidth: CGFloat = 1
+private let launchpadRestingBorderOpacity = 0.4
+private let launchpadOnBorderOpacity = 0.35
+private let launchpadAlertBorderOpacity = 0.3
 
 /// The frosted surface every launchpad tile sits on: the same
 /// blur + dark-scrim + control-fill stack the app uses for its floating tiles
@@ -403,7 +413,9 @@ private func tileBorder(isOn: Bool, themeStore: ThemeStore) -> some View {
     let radius = AppConstants.Launcher.Launchpad.cornerRadius
     return RoundedRectangle(cornerRadius: radius, style: .continuous)
         .strokeBorder(
-            isOn ? themeStore.accentColor().opacity(0.35) : themeStore.dividerColor().opacity(0.4),
-            lineWidth: 1
+            isOn
+                ? themeStore.accentColor().opacity(launchpadOnBorderOpacity)
+                : themeStore.dividerColor().opacity(launchpadRestingBorderOpacity),
+            lineWidth: launchpadBorderWidth
         )
 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
@@ -1,0 +1,409 @@
+import SwiftUI
+
+/// The empty-state launchpad: a 6-column bento of L/M/S tiles shown below the
+/// search bar when the query is empty (see "Empty State Spec"). Tile order,
+/// sizes, labels, and mnemonics come from the shared `look_qactions` catalog;
+/// this view lays them out and (in this pass) renders mock state, except the L
+/// slot, which reads the live Todo / Pomo stores.
+struct EmptyStateLaunchpadView: View {
+    let tiles: [LaunchpadTileModel]
+    var controller: LaunchpadController
+    var themeStore: ThemeStore
+
+    private typealias Const = AppConstants.Launcher.Launchpad
+
+    private var byID: [String: LaunchpadTileModel] {
+        Dictionary(tiles.map { ($0.actionId, $0) }, uniquingKeysWith: { first, _ in first })
+    }
+
+    var body: some View {
+        GeometryReader { geo in
+            let cell = cellWidth(total: geo.size.width)
+            layout(cell: cell)
+        }
+        .frame(height: totalHeight)
+        .padding(.top, Const.outerTopPadding)
+    }
+
+    // MARK: Geometry
+
+    private func cellWidth(total: CGFloat) -> CGFloat {
+        let gaps = Const.gap * CGFloat(Const.columns - 1)
+        return max(0, (total - gaps) / CGFloat(Const.columns))
+    }
+
+    private func width(columns: Int, cell: CGFloat) -> CGFloat {
+        CGFloat(columns) * cell + Const.gap * CGFloat(columns - 1)
+    }
+
+    private func height(rows: Int) -> CGFloat {
+        CGFloat(rows) * Const.rowHeight + Const.gap * CGFloat(rows - 1)
+    }
+
+    private var totalHeight: CGFloat { height(rows: 3) }
+
+    // MARK: Layout
+    //
+    // The spec's fixed order tiles a 6-column grid as three rows:
+    //   row 0/1 cols 0-1: L slot (2x2)   | cols 2-5: BT, Wi-Fi, Battery(2)
+    //                                     |           Theme(2), Focus, Saver
+    //   row 2 cols 0-5: Mic, Restart, Shut Down, Now Playing(3)
+    // SwiftUI has no cell spanning, so the arrangement is composed explicitly
+    // from the known order rather than auto-packed.
+
+    @ViewBuilder
+    private func layout(cell: CGFloat) -> some View {
+        VStack(spacing: Const.gap) {
+            HStack(alignment: .top, spacing: Const.gap) {
+                slot(cell: cell)
+                    .frame(width: width(columns: 2, cell: cell), height: height(rows: 2))
+
+                VStack(spacing: Const.gap) {
+                    HStack(spacing: Const.gap) {
+                        tileView(LaunchpadActionID.bluetooth, cell: cell)
+                        tileView(LaunchpadActionID.wifi, cell: cell)
+                        tileView(LaunchpadActionID.battery, cell: cell)
+                    }
+                    HStack(spacing: Const.gap) {
+                        tileView(LaunchpadActionID.theme, cell: cell)
+                        tileView(LaunchpadActionID.focus, cell: cell)
+                        tileView(LaunchpadActionID.saver, cell: cell)
+                    }
+                }
+            }
+
+            HStack(spacing: Const.gap) {
+                tileView(LaunchpadActionID.mic, cell: cell)
+                tileView(LaunchpadActionID.restart, cell: cell)
+                tileView(LaunchpadActionID.shutdown, cell: cell)
+                tileView(LaunchpadActionID.nowPlaying, cell: cell)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func slot(cell: CGFloat) -> some View {
+        LaunchpadLSlotView(themeStore: themeStore)
+    }
+
+    /// Renders the tile for `actionID` at its natural size, sourcing labels and
+    /// the mnemonic from the decoded catalog model.
+    @ViewBuilder
+    private func tileView(_ actionID: String, cell: CGFloat) -> some View {
+        if let model = byID[actionID] {
+            let w = width(columns: model.columnSpan, cell: cell)
+            let h = height(rows: model.size.rows)
+            tileContent(model)
+                .frame(width: w, height: h)
+        }
+    }
+
+    @ViewBuilder
+    private func tileContent(_ model: LaunchpadTileModel) -> some View {
+        switch model.role {
+        case .toggle:
+            LaunchpadToggleTile(
+                model: model,
+                isOn: controller.isOn(model.actionId),
+                themeStore: themeStore
+            ) { controller.activate(model) }
+        case .info:
+            LaunchpadInfoTile(model: model, value: Const.mockBatteryValue, themeStore: themeStore)
+        case .action:
+            LaunchpadActionTile(
+                model: model,
+                themeStore: themeStore,
+                micMuted: model.actionId == LaunchpadActionID.mic ? controller.micMuted : false,
+                confirming: controller.pendingConfirmActionID == model.actionId
+            ) { controller.activate(model) }
+        case .media:
+            LaunchpadMediaTile(
+                model: model,
+                isPlaying: controller.isPlaying,
+                themeStore: themeStore
+            ) { controller.activate(model) }
+        case .slot:
+            EmptyView()
+        }
+    }
+}
+
+// MARK: - Mnemonic helper
+
+/// Builds a label with one character tinted in the theme's warning color (the
+/// spec's "yellow"), matching `⌘<char>`. Falls back to the plain label when the
+/// mnemonic character does not occur in it.
+private func mnemonicText(
+    _ label: String,
+    mnemonic: Character?,
+    font: Font,
+    base: Color,
+    highlight: Color
+) -> Text {
+    guard let mnemonic,
+          let range = label.range(
+            of: String(mnemonic),
+            options: [.caseInsensitive]
+          )
+    else {
+        return Text(label).font(font).foregroundColor(base)
+    }
+    let before = String(label[label.startIndex..<range.lowerBound])
+    let match = String(label[range])
+    let after = String(label[range.upperBound...])
+    return Text(before).font(font).foregroundColor(base)
+        + Text(match).font(font).foregroundColor(highlight)
+        + Text(after).font(font).foregroundColor(base)
+}
+
+// MARK: - Tiles
+
+/// A stateful on/off tile (Bluetooth, Wi-Fi, Theme, Focus, Saver). On uses the
+/// accent color plus a subtle accent border.
+private struct LaunchpadToggleTile: View {
+    let model: LaunchpadTileModel
+    let isOn: Bool
+    var themeStore: ThemeStore
+    var onTap: () -> Void
+
+    private typealias Const = AppConstants.Launcher.Launchpad
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 8) {
+                Image(systemName: iconName)
+                    .font(.system(size: 18, weight: .medium))
+                    .foregroundColor(isOn ? themeStore.accentColor() : themeStore.mutedTextColor())
+                VStack(alignment: .leading, spacing: 1) {
+                    mnemonicText(
+                        model.title,
+                        mnemonic: model.mnemonic,
+                        font: themeStore.uiFont(size: Const.smallLabelFontSize, weight: .semibold),
+                        base: isOn ? themeStore.fontColor() : themeStore.secondaryTextColor(),
+                        highlight: themeStore.warningColor()
+                    )
+                    .lineLimit(1)
+                    Text(stateLabel)
+                        .font(themeStore.uiFont(size: Const.captionFontSize - 1))
+                        .foregroundColor(isOn ? themeStore.accentColor() : themeStore.mutedTextColor())
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 10)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+            .background(
+                frostedTile(
+                    themeStore: themeStore,
+                    tint: isOn ? themeStore.accentColor() : nil,
+                    tintOpacity: isOn ? launchpadOnTintOpacity : 0
+                )
+            )
+            .overlay(tileBorder(isOn: isOn, themeStore: themeStore))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var stateLabel: String {
+        if isOn { return model.onLabel ?? "On" }
+        return model.offLabel ?? "Off"
+    }
+
+    private var iconName: String {
+        switch model.actionId {
+        case LaunchpadActionID.bluetooth: return "antenna.radiowaves.left.and.right"
+        case LaunchpadActionID.wifi: return "wifi"
+        case LaunchpadActionID.theme: return isOn ? "moon.fill" : "sun.max.fill"
+        case LaunchpadActionID.focus: return "moon.circle.fill"
+        case LaunchpadActionID.saver: return "bolt.fill"
+        default: return "circle"
+        }
+    }
+}
+
+/// A read-only info tile (Battery): label plus a live value.
+private struct LaunchpadInfoTile: View {
+    let model: LaunchpadTileModel
+    let value: String
+    var themeStore: ThemeStore
+
+    private typealias Const = AppConstants.Launcher.Launchpad
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "battery.100")
+                .font(.system(size: 18, weight: .medium))
+                .foregroundColor(themeStore.accentColor())
+            VStack(alignment: .leading, spacing: 1) {
+                Text(model.title.uppercased())
+                    .font(themeStore.uiFont(size: Const.captionFontSize - 1, weight: .medium))
+                    .foregroundColor(themeStore.mutedTextColor())
+                Text(value)
+                    .font(themeStore.uiFont(size: Const.valueFontSize - 6, weight: .bold))
+                    .foregroundColor(themeStore.fontColor())
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 12)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        .background(frostedTile(themeStore: themeStore))
+        .overlay(tileBorder(isOn: false, themeStore: themeStore))
+    }
+}
+
+/// A compact system-action tile (Mic, Restart, Shut Down). Mic turns amber when
+/// muted; Restart / Shut Down use the caution color and show an inline confirm.
+private struct LaunchpadActionTile: View {
+    let model: LaunchpadTileModel
+    var themeStore: ThemeStore
+    let micMuted: Bool
+    let confirming: Bool
+    var onTap: () -> Void
+
+    private typealias Const = AppConstants.Launcher.Launchpad
+
+    private var isDanger: Bool {
+        model.actionId == LaunchpadActionID.restart || model.actionId == LaunchpadActionID.shutdown
+    }
+
+    private var tint: Color {
+        if confirming { return themeStore.dangerColor() }
+        if micMuted { return themeStore.warningColor() }
+        if isDanger { return themeStore.dangerColor() }
+        return themeStore.secondaryTextColor()
+    }
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(spacing: 6) {
+                Image(systemName: iconName)
+                    .font(.system(size: 18, weight: .medium))
+                    .foregroundColor(tint)
+                mnemonicText(
+                    confirming ? "Confirm?" : model.title,
+                    mnemonic: confirming ? nil : model.mnemonic,
+                    font: themeStore.uiFont(size: Const.smallLabelFontSize, weight: .semibold),
+                    base: confirming ? themeStore.dangerColor() : themeStore.secondaryTextColor(),
+                    highlight: themeStore.warningColor()
+                )
+                .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(
+                frostedTile(
+                    themeStore: themeStore,
+                    tint: (confirming || micMuted) ? themeStore.dangerColor() : nil,
+                    tintOpacity: (confirming || micMuted) ? launchpadDangerTintOpacity : 0
+                )
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: Const.cornerRadius, style: .continuous)
+                    .strokeBorder(
+                        (confirming || micMuted || isDanger)
+                            ? tint.opacity(0.3)
+                            : themeStore.dividerColor().opacity(0.4),
+                        lineWidth: 1
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var iconName: String {
+        switch model.actionId {
+        case LaunchpadActionID.mic: return micMuted ? "mic.slash.fill" : "mic.fill"
+        case LaunchpadActionID.restart: return "arrow.clockwise"
+        case LaunchpadActionID.shutdown: return "power"
+        default: return "circle"
+        }
+    }
+}
+
+/// The Now Playing tile: track name plus a Pause/Play control (⌘P).
+private struct LaunchpadMediaTile: View {
+    let model: LaunchpadTileModel
+    let isPlaying: Bool
+    var themeStore: ThemeStore
+    var onToggle: () -> Void
+
+    private typealias Const = AppConstants.Launcher.Launchpad
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "music.note")
+                .font(.system(size: 18, weight: .medium))
+                .foregroundColor(themeStore.accentColor())
+            VStack(alignment: .leading, spacing: 1) {
+                Text(model.title.uppercased())
+                    .font(themeStore.uiFont(size: Const.captionFontSize - 1, weight: .medium))
+                    .foregroundColor(themeStore.mutedTextColor())
+                Text(trackTitle)
+                    .font(themeStore.uiFont(size: Const.titleFontSize, weight: .bold))
+                    .foregroundColor(isPlaying ? themeStore.fontColor() : themeStore.mutedTextColor())
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 0)
+            Button(action: onToggle) {
+                VStack(spacing: 2) {
+                    Image(systemName: isPlaying ? "pause.fill" : "play.fill")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundColor(themeStore.fontColor())
+                    mnemonicText(
+                        isPlaying ? "Pause" : "Play",
+                        mnemonic: model.mnemonic,
+                        font: themeStore.uiFont(size: Const.captionFontSize - 1, weight: .semibold),
+                        base: themeStore.secondaryTextColor(),
+                        highlight: themeStore.warningColor()
+                    )
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 6)
+                .background(themeStore.controlFillColor())
+                .clipShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 12)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        .background(frostedTile(themeStore: themeStore))
+        .overlay(tileBorder(isOn: false, themeStore: themeStore))
+    }
+
+    private var trackTitle: String {
+        isPlaying ? "Kiasmos - Blurred" : AppConstants.Launcher.Launchpad.mockNowPlayingTitle
+    }
+}
+
+// MARK: - Shared tile chrome
+
+/// Scrim opacity layered over the blur, matching `LauncherView.tileBackground`
+/// so launchpad tiles read with the same depth as the rest of the floating UI.
+private let launchpadTileScrimOpacity = 0.30
+private let launchpadOnTintOpacity = 0.22
+private let launchpadDangerTintOpacity = 0.16
+
+/// The frosted surface every launchpad tile sits on: the same
+/// blur + dark-scrim + control-fill stack the app uses for its floating tiles
+/// (`LauncherView.tileBackground(floats:)`), so opacity and material stay
+/// unified. An optional tint (accent for on-state toggles, caution for a
+/// confirming/muted action) layers on top.
+func frostedTile(themeStore: ThemeStore, tint: Color? = nil, tintOpacity: Double = 0) -> some View {
+    let radius = AppConstants.Launcher.Launchpad.cornerRadius
+    return ZStack {
+        VisualEffectBlur(material: themeStore.settings.blurMaterial.material)
+        Color.black.opacity(launchpadTileScrimOpacity)
+        themeStore.controlFillColor()
+        if let tint {
+            tint.opacity(tintOpacity)
+        }
+    }
+    .clipShape(RoundedRectangle(cornerRadius: radius, style: .continuous))
+}
+
+private func tileBorder(isOn: Bool, themeStore: ThemeStore) -> some View {
+    let radius = AppConstants.Launcher.Launchpad.cornerRadius
+    return RoundedRectangle(cornerRadius: radius, style: .continuous)
+        .strokeBorder(
+            isOn ? themeStore.accentColor().opacity(0.35) : themeStore.dividerColor().opacity(0.4),
+            lineWidth: 1
+        )
+}

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Launchpad.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Launchpad.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Empty-state launchpad wiring: loads the shared tile catalog once, exposes
+/// whether the launchpad is currently on screen, and routes Command-mnemonic
+/// key presses to it. Rendering lives in `EmptyStateLaunchpadView`; the mock
+/// interactive state lives in `LaunchpadController`.
+extension LauncherView {
+    /// Decodes the shared launchpad layout once and wires the controller's
+    /// banner sink. Idempotent, so it is safe to call from `onAppear`.
+    func configureLaunchpadIfNeeded() {
+        if launchpadTiles.isEmpty {
+            launchpadTiles = EngineBridge.shared.launchpadLayout()
+            launchpadController.configure(tiles: launchpadTiles)
+        }
+        // The controller cannot reach the view's banner directly; forward it.
+        launchpadController.onBanner = { message in
+            showBanner(message, style: .info, duration: 1.4)
+        }
+    }
+
+    /// True while the empty-state launchpad is the visible content (empty query,
+    /// not in command mode / settings / help). Gates the Command-mnemonic keys so
+    /// they only fire when the strip is actually shown.
+    var isLaunchpadActive: Bool {
+        hidesResultsForEmptyQuery && !launchpadTiles.isEmpty
+    }
+
+    /// Routes a Command-mnemonic character to the launchpad. Returns true when a
+    /// tile handled it (so the key monitor swallows the event).
+    func handleLaunchpadMnemonic(_ character: Character) -> Bool {
+        guard isLaunchpadActive else { return false }
+        return launchpadController.handleMnemonic(character)
+    }
+
+    /// Cancels a pending Restart / Shut Down confirm on Escape. Returns true when
+    /// a prompt was dismissed, so the monitor stops the key from also hiding the
+    /// launcher.
+    func cancelLaunchpadConfirmIfNeeded() -> Bool {
+        guard isLaunchpadActive else { return false }
+        return launchpadController.cancelConfirm()
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
@@ -231,6 +231,15 @@ extension LauncherView {
             },
             hasToggleQuickAction: { [self] in
                 hasToggleQuickAction
+            },
+            isLaunchpadActive: { [self] in
+                isLaunchpadActive
+            },
+            onLaunchpadMnemonic: { [self] character in
+                handleLaunchpadMnemonic(character)
+            },
+            onLaunchpadEscape: { [self] in
+                cancelLaunchpadConfirmIfNeeded()
             }
         )
     }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -70,6 +70,10 @@ struct LauncherView: View {
     @State var activeCommandID: String?
     @State var commandFeedback = ""
     @State var keyboardMonitor = KeyboardSelectionMonitor()
+    /// Empty-state launchpad: the decoded tile layout (from the shared catalog)
+    /// and the controller holding its interactive state.
+    @State var launchpadTiles: [LaunchpadTileModel] = []
+    @State var launchpadController = LaunchpadController()
     @State var searchTask: Task<Void, Never>?
     @State var latestSearchID: UInt64 = 0
     @State var bannerMessage: String?
@@ -623,6 +627,7 @@ struct LauncherView: View {
         .ignoresSafeArea()
         .onAppear {
             refreshSearchResults()
+            configureLaunchpadIfNeeded()
             startKeyboardNavigationIfNeeded()
             focusActiveInput()
             refreshClipboardMonitoringMode()
@@ -893,8 +898,16 @@ struct LauncherView: View {
             } else if isRecentQuery && displayedResults.isEmpty {
                 floatingPanel { RecentEmptyStateView(themeStore: themeStore) }
             } else if hidesResultsForEmptyQuery {
-                // Empty query while floating: rest with just the top bar, nothing
-                // below. A spacer keeps the bar pinned to the top.
+                // Empty query while floating: the launchpad control strip sits
+                // below the top bar; a spacer keeps them pinned to the top. When
+                // the catalog fails to decode we fall back to the bare rest state.
+                if !launchpadTiles.isEmpty {
+                    EmptyStateLaunchpadView(
+                        tiles: launchpadTiles,
+                        controller: launchpadController,
+                        themeStore: themeStore
+                    )
+                }
                 Spacer(minLength: 0)
             } else {
                 resultsRow
@@ -1180,7 +1193,7 @@ struct LauncherView: View {
     /// With an empty query on the home screen, rest as just the search bar - hide
     /// the results columns and the hint bar below it. Applies in both modes (gap
     /// or no gap), so an empty launcher is always just the top bar.
-    private var hidesResultsForEmptyQuery: Bool {
+    var hidesResultsForEmptyQuery: Bool {
         isQueryEmpty
             && !isCommandMode
             && !appUIState.showsThemeSettings

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -628,6 +628,7 @@ struct LauncherView: View {
         .onAppear {
             refreshSearchResults()
             configureLaunchpadIfNeeded()
+            Task { await launchpadController.refreshWeather() }
             startKeyboardNavigationIfNeeded()
             focusActiveInput()
             refreshClipboardMonitoringMode()

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LaunchpadController.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LaunchpadController.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Observation
+
+/// Holds the interactive state for the empty-state launchpad and routes tile
+/// activations (clicks and Command-mnemonics) to it.
+///
+/// This is the layout-only pass: toggles and the mic/now-playing controls flip
+/// local mock state, and Restart / Shut Down open an inline confirm that fires a
+/// banner instead of a real power action. Wiring each tile to a live
+/// `SystemControl` adapter (Wi-Fi, Theme, Focus, Saver, Mic, ...) lands in
+/// follow-up PRs; only this controller and the native reads change then.
+@MainActor
+@Observable
+final class LaunchpadController {
+    /// On/off state for the stateful toggle tiles, keyed by `action_id`.
+    /// Seeded with representative mock values for the layout pass.
+    private(set) var toggles: [String: Bool] = [
+        LaunchpadActionID.bluetooth: false,
+        LaunchpadActionID.wifi: true,
+        LaunchpadActionID.theme: true,
+        LaunchpadActionID.focus: false,
+        LaunchpadActionID.saver: false,
+    ]
+
+    /// Mic mute state (true = muted); rendered amber when muted.
+    private(set) var micMuted = false
+
+    /// Now Playing transport state (mock).
+    private(set) var isPlaying = false
+
+    /// The destructive tile currently awaiting an inline confirm, or nil.
+    private(set) var pendingConfirmActionID: String?
+
+    /// The tile layout, needed to resolve a pressed mnemonic to a tile.
+    private var tiles: [LaunchpadTileModel] = []
+
+    /// Called to surface a short banner for mock actions. Set by the view.
+    var onBanner: ((String) -> Void)?
+
+    func configure(tiles: [LaunchpadTileModel]) {
+        self.tiles = tiles
+    }
+
+    func isOn(_ actionID: String) -> Bool {
+        toggles[actionID] ?? false
+    }
+
+    /// Activates a tile: toggles flip, Mic mutes, Now Playing plays/pauses, and
+    /// the destructive tiles open (or confirm) the inline confirm prompt.
+    func activate(_ tile: LaunchpadTileModel) {
+        // Any activation other than confirming the pending tile clears a stale
+        // confirm, so the prompt never lingers on an unrelated press.
+        if pendingConfirmActionID != nil, pendingConfirmActionID != tile.actionId {
+            pendingConfirmActionID = nil
+        }
+
+        switch tile.actionId {
+        case LaunchpadActionID.restart, LaunchpadActionID.shutdown:
+            if pendingConfirmActionID == tile.actionId {
+                confirmPending()
+            } else {
+                pendingConfirmActionID = tile.actionId
+            }
+        case LaunchpadActionID.mic:
+            micMuted.toggle()
+            onBanner?(micMuted ? "Mic muted" : "Mic on")
+        case LaunchpadActionID.nowPlaying:
+            isPlaying.toggle()
+        default:
+            if tile.role == .toggle {
+                toggles[tile.actionId] = !isOn(tile.actionId)
+            }
+        }
+    }
+
+    /// Fires the pending destructive action (mock) and clears the prompt.
+    func confirmPending() {
+        guard let actionID = pendingConfirmActionID else { return }
+        let label = actionID == LaunchpadActionID.restart ? "Restart" : "Shut Down"
+        onBanner?("\(label) (demo)")
+        pendingConfirmActionID = nil
+    }
+
+    /// Cancels the inline confirm. Returns true if a prompt was actually
+    /// dismissed, so the caller (Esc handler) knows to swallow the key.
+    @discardableResult
+    func cancelConfirm() -> Bool {
+        guard pendingConfirmActionID != nil else { return false }
+        pendingConfirmActionID = nil
+        return true
+    }
+
+    /// Routes a Command-mnemonic key press to its tile. Returns true when a tile
+    /// matched and was activated (so the key monitor swallows the event).
+    func handleMnemonic(_ character: Character) -> Bool {
+        let lowered = Character(character.lowercased())
+        guard let tile = tiles.first(where: { tile in
+            guard let mnemonic = tile.mnemonic else { return false }
+            return Character(mnemonic.lowercased()) == lowered
+        }) else { return false }
+        activate(tile)
+        return true
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LaunchpadController.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LaunchpadController.swift
@@ -28,6 +28,12 @@ final class LaunchpadController {
     /// Now Playing transport state (mock).
     private(set) var isPlaying = false
 
+    /// Latest resolved weather for the Weather tile, or nil until the first
+    /// successful fetch (the tile shows a placeholder meanwhile).
+    private(set) var weather: WeatherSnapshot?
+
+    private let weatherService = WeatherService.shared
+
     /// The destructive tile currently awaiting an inline confirm, or nil.
     private(set) var pendingConfirmActionID: String?
 
@@ -39,6 +45,15 @@ final class LaunchpadController {
 
     func configure(tiles: [LaunchpadTileModel]) {
         self.tiles = tiles
+    }
+
+    /// Resolves the Weather tile's value. Cheap to call on every launcher open:
+    /// the service serves a fresh cache without touching the network and only
+    /// refetches once the reading goes stale.
+    func refreshWeather() async {
+        if let snapshot = await weatherService.currentWeather() {
+            weather = snapshot
+        }
     }
 
     func isOn(_ actionID: String) -> Bool {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LaunchpadController.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LaunchpadController.swift
@@ -49,11 +49,12 @@ final class LaunchpadController {
 
     /// Resolves the Weather tile's value. Cheap to call on every launcher open:
     /// the service serves a fresh cache without touching the network and only
-    /// refetches once the reading goes stale.
+    /// refetches once the reading goes stale. Assigned unconditionally: the
+    /// service already falls back to a compatible cache on failure, so a nil
+    /// result means there is no usable reading and the tile should clear rather
+    /// than keep a stale value (e.g. in the wrong unit after a region change).
     func refreshWeather() async {
-        if let snapshot = await weatherService.currentWeather() {
-            weather = snapshot
-        }
+        weather = await weatherService.currentWeather()
     }
 
     func isOn(_ actionID: String) -> Bool {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LaunchpadLSlotView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LaunchpadLSlotView.swift
@@ -1,0 +1,239 @@
+import Combine
+import SwiftUI
+
+/// The launchpad's L slot (2x2). Priority-driven and, per the spec, rotates
+/// every 5s with a crossfade when more than one source applies:
+///
+/// - Todo when there are remaining tasks today.
+/// - Pomo when a Pomodoro session is running.
+/// - Clock as the fallback when neither applies.
+///
+/// Both active -> rotate Todo <-> Pomo; one active -> static; none -> Clock.
+/// This is the one launchpad tile wired to live state in the layout pass, since
+/// the Todo and Pomo stores already exist.
+struct LaunchpadLSlotView: View {
+    var themeStore: ThemeStore
+
+    private typealias Const = AppConstants.Launcher.Launchpad
+
+    @State private var rotationIndex = 0
+
+    private let rotateTimer = Timer.publish(
+        every: AppConstants.Launcher.Launchpad.lSlotRotateSeconds,
+        on: .main,
+        in: .common
+    ).autoconnect()
+
+    private enum Slot: Equatable { case todo, pomo, clock }
+
+    private var applicableSlots: [Slot] {
+        var slots: [Slot] = []
+        if todoRemaining > 0 { slots.append(.todo) }
+        if PomoSharedState.shared.activeIndex != nil { slots.append(.pomo) }
+        return slots
+    }
+
+    private var todoRemaining: Int {
+        TodoSharedState.shared.today?.openCount ?? 0
+    }
+
+    private var current: Slot {
+        let slots = applicableSlots
+        guard !slots.isEmpty else { return .clock }
+        return slots[rotationIndex % slots.count]
+    }
+
+    var body: some View {
+        ZStack {
+            switch current {
+            case .todo:
+                LaunchpadTodoTile(themeStore: themeStore)
+            case .pomo:
+                LaunchpadPomoTile(themeStore: themeStore)
+            case .clock:
+                LaunchpadClockTile(themeStore: themeStore)
+            }
+        }
+        .id(current)
+        .transition(.opacity)
+        .animation(.easeInOut(duration: Const.rotateFadeSeconds), value: current)
+        .onReceive(rotateTimer) { _ in
+            let count = applicableSlots.count
+            guard count > 1 else { return }
+            rotationIndex = (rotationIndex + 1) % count
+        }
+    }
+}
+
+// MARK: - Todo tile
+
+/// Done/total today plus a rotating next-task name (cycles per the spec).
+private struct LaunchpadTodoTile: View {
+    var themeStore: ThemeStore
+
+    private typealias Const = AppConstants.Launcher.Launchpad
+
+    @State private var taskIndex = 0
+
+    private let taskTimer = Timer.publish(
+        every: AppConstants.Launcher.Launchpad.todoTaskRotateSeconds,
+        on: .main,
+        in: .common
+    ).autoconnect()
+
+    private var stat: TodoStat { TodoSharedState.shared.todayStat }
+    private var openTasks: [String] {
+        TodoSharedState.shared.today?.tasks.filter { !$0.done }.map(\.name) ?? []
+    }
+
+    var body: some View {
+        LaunchpadSlotCard(themeStore: themeStore, iconName: "checklist", pill: "/todo") {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Text("\(stat.done)/\(stat.total)")
+                        .font(themeStore.uiFont(size: 26, weight: .bold))
+                        .foregroundColor(themeStore.fontColor())
+                    Text("done today")
+                        .font(themeStore.uiFont(size: Const.titleFontSize))
+                        .foregroundColor(themeStore.secondaryTextColor())
+                }
+                HStack(spacing: 6) {
+                    Circle()
+                        .fill(themeStore.accentColor())
+                        .frame(width: 5, height: 5)
+                    Text(nextTaskLabel)
+                        .font(themeStore.uiFont(size: Const.captionFontSize + 1))
+                        .foregroundColor(themeStore.secondaryTextColor())
+                        .lineLimit(1)
+                        .id(taskIndex)
+                        .transition(.opacity)
+                }
+                .animation(.easeInOut(duration: 0.35), value: taskIndex)
+            }
+        }
+        .onReceive(taskTimer) { _ in
+            guard openTasks.count > 1 else { return }
+            taskIndex = (taskIndex + 1) % openTasks.count
+        }
+    }
+
+    private var nextTaskLabel: String {
+        let tasks = openTasks
+        guard !tasks.isEmpty else { return "All clear" }
+        return tasks[taskIndex % tasks.count]
+    }
+}
+
+// MARK: - Pomo tile
+
+/// Live countdown, phase + session, and a progress bar for the running session.
+private struct LaunchpadPomoTile: View {
+    var themeStore: ThemeStore
+
+    private typealias Const = AppConstants.Launcher.Launchpad
+
+    private var state: PomoState { PomoSharedState.shared }
+
+    var body: some View {
+        LaunchpadSlotCard(themeStore: themeStore, iconName: "timer", pill: "/pomo") {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(PomoCommand.formattedRemaining(state.secondsLeft))
+                    .font(themeStore.uiFont(size: 30, weight: .bold))
+                    .foregroundColor(themeStore.fontColor())
+                    .monospacedDigit()
+                Text(phaseLabel)
+                    .font(themeStore.uiFont(size: Const.captionFontSize + 1))
+                    .foregroundColor(themeStore.secondaryTextColor())
+                ProgressView(value: min(max(state.progress, 0), 1))
+                    .tint(themeStore.accentColor())
+                    .frame(height: 3)
+            }
+        }
+    }
+
+    private var phaseLabel: String {
+        let phase = state.currentSession?.type == .focus ? "Focus" : "Break"
+        guard let index = state.activeIndex else { return phase }
+        return "\(phase) - session \(index + 1)/\(state.sessions.count)"
+    }
+}
+
+// MARK: - Clock tile
+
+/// Live time + date fallback. Non-sensitive; safe during screen-share.
+private struct LaunchpadClockTile: View {
+    var themeStore: ThemeStore
+
+    private typealias Const = AppConstants.Launcher.Launchpad
+
+    @State private var now = Date()
+
+    private let tickTimer = Timer.publish(
+        every: AppConstants.Launcher.Launchpad.clockTickSeconds,
+        on: .main,
+        in: .common
+    ).autoconnect()
+
+    var body: some View {
+        LaunchpadSlotCard(themeStore: themeStore, iconName: "clock", pill: nil) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(now, format: .dateTime.hour().minute())
+                    .font(themeStore.uiFont(size: 30, weight: .bold))
+                    .foregroundColor(themeStore.fontColor())
+                    .monospacedDigit()
+                Text(now, format: .dateTime.weekday().month().day())
+                    .font(themeStore.uiFont(size: Const.titleFontSize))
+                    .foregroundColor(themeStore.secondaryTextColor())
+            }
+        }
+        .onReceive(tickTimer) { now = $0 }
+    }
+}
+
+// MARK: - Shared L-slot card chrome
+
+/// The common 2x2 card frame: an icon badge in the top-left, an optional command
+/// pill in the top-right, and the slot's content pinned to the bottom.
+private struct LaunchpadSlotCard<Content: View>: View {
+    var themeStore: ThemeStore
+    let iconName: String
+    let pill: String?
+    @ViewBuilder var content: () -> Content
+
+    private typealias Const = AppConstants.Launcher.Launchpad
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 11, style: .continuous)
+                        .fill(themeStore.selectionFillColor())
+                    Image(systemName: iconName)
+                        .font(.system(size: 20, weight: .medium))
+                        .foregroundColor(themeStore.accentColor())
+                }
+                .frame(width: 40, height: 40)
+                Spacer(minLength: 0)
+                if let pill {
+                    Text(pill)
+                        .font(themeStore.uiFont(size: Const.captionFontSize - 0.5))
+                        .foregroundColor(themeStore.fontColor())
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 2)
+                        .background(
+                            Capsule().fill(themeStore.selectionFillColor())
+                        )
+                }
+            }
+            Spacer(minLength: 0)
+            content()
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(frostedTile(themeStore: themeStore))
+        .overlay(
+            RoundedRectangle(cornerRadius: Const.cornerRadius, style: .continuous)
+                .strokeBorder(themeStore.dividerColor().opacity(0.4), lineWidth: 1)
+        )
+    }
+}

--- a/bridge/ffi/src/lib.rs
+++ b/bridge/ffi/src/lib.rs
@@ -215,6 +215,17 @@ pub extern "C" fn look_qactions_json(result_id: *const c_char, kind: *const c_ch
     .unwrap_or(std::ptr::null_mut())
 }
 
+/// JSON array of launchpad tiles for the empty-state control strip (or `[]`).
+/// The layout is fixed and input-free, so this takes no arguments. Free the
+/// result with `look_free_cstring`.
+#[unsafe(no_mangle)]
+pub extern "C" fn look_quick_actions_launchpad_json() -> *mut c_char {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(
+        qactions_api::look_quick_actions_launchpad_json_impl,
+    ))
+    .unwrap_or(std::ptr::null_mut())
+}
+
 /// Definitional entity JSON for `query` (a JSON string or `null`).
 #[unsafe(no_mangle)]
 pub extern "C" fn look_definitional_entity_json(query: *const c_char) -> *mut c_char {

--- a/bridge/ffi/src/qactions_api.rs
+++ b/bridge/ffi/src/qactions_api.rs
@@ -22,3 +22,14 @@ pub(crate) fn look_qactions_json_impl(
         CString::new(json).unwrap_or_else(|_| CString::new(JSON_EMPTY_ARRAY).expect("valid"));
     store_json_allocation(cstring)
 }
+
+/// JSON array of `LaunchpadTile` describing the empty-state launchpad layout
+/// (fixed order, sizes, mnemonics), or `[]` on any serialization failure. The
+/// layout is input-free, so this takes no arguments.
+pub(crate) fn look_quick_actions_launchpad_json_impl() -> *mut c_char {
+    let tiles = look_qactions::launchpad_layout();
+    let json = serde_json::to_string(&tiles).unwrap_or_else(|_| JSON_EMPTY_ARRAY.to_string());
+    let cstring =
+        CString::new(json).unwrap_or_else(|_| CString::new(JSON_EMPTY_ARRAY).expect("valid"));
+    store_json_allocation(cstring)
+}

--- a/core/qactions/src/lib.rs
+++ b/core/qactions/src/lib.rs
@@ -351,8 +351,10 @@ mod tests {
         let mut seen = std::collections::HashSet::new();
         for tile in launchpad_layout() {
             if let Some(ch) = tile.mnemonic {
+                // Shells match mnemonics case-insensitively, so `b` and `B`
+                // would collide at runtime and leave one tile unreachable.
                 assert!(
-                    seen.insert(ch),
+                    seen.insert(ch.to_ascii_lowercase()),
                     "duplicate mnemonic {ch} on {}",
                     tile.action_id
                 );

--- a/core/qactions/src/lib.rs
+++ b/core/qactions/src/lib.rs
@@ -55,6 +55,9 @@ pub mod action_id {
     pub const SHUTDOWN: &str = "shutdown";
     pub const BATTERY: &str = "battery";
     pub const NOW_PLAYING: &str = "nowplaying";
+    /// A read-only weather tile. Presentational like Battery: no descriptor and
+    /// no native adapter, its value is resolved by each shell (see follow-up).
+    pub const WEATHER: &str = "weather";
     /// The launchpad's L slot: a presentational Todo/Pomo/Clock rotation, not a
     /// system control, so it has no descriptor and no native adapter.
     pub const L_SLOT: &str = "lslot";
@@ -131,6 +134,8 @@ pub enum TileRole {
     Action,
     /// Now Playing: track name plus a play/pause transport.
     Media,
+    /// Read-only weather (condition icon + temperature), resolved natively.
+    Weather,
     /// The rotating Todo / Pomo / Clock slot; rendered entirely by the shell.
     Slot,
 }
@@ -150,6 +155,9 @@ pub struct LaunchpadTile {
     /// Column span override, used by the Now Playing tile (spans 3). `None`
     /// falls back to the natural width of `size`.
     pub span: Option<u8>,
+    /// Row span override, used by the Weather tile (stands 2 rows tall in a
+    /// single column). `None` falls back to the natural height of `size`.
+    pub row_span: Option<u8>,
     /// On/off captions for toggle tiles (e.g. Theme's Dark/Light), from the
     /// shared descriptor. `None` for non-toggle tiles.
     pub on_label: Option<String>,
@@ -168,6 +176,7 @@ fn tile(action_id: &str, size: TileSize, role: TileRole, mnemonic: Option<char>)
         role,
         mnemonic,
         span: None,
+        row_span: None,
         on_label: descriptor.as_ref().and_then(|d| d.on_label.clone()),
         off_label: descriptor.and_then(|d| d.off_label),
     }
@@ -176,8 +185,11 @@ fn tile(action_id: &str, size: TileSize, role: TileRole, mnemonic: Option<char>)
 /// The fixed empty-state launchpad layout, in placement order. This exact order
 /// and these sizes tile the 6-column grid with no gaps in every state:
 ///
-/// L slot -> BT -> Wi-Fi -> Battery (M) -> Theme (M) -> Focus -> Saver -> Mic ->
-/// Restart -> Shut Down -> Now Playing (M, span 3).
+/// L slot -> BT -> Wi-Fi -> Battery -> Theme -> Focus -> Saver -> Weather ->
+/// Mic -> Restart -> Shut Down -> Now Playing (M, span 3).
+///
+/// Battery and Theme are single-column (S); the freed column on the right of the
+/// middle block is filled by the Weather tile, which stands two rows tall.
 ///
 /// The order and mnemonics are shared so every platform shell renders the same
 /// control strip; only the native state reads differ.
@@ -193,6 +205,19 @@ pub fn launchpad_layout() -> Vec<LaunchpadTile> {
         role: role::Media,
         mnemonic: Some('P'),
         span: Some(3),
+        row_span: None,
+        on_label: None,
+        off_label: None,
+    };
+
+    let weather = LaunchpadTile {
+        action_id: id::WEATHER.to_string(),
+        title: "Weather".to_string(),
+        size: size::S,
+        role: role::Weather,
+        mnemonic: None,
+        span: None,
+        row_span: Some(2),
         on_label: None,
         off_label: None,
     };
@@ -205,6 +230,7 @@ pub fn launchpad_layout() -> Vec<LaunchpadTile> {
             role: role::Slot,
             mnemonic: None,
             span: None,
+            row_span: None,
             on_label: None,
             off_label: None,
         },
@@ -213,16 +239,18 @@ pub fn launchpad_layout() -> Vec<LaunchpadTile> {
         LaunchpadTile {
             action_id: id::BATTERY.to_string(),
             title: "Battery".to_string(),
-            size: size::M,
+            size: size::S,
             role: role::Info,
             mnemonic: None,
             span: None,
+            row_span: None,
             on_label: None,
             off_label: None,
         },
-        tile(id::THEME, size::M, role::Toggle, Some('T')),
+        tile(id::THEME, size::S, role::Toggle, Some('T')),
         tile(id::FOCUS, size::S, role::Toggle, Some('F')),
         tile(id::SAVER, size::S, role::Toggle, Some('S')),
+        weather,
         tile(id::MIC, size::S, role::Action, Some('M')),
         tile(id::RESTART, size::S, role::Action, Some('R')),
         tile(id::SHUTDOWN, size::S, role::Action, Some('D')),
@@ -307,6 +335,7 @@ mod tests {
                 action_id::THEME,
                 action_id::FOCUS,
                 action_id::SAVER,
+                action_id::WEATHER,
                 action_id::MIC,
                 action_id::RESTART,
                 action_id::SHUTDOWN,
@@ -319,10 +348,11 @@ mod tests {
     fn launchpad_control_tiles_resolve_to_a_descriptor() {
         // Every tile backed by a system control must have a catalog descriptor so
         // its title/labels stay in sync; the presentational tiles (L slot,
-        // Battery, Now Playing) intentionally have none.
+        // Battery, Weather, Now Playing) intentionally have none.
         let presentational = [
             action_id::L_SLOT,
             action_id::BATTERY,
+            action_id::WEATHER,
             action_id::NOW_PLAYING,
         ];
         for tile in launchpad_layout() {
@@ -344,6 +374,18 @@ mod tests {
             .expect("now playing tile present");
         assert_eq!(now_playing.span, Some(3));
         assert_eq!(now_playing.role, TileRole::Media);
+    }
+
+    #[test]
+    fn weather_tile_stands_two_rows_tall() {
+        let layout = launchpad_layout();
+        let weather = layout
+            .iter()
+            .find(|t| t.action_id == action_id::WEATHER)
+            .expect("weather tile present");
+        assert_eq!(weather.size, TileSize::S);
+        assert_eq!(weather.row_span, Some(2));
+        assert_eq!(weather.role, TileRole::Weather);
     }
 
     #[test]

--- a/core/qactions/src/lib.rs
+++ b/core/qactions/src/lib.rs
@@ -41,23 +41,193 @@ pub struct ActionDescriptor {
     pub info: Vec<InfoFieldSpec>,
 }
 
+/// Shared `action_id` constants. Kept as named constants (not inline literals)
+/// so the descriptor catalog, the launchpad layout, and their tests all agree on
+/// one spelling.
+pub mod action_id {
+    pub const BLUETOOTH: &str = "bluetooth";
+    pub const WIFI: &str = "wifi";
+    pub const THEME: &str = "theme";
+    pub const FOCUS: &str = "focus";
+    pub const SAVER: &str = "saver";
+    pub const MIC: &str = "mic";
+    pub const RESTART: &str = "restart";
+    pub const SHUTDOWN: &str = "shutdown";
+    pub const BATTERY: &str = "battery";
+    pub const NOW_PLAYING: &str = "nowplaying";
+    /// The launchpad's L slot: a presentational Todo/Pomo/Clock rotation, not a
+    /// system control, so it has no descriptor and no native adapter.
+    pub const L_SLOT: &str = "lslot";
+}
+
+const STATUS_INFO_KEY: &str = "status";
+
+fn toggle(action_id: &str, title: &str, on_label: &str, off_label: &str) -> ActionDescriptor {
+    ActionDescriptor {
+        action_id: action_id.to_string(),
+        title: title.to_string(),
+        control: ControlKind::Toggle,
+        on_label: Some(on_label.to_string()),
+        off_label: Some(off_label.to_string()),
+        info: vec![InfoFieldSpec {
+            label: "Status".to_string(),
+            value_key: STATUS_INFO_KEY.to_string(),
+        }],
+    }
+}
+
+fn button(action_id: &str, title: &str) -> ActionDescriptor {
+    ActionDescriptor {
+        action_id: action_id.to_string(),
+        title: title.to_string(),
+        control: ControlKind::Button,
+        on_label: None,
+        off_label: None,
+        info: vec![],
+    }
+}
+
 /// The action definition for `action_id`, or `None` if unknown. This is the
 /// shared, platform-neutral catalog - add new controls here.
 pub fn descriptor(action_id: &str) -> Option<ActionDescriptor> {
+    use crate::action_id as id;
     match action_id {
-        "bluetooth" => Some(ActionDescriptor {
-            action_id: "bluetooth".to_string(),
-            title: "Bluetooth".to_string(),
-            control: ControlKind::Toggle,
-            on_label: Some("On".to_string()),
-            off_label: Some("Off".to_string()),
-            info: vec![InfoFieldSpec {
-                label: "Status".to_string(),
-                value_key: "status".to_string(),
-            }],
-        }),
+        id::BLUETOOTH => Some(toggle(id::BLUETOOTH, "Bluetooth", "On", "Off")),
+        id::WIFI => Some(toggle(id::WIFI, "Wi-Fi", "On", "Off")),
+        id::THEME => Some(toggle(id::THEME, "Theme", "Dark", "Light")),
+        id::FOCUS => Some(toggle(id::FOCUS, "Focus", "On", "Off")),
+        id::SAVER => Some(toggle(id::SAVER, "Saver", "On", "Off")),
+        id::MIC => Some(toggle(id::MIC, "Mic", "On", "Muted")),
+        id::RESTART => Some(button(id::RESTART, "Restart")),
+        id::SHUTDOWN => Some(button(id::SHUTDOWN, "Shut Down")),
         _ => None,
     }
+}
+
+/// A launchpad tile's footprint in the 6-column bento grid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TileSize {
+    /// Large, 2 columns x 2 rows.
+    L,
+    /// Medium, 2 columns x 1 row (unless overridden by `span`).
+    M,
+    /// Small, 1 column x 1 row.
+    S,
+}
+
+/// How a launchpad tile is drawn. `ControlKind` only distinguishes toggle vs
+/// button; the launchpad also has read-only info tiles, a media transport, and
+/// the rotating L slot, so it needs its own presentation role.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TileRole {
+    /// Stateful on/off control (Bluetooth, Wi-Fi, Theme, Focus, Saver).
+    Toggle,
+    /// Read-only live value (Battery).
+    Info,
+    /// A fire-once system action rendered as a compact button (Mic, Restart,
+    /// Shut Down).
+    Action,
+    /// Now Playing: track name plus a play/pause transport.
+    Media,
+    /// The rotating Todo / Pomo / Clock slot; rendered entirely by the shell.
+    Slot,
+}
+
+/// One tile in the empty-state launchpad. Carries everything the platform shell
+/// needs to place and label it; live state (toggle value, battery %, track) is
+/// resolved natively.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LaunchpadTile {
+    pub action_id: String,
+    pub title: String,
+    pub size: TileSize,
+    pub role: TileRole,
+    /// The keyboard-mnemonic character, triggered with the platform command
+    /// modifier. `None` for non-actionable tiles (L slot, Battery).
+    pub mnemonic: Option<char>,
+    /// Column span override, used by the Now Playing tile (spans 3). `None`
+    /// falls back to the natural width of `size`.
+    pub span: Option<u8>,
+    /// On/off captions for toggle tiles (e.g. Theme's Dark/Light), from the
+    /// shared descriptor. `None` for non-toggle tiles.
+    pub on_label: Option<String>,
+    pub off_label: Option<String>,
+}
+
+fn tile(action_id: &str, size: TileSize, role: TileRole, mnemonic: Option<char>) -> LaunchpadTile {
+    let descriptor = descriptor(action_id);
+    LaunchpadTile {
+        action_id: action_id.to_string(),
+        title: descriptor
+            .as_ref()
+            .map(|d| d.title.clone())
+            .unwrap_or_default(),
+        size,
+        role,
+        mnemonic,
+        span: None,
+        on_label: descriptor.as_ref().and_then(|d| d.on_label.clone()),
+        off_label: descriptor.and_then(|d| d.off_label),
+    }
+}
+
+/// The fixed empty-state launchpad layout, in placement order. This exact order
+/// and these sizes tile the 6-column grid with no gaps in every state:
+///
+/// L slot -> BT -> Wi-Fi -> Battery (M) -> Theme (M) -> Focus -> Saver -> Mic ->
+/// Restart -> Shut Down -> Now Playing (M, span 3).
+///
+/// The order and mnemonics are shared so every platform shell renders the same
+/// control strip; only the native state reads differ.
+pub fn launchpad_layout() -> Vec<LaunchpadTile> {
+    use crate::action_id as id;
+    use TileRole as role;
+    use TileSize as size;
+
+    let now_playing = LaunchpadTile {
+        action_id: id::NOW_PLAYING.to_string(),
+        title: "Now Playing".to_string(),
+        size: size::M,
+        role: role::Media,
+        mnemonic: Some('P'),
+        span: Some(3),
+        on_label: None,
+        off_label: None,
+    };
+
+    vec![
+        LaunchpadTile {
+            action_id: id::L_SLOT.to_string(),
+            title: String::new(),
+            size: size::L,
+            role: role::Slot,
+            mnemonic: None,
+            span: None,
+            on_label: None,
+            off_label: None,
+        },
+        tile(id::BLUETOOTH, size::S, role::Toggle, Some('B')),
+        tile(id::WIFI, size::S, role::Toggle, Some('W')),
+        LaunchpadTile {
+            action_id: id::BATTERY.to_string(),
+            title: "Battery".to_string(),
+            size: size::M,
+            role: role::Info,
+            mnemonic: None,
+            span: None,
+            on_label: None,
+            off_label: None,
+        },
+        tile(id::THEME, size::M, role::Toggle, Some('T')),
+        tile(id::FOCUS, size::S, role::Toggle, Some('F')),
+        tile(id::SAVER, size::S, role::Toggle, Some('S')),
+        tile(id::MIC, size::S, role::Action, Some('M')),
+        tile(id::RESTART, size::S, role::Action, Some('R')),
+        tile(id::SHUTDOWN, size::S, role::Action, Some('D')),
+        now_playing,
+    ]
 }
 
 /// Descriptors that apply to a search result. Resolves the (platform-specific)
@@ -121,6 +291,73 @@ mod tests {
     #[test]
     fn unknown_action_is_none() {
         assert!(descriptor("nope").is_none());
+    }
+
+    #[test]
+    fn launchpad_layout_matches_the_fixed_spec_order() {
+        let layout = launchpad_layout();
+        let ids: Vec<&str> = layout.iter().map(|t| t.action_id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec![
+                action_id::L_SLOT,
+                action_id::BLUETOOTH,
+                action_id::WIFI,
+                action_id::BATTERY,
+                action_id::THEME,
+                action_id::FOCUS,
+                action_id::SAVER,
+                action_id::MIC,
+                action_id::RESTART,
+                action_id::SHUTDOWN,
+                action_id::NOW_PLAYING,
+            ]
+        );
+    }
+
+    #[test]
+    fn launchpad_control_tiles_resolve_to_a_descriptor() {
+        // Every tile backed by a system control must have a catalog descriptor so
+        // its title/labels stay in sync; the presentational tiles (L slot,
+        // Battery, Now Playing) intentionally have none.
+        let presentational = [
+            action_id::L_SLOT,
+            action_id::BATTERY,
+            action_id::NOW_PLAYING,
+        ];
+        for tile in launchpad_layout() {
+            if presentational.contains(&tile.action_id.as_str()) {
+                continue;
+            }
+            let d = descriptor(&tile.action_id)
+                .unwrap_or_else(|| panic!("no descriptor for {}", tile.action_id));
+            assert_eq!(d.title, tile.title);
+        }
+    }
+
+    #[test]
+    fn now_playing_spans_three_columns() {
+        let layout = launchpad_layout();
+        let now_playing = layout
+            .iter()
+            .find(|t| t.action_id == action_id::NOW_PLAYING)
+            .expect("now playing tile present");
+        assert_eq!(now_playing.span, Some(3));
+        assert_eq!(now_playing.role, TileRole::Media);
+    }
+
+    #[test]
+    fn actionable_tiles_carry_unique_mnemonics() {
+        let mut seen = std::collections::HashSet::new();
+        for tile in launchpad_layout() {
+            if let Some(ch) = tile.mnemonic {
+                assert!(
+                    seen.insert(ch),
+                    "duplicate mnemonic {ch} on {}",
+                    tile.action_id
+                );
+            }
+        }
     }
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a launcher empty-state “launchpad” quick-action tile grid with interactive tiles (toggles, media controls, and destructive restart/shutdown confirmations).
  * Added keyboard mnemonic support for quick-launch tiles and Escape to dismiss pending confirmations.
  * Introduced a Weather tile with async fetching and caching for quick, updated display.

* **Bug Fixes**
  * Improved the launcher floating/empty-query experience to show the launchpad content when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



## Why

#288 


## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [x] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [ ] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [ ] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [ ] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [ ] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [ ] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [ ] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

<img width="912" height="423" alt="image" src="https://github.com/user-attachments/assets/5a7257c1-db6a-4cab-9000-879de1ab8bef" />


## Checklist

- [x] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


