### PR TITLE
chore: Post localized apps improvement

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -19,6 +19,10 @@ on:
       - "apps/linows/flake.nix"
       - "apps/linows/flake.lock"
 
+concurrency:
+  group: ci-nix-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -27,14 +31,19 @@ jobs:
 
       - uses: DeterminateSystems/nix-installer-action@main
 
-      - uses: DeterminateSystems/magic-nix-cache-action@main
-
+      # Pushes populate the cache so later runs reuse the dependency closure
+      # instead of recompiling it. Fork PRs cannot read secrets, so the token
+      # is empty there and the action falls back to read-only automatically.
       - uses: cachix/cachix-action@v15
         with:
           name: look
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
+      # -L streams the derivation's build log. Without it nix buffers the whole
+      # compile into one silent block, which makes a slow or stuck build
+      # impossible to diagnose from the Actions log.
       - name: Build
-        run: nix build ./apps/linows#default
+        run: nix build ./apps/linows#default -L
 
       - name: Verify version
         run: ./result/bin/lookapp --version

--- a/apps/linows/flake.nix
+++ b/apps/linows/flake.nix
@@ -31,7 +31,12 @@
           # 0.40) uses cfg_select!, stable only since Rust 1.95, so the default
           # toolchain fails to build it. Pin the build toolchain to match the
           # devShell instead of relying on nixpkgs' older default.
-          rustToolchain = pkgs.rust-bin.stable."1.95.0".default;
+          #
+          # `minimal` (cargo + rustc + rust-std) rather than `default`: building
+          # never invokes clippy or rustfmt, and `default` also drags in
+          # rust-docs, which is 632 MiB unpacked. The devShell keeps `default`
+          # because contributors do want those tools.
+          rustToolchain = pkgs.rust-bin.stable."1.95.0".minimal;
           rustPlatform = pkgs.makeRustPlatform {
             cargo = rustToolchain;
             rustc = rustToolchain;

--- a/apps/linows/nix/package.nix
+++ b/apps/linows/nix/package.nix
@@ -50,6 +50,12 @@ rustPlatform.buildRustPackage {
 
   buildAndTestSubdir = "apps/linows/src-tauri";
 
+  # buildRustPackage runs `cargo test` by default, which recompiles the
+  # workspace as test harnesses on top of the release build. `ci.yml` already
+  # runs `cargo test --locked` for this same manifest on Linux, with a warm
+  # cargo cache, so doing it again here only lengthens the Nix build.
+  doCheck = false;
+
   nativeBuildInputs = [
     pkg-config
     wrapGAppsHook3

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -432,7 +432,9 @@ ignored_patterns_sample=\n\
 # ignored_patterns_sqlite=~/Documents/git/project/**/*.db-wal|~/Documents/git/project/**/*.db-shm\n\
 # ignored_patterns_temp=~/Downloads/*.tmp|~/Downloads/**/*.part\n\
 lazy_indexing_enabled=true\n\
-# macOS 15.4+ only. Enabling this may increase memory use by caching bundle metadata.\n\
+# Localized app and System Settings names. macOS 15.4+ only. Slows the first\n\
+# index pass (~3ms -> ~35ms on a 134-app machine) and caches bundle metadata\n\
+# for the process lifetime.\n\
 localized_app_names=false\n\
 skip_dir_names=node_modules,target,build,dist,library,applications,old firefox data,deriveddata,pods,vendor,out,coverage,tmp,cache,venv\n\
 \n\

--- a/core/engine/src/index/settings.rs
+++ b/core/engine/src/index/settings.rs
@@ -2,7 +2,6 @@ use crate::index::SETTINGS_CANDIDATE_ID_PREFIX;
 use crate::platform;
 use crate::platform::SettingsCatalogEntry;
 use look_indexing::{Candidate, CandidateKind};
-#[cfg(target_os = "macos")]
 use std::collections::HashMap;
 use std::sync::mpsc;
 
@@ -13,18 +12,10 @@ pub fn discover_system_settings_entries(
     // With a settings app (gnome-control-center family), emit the whole catalog.
     // e.g. gnome-control-center on GNOME, skipped on i3/sway/minimal distros.
     if platform::has_settings_app() {
-        #[cfg(target_os = "macos")]
-        let localized = localized_app_names
-            .then(build_localized_title_map)
-            .unwrap_or_default();
-        #[cfg(not(target_os = "macos"))]
-        let _ = localized_app_names;
+        let localized = localized_titles(localized_app_names);
 
         for entry in platform::settings_catalog() {
-            #[cfg(target_os = "macos")]
-            emit_entry_localized(&tx, entry, &localized);
-            #[cfg(not(target_os = "macos"))]
-            emit_entry(&tx, entry);
+            emit_entry(&tx, entry, &display_title(entry, &localized));
         }
 
         // Windows extras: classic .cpl / .msc / .exe applets that Settings
@@ -49,7 +40,7 @@ fn emit_settings_fallback_entries(tx: &mpsc::SyncSender<Candidate>) {
             .iter()
             .find(|e| e.target == "bluetooth")
     {
-        emit_entry(tx, entry);
+        emit_entry(tx, entry, entry.title);
     }
 }
 
@@ -60,74 +51,7 @@ fn emit_settings_fallback_entries(tx: &mpsc::SyncSender<Candidate>) {
 #[cfg(not(target_os = "linux"))]
 fn emit_settings_fallback_entries(_tx: &mpsc::SyncSender<Candidate>) {}
 
-#[cfg(not(target_os = "macos"))]
-fn emit_entry(tx: &mpsc::SyncSender<Candidate>, entry: &SettingsCatalogEntry) {
-    let mut candidate = Candidate::new(
-        &candidate_id(entry),
-        CandidateKind::App,
-        entry.title,
-        &target_path(entry),
-    );
-    candidate.subtitle = Some(subtitle(entry).into());
-    let _ = tx.send(candidate);
-}
-
-#[cfg(target_os = "macos")]
-fn build_localized_title_map() -> HashMap<String, String> {
-    if !platform::localized_names_available() {
-        return HashMap::new();
-    }
-    let Ok(entries) = std::fs::read_dir(platform::SETTINGS_EXTENSIONS_DIR) else {
-        return HashMap::new();
-    };
-    let mut map = HashMap::new();
-
-    let catalog_targets: HashMap<&str, &SettingsCatalogEntry> = platform::settings_catalog()
-        .iter()
-        .map(|e| (e.target, e))
-        .collect();
-
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.extension().and_then(|s| s.to_str()) != Some(platform::SETTINGS_EXTENSION_NAME) {
-            continue;
-        }
-        let Some(path_str) = path.to_str() else {
-            continue;
-        };
-
-        objc2::rc::autoreleasepool(|_| {
-            let Some(bundle_id) = platform::read_bundle_identifier(path_str) else {
-                return;
-            };
-
-            if let Some(catalog_entry) = catalog_targets.get(bundle_id.as_str())
-                && let Some(localized) = platform::read_localized_display_name(
-                    path_str,
-                    platform::SETTINGS_BUNDLE_EXTENSION,
-                )
-            {
-                let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
-                if localized != catalog_entry.title && localized != stem {
-                    map.insert(bundle_id, localized);
-                }
-            }
-        });
-    }
-
-    map
-}
-
-#[cfg(target_os = "macos")]
-fn emit_entry_localized(
-    tx: &mpsc::SyncSender<Candidate>,
-    entry: &SettingsCatalogEntry,
-    localized: &HashMap<String, String>,
-) {
-    let title = localized
-        .get(entry.target)
-        .map(|s| s.as_str())
-        .unwrap_or(entry.title);
+fn emit_entry(tx: &mpsc::SyncSender<Candidate>, entry: &SettingsCatalogEntry, title: &str) {
     let mut candidate = Candidate::new(
         &candidate_id(entry),
         CandidateKind::App,
@@ -136,6 +60,38 @@ fn emit_entry_localized(
     );
     candidate.subtitle = Some(subtitle(entry).into());
     let _ = tx.send(candidate);
+}
+
+/// Localized pane names, keyed by `SettingsCatalogEntry::target`. Only macOS
+/// has a source for these, so everywhere else this stays empty and the catalog
+/// titles are used verbatim.
+type LocalizedTitles = HashMap<&'static str, String>;
+
+fn localized_titles(localized_app_names: bool) -> LocalizedTitles {
+    if !localized_app_names {
+        return LocalizedTitles::new();
+    }
+    #[cfg(target_os = "macos")]
+    {
+        platform::localized_settings_titles(platform::settings_catalog())
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        LocalizedTitles::new()
+    }
+}
+
+/// Renders a pane as `<localized> (<English>)` when the two differ.
+///
+/// Keeping the catalog title in the *title* is what makes the English name
+/// stay searchable: settings subtitles are only scored for settings-shaped
+/// queries, so a title that dropped the English name would make the pane
+/// unreachable by queries like `wifi` on a non-English system.
+fn display_title(entry: &SettingsCatalogEntry, localized: &LocalizedTitles) -> String {
+    match localized.get(entry.target) {
+        Some(localized_title) => format!("{localized_title} ({})", entry.title),
+        None => entry.title.to_string(),
+    }
 }
 
 #[cfg(target_os = "windows")]
@@ -262,6 +218,63 @@ mod tests {
     #[test]
     fn localized_discovery_outputs_valid_settings_candidates() {
         assert_valid_settings_candidates(discover_settings(true));
+    }
+
+    /// The English catalog title has to survive localization, otherwise queries
+    /// like `wifi` stop reaching the pane on a non-English system.
+    #[test]
+    fn localized_title_keeps_the_english_catalog_title() {
+        // "Bluetooth" in Simplified Chinese.
+        const LOCALIZED_NAME: &str = "蓝牙";
+        let entry = &platform::settings_catalog()[0];
+        let localized = LocalizedTitles::from([(entry.target, LOCALIZED_NAME.to_string())]);
+
+        let title = display_title(entry, &localized);
+
+        assert!(title.contains(LOCALIZED_NAME), "missing localized name");
+        assert!(
+            title.contains(entry.title),
+            "missing English catalog title: {title}"
+        );
+    }
+
+    /// End-to-end guard for the same thing, through the real query engine:
+    /// settings subtitles are only scored for settings-shaped queries, so the
+    /// pane is reachable by its English name only while that name is in the
+    /// title. `wifi` is not one of the settings query hints, which makes it the
+    /// case that regressed when the title was replaced outright.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn english_query_still_reaches_a_localized_pane() {
+        // "Wi-Fi" in Simplified Chinese, as System Settings shows it.
+        const LOCALIZED_WIFI: &str = "无线局域网";
+        let entry = platform::settings_catalog()
+            .iter()
+            .find(|entry| entry.title == "Wi-Fi")
+            .expect("catalog has a Wi-Fi pane");
+        let localized = LocalizedTitles::from([(entry.target, LOCALIZED_WIFI.to_string())]);
+
+        let (tx, rx) = mpsc::sync_channel(1);
+        emit_entry(&tx, entry, &display_title(entry, &localized));
+        drop(tx);
+        let engine = crate::QueryEngine::new(rx.into_iter().collect());
+
+        assert_eq!(engine.search("wifi", 5).len(), 1, "English query lost it");
+        assert_eq!(
+            engine.search(LOCALIZED_WIFI, 5).len(),
+            1,
+            "localized query lost it"
+        );
+    }
+
+    /// No localized entry means no decoration: the title stays exactly what the
+    /// catalog says on every platform.
+    #[test]
+    fn untranslated_title_is_the_catalog_title_verbatim() {
+        let entry = &platform::settings_catalog()[0];
+        let localized = localized_titles(false);
+
+        assert_eq!(display_title(entry, &localized), entry.title);
     }
 
     fn discover_settings(localized_app_names: bool) -> Vec<Candidate> {

--- a/core/engine/src/platform/macos/apps.rs
+++ b/core/engine/src/platform/macos/apps.rs
@@ -5,23 +5,61 @@ use crate::platform::paths::{candidate_id_path_component, path_is_same_or_child}
 use look_indexing::{Candidate, CandidateKind};
 use std::collections::HashSet;
 use std::fs;
+use std::path::Path;
 use std::sync::mpsc;
 
+/// Used when a bundle path has no readable file stem, which should not happen
+/// for a real `.app` but keeps the candidate from having an empty title.
+const FALLBACK_APP_NAME: &str = "App";
+
 pub(crate) fn discover_installed_apps(config: &RuntimeConfig, tx: mpsc::SyncSender<Candidate>) {
+    let mut bundles = Vec::new();
     for root in merged_app_scan_roots(
         &config.app_scan_roots,
         &macos::additional_app_scan_roots(),
         macos::REQUIRED_APP_SCAN_ROOTS,
     ) {
-        walk_apps(
+        collect_app_bundles(
             &root,
             config.app_scan_depth,
-            config.localized_app_names,
-            &tx,
             &config.app_exclude_paths,
-            &config.app_exclude_names,
+            &mut bundles,
         );
     }
+
+    // Resolved in one batch rather than inline in the walk: each name costs an
+    // Info.plist read, and batching lets those run on a thread pool.
+    let localized = if config.localized_app_names {
+        macos::read_localized_display_names(&bundles, macos::APP_BUNDLE_EXTENSION)
+    } else {
+        vec![None; bundles.len()]
+    };
+
+    for (path, localized) in bundles.iter().zip(localized) {
+        emit_app(&tx, path, localized, &config.app_exclude_names);
+    }
+}
+
+fn emit_app(
+    tx: &mpsc::SyncSender<Candidate>,
+    path: &str,
+    localized: Option<String>,
+    app_exclude_names: &[String],
+) {
+    let bundle_name = Path::new(path)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or(FALLBACK_APP_NAME);
+    let title = localized.unwrap_or_else(|| bundle_name.to_string());
+    if should_exclude_app(&title, bundle_name, app_exclude_names) {
+        return;
+    }
+
+    let key = format!(
+        "{APP_CANDIDATE_ID_PREFIX}{}",
+        candidate_id_path_component(path)
+    );
+    let _ = tx.send(Candidate::new(&key, CandidateKind::App, &title, path));
 }
 
 fn merged_app_scan_roots(
@@ -50,13 +88,14 @@ fn merged_app_scan_roots(
     out
 }
 
-fn walk_apps(
+/// Appends every `.app` bundle under `path` to `out`. Naming is left to the
+/// caller so the Info.plist reads can be batched across the whole scan instead
+/// of happening one directory entry at a time.
+fn collect_app_bundles(
     path: &str,
     depth: usize,
-    use_localized_names: bool,
-    tx: &mpsc::SyncSender<Candidate>,
     app_exclude_paths: &[String],
-    app_exclude_names: &[String],
+    out: &mut Vec<String>,
 ) {
     if should_exclude_path(path, app_exclude_paths) {
         return;
@@ -91,41 +130,9 @@ fn walk_apps(
         }
 
         if app_path_str.ends_with(macos::APP_BUNDLE_EXTENSION) {
-            let bundle_name = app_path
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or("App");
-            let title = if use_localized_names {
-                objc2::rc::autoreleasepool(|_| {
-                    macos::read_localized_display_name(app_path_str, macos::APP_BUNDLE_EXTENSION)
-                })
-            } else {
-                None
-            }
-            .unwrap_or_else(|| bundle_name.to_string());
-            if should_exclude_app(&title, bundle_name, app_exclude_names) {
-                continue;
-            }
-
-            let key = format!(
-                "{APP_CANDIDATE_ID_PREFIX}{}",
-                candidate_id_path_component(app_path_str)
-            );
-            let _ = tx.send(Candidate::new(
-                &key,
-                CandidateKind::App,
-                &title,
-                app_path_str,
-            ));
+            out.push(app_path_str.to_string());
         } else if is_dir {
-            walk_apps(
-                app_path_str,
-                depth - 1,
-                use_localized_names,
-                tx,
-                app_exclude_paths,
-                app_exclude_names,
-            );
+            collect_app_bundles(app_path_str, depth - 1, app_exclude_paths, out);
         }
     }
 }
@@ -140,22 +147,24 @@ fn should_exclude_path(path: &str, app_exclude_paths: &[String]) -> bool {
     })
 }
 
+fn normalize_app_name(name: &str) -> String {
+    let name = name.trim();
+    name.strip_suffix(macos::APP_BUNDLE_EXTENSION)
+        .unwrap_or(name)
+        .trim()
+        .to_lowercase()
+}
+
 fn should_exclude_app_name(name: &str, app_exclude_names: &[String]) -> bool {
-    let normalized_name = name
-        .trim()
-        .trim_end_matches(macos::APP_BUNDLE_EXTENSION)
-        .trim()
-        .to_lowercase();
+    let normalized_name = normalize_app_name(name);
     app_exclude_names.iter().any(|entry| {
-        let normalized_exclude = entry
-            .trim()
-            .trim_end_matches(macos::APP_BUNDLE_EXTENSION)
-            .trim()
-            .to_lowercase();
+        let normalized_exclude = normalize_app_name(entry);
         !normalized_exclude.is_empty() && normalized_exclude == normalized_name
     })
 }
 
+/// Excludes on either name: `app_exclude_names` is written by hand, so it
+/// holds whichever of the two the user happened to see in the launcher.
 fn should_exclude_app(title: &str, bundle_name: &str, app_exclude_names: &[String]) -> bool {
     should_exclude_app_name(title, app_exclude_names)
         || should_exclude_app_name(bundle_name, app_exclude_names)
@@ -164,43 +173,14 @@ fn should_exclude_app(title: &str, bundle_name: &str, app_exclude_names: &[Strin
 #[cfg(test)]
 mod tests {
     use super::{
-        merged_app_scan_roots, should_exclude_app, should_exclude_app_name, should_exclude_path,
-        walk_apps,
+        collect_app_bundles, emit_app, merged_app_scan_roots, should_exclude_app,
+        should_exclude_app_name, should_exclude_path,
     };
+    use crate::platform::macos::test_support::TempDir;
     use look_indexing::Candidate;
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::sync::mpsc;
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    struct TempDir {
-        path: PathBuf,
-    }
-
-    impl TempDir {
-        fn new(name: &str) -> Self {
-            let unique = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("system time after epoch")
-                .as_nanos();
-            let path = std::env::temp_dir().join(format!(
-                "look-macos-apps-{name}-{}-{unique}",
-                std::process::id()
-            ));
-            fs::create_dir_all(&path).expect("create temp dir");
-            Self { path }
-        }
-
-        fn path(&self) -> &Path {
-            &self.path
-        }
-    }
-
-    impl Drop for TempDir {
-        fn drop(&mut self) {
-            let _ = fs::remove_dir_all(&self.path);
-        }
-    }
 
     fn create_app(root: &Path, name: &str) -> PathBuf {
         let app = root.join(name);
@@ -213,19 +193,27 @@ mod tests {
         std::os::unix::fs::symlink(target, link).expect("create symlink");
     }
 
-    fn collect_apps(root: &Path) -> Vec<Candidate> {
-        let (tx, rx) = mpsc::sync_channel(16);
-        let empty = Vec::<String>::new();
-        walk_apps(
+    /// Mirrors `discover_installed_apps` without a `RuntimeConfig`: walk, then
+    /// emit with no localized names.
+    fn collect_apps_excluding(root: &Path, app_exclude_names: &[String]) -> Vec<Candidate> {
+        let mut bundles = Vec::new();
+        collect_app_bundles(
             root.to_str().expect("utf-8 temp path"),
             3,
-            false,
-            &tx,
-            &empty,
-            &empty,
+            &[],
+            &mut bundles,
         );
+
+        let (tx, rx) = mpsc::sync_channel(16);
+        for path in &bundles {
+            emit_app(&tx, path, None, app_exclude_names);
+        }
         drop(tx);
         rx.into_iter().collect()
+    }
+
+    fn collect_apps(root: &Path) -> Vec<Candidate> {
+        collect_apps_excluding(root, &[])
     }
 
     #[test]
@@ -324,19 +312,49 @@ mod tests {
     fn excludes_app_by_bundle_filename() {
         let tmp = TempDir::new("exclude-filename");
         create_app(tmp.path(), "Client Riot.app");
-        let (tx, rx) = mpsc::sync_channel(16);
-        let empty = Vec::<String>::new();
-        walk_apps(
+
+        let apps = collect_apps_excluding(tmp.path(), &["Client Riot".to_string()]);
+
+        assert!(apps.is_empty());
+    }
+
+    /// The walk and the name resolution are separate passes zipped back
+    /// together, so the collected order is the contract between them.
+    #[test]
+    fn collected_bundles_are_the_app_directories_only() {
+        let tmp = TempDir::new("collect-bundles");
+        create_app(tmp.path(), "Alpha.app");
+        create_app(tmp.path(), "Beta.app");
+        fs::create_dir_all(tmp.path().join("Not An App")).expect("create plain dir");
+
+        let mut bundles = Vec::new();
+        collect_app_bundles(
             tmp.path().to_str().expect("utf-8 temp path"),
             3,
-            false,
-            &tx,
-            &empty,
-            &["Client Riot".to_string()],
+            &[],
+            &mut bundles,
         );
+        bundles.sort();
+
+        assert_eq!(bundles.len(), 2);
+        assert!(bundles[0].ends_with("Alpha.app"));
+        assert!(bundles[1].ends_with("Beta.app"));
+    }
+
+    /// A localized title is used verbatim; the bundle file name is the fallback.
+    #[test]
+    fn emitted_title_prefers_the_localized_name() {
+        let tmp = TempDir::new("emit-title");
+        let app = create_app(tmp.path(), "WeChat.app");
+        let path = app.to_str().expect("utf-8 app path");
+
+        let (tx, rx) = mpsc::sync_channel(2);
+        emit_app(&tx, path, Some("微信".to_string()), &[]);
+        emit_app(&tx, path, None, &[]);
         drop(tx);
 
-        assert!(rx.into_iter().collect::<Vec<_>>().is_empty());
+        let titles: Vec<String> = rx.into_iter().map(|c| c.title.to_string()).collect();
+        assert_eq!(titles, vec!["微信".to_string(), "WeChat".to_string()]);
     }
 
     #[test]

--- a/core/engine/src/platform/macos/mod.rs
+++ b/core/engine/src/platform/macos/mod.rs
@@ -1,8 +1,14 @@
 mod apps;
 mod settings_catalog;
+#[cfg(test)]
+mod test_support;
 
+use std::collections::HashMap;
 use std::env;
+use std::path::Path;
 
+use crate::platform::SettingsCatalogEntry;
+use objc2::rc::Retained;
 use objc2_foundation::{NSArray, NSBundle, NSLocale, NSString};
 
 pub(crate) const APP_SCAN_ROOTS: &[&str] = &[
@@ -23,20 +29,31 @@ pub(crate) const FILE_SCAN_ROOT_SUFFIXES: &[&str] = &["Desktop", "Documents", "D
 pub(crate) const SETTINGS_URL_SCHEME_PREFIX: &str = "x-apple.systempreferences:";
 pub(crate) const SETTINGS_SUBTITLE_PREFIX: &str = "System Settings ";
 pub(crate) const APP_BUNDLE_EXTENSION: &str = ".app";
-pub(crate) const SETTINGS_BUNDLE_EXTENSION: &str = ".appex";
-pub(crate) const SETTINGS_EXTENSION_NAME: &str = "appex";
+const SETTINGS_BUNDLE_EXTENSION: &str = ".appex";
 const INFO_PLIST_STRINGS_TABLE: &str = "InfoPlist";
 const DISPLAY_NAME_KEYS: [&str; 2] = ["CFBundleDisplayName", "CFBundleName"];
+
+/// Reading a bundle's name costs one Info.plist read, which dominates both
+/// scans and is independent per bundle, so the reads are spread over a small
+/// pool. Measured cold on 92 apps: ~69ms on one thread, ~23ms on four. Capped
+/// well under the core count because indexing is background work.
+const MAX_BUNDLE_READ_THREADS: usize = 4;
+/// Below this many bundles per thread, spawning costs more than it saves.
+const MIN_BUNDLES_PER_READ_THREAD: usize = 8;
 
 pub(crate) use apps::discover_installed_apps;
 pub(crate) use settings_catalog::SETTINGS_CATALOG;
 
-/// macOS 13+ only. Settings panes use `.appex` extensions under
-/// `/System/Library/ExtensionKit/Extensions/`. On macOS 12 and earlier,
-/// they use `.prefPane` bundles in `/System/Library/PreferencePanes/`.
-pub(crate) const SETTINGS_EXTENSIONS_DIR: &str = "/System/Library/ExtensionKit/Extensions";
+/// Settings panes ship as `.appex` bundles here on macOS 13+. On macOS 12 and
+/// earlier they are `.prefPane` bundles in `/System/Library/PreferencePanes/`,
+/// which this never reads: localized names need macOS 15.4+ anyway, so the
+/// older layout can't reach this path.
+const SETTINGS_EXTENSIONS_DIR: &str = "/System/Library/ExtensionKit/Extensions";
 
-pub(crate) fn localized_names_available() -> bool {
+/// `localizedStringForKey:value:table:localizations:` is the only API that
+/// resolves a bundle's name against an explicit language list rather than the
+/// running process's language, and it landed in macOS 15.4.
+fn localized_names_available() -> bool {
     objc2::available!(macos = 15.4)
 }
 
@@ -48,36 +65,146 @@ pub(crate) fn additional_app_scan_roots() -> Vec<String> {
         .unwrap_or_default()
 }
 
-/// Returns the bundle name localized for the user's preferred languages.
-pub(crate) fn read_localized_display_name(path: &str, strip_suffix: &str) -> Option<String> {
-    if !localized_names_available() {
-        return None;
-    }
-    let path_string = NSString::from_str(path);
-    let bundle = NSBundle::bundleWithPath(&path_string)?;
-    read_bundle_name_for_user_languages(&bundle, path, strip_suffix)
-}
-
-pub(crate) fn read_bundle_identifier(path: &str) -> Option<String> {
-    let path_string = NSString::from_str(path);
-    let bundle = NSBundle::bundleWithPath(&path_string)?;
-    bundle
-        .bundleIdentifier()
-        .map(|identifier| identifier.to_string())
-}
-
-fn read_bundle_name_for_user_languages(
-    bundle: &NSBundle,
-    path: &str,
+/// Bundle names localized for the user's preferred languages, one entry per
+/// input path and in the same order. `None` means the bundle has no usable
+/// name and the caller should keep whatever it already had.
+pub(crate) fn read_localized_display_names(
+    paths: &[String],
     strip_suffix: &str,
-) -> Option<String> {
-    let localizations = NSLocale::preferredLanguages();
-    read_bundle_name_for_languages(bundle, path, strip_suffix, &localizations)
+) -> Vec<Option<String>> {
+    if !localized_names_available() {
+        return vec![None; paths.len()];
+    }
+    read_bundles(paths, |bundle, languages, _| {
+        read_bundle_name_for_languages(bundle, strip_suffix, languages)
+    })
+}
+
+/// Loads each path as a bundle and applies `read` to it, spreading the work
+/// over a small thread pool. Returns one entry per input path, in input order.
+fn read_bundles<T, F>(paths: &[String], read: F) -> Vec<Option<T>>
+where
+    T: Send,
+    F: Fn(&NSBundle, &NSArray<NSString>, &str) -> Option<T> + Sync,
+{
+    let read_chunk = |chunk: &[String]| -> Vec<Option<T>> {
+        // Hoisted per chunk rather than per bundle: the list is the same every
+        // time and building it costs about as much as a bundle load.
+        let languages = NSLocale::preferredLanguages();
+        chunk
+            .iter()
+            .map(|path| {
+                objc2::rc::autoreleasepool(|_| {
+                    let bundle = load_bundle(path)?;
+                    read(&bundle, &languages, path)
+                })
+            })
+            .collect()
+    };
+
+    let threads = bundle_read_threads(paths.len());
+    if threads == 1 {
+        return read_chunk(paths);
+    }
+
+    let mut names = Vec::with_capacity(paths.len());
+    std::thread::scope(|scope| {
+        let workers: Vec<_> = paths
+            .chunks(paths.len().div_ceil(threads))
+            .map(|chunk| {
+                let read_chunk = &read_chunk;
+                scope.spawn(move || read_chunk(chunk))
+            })
+            .collect();
+        for worker in workers {
+            let Ok(chunk_names) = worker.join() else {
+                eprintln!("look index: bundle metadata worker panicked");
+                return;
+            };
+            names.extend(chunk_names);
+        }
+    });
+
+    // Callers zip this against `paths`, so a short result would shift every
+    // name onto the wrong bundle. A panicked worker costs one serial retry.
+    if names.len() == paths.len() {
+        names
+    } else {
+        read_chunk(paths)
+    }
+}
+
+fn bundle_read_threads(bundle_count: usize) -> usize {
+    let cores = std::thread::available_parallelism()
+        .map(|cores| cores.get())
+        .unwrap_or(1);
+    bundle_count
+        .div_ceil(MIN_BUNDLES_PER_READ_THREAD)
+        .min(cores)
+        .clamp(1, MAX_BUNDLE_READ_THREADS)
+}
+
+/// Maps every settings catalog target that ships a matching `.appex` bundle to
+/// its localized pane name, keyed by `SettingsCatalogEntry::target`. Targets
+/// whose localized name equals the catalog title (or the bundle's own file
+/// name) are left out, so callers can treat a hit as "this differs from the
+/// English title".
+///
+/// The whole scan lives here rather than in `index::settings` so Foundation
+/// types stay behind the platform boundary, and so each bundle is loaded once
+/// instead of once per property read.
+pub(crate) fn localized_settings_titles(
+    catalog: &'static [SettingsCatalogEntry],
+) -> HashMap<&'static str, String> {
+    localized_settings_titles_in(catalog, SETTINGS_EXTENSIONS_DIR)
+}
+
+fn localized_settings_titles_in(
+    catalog: &'static [SettingsCatalogEntry],
+    extensions_dir: &str,
+) -> HashMap<&'static str, String> {
+    if !localized_names_available() {
+        return HashMap::new();
+    }
+    let Ok(entries) = std::fs::read_dir(extensions_dir) else {
+        return HashMap::new();
+    };
+
+    let paths: Vec<String> = entries
+        .flatten()
+        .filter_map(|entry| entry.path().to_str().map(str::to_string))
+        .filter(|path| path.ends_with(SETTINGS_BUNDLE_EXTENSION))
+        .collect();
+
+    let targets: HashMap<&str, &SettingsCatalogEntry> =
+        catalog.iter().map(|entry| (entry.target, entry)).collect();
+
+    read_bundles(&paths, |bundle, languages, path| {
+        let identifier = bundle.bundleIdentifier()?.to_string();
+        // Only catalog panes are worth the localized-name lookup: the directory
+        // holds hundreds of extensions, the catalog around thirty.
+        let entry = targets.get(identifier.as_str())?;
+        let localized =
+            read_bundle_name_for_languages(bundle, SETTINGS_BUNDLE_EXTENSION, languages)?;
+
+        let stem = Path::new(path)
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .unwrap_or_default();
+        (localized != entry.title && localized != stem).then_some((entry.target, localized))
+    })
+    .into_iter()
+    .flatten()
+    .collect()
+}
+
+fn load_bundle(path: &str) -> Option<Retained<NSBundle>> {
+    let path_string = NSString::from_str(path);
+    NSBundle::bundleWithPath(&path_string)
 }
 
 fn read_bundle_name_for_languages(
     bundle: &NSBundle,
-    path: &str,
     strip_suffix: &str,
     localizations: &NSArray<NSString>,
 ) -> Option<String> {
@@ -85,9 +212,13 @@ fn read_bundle_name_for_languages(
 
     for key in DISPLAY_NAME_KEYS {
         let key = NSString::from_str(key);
+        // A blank Info.plist value has to collapse to `None`: passing an empty
+        // string as the fallback makes `localizedStringForKey:` echo the key
+        // back, which would otherwise be indexed as the app's title.
         let fallback = bundle
             .objectForInfoDictionaryKey(&key)
-            .and_then(|value| value.downcast::<NSString>().ok());
+            .and_then(|value| value.downcast::<NSString>().ok())
+            .filter(|value| !value.to_string().trim().is_empty());
         let name = bundle.localizedStringForKey_value_table_localizations(
             &key,
             fallback.as_deref(),
@@ -97,37 +228,67 @@ fn read_bundle_name_for_languages(
         if fallback.is_none() && name == key {
             continue;
         }
-        if let Some(name) = normalize_display_name(&name.to_string(), path, strip_suffix) {
+        if let Some(name) = normalize_display_name(&name.to_string(), strip_suffix) {
             return Some(name);
         }
     }
     None
 }
 
-fn normalize_display_name(display_name: &str, path: &str, strip_suffix: &str) -> Option<String> {
+fn normalize_display_name(display_name: &str, strip_suffix: &str) -> Option<String> {
     let name = display_name.trim();
-    if name.is_empty() || name == path {
-        return None;
-    }
-
     let name = name.strip_suffix(strip_suffix).unwrap_or(name).trim();
     (!name.is_empty()).then(|| name.to_string())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{APP_BUNDLE_EXTENSION, localized_names_available, read_bundle_name_for_languages};
-    use objc2_foundation::{NSArray, NSBundle, NSString};
+    use super::test_support::TempDir;
+    use super::{
+        APP_BUNDLE_EXTENSION, MIN_BUNDLES_PER_READ_THREAD, SETTINGS_BUNDLE_EXTENSION,
+        SettingsCatalogEntry, bundle_read_threads, load_bundle, localized_names_available,
+        localized_settings_titles_in, read_bundle_name_for_languages, read_localized_display_names,
+    };
+    use objc2_foundation::{NSArray, NSString};
     use std::fs;
-    use std::path::PathBuf;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::path::Path;
 
-    struct TempBundle(PathBuf);
+    /// "Localization test" in Simplified Chinese, to prove the name really came
+    /// from the zh-Hans strings file rather than the Info.plist fallback.
+    const LOCALIZED_FIXTURE_NAME: &str = "本地化测试";
+    const FIXTURE_LANGUAGE: &str = "zh-Hans";
 
-    impl Drop for TempBundle {
-        fn drop(&mut self) {
-            let _ = fs::remove_dir_all(&self.0);
+    /// Writes a bundle whose Info.plist carries `info_plist_body`, plus a
+    /// `zh-Hans` InfoPlist.strings when `localized_name` is set.
+    fn write_bundle(path: &Path, info_plist_body: &str, localized_name: Option<&str>) {
+        let resources = path.join(format!("Contents/Resources/{FIXTURE_LANGUAGE}.lproj"));
+        fs::create_dir_all(&resources).expect("create test bundle resources");
+        fs::write(
+            path.join("Contents/Info.plist"),
+            format!(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+{info_plist_body}
+</dict></plist>"#
+            ),
+        )
+        .expect("write test bundle Info.plist");
+        if let Some(localized_name) = localized_name {
+            fs::write(
+                resources.join("InfoPlist.strings"),
+                format!("\"CFBundleDisplayName\" = \"{localized_name}\";\n"),
+            )
+            .expect("write localized display name");
         }
+    }
+
+    fn read_fixture_name(path: &Path, strip_suffix: &str) -> Option<String> {
+        let path = path.to_str().expect("UTF-8 test bundle path");
+        let bundle = load_bundle(path).expect("load test bundle");
+        let language = NSString::from_str(FIXTURE_LANGUAGE);
+        let languages = NSArray::from_slice(&[&*language]);
+        read_bundle_name_for_languages(&bundle, strip_suffix, &languages)
     }
 
     #[test]
@@ -137,42 +298,130 @@ mod tests {
             return;
         }
 
-        let unique = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system clock after Unix epoch")
-            .as_nanos();
-        let app = TempBundle(std::env::temp_dir().join(format!(
-            "look-localized-name-{unique}{APP_BUNDLE_EXTENSION}"
-        )));
-        let resources = app.0.join("Contents/Resources/zh-Hans.lproj");
-        fs::create_dir_all(&resources).expect("create test bundle resources");
-        fs::write(
-            app.0.join("Contents/Info.plist"),
-            r#"<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0"><dict>
-<key>CFBundleIdentifier</key><string>test.look.localized-name</string>
-<key>CFBundleDisplayName</key><string>English Fixture</string>
-</dict></plist>"#,
-        )
-        .expect("write test bundle Info.plist");
-        fs::write(
-            resources.join("InfoPlist.strings"),
-            "\"CFBundleDisplayName\" = \"\u{672c}\u{5730}\u{5316}\u{6d4b}\u{8bd5}\";\n",
-        )
-        .expect("write localized display name");
-
-        let app_path = app.0.to_str().expect("UTF-8 test bundle path");
-        let app_path_string = NSString::from_str(app_path);
-        let bundle = NSBundle::bundleWithPath(&app_path_string).expect("load test bundle");
-        let language = NSString::from_str("zh-Hans");
-        let languages = NSArray::from_slice(&[&*language]);
-        let name =
-            read_bundle_name_for_languages(&bundle, app_path, APP_BUNDLE_EXTENSION, &languages);
+        let dir = TempDir::new("localized-name");
+        let app = dir.path().join(format!("Fixture{APP_BUNDLE_EXTENSION}"));
+        write_bundle(
+            &app,
+            "<key>CFBundleIdentifier</key><string>test.look.localized-name</string>
+<key>CFBundleDisplayName</key><string>English Fixture</string>",
+            Some(LOCALIZED_FIXTURE_NAME),
+        );
 
         assert_eq!(
-            name.as_deref(),
-            Some("\u{672c}\u{5730}\u{5316}\u{6d4b}\u{8bd5}")
+            read_fixture_name(&app, APP_BUNDLE_EXTENSION).as_deref(),
+            Some(LOCALIZED_FIXTURE_NAME)
         );
+    }
+
+    /// A blank `CFBundleDisplayName` makes `localizedStringForKey:` echo the
+    /// key back; the name must fall through to `CFBundleName` instead of being
+    /// indexed as "CFBundleDisplayName".
+    #[test]
+    fn blank_display_name_falls_through_to_bundle_name() {
+        if !localized_names_available() {
+            eprintln!("skipping: localized bundle names need macOS 15.4+");
+            return;
+        }
+
+        let dir = TempDir::new("blank-display-name");
+        let app = dir.path().join(format!("Fixture{APP_BUNDLE_EXTENSION}"));
+        write_bundle(
+            &app,
+            "<key>CFBundleIdentifier</key><string>test.look.blank-display-name</string>
+<key>CFBundleDisplayName</key><string></string>
+<key>CFBundleName</key><string>Real Name</string>",
+            None,
+        );
+
+        assert_eq!(
+            read_fixture_name(&app, APP_BUNDLE_EXTENSION).as_deref(),
+            Some("Real Name")
+        );
+    }
+
+    #[test]
+    fn settings_titles_map_only_catalog_targets_with_a_differing_localized_name() {
+        if !localized_names_available() {
+            eprintln!("skipping: localized bundle names need macOS 15.4+");
+            return;
+        }
+
+        static CATALOG: &[SettingsCatalogEntry] = &[SettingsCatalogEntry {
+            title: "Fixture Pane",
+            target: "test.look.settings-fixture",
+            candidate_id_suffix: "test.look.settings-fixture",
+            aliases: "settings fixture",
+        }];
+
+        let dir = TempDir::new("settings-extensions");
+        write_bundle(
+            &dir.path()
+                .join(format!("Fixture{SETTINGS_BUNDLE_EXTENSION}")),
+            "<key>CFBundleIdentifier</key><string>test.look.settings-fixture</string>
+<key>CFBundleDisplayName</key><string>Fixture Pane</string>",
+            Some(LOCALIZED_FIXTURE_NAME),
+        );
+        // Not in the catalog: must be skipped rather than indexed.
+        write_bundle(
+            &dir.path()
+                .join(format!("Unlisted{SETTINGS_BUNDLE_EXTENSION}")),
+            "<key>CFBundleIdentifier</key><string>test.look.unlisted</string>
+<key>CFBundleDisplayName</key><string>Unlisted Pane</string>",
+            Some("Unlisted Localized"),
+        );
+
+        let titles =
+            localized_settings_titles_in(CATALOG, dir.path().to_str().expect("UTF-8 temp path"));
+
+        assert_eq!(titles.len(), 1);
+        assert_eq!(
+            titles.get("test.look.settings-fixture").map(String::as_str),
+            Some(LOCALIZED_FIXTURE_NAME)
+        );
+    }
+
+    /// Callers zip the result against the input, so a batch spread over several
+    /// threads has to come back one-per-input and in the original order. Sized
+    /// past the per-thread threshold so the parallel path is the one under test.
+    #[test]
+    fn batched_names_stay_aligned_with_their_input_paths() {
+        if !localized_names_available() {
+            eprintln!("skipping: localized bundle names need macOS 15.4+");
+            return;
+        }
+
+        let bundle_count = MIN_BUNDLES_PER_READ_THREAD * 3;
+        assert!(
+            bundle_read_threads(bundle_count) > 1,
+            "fixture too small to exercise the threaded path"
+        );
+
+        let dir = TempDir::new("batched-names");
+        let mut paths = Vec::new();
+        for index in 0..bundle_count {
+            let app = dir
+                .path()
+                .join(format!("Fixture{index}{APP_BUNDLE_EXTENSION}"));
+            write_bundle(
+                &app,
+                &format!(
+                    "<key>CFBundleIdentifier</key><string>test.look.batch{index}</string>
+<key>CFBundleDisplayName</key><string>English {index}</string>"
+                ),
+                Some(&format!("{LOCALIZED_FIXTURE_NAME}{index}")),
+            );
+            paths.push(app.to_str().expect("UTF-8 test bundle path").to_string());
+        }
+
+        let names = read_localized_display_names(&paths, APP_BUNDLE_EXTENSION);
+
+        assert_eq!(names.len(), paths.len());
+        for (index, name) in names.iter().enumerate() {
+            assert_eq!(
+                name.as_deref(),
+                Some(format!("{LOCALIZED_FIXTURE_NAME}{index}").as_str()),
+                "bundle {index} came back out of order"
+            );
+        }
     }
 }

--- a/core/engine/src/platform/macos/test_support.rs
+++ b/core/engine/src/platform/macos/test_support.rs
@@ -1,0 +1,38 @@
+//! Shared fixtures for the macOS platform tests. Both the app walk and the
+//! bundle-metadata reads need throwaway directories of `.app`/`.appex` bundles.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// A directory under the system temp dir, removed when it goes out of scope.
+/// The name carries the pid and a nanosecond stamp so concurrent test binaries
+/// never collide.
+pub(super) struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    pub(super) fn new(label: &str) -> Self {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock after Unix epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "look-macos-{label}-{}-{unique}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path).expect("create temporary directory");
+        Self { path }
+    }
+
+    pub(super) fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}

--- a/core/engine/src/platform/mod.rs
+++ b/core/engine/src/platform/mod.rs
@@ -55,10 +55,7 @@ pub(crate) fn discover_macos_installed_apps(
 }
 
 #[cfg(target_os = "macos")]
-pub(crate) use macos::{
-    SETTINGS_BUNDLE_EXTENSION, SETTINGS_EXTENSION_NAME, SETTINGS_EXTENSIONS_DIR,
-    localized_names_available, read_bundle_identifier, read_localized_display_name,
-};
+pub(crate) use macos::localized_settings_titles;
 
 #[cfg(target_os = "linux")]
 pub(crate) fn discover_linux_installed_apps(

--- a/docs/backend-guide.md
+++ b/docs/backend-guide.md
@@ -96,7 +96,8 @@ Runtime file: `~/.look.config` (or `LOOK_CONFIG_PATH`).
 - `file_scan_roots`, `file_scan_extra_roots`, `file_scan_depth` (default: 4, range: 1-12), `file_scan_limit` (default: 4000, range: 500-50000), `file_exclude_paths`
 - `skip_dir_names`
 - `lazy_indexing_enabled` (default: true) - when true, launcher-open refresh runs only when the index is dirty
-- `localized_app_names` (default: false, macOS 15.4+) - when true, uses Foundation bundle metadata to resolve localized display names for apps and System Settings entries at index time. Older macOS versions keep non-localized names. Foundation may retain metadata for indexed bundles for the process lifetime, increasing memory use with large app catalogs.
+- `localized_app_names` (default: false, macOS 15.4+) - when true, resolves localized display names for apps and System Settings entries at index time via Foundation bundle metadata. Apps take the localized name as their title; settings panes render as `<localized> (<English>)` so English queries keep reaching them. Older macOS versions and other platforms keep the non-localized names.
+  - Cost: measured on a 134-app machine, the app+settings index pass goes from ~3 ms to ~35 ms on the first run, then ~10 ms once Foundation's bundle cache is warm. The per-bundle Info.plist reads are spread over a small thread pool, which is what keeps the first run cheap. This runs at index time, not per keystroke. Foundation retains that metadata for the process lifetime, so memory grows with the size of the app catalog.
 - `backend_log_level`
 - `launch_at_login`
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved localized app and system settings names on macOS.
  - Localized titles now remain searchable using their English catalog names.
  - App names are resolved more consistently, with improved fallback behavior.

- **Performance**
  - Streamlined localized metadata indexing to reduce repeated bundle reads.

- **Documentation**
  - Clarified the indexing-time and memory considerations of localized app names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [x] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


