### PR TITLE
chore: Macos superactions improvement

### DIFF
--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -375,6 +375,14 @@ enum AppConstants {
             static let lunarLabel = "Lunar"
             /// Caption when today falls in the intercalary (leap) lunar month.
             static let lunarLeapLabel = "Lunar leap"
+
+            /// SF Symbol for the Battery info tile, and its label when a battery
+            /// is present.
+            static let batteryIconName = "battery.100"
+            /// On a machine with no battery (e.g. a Mac mini), the Battery tile
+            /// shows system uptime instead, with this label and icon.
+            static let uptimeLabel = "Uptime"
+            static let uptimeIconName = "clock.arrow.circlepath"
         }
 
         static let commandCatalog: [AppCommand] = [

--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -362,6 +362,19 @@ enum AppConstants {
             static let nowPlayingPollSeconds: TimeInterval = 1.5
             /// Placeholder shown in the Weather tile until the live source lands.
             static let weatherPlaceholderValue = "--°"
+
+            /// Vertical gap between the time / date / lunar lines in the Todo or
+            /// Pomo header clock, so the three lines don't read as one block.
+            static let headerClockLineSpacing: CGFloat = 3
+            /// Time line (top, brightest) of the Todo / Pomo header clock.
+            static let headerClockTimeFontSize: CGFloat = 15.5
+            /// Gregorian-date and lunar-date lines below it.
+            static let headerClockDateFontSize: CGFloat = 12.5
+
+            /// Caption under today's lunar day/month in the clock tile.
+            static let lunarLabel = "Lunar"
+            /// Caption when today falls in the intercalary (leap) lunar month.
+            static let lunarLeapLabel = "Lunar leap"
         }
 
         static let commandCatalog: [AppCommand] = [

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
@@ -203,9 +203,8 @@ final class EngineBridge: @unchecked Sendable {
         look_request_index_refresh()
     }
 
-    /// Today's (or any date's) lunar date from the shared core. `tzHours` is the
-    /// viewer's UTC offset in hours, which selects the calendar variant (7 =
-    /// Vietnamese, 8 = Chinese), matching how linows calls the same crate.
+    /// Lunar date from the shared core. `tzHours` is the viewer's UTC offset,
+    /// which selects the calendar variant (7 = Vietnamese, 8 = Chinese).
     nonisolated func lunarDate(year: Int, month: Int, day: Int, tzHours: Double) -> LunarDate? {
         guard let ptr = look_lunar_date_json(Int64(year), Int64(month), Int64(day), tzHours) else {
             return nil

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
@@ -80,6 +80,19 @@ private func look_todo_list_json() -> UnsafeMutablePointer<CChar>?
 nonisolated
 private func look_todo_save_json(_ json: UnsafePointer<CChar>?) -> Bool
 
+@_silgen_name("look_lunar_date_json")
+nonisolated
+private func look_lunar_date_json(_ year: Int64, _ month: Int64, _ day: Int64, _ tz: Double) -> UnsafeMutablePointer<CChar>?
+
+/// A resolved lunar date from the shared `core/lunar` crate (East Asian
+/// lunisolar calendar). `leap` marks the intercalary month of a 13-month year.
+nonisolated struct LunarDate: Decodable {
+    let day: Int
+    let month: Int
+    let year: Int
+    let leap: Bool
+}
+
 final class EngineBridge: @unchecked Sendable {
     static let shared = EngineBridge()
 
@@ -188,6 +201,18 @@ final class EngineBridge: @unchecked Sendable {
     @discardableResult
     nonisolated func requestIndexRefresh() -> Bool {
         look_request_index_refresh()
+    }
+
+    /// Today's (or any date's) lunar date from the shared core. `tzHours` is the
+    /// viewer's UTC offset in hours, which selects the calendar variant (7 =
+    /// Vietnamese, 8 = Chinese), matching how linows calls the same crate.
+    nonisolated func lunarDate(year: Int, month: Int, day: Int, tzHours: Double) -> LunarDate? {
+        guard let ptr = look_lunar_date_json(Int64(year), Int64(month), Int64(day), tzHours) else {
+            return nil
+        }
+        defer { look_free_cstring(ptr) }
+        guard let data = String(cString: ptr).data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(LunarDate.self, from: data)
     }
 
     nonisolated func translate(text: String, targetLang: String = "en") -> TranslationResult? {

--- a/apps/macos/LauncherApp/look-app/Support/SystemUptime.swift
+++ b/apps/macos/LauncherApp/look-app/Support/SystemUptime.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Human-readable system uptime, e.g. "2d 3h 14m" (the day part is dropped under
+/// 24h). Shared by the /sys command and the launchpad Battery/Uptime tile so both
+/// format it identically.
+nonisolated enum SystemUptime {
+    private enum Const {
+        static let secondsPerDay = 86400
+        static let secondsPerHour = 3600
+        static let secondsPerMinute = 60
+    }
+
+    static func formattedShort() -> String {
+        let uptime = Int(ProcessInfo.processInfo.systemUptime)
+        let days = uptime / Const.secondsPerDay
+        let hours = (uptime % Const.secondsPerDay) / Const.secondsPerHour
+        let minutes = (uptime % Const.secondsPerHour) / Const.secondsPerMinute
+
+        var result = ""
+        if days > 0 {
+            result += "\(days)d "
+        }
+        result += "\(hours)h \(minutes)m"
+        return result
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
@@ -298,6 +298,22 @@ final class ThemeStore: ObservableObject {
         return .system(size: resolvedSize, weight: weight)
     }
 
+    /// The AppKit twin of `uiFont`, for NSView-backed inputs (the smooth-caret
+    /// fields). Same family / size / scale resolution so the search and command
+    /// bars render in the user's theme font instead of the system default.
+    func uiNSFont(size: CGFloat? = nil, weight: NSFont.Weight = .regular) -> NSFont {
+        let baseSize = size ?? CGFloat(settings.fontSize)
+        let resolvedSize = max(8, baseSize * uiScale)
+        let resolvedName = settings.fontName.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !resolvedName.isEmpty,
+           let fontName = resolveUsableFontName(resolvedName),
+           let custom = NSFont(name: fontName, size: resolvedSize) {
+            return custom
+        }
+
+        return .systemFont(ofSize: resolvedSize, weight: weight)
+    }
+
     func fontNameSuggestions(for input: String, limit: Int = 8) -> [String] {
         let allFonts = cachedFontFamilies
         let query = input.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/apps/macos/LauncherApp/look-app/Support/UI/Motion.swift
+++ b/apps/macos/LauncherApp/look-app/Support/UI/Motion.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+
+/// Shared motion vocabulary for the launcher. Kept in one place so every animated
+/// surface (tile spawn cascade, selection glide) reads with the same physics, and
+/// the feel can be tuned here instead of hunting numbers through the views.
+///
+/// The launcher leans on native SwiftUI springs rather than porting the linows CSS
+/// curves one for one: springs give the "settle" the empty query reveal is after
+/// (modelled on the iOS unlock, where icons start slightly enlarged and settle to
+/// their resting size) without hand tuned keyframes.
+enum Motion {
+    /// The "materialize on open" reveal for launchpad / quick action tiles. Tiles
+    /// start slightly enlarged and transparent, then spring down to rest, cascaded
+    /// by a per tile delay so the grid settles in instead of popping all at once.
+    enum Spawn {
+        /// Scale a tile starts at before settling to 1.0 (the unlock zoom out).
+        static let startScale: CGFloat = 1.05
+        /// Delay added per tile so the grid cascades rather than popping at once.
+        static let staggerSeconds: Double = 0.02
+        /// Ceiling on the cascade so a large grid never trails on too long.
+        static let maxStaggerSeconds: Double = 0.22
+        static let response: Double = 0.42
+        static let dampingFraction: Double = 0.82
+
+        static func animation(index: Int) -> Animation {
+            let delay = min(Double(max(0, index)) * staggerSeconds, maxStaggerSeconds)
+            return .spring(response: response, dampingFraction: dampingFraction).delay(delay)
+        }
+    }
+
+    /// The selection highlight gliding between rows on keyboard navigation. Fast
+    /// enough to feel responsive to held arrow keys, damped enough not to wobble.
+    enum Selection {
+        /// Shared `matchedGeometryEffect` id for the single sliding pill.
+        static let geometryID = "look.selection.pill"
+        static let response: Double = 0.3
+        static let dampingFraction: Double = 0.85
+
+        static var glide: Animation {
+            .spring(response: response, dampingFraction: dampingFraction)
+        }
+    }
+
+    /// The gliding "monkeytype" caret in the search field. `SmoothCaretTextField`
+    /// suppresses the native insertion point and animates a bar to the real caret
+    /// position, so the cursor slides as you type instead of jumping.
+    enum Caret {
+        static let width: CGFloat = 2
+        static let cornerRadius: CGFloat = 1
+        /// Added to the font's line height so the bar reads as a caret, not a full
+        /// line-height block.
+        static let heightScale: CGFloat = 1.05
+        /// How long the bar takes to glide to a new caret position.
+        static let glideSeconds: CFTimeInterval = 0.105
+        /// One full blink cycle while the field is idle.
+        static let blinkPeriodSeconds: CFTimeInterval = 1.05
+        /// Idle time after the last keystroke before the blink resumes; the bar
+        /// stays solid while actively typing.
+        static let blinkResumeSeconds: TimeInterval = 0.4
+    }
+
+    /// House easing (linows' signature glide) as cubic-bezier control points, used
+    /// where an explicit curve is needed (the CoreAnimation caret). The spring
+    /// driven spawn / selection motion approximates the same feel natively.
+    static let houseCurveControlPoints: (Float, Float, Float, Float) = (0.22, 1, 0.36, 1)
+}
+
+/// Plays the spawn reveal when the view first appears and again whenever `token`
+/// changes. The launcher re-arms this on every window show, so the cascade replays
+/// each time Look opens (the AppKit window is only ordered out, never torn down, so
+/// `onAppear` alone would fire just once per process).
+private struct SpawnReveal: ViewModifier {
+    let index: Int
+    let token: UInt64
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var shown = false
+
+    func body(content: Content) -> some View {
+        content
+            .opacity(shown ? 1 : 0)
+            .scaleEffect(shown ? 1 : Motion.Spawn.startScale)
+            .onAppear { rearm() }
+            .onChange(of: token) { _, _ in rearm() }
+    }
+
+    private func rearm() {
+        if reduceMotion {
+            shown = true
+            return
+        }
+        // Snap to the hidden frame with no animation, then let the next runloop
+        // tick animate to shown: SwiftUI needs the two states in separate
+        // transactions to capture a "from" value (the reflow linows forces in JS).
+        shown = false
+        DispatchQueue.main.async {
+            withAnimation(Motion.Spawn.animation(index: index)) {
+                shown = true
+            }
+        }
+    }
+}
+
+extension View {
+    /// Reveals the view with the shared spawn cascade. `index` sets its place in the
+    /// stagger; changing `token` replays the reveal (the launcher bumps it on show).
+    func spawnReveal(index: Int, token: UInt64) -> some View {
+        modifier(SpawnReveal(index: index, token: token))
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/UI/Motion.swift
+++ b/apps/macos/LauncherApp/look-app/Support/UI/Motion.swift
@@ -1,21 +1,12 @@
 import SwiftUI
 
-/// Shared motion vocabulary for the launcher. Kept in one place so every animated
-/// surface (tile spawn cascade, selection glide) reads with the same physics, and
-/// the feel can be tuned here instead of hunting numbers through the views.
-///
-/// The launcher leans on native SwiftUI springs rather than porting the linows CSS
-/// curves one for one: springs give the "settle" the empty query reveal is after
-/// (modelled on the iOS unlock, where icons start slightly enlarged and settle to
-/// their resting size) without hand tuned keyframes.
+/// Shared motion constants for the launcher, so every animated surface reads with
+/// the same physics and the feel is tuned in one place.
 enum Motion {
-    /// The "materialize on open" reveal for launchpad / quick action tiles. Tiles
-    /// start slightly enlarged and transparent, then spring down to rest, cascaded
-    /// by a per tile delay so the grid settles in instead of popping all at once.
+    /// The "materialize on open" reveal: tiles start slightly enlarged and
+    /// transparent, then spring to rest, staggered so the grid settles in.
     enum Spawn {
-        /// Scale a tile starts at before settling to 1.0 (the unlock zoom out).
         static let startScale: CGFloat = 1.05
-        /// Delay added per tile so the grid cascades rather than popping at once.
         static let staggerSeconds: Double = 0.02
         /// Ceiling on the cascade so a large grid never trails on too long.
         static let maxStaggerSeconds: Double = 0.22
@@ -28,10 +19,8 @@ enum Motion {
         }
     }
 
-    /// The selection highlight gliding between rows on keyboard navigation. Fast
-    /// enough to feel responsive to held arrow keys, damped enough not to wobble.
+    /// The single highlight pill gliding between rows on keyboard navigation.
     enum Selection {
-        /// Shared `matchedGeometryEffect` id for the single sliding pill.
         static let geometryID = "look.selection.pill"
         static let response: Double = 0.3
         static let dampingFraction: Double = 0.85
@@ -41,34 +30,26 @@ enum Motion {
         }
     }
 
-    /// The gliding "monkeytype" caret in the search field. `SmoothCaretTextField`
-    /// suppresses the native insertion point and animates a bar to the real caret
-    /// position, so the cursor slides as you type instead of jumping.
+    /// The gliding search-field caret (see `SmoothCaretTextField`).
     enum Caret {
         static let width: CGFloat = 2
         static let cornerRadius: CGFloat = 1
-        /// Added to the font's line height so the bar reads as a caret, not a full
-        /// line-height block.
+        /// Multiplier on the font's line height so the bar reads as a caret.
         static let heightScale: CGFloat = 1.05
-        /// How long the bar takes to glide to a new caret position.
         static let glideSeconds: CFTimeInterval = 0.105
-        /// One full blink cycle while the field is idle.
         static let blinkPeriodSeconds: CFTimeInterval = 1.05
-        /// Idle time after the last keystroke before the blink resumes; the bar
-        /// stays solid while actively typing.
+        /// Idle time after a keystroke before the blink resumes (solid while typing).
         static let blinkResumeSeconds: TimeInterval = 0.4
     }
 
-    /// House easing (linows' signature glide) as cubic-bezier control points, used
-    /// where an explicit curve is needed (the CoreAnimation caret). The spring
-    /// driven spawn / selection motion approximates the same feel natively.
+    /// House easing as cubic-bezier control points, for the CoreAnimation caret
+    /// (the spring-driven motion above approximates the same feel natively).
     static let houseCurveControlPoints: (Float, Float, Float, Float) = (0.22, 1, 0.36, 1)
 }
 
-/// Plays the spawn reveal when the view first appears and again whenever `token`
-/// changes. The launcher re-arms this on every window show, so the cascade replays
-/// each time Look opens (the AppKit window is only ordered out, never torn down, so
-/// `onAppear` alone would fire just once per process).
+/// Plays the spawn reveal on appear and whenever `token` changes. The launcher
+/// bumps `token` on every window show, so the cascade replays each open (the
+/// window is only ordered out, so `onAppear` alone fires once per process).
 private struct SpawnReveal: ViewModifier {
     let index: Int
     let token: UInt64
@@ -88,9 +69,9 @@ private struct SpawnReveal: ViewModifier {
             shown = true
             return
         }
-        // Snap to the hidden frame with no animation, then let the next runloop
-        // tick animate to shown: SwiftUI needs the two states in separate
-        // transactions to capture a "from" value (the reflow linows forces in JS).
+        // Snap to hidden with no animation, then animate to shown on the next
+        // runloop tick: the two states need separate transactions to capture a
+        // "from" value and actually animate.
         shown = false
         DispatchQueue.main.async {
             withAnimation(Motion.Spawn.animation(index: index)) {

--- a/apps/macos/LauncherApp/look-app/Views/Commands/SystemInfoCommand.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/SystemInfoCommand.swift
@@ -304,20 +304,9 @@ nonisolated enum SystemInfoCommand {
     }
 
     private static func getUptimeItems() -> [SystemInfoItem] {
-        let uptime = ProcessInfo.processInfo.systemUptime
-        let days = Int(uptime) / 86400
-        let hours = (Int(uptime) % 86400) / 3600
-        let minutes = (Int(uptime) % 3600) / 60
-
-        var uptimeStr = ""
-        if days > 0 {
-            uptimeStr += "\(days)d "
-        }
-        uptimeStr += "\(hours)h \(minutes)m"
-
         return [
             SystemInfoItem(label: "", value: "Uptime", isHeader: true),
-            SystemInfoItem(label: "Time", value: uptimeStr, isHeader: false)
+            SystemInfoItem(label: "Time", value: SystemUptime.formattedShort(), isHeader: false)
         ]
     }
 

--- a/apps/macos/LauncherApp/look-app/Views/Commands/TodoView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/TodoView.swift
@@ -105,11 +105,16 @@ struct TodoView: View {
                 .foregroundStyle(themeStore.accentColor())
 
             if page == .tasks {
-                TextField("Search tasks & dates", text: $search)
-                    .textFieldStyle(.plain)
-                    .focused($searchFocused)
-                    .font(themeStore.uiFont(size: 13.5))
-                    .foregroundStyle(themeStore.fontColor())
+                SmoothCaretTextField(
+                    text: $search,
+                    placeholder: "Search tasks & dates",
+                    isFocused: $searchFocused,
+                    font: themeStore.uiNSFont(size: 13.5),
+                    textColor: NSColor(themeStore.fontColor()),
+                    caretColor: NSColor(themeStore.accentColor()),
+                    onSubmit: {}
+                )
+                    .frame(maxWidth: .infinity)
 
                 if !search.isEmpty {
                     Button {

--- a/apps/macos/LauncherApp/look-app/Views/Commands/TodoView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/TodoView.swift
@@ -109,9 +109,8 @@ struct TodoView: View {
                     text: $search,
                     placeholder: "Search tasks & dates",
                     isFocused: $searchFocused,
-                    font: themeStore.uiNSFont(size: 13.5),
-                    textColor: NSColor(themeStore.fontColor()),
-                    caretColor: NSColor(themeStore.accentColor()),
+                    themeStore: themeStore,
+                    fontSize: 13.5,
                     onSubmit: {}
                 )
                     .frame(maxWidth: .infinity)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
@@ -143,7 +143,9 @@ struct EmptyStateLaunchpadView: View {
         case .info:
             LaunchpadInfoTile(
                 model: model,
-                value: controller.displayValue(for: model.actionId) ?? Const.infoPlaceholderValue,
+                batteryValue: controller.displayValue(for: model.actionId),
+                showsUptime: model.actionId == LaunchpadActionID.battery
+                    && controller.isUnavailable(model.actionId),
                 themeStore: themeStore
             )
         case .action:
@@ -265,26 +267,45 @@ private struct LaunchpadToggleTile: View {
     }
 }
 
-/// A read-only info tile (Battery): label plus a live value.
+/// A read-only info tile (Battery): label plus a live value. On a machine with
+/// no battery (e.g. a Mac mini), it falls back to showing system uptime instead
+/// of a dead placeholder.
 private struct LaunchpadInfoTile: View {
     let model: LaunchpadTileModel
-    let value: String
+    /// The battery percent string (e.g. "85%"), or nil while unread / unavailable.
+    let batteryValue: String?
+    /// True when there is no battery, so the tile shows uptime instead.
+    let showsUptime: Bool
     var themeStore: ThemeStore
 
     private typealias Const = AppConstants.Launcher.Launchpad
 
+    private var iconName: String {
+        showsUptime ? Const.uptimeIconName : Const.batteryIconName
+    }
+
+    private var label: String {
+        (showsUptime ? Const.uptimeLabel : model.title).uppercased()
+    }
+
+    private var value: String {
+        showsUptime ? SystemUptime.formattedShort() : (batteryValue ?? Const.infoPlaceholderValue)
+    }
+
     var body: some View {
         HStack(spacing: 10) {
-            Image(systemName: "battery.100")
+            Image(systemName: iconName)
                 .font(.system(size: 18, weight: .medium))
                 .foregroundColor(themeStore.accentColor())
             VStack(alignment: .leading, spacing: 1) {
-                Text(model.title.uppercased())
+                Text(label)
                     .font(themeStore.uiFont(size: Const.captionFontSize - 1, weight: .medium))
                     .foregroundColor(themeStore.mutedTextColor())
                 Text(value)
                     .font(themeStore.uiFont(size: Const.valueFontSize - 6, weight: .bold))
                     .foregroundColor(themeStore.fontColor())
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
             }
             Spacer(minLength: 0)
         }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
@@ -9,8 +9,27 @@ struct EmptyStateLaunchpadView: View {
     let tiles: [LaunchpadTileModel]
     var controller: LaunchpadController
     var themeStore: ThemeStore
+    /// Changes each time the launcher opens, replaying the spawn cascade.
+    var revealToken: UInt64 = 0
 
     private typealias Const = AppConstants.Launcher.Launchpad
+
+    /// Reading-order position of each tile in the spawn cascade, so the grid
+    /// settles in top-left to bottom-right rather than all at once.
+    private enum RevealIndex {
+        static let slot = 0
+        static let bluetooth = 1
+        static let wifi = 2
+        static let battery = 3
+        static let theme = 4
+        static let keepAwake = 5
+        static let screensaver = 6
+        static let weather = 7
+        static let mic = 8
+        static let restart = 9
+        static let shutdown = 10
+        static let nowPlaying = 11
+    }
 
     private var byID: [String: LaunchpadTileModel] {
         Dictionary(tiles.map { ($0.actionId, $0) }, uniquingKeysWith: { first, _ in first })
@@ -66,28 +85,29 @@ struct EmptyStateLaunchpadView: View {
             HStack(alignment: .top, spacing: Const.gap) {
                 slot(cell: cell)
                     .frame(width: width(columns: 2, cell: cell), height: height(rows: 2))
+                    .spawnReveal(index: RevealIndex.slot, token: revealToken)
 
                 VStack(spacing: Const.gap) {
                     HStack(spacing: Const.gap) {
-                        tileView(LaunchpadActionID.bluetooth, cell: cell)
-                        tileView(LaunchpadActionID.wifi, cell: cell)
-                        tileView(LaunchpadActionID.battery, cell: cell)
+                        tileView(LaunchpadActionID.bluetooth, cell: cell, reveal: RevealIndex.bluetooth)
+                        tileView(LaunchpadActionID.wifi, cell: cell, reveal: RevealIndex.wifi)
+                        tileView(LaunchpadActionID.battery, cell: cell, reveal: RevealIndex.battery)
                     }
                     HStack(spacing: Const.gap) {
-                        tileView(LaunchpadActionID.theme, cell: cell)
-                        tileView(LaunchpadActionID.keepAwake, cell: cell)
-                        tileView(LaunchpadActionID.screensaver, cell: cell)
+                        tileView(LaunchpadActionID.theme, cell: cell, reveal: RevealIndex.theme)
+                        tileView(LaunchpadActionID.keepAwake, cell: cell, reveal: RevealIndex.keepAwake)
+                        tileView(LaunchpadActionID.screensaver, cell: cell, reveal: RevealIndex.screensaver)
                     }
                 }
 
-                tileView(LaunchpadActionID.weather, cell: cell)
+                tileView(LaunchpadActionID.weather, cell: cell, reveal: RevealIndex.weather)
             }
 
             HStack(spacing: Const.gap) {
-                tileView(LaunchpadActionID.mic, cell: cell)
-                tileView(LaunchpadActionID.restart, cell: cell)
-                tileView(LaunchpadActionID.shutdown, cell: cell)
-                tileView(LaunchpadActionID.nowPlaying, cell: cell)
+                tileView(LaunchpadActionID.mic, cell: cell, reveal: RevealIndex.mic)
+                tileView(LaunchpadActionID.restart, cell: cell, reveal: RevealIndex.restart)
+                tileView(LaunchpadActionID.shutdown, cell: cell, reveal: RevealIndex.shutdown)
+                tileView(LaunchpadActionID.nowPlaying, cell: cell, reveal: RevealIndex.nowPlaying)
             }
         }
     }
@@ -98,14 +118,16 @@ struct EmptyStateLaunchpadView: View {
     }
 
     /// Renders the tile for `actionID` at its natural size, sourcing labels and
-    /// the mnemonic from the decoded catalog model.
+    /// the mnemonic from the decoded catalog model. `reveal` places it in the
+    /// spawn cascade.
     @ViewBuilder
-    private func tileView(_ actionID: String, cell: CGFloat) -> some View {
+    private func tileView(_ actionID: String, cell: CGFloat, reveal: Int) -> some View {
         if let model = byID[actionID] {
             let w = width(columns: model.columnSpan, cell: cell)
             let h = height(rows: model.rowSpanCount)
             tileContent(model)
                 .frame(width: w, height: h)
+                .spawnReveal(index: reveal, token: revealToken)
         }
     }
 

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
@@ -8,7 +8,15 @@ struct LauncherRowView: View {
     let result: LauncherResult
     let isSelected: Bool
     let isPicked: Bool
+    /// Shared namespace for the single selection pill that glides between rows
+    /// (see `Motion.Selection`). Only the selected row is the geometry source.
+    let selectionNamespace: Namespace.ID
     let onOpen: () -> Void
+
+    private enum Layout {
+        static let cornerRadius: CGFloat = 8
+        static let borderWidth: CGFloat = 1
+    }
 
     private var isPrefixSuggestion: Bool {
         result.id.hasPrefix(AppConstants.Launcher.PrefixSuggestion.resultIDPrefix)
@@ -125,14 +133,20 @@ struct LauncherRowView: View {
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 8)
-            .background(
-                isSelected ? themeStore.selectionFillColor() : .clear,
-                in: RoundedRectangle(cornerRadius: 8, style: .continuous)
-            )
-            .overlay {
+            .background {
+                // One pill shared across rows via matchedGeometryEffect: on
+                // keyboard navigation it glides from the old row to this one
+                // (the move is wrapped in `Motion.Selection.glide`); on click or
+                // a results refresh the selection changes outside an animation,
+                // so it snaps instantly.
                 if isSelected {
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .stroke(themeStore.dividerColor(), lineWidth: 1)
+                    RoundedRectangle(cornerRadius: Layout.cornerRadius, style: .continuous)
+                        .fill(themeStore.selectionFillColor())
+                        .overlay {
+                            RoundedRectangle(cornerRadius: Layout.cornerRadius, style: .continuous)
+                                .stroke(themeStore.dividerColor(), lineWidth: Layout.borderWidth)
+                        }
+                        .matchedGeometryEffect(id: Motion.Selection.geometryID, in: selectionNamespace)
                 }
             }
             .contentShape(Rectangle())

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
@@ -134,11 +134,10 @@ struct LauncherRowView: View {
             .padding(.horizontal, 10)
             .padding(.vertical, 8)
             .background {
-                // One pill shared across rows via matchedGeometryEffect: on
-                // keyboard navigation it glides from the old row to this one
-                // (the move is wrapped in `Motion.Selection.glide`); on click or
-                // a results refresh the selection changes outside an animation,
-                // so it snaps instantly.
+                // One pill shared across rows via matchedGeometryEffect. It
+                // glides when the selection change is wrapped in
+                // `Motion.Selection.glide` (keyboard nav) and snaps otherwise
+                // (click, results refresh).
                 if isSelected {
                     RoundedRectangle(cornerRadius: Layout.cornerRadius, style: .continuous)
                         .fill(themeStore.selectionFillColor())

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct SearchInputBar: View {
@@ -17,20 +18,18 @@ struct SearchInputBar: View {
         HStack(spacing: 8) {
             Image(systemName: isCommandMode ? "terminal" : "magnifyingglass")
                 .foregroundStyle(isCommandMode ? themeStore.accentColor() : themeStore.secondaryTextColor())
-            TextField(
-                isCommandMode
+            SmoothCaretTextField(
+                text: $text,
+                placeholder: isCommandMode
                     ? (activeCommand?.placeholder ?? AppConstants.Launcher.commandModePlaceholder)
                     : AppConstants.Launcher.searchPlaceholder,
-                text: $text
+                isFocused: isQueryFocused,
+                font: themeStore.uiNSFont(),
+                textColor: NSColor(themeStore.fontColor()),
+                caretColor: NSColor(themeStore.accentColor()),
+                onSubmit: onSubmit
             )
-                .textFieldStyle(.plain)
-                .focused(isQueryFocused)
-                .onTapGesture {
-                    DispatchQueue.main.async {
-                        isQueryFocused.wrappedValue = true
-                    }
-                }
-                .onSubmit(onSubmit)
+                .frame(maxWidth: .infinity)
 
             if isCommandMode {
                 if let command = activeCommand {
@@ -130,10 +129,16 @@ struct CommandInputBar: View {
             Image(systemName: command.symbolName)
                 .foregroundStyle(themeStore.accentColor())
 
-            TextField(command.placeholder, text: $text)
-                .textFieldStyle(.plain)
-                .focused(isQueryFocused)
-                .onSubmit(onSubmit)
+            SmoothCaretTextField(
+                text: $text,
+                placeholder: command.placeholder,
+                isFocused: isQueryFocused,
+                font: themeStore.uiNSFont(),
+                textColor: NSColor(themeStore.fontColor()),
+                caretColor: NSColor(themeStore.accentColor()),
+                onSubmit: onSubmit
+            )
+                .frame(maxWidth: .infinity)
 
             Text("/\(command.id)")
                 .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular))
@@ -185,6 +190,9 @@ struct ResultsListView: View {
     let onSelect: (String) -> Void
     let onOpen: (String) -> Void
 
+    /// Backs the single selection pill that glides between rows.
+    @Namespace private var selectionNamespace
+
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView(.vertical, showsIndicators: false) {
@@ -194,6 +202,7 @@ struct ResultsListView: View {
                             result: result,
                             isSelected: selectedID == result.id,
                             isPicked: pickedKeys.contains("\(result.kind.rawValue)|\(result.path)"),
+                            selectionNamespace: selectionNamespace,
                             onOpen: {
                                 onSelect(result.id)
                                 onOpen(result.id)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
@@ -24,9 +24,7 @@ struct SearchInputBar: View {
                     ? (activeCommand?.placeholder ?? AppConstants.Launcher.commandModePlaceholder)
                     : AppConstants.Launcher.searchPlaceholder,
                 isFocused: isQueryFocused,
-                font: themeStore.uiNSFont(),
-                textColor: NSColor(themeStore.fontColor()),
-                caretColor: NSColor(themeStore.accentColor()),
+                themeStore: themeStore,
                 onSubmit: onSubmit
             )
                 .frame(maxWidth: .infinity)
@@ -133,9 +131,7 @@ struct CommandInputBar: View {
                 text: $text,
                 placeholder: command.placeholder,
                 isFocused: isQueryFocused,
-                font: themeStore.uiNSFont(),
-                textColor: NSColor(themeStore.fontColor()),
-                caretColor: NSColor(themeStore.accentColor()),
+                themeStore: themeStore,
                 onSubmit: onSubmit
             )
                 .frame(maxWidth: .infinity)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
@@ -108,7 +108,12 @@ extension LauncherView {
             return
         }
 
-        selectedResultID = displayedResults[nextIndex].id
+        // Wrapped so the selection pill glides between rows on arrow-key moves.
+        // Click selection and results refreshes assign outside this animation, so
+        // the pill snaps rather than sliding across unrelated rows.
+        withAnimation(Motion.Selection.glide) {
+            selectedResultID = displayedResults[nextIndex].id
+        }
     }
 
     func autocompleteSelectedCommand() {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+WindowControl.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+WindowControl.swift
@@ -129,6 +129,9 @@ extension LauncherView {
         }
 
         hotkeyLog.notice("toggle: -> SHOW branch")
+        // Re-arm the spawn cascade so the launchpad tiles and quick actions
+        // settle in fresh on every open, not just the first per process.
+        appearanceRevealToken &+= 1
         captureFrontmostAppForRestoreIfNeeded()
         _ = bridge.requestIndexRefresh()
         // Warm the on-device model the instant the launcher opens so the first

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -93,6 +93,9 @@ struct LauncherView: View {
     @State var recentlyKilledPIDs: Set<Int32> = []
     @State var showsHelpScreen = false
     @State var focusRequestToken: UInt64 = 0
+    /// Bumped every time the launcher window is shown, so the empty state tiles and
+    /// quick actions replay their spawn cascade on each open (see `Motion.Spawn`).
+    @State var appearanceRevealToken: UInt64 = 0
     @State var lookupDefinition: LookupDefinition?
     @State var pidToRestoreOnHide: pid_t?
     @StateObject var runningAppsService = RunningAppsService()
@@ -907,7 +910,8 @@ struct LauncherView: View {
                     EmptyStateLaunchpadView(
                         tiles: launchpadTiles,
                         controller: launchpadController,
-                        themeStore: themeStore
+                        themeStore: themeStore,
+                        revealToken: appearanceRevealToken
                     )
                 }
                 Spacer(minLength: 0)
@@ -1070,6 +1074,7 @@ struct LauncherView: View {
                     quickActionInfo: quickActionInfo,
                     pendingQuickActionItems: pendingQuickActions,
                     busyQuickActionIds: busyQuickActionIds,
+                    quickActionsRevealToken: appearanceRevealToken,
                     onRunQuickAction: { descriptor, intent in
                         runQuickAction(descriptor, intent: intent)
                     },

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LaunchpadController.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LaunchpadController.swift
@@ -140,6 +140,14 @@ final class LaunchpadController {
         return nil
     }
 
+    /// True only once the adapter has reported the tile as genuinely unavailable
+    /// (e.g. Battery on a desktop Mac), as opposed to not-yet-read. Lets the
+    /// Battery tile fall back to showing uptime instead of a dead "--".
+    func isUnavailable(_ actionID: String) -> Bool {
+        if case .unavailable = systemStates[actionID] { return true }
+        return false
+    }
+
     /// Activates a tile. Destructive tiles gate on an inline confirm first;
     /// everything else routes to its native adapter when one exists, and falls
     /// back to mock state otherwise.

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LaunchpadLSlotView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LaunchpadLSlotView.swift
@@ -211,7 +211,7 @@ private enum LunarToday {
 }
 
 /// Today's lunar day/month plus a "Lunar" (or "Lunar leap") caption, shown in the
-/// clock tile's header corner. Mirrors the linows clock readout.
+/// clock tile's header corner.
 private struct LunarBadge: View {
     let lunar: LunarDate
     var themeStore: ThemeStore
@@ -233,10 +233,8 @@ private struct LunarBadge: View {
 
 // MARK: - Header clock
 
-/// A compact time + date + lunar date shown in a slot card's header, so the
-/// current date stays visible while the Todo or Pomo slot occupies the tile
-/// (which otherwise hides the Clock slot). Time and Gregorian date read at full
-/// strength; the lunar date sits dimmed below.
+/// Time + Gregorian date (full strength) with the lunar date dimmed below, kept
+/// visible while the Todo or Pomo slot occupies the tile.
 private struct LaunchpadHeaderClock: View {
     var themeStore: ThemeStore
 

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LaunchpadLSlotView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LaunchpadLSlotView.swift
@@ -68,7 +68,7 @@ private struct LaunchpadTodoTile: View {
     }
 
     var body: some View {
-        LaunchpadSlotCard(themeStore: themeStore, iconName: "checklist", pill: "/todo", showsClock: true) {
+        LaunchpadSlotCard(themeStore: themeStore, iconName: "checklist", showsClock: true) {
             VStack(alignment: .leading, spacing: 6) {
                 HStack(alignment: .firstTextBaseline, spacing: 6) {
                     Text("\(stat.done)/\(stat.total)")
@@ -116,7 +116,7 @@ private struct LaunchpadPomoTile: View {
     private var state: PomoState { PomoSharedState.shared }
 
     var body: some View {
-        LaunchpadSlotCard(themeStore: themeStore, iconName: "timer", pill: "/pomo", showsClock: true) {
+        LaunchpadSlotCard(themeStore: themeStore, iconName: "timer", showsClock: true) {
             VStack(alignment: .leading, spacing: 8) {
                 Text(PomoCommand.formattedRemaining(state.secondsLeft))
                     .font(themeStore.uiFont(size: 30, weight: .bold))
@@ -141,13 +141,16 @@ private struct LaunchpadPomoTile: View {
 
 // MARK: - Clock tile
 
-/// Live time + date fallback. Non-sensitive; safe during screen-share.
+/// Live time + date fallback, with today's lunar date in the top-right corner
+/// (read from the shared `core/lunar` crate). Non-sensitive; safe during
+/// screen-share.
 private struct LaunchpadClockTile: View {
     var themeStore: ThemeStore
 
     private typealias Const = AppConstants.Launcher.Launchpad
 
     @State private var now = Date()
+    @State private var lunar: LunarDate?
 
     private let tickTimer = Timer.publish(
         every: AppConstants.Launcher.Launchpad.clockTickSeconds,
@@ -156,7 +159,11 @@ private struct LaunchpadClockTile: View {
     ).autoconnect()
 
     var body: some View {
-        LaunchpadSlotCard(themeStore: themeStore, iconName: "clock", pill: nil) {
+        LaunchpadSlotCard(
+            themeStore: themeStore,
+            iconName: "clock",
+            headerTrailing: lunar.map { AnyView(LunarBadge(lunar: $0, themeStore: themeStore)) }
+        ) {
             VStack(alignment: .leading, spacing: 6) {
                 Text(now, format: .dateTime.hour().minute())
                     .font(themeStore.uiFont(size: 30, weight: .bold))
@@ -167,21 +174,76 @@ private struct LaunchpadClockTile: View {
                     .foregroundColor(themeStore.secondaryTextColor())
             }
         }
-        .onReceive(tickTimer) { now = $0 }
+        .onAppear { refreshLunar(for: now) }
+        .onReceive(tickTimer) { tick in
+            // Recompute only when the calendar day rolls over (the lunar date is
+            // stable within a day), or if the first read hasn't landed yet.
+            if lunar == nil || !Calendar.current.isDate(tick, inSameDayAs: now) {
+                refreshLunar(for: tick)
+            }
+            now = tick
+        }
+    }
+
+    private func refreshLunar(for date: Date) {
+        lunar = LunarToday.resolve(for: date)
+    }
+}
+
+/// Resolves a Gregorian date to its lunar date via the shared core, at the
+/// viewer's local UTC offset. Shared by the clock tile and the header clock so
+/// the conversion lives in one place.
+private enum LunarToday {
+    static func resolve(for date: Date) -> LunarDate? {
+        let parts = Calendar.current.dateComponents([.year, .month, .day], from: date)
+        guard let year = parts.year, let month = parts.month, let day = parts.day else { return nil }
+        let tzHours = Double(TimeZone.current.secondsFromGMT(for: date)) / 3600.0
+        return EngineBridge.shared.lunarDate(year: year, month: month, day: day, tzHours: tzHours)
+    }
+
+    /// The compact one-line label used in the header clock, e.g. "12/6 Lunar".
+    static func inlineLabel(_ lunar: LunarDate) -> String {
+        let name = lunar.leap
+            ? AppConstants.Launcher.Launchpad.lunarLeapLabel
+            : AppConstants.Launcher.Launchpad.lunarLabel
+        return "\(lunar.day)/\(lunar.month) \(name)"
+    }
+}
+
+/// Today's lunar day/month plus a "Lunar" (or "Lunar leap") caption, shown in the
+/// clock tile's header corner. Mirrors the linows clock readout.
+private struct LunarBadge: View {
+    let lunar: LunarDate
+    var themeStore: ThemeStore
+
+    private typealias Const = AppConstants.Launcher.Launchpad
+
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 0) {
+            Text("\(lunar.day)/\(lunar.month)")
+                .font(themeStore.uiFont(size: Const.captionFontSize + 5, weight: .semibold))
+                .foregroundColor(themeStore.secondaryTextColor())
+                .monospacedDigit()
+            Text(lunar.leap ? Const.lunarLeapLabel : Const.lunarLabel)
+                .font(themeStore.uiFont(size: Const.captionFontSize - 1))
+                .foregroundColor(themeStore.mutedTextColor())
+        }
     }
 }
 
 // MARK: - Header clock
 
-/// A compact time + date shown in a slot card's header, so the current time
-/// stays visible while the Todo or Pomo slot occupies the tile (which otherwise
-/// hides the Clock slot).
+/// A compact time + date + lunar date shown in a slot card's header, so the
+/// current date stays visible while the Todo or Pomo slot occupies the tile
+/// (which otherwise hides the Clock slot). Time and Gregorian date read at full
+/// strength; the lunar date sits dimmed below.
 private struct LaunchpadHeaderClock: View {
     var themeStore: ThemeStore
 
     private typealias Const = AppConstants.Launcher.Launchpad
 
     @State private var now = Date()
+    @State private var lunar: LunarDate?
 
     private let tickTimer = Timer.publish(
         every: AppConstants.Launcher.Launchpad.clockTickSeconds,
@@ -190,30 +252,44 @@ private struct LaunchpadHeaderClock: View {
     ).autoconnect()
 
     var body: some View {
-        VStack(alignment: .trailing, spacing: 0) {
+        VStack(alignment: .trailing, spacing: Const.headerClockLineSpacing) {
             Text(now, format: .dateTime.hour().minute())
-                .font(themeStore.uiFont(size: Const.captionFontSize + 2, weight: .semibold))
+                .font(themeStore.uiFont(size: Const.headerClockTimeFontSize, weight: .semibold))
                 .foregroundColor(themeStore.secondaryTextColor())
                 .monospacedDigit()
             Text(now, format: .dateTime.weekday().month().day())
-                .font(themeStore.uiFont(size: Const.captionFontSize - 1))
-                .foregroundColor(themeStore.mutedTextColor())
+                .font(themeStore.uiFont(size: Const.headerClockDateFontSize))
+                .foregroundColor(themeStore.secondaryTextColor())
+            if let lunar {
+                Text(LunarToday.inlineLabel(lunar))
+                    .font(themeStore.uiFont(size: Const.headerClockDateFontSize))
+                    .foregroundColor(themeStore.mutedTextColor())
+                    .monospacedDigit()
+            }
         }
-        .onReceive(tickTimer) { now = $0 }
+        .onAppear { lunar = LunarToday.resolve(for: now) }
+        .onReceive(tickTimer) { tick in
+            if lunar == nil || !Calendar.current.isDate(tick, inSameDayAs: now) {
+                lunar = LunarToday.resolve(for: tick)
+            }
+            now = tick
+        }
     }
 }
 
 // MARK: - Shared L-slot card chrome
 
-/// The common 2x2 card frame: an icon badge in the top-left, an optional command
-/// pill in the top-right, and the slot's content pinned to the bottom. When
+/// The common 2x2 card frame: an icon badge in the top-left, an optional header
+/// readout in the top-right, and the slot's content pinned to the bottom. When
 /// `showsClock` is set, a compact time + date sits in the header so it stays
 /// visible even while the Todo or Pomo slot occupies the tile.
 private struct LaunchpadSlotCard<Content: View>: View {
     var themeStore: ThemeStore
     let iconName: String
-    let pill: String?
     var showsClock: Bool = false
+    /// Optional readout pinned to the header's top-right (e.g. the clock tile's
+    /// lunar date). Stays inside this card, beside the icon.
+    var headerTrailing: AnyView? = nil
     @ViewBuilder var content: () -> Content
 
     private typealias Const = AppConstants.Launcher.Launchpad
@@ -233,15 +309,8 @@ private struct LaunchpadSlotCard<Content: View>: View {
                 if showsClock {
                     LaunchpadHeaderClock(themeStore: themeStore)
                 }
-                if let pill {
-                    Text(pill)
-                        .font(themeStore.uiFont(size: Const.captionFontSize - 0.5))
-                        .foregroundColor(themeStore.fontColor())
-                        .padding(.horizontal, 7)
-                        .padding(.vertical, 2)
-                        .background(
-                            Capsule().fill(themeStore.selectionFillColor())
-                        )
+                if let headerTrailing {
+                    headerTrailing
                 }
             }
             Spacer(minLength: 0)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/QuickActionsSection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/QuickActionsSection.swift
@@ -18,6 +18,8 @@ struct QuickActionsSection: View {
     /// clickable that the guard in `runQuickAction` would silently swallow.
     let busyActionIds: Set<String>
     let themeStore: ThemeStore
+    /// Changes each time the launcher opens, replaying the spawn cascade.
+    var revealToken: UInt64 = 0
     /// A control was activated by click (Cmd+O runs the same path).
     var onRun: (QuickActionDescriptor, ActionIntent) -> Void = { _, _ in }
     /// A list item (e.g. a device row) was clicked to connect/disconnect.
@@ -29,7 +31,7 @@ struct QuickActionsSection: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: Layout.rowSpacing) {
-            ForEach(descriptors) { descriptor in
+            ForEach(Array(descriptors.enumerated()), id: \.element.id) { index, descriptor in
                 QuickActionControl(
                     descriptor: descriptor,
                     state: states[descriptor.actionId],
@@ -40,6 +42,7 @@ struct QuickActionsSection: View {
                     onRun: { intent in onRun(descriptor, intent) },
                     onActivateItem: { item in onActivateItem(descriptor, item) }
                 )
+                .spawnReveal(index: index, token: revealToken)
             }
         }
     }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
@@ -14,6 +14,8 @@ struct ResultPreviewView: View {
     /// Actions with something applying: their controls render inert (see
     /// `LauncherView.busyQuickActionIds`).
     var busyQuickActionIds: Set<String> = []
+    /// Changes each time the launcher opens, replaying the quick-action cascade.
+    var quickActionsRevealToken: UInt64 = 0
     var onRunQuickAction: (QuickActionDescriptor, ActionIntent) -> Void = { _, _ in }
     var onActivateQuickActionItem: (QuickActionDescriptor, QuickActionListItem) -> Void = { _, _ in }
     var onDeleteClipboard: (() -> Void)? = nil
@@ -171,6 +173,7 @@ struct ResultPreviewView: View {
                         pendingItems: pendingQuickActionItems,
                         busyActionIds: busyQuickActionIds,
                         themeStore: themeStore,
+                        revealToken: quickActionsRevealToken,
                         onRun: onRunQuickAction,
                         onActivateItem: onActivateQuickActionItem
                     )

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/SmoothCaretTextField.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/SmoothCaretTextField.swift
@@ -1,23 +1,23 @@
 import AppKit
 import SwiftUI
 
-/// The search field's editable input, with a "monkeytype" caret: the native
-/// insertion point is suppressed and a bar is drawn that glides to the real caret
-/// position (solid while typing, blinking when idle).
-///
-/// Built as an `NSTextField` subclass rather than a custom `NSTextView` so the
-/// launcher's existing focus recovery (`findEditableTextField`, which looks for an
-/// editable `NSTextField`) keeps finding and focusing it unchanged. The caret is
-/// read from the field editor's layout, so it stays correct for any cursor
-/// position, not just the end of the text.
+/// The search field's editable input, with a gliding caret (solid while typing,
+/// blinking when idle). An `NSTextField` subclass, not a custom `NSTextView`, so
+/// the launcher's existing focus recovery (`findEditableTextField`, which looks
+/// for an editable `NSTextField`) keeps working unchanged.
 struct SmoothCaretTextField: NSViewRepresentable {
     @Binding var text: String
     var placeholder: String
     var isFocused: FocusState<Bool>.Binding
-    var font: NSFont
-    var textColor: NSColor
-    var caretColor: NSColor
+    var themeStore: ThemeStore
+    /// Overrides the base theme font size when set (the Todo search bar runs a
+    /// touch larger). Colors and family always follow the theme.
+    var fontSize: CGFloat? = nil
     var onSubmit: () -> Void
+
+    private var font: NSFont { themeStore.uiNSFont(size: fontSize) }
+    private var textColor: NSColor { NSColor(themeStore.fontColor()) }
+    private var caretColor: NSColor { NSColor(themeStore.accentColor()) }
 
     func makeNSView(context: Context) -> CaretTextField {
         let field = CaretTextField()
@@ -50,13 +50,10 @@ struct SmoothCaretTextField: NSViewRepresentable {
         field.caretColor = caretColor
         applyPlaceholder(to: field)
 
-        // Bridge SwiftUI focus INTO first responder, one direction only.
-        // `currentEditor()` is non-nil exactly while the field is being edited, a
-        // stable "focused" signal (the first-responder identity flickers during
-        // layout and caused a makeFirstResponder feedback loop). Focus-in stops
-        // firing as soon as editing begins, so it can't loop. Blur is left to
-        // natural resignation (window hide / view swap) rather than a second
-        // branch here, which would ping-pong against the async begin-editing sync.
+        // Bridge focus INTO first responder only. `currentEditor() != nil` is a
+        // stable "editing" signal (unlike first-responder identity, which flickers
+        // during layout and loops makeFirstResponder). Blur is left to natural
+        // resignation (window hide / view swap), avoiding a two-way ping-pong.
         let isEditing = field.currentEditor() != nil
         if isFocused.wrappedValue, !isEditing, field.window != nil {
             DispatchQueue.main.async {
@@ -116,6 +113,8 @@ final class CaretTextField: NSTextField {
         didSet { caretLayer.backgroundColor = caretColor.cgColor }
     }
 
+    private static let blinkKey = "blink"
+
     private let caretLayer = CALayer()
     private var selectionObserver: NSObjectProtocol?
     private var blinkResumeTimer: Timer?
@@ -165,16 +164,14 @@ final class CaretTextField: NSTextField {
         super.textDidEndEditing(notification)
         stopObservingSelection()
         blinkResumeTimer?.invalidate()
-        caretLayer.removeAnimation(forKey: "blink")
+        caretLayer.removeAnimation(forKey: Self.blinkKey)
         caretLayer.opacity = 0
     }
 
     // MARK: - Native caret suppression
 
-    /// The field editor is shared per window, so clear the insertion point only
-    /// while we own it; `textDidEndEditing` fires before another field edits, and
-    /// each field editor session redraws its own caret, so no manual restore of
-    /// the colour is needed.
+    /// Clears the native insertion point while we own the shared field editor. No
+    /// restore needed: the next field's editing session redraws its own caret.
     private func suppressNativeCaret() {
         (currentEditor() as? NSTextView)?.insertionPointColor = .clear
     }
@@ -230,7 +227,7 @@ final class CaretTextField: NSTextField {
     // MARK: - Blink / solid-while-typing
 
     private func registerTyping() {
-        caretLayer.removeAnimation(forKey: "blink")
+        caretLayer.removeAnimation(forKey: Self.blinkKey)
         caretLayer.opacity = 1
         blinkResumeTimer?.invalidate()
         blinkResumeTimer = Timer.scheduledTimer(
@@ -249,7 +246,7 @@ final class CaretTextField: NSTextField {
         blink.duration = Motion.Caret.blinkPeriodSeconds
         blink.repeatCount = .infinity
         blink.calculationMode = .cubic
-        caretLayer.add(blink, forKey: "blink")
+        caretLayer.add(blink, forKey: Self.blinkKey)
     }
 
     // MARK: - Selection tracking

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/SmoothCaretTextField.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/SmoothCaretTextField.swift
@@ -118,6 +118,11 @@ final class CaretTextField: NSTextField {
     private let caretLayer = CALayer()
     private var selectionObserver: NSObjectProtocol?
     private var blinkResumeTimer: Timer?
+    /// The shared field editor we suppressed, and the caret color it had before,
+    /// so we can restore it on end-editing (the editor is reused by other native
+    /// text fields in the same window).
+    private weak var suppressedEditor: NSTextView?
+    private var savedInsertionPointColor: NSColor?
 
     private static let glideTiming: CAMediaTimingFunction = {
         let c = Motion.houseCurveControlPoints
@@ -162,6 +167,7 @@ final class CaretTextField: NSTextField {
 
     override func textDidEndEditing(_ notification: Notification) {
         super.textDidEndEditing(notification)
+        restoreNativeCaret()
         stopObservingSelection()
         blinkResumeTimer?.invalidate()
         caretLayer.removeAnimation(forKey: Self.blinkKey)
@@ -170,10 +176,21 @@ final class CaretTextField: NSTextField {
 
     // MARK: - Native caret suppression
 
-    /// Clears the native insertion point while we own the shared field editor. No
-    /// restore needed: the next field's editing session redraws its own caret.
+    /// Hides the native insertion point on the shared window field editor while we
+    /// draw our own, remembering the editor and its prior color.
     private func suppressNativeCaret() {
-        (currentEditor() as? NSTextView)?.insertionPointColor = .clear
+        guard let editor = currentEditor() as? NSTextView else { return }
+        suppressedEditor = editor
+        savedInsertionPointColor = editor.insertionPointColor
+        editor.insertionPointColor = .clear
+    }
+
+    /// Restores the field editor's caret color on end-editing, so other native
+    /// text fields in the window (Pomo name, Todo drafts) keep a visible caret.
+    private func restoreNativeCaret() {
+        suppressedEditor?.insertionPointColor = savedInsertionPointColor ?? .textColor
+        suppressedEditor = nil
+        savedInsertionPointColor = nil
     }
 
     // MARK: - Caret geometry

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/SmoothCaretTextField.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/SmoothCaretTextField.swift
@@ -1,0 +1,274 @@
+import AppKit
+import SwiftUI
+
+/// The search field's editable input, with a "monkeytype" caret: the native
+/// insertion point is suppressed and a bar is drawn that glides to the real caret
+/// position (solid while typing, blinking when idle).
+///
+/// Built as an `NSTextField` subclass rather than a custom `NSTextView` so the
+/// launcher's existing focus recovery (`findEditableTextField`, which looks for an
+/// editable `NSTextField`) keeps finding and focusing it unchanged. The caret is
+/// read from the field editor's layout, so it stays correct for any cursor
+/// position, not just the end of the text.
+struct SmoothCaretTextField: NSViewRepresentable {
+    @Binding var text: String
+    var placeholder: String
+    var isFocused: FocusState<Bool>.Binding
+    var font: NSFont
+    var textColor: NSColor
+    var caretColor: NSColor
+    var onSubmit: () -> Void
+
+    func makeNSView(context: Context) -> CaretTextField {
+        let field = CaretTextField()
+        field.delegate = context.coordinator
+        field.isBordered = false
+        field.drawsBackground = false
+        field.focusRingType = .none
+        field.usesSingleLineMode = true
+        field.cell?.isScrollable = true
+        field.cell?.wraps = false
+        field.lineBreakMode = .byClipping
+        field.font = font
+        field.textColor = textColor
+        field.caretColor = caretColor
+        field.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        field.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        applyPlaceholder(to: field)
+        return field
+    }
+
+    func updateNSView(_ field: CaretTextField, context: Context) {
+        context.coordinator.parent = self
+
+        if field.stringValue != text {
+            field.stringValue = text
+            field.refreshCaret(animated: true)
+        }
+        field.font = font
+        field.textColor = textColor
+        field.caretColor = caretColor
+        applyPlaceholder(to: field)
+
+        // Bridge SwiftUI focus INTO first responder, one direction only.
+        // `currentEditor()` is non-nil exactly while the field is being edited, a
+        // stable "focused" signal (the first-responder identity flickers during
+        // layout and caused a makeFirstResponder feedback loop). Focus-in stops
+        // firing as soon as editing begins, so it can't loop. Blur is left to
+        // natural resignation (window hide / view swap) rather than a second
+        // branch here, which would ping-pong against the async begin-editing sync.
+        let isEditing = field.currentEditor() != nil
+        if isFocused.wrappedValue, !isEditing, field.window != nil {
+            DispatchQueue.main.async {
+                guard field.currentEditor() == nil, field.window != nil else { return }
+                field.window?.makeFirstResponder(field)
+            }
+        }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    private func applyPlaceholder(to field: CaretTextField) {
+        field.placeholderAttributedString = NSAttributedString(
+            string: placeholder,
+            attributes: [
+                .foregroundColor: NSColor.secondaryLabelColor,
+                .font: font,
+            ]
+        )
+    }
+
+    final class Coordinator: NSObject, NSTextFieldDelegate {
+        var parent: SmoothCaretTextField
+
+        init(_ parent: SmoothCaretTextField) { self.parent = parent }
+
+        func controlTextDidChange(_ obj: Notification) {
+            guard let field = obj.object as? CaretTextField else { return }
+            parent.text = field.stringValue
+        }
+
+        func controlTextDidBeginEditing(_ obj: Notification) {
+            DispatchQueue.main.async { self.parent.isFocused.wrappedValue = true }
+        }
+
+        func controlTextDidEndEditing(_ obj: Notification) {
+            DispatchQueue.main.async { self.parent.isFocused.wrappedValue = false }
+        }
+
+        func control(_ control: NSControl, textView: NSTextView, doCommandBy selector: Selector) -> Bool {
+            // Plain Return submits (Cmd+Return is consumed upstream by the
+            // keyboard monitor, so it never reaches here). Consume it so the
+            // field editor doesn't beep trying to insert a newline.
+            if selector == #selector(NSResponder.insertNewline(_:)) {
+                parent.onSubmit()
+                return true
+            }
+            return false
+        }
+    }
+}
+
+/// The `NSTextField` that owns the caret bar. Kept file-internal to the smooth
+/// caret; nothing else should instantiate it.
+final class CaretTextField: NSTextField {
+    var caretColor: NSColor = .labelColor {
+        didSet { caretLayer.backgroundColor = caretColor.cgColor }
+    }
+
+    private let caretLayer = CALayer()
+    private var selectionObserver: NSObjectProtocol?
+    private var blinkResumeTimer: Timer?
+
+    private static let glideTiming: CAMediaTimingFunction = {
+        let c = Motion.houseCurveControlPoints
+        return CAMediaTimingFunction(controlPoints: c.0, c.1, c.2, c.3)
+    }()
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        configureCaretLayer()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        configureCaretLayer()
+    }
+
+    private func configureCaretLayer() {
+        wantsLayer = true
+        caretLayer.backgroundColor = caretColor.cgColor
+        caretLayer.cornerRadius = Motion.Caret.cornerRadius
+        caretLayer.opacity = 0
+        caretLayer.zPosition = 1
+        layer?.addSublayer(caretLayer)
+    }
+
+    // MARK: - Editing lifecycle
+
+    override func textDidBeginEditing(_ notification: Notification) {
+        super.textDidBeginEditing(notification)
+        suppressNativeCaret()
+        observeSelection()
+        caretLayer.opacity = 1
+        refreshCaret(animated: false)
+        registerTyping()
+    }
+
+    override func textDidChange(_ notification: Notification) {
+        super.textDidChange(notification)
+        registerTyping()
+        refreshCaret(animated: true)
+    }
+
+    override func textDidEndEditing(_ notification: Notification) {
+        super.textDidEndEditing(notification)
+        stopObservingSelection()
+        blinkResumeTimer?.invalidate()
+        caretLayer.removeAnimation(forKey: "blink")
+        caretLayer.opacity = 0
+    }
+
+    // MARK: - Native caret suppression
+
+    /// The field editor is shared per window, so clear the insertion point only
+    /// while we own it; `textDidEndEditing` fires before another field edits, and
+    /// each field editor session redraws its own caret, so no manual restore of
+    /// the colour is needed.
+    private func suppressNativeCaret() {
+        (currentEditor() as? NSTextView)?.insertionPointColor = .clear
+    }
+
+    // MARK: - Caret geometry
+
+    /// Recomputes the bar's frame from the field editor's layout and moves it,
+    /// gliding when `animated`.
+    func refreshCaret(animated: Bool) {
+        guard window?.firstResponder === currentEditor(), let rect = caretRect() else { return }
+        CATransaction.begin()
+        if animated {
+            CATransaction.setAnimationDuration(Motion.Caret.glideSeconds)
+            CATransaction.setAnimationTimingFunction(Self.glideTiming)
+        } else {
+            CATransaction.setDisableActions(true)
+        }
+        caretLayer.frame = rect
+        CATransaction.commit()
+    }
+
+    private func caretRect() -> CGRect? {
+        guard
+            let editor = currentEditor() as? NSTextView,
+            let layoutManager = editor.layoutManager,
+            let container = editor.textContainer
+        else { return nil }
+
+        let caretLocation = editor.selectedRange().location
+        layoutManager.ensureLayout(for: container)
+
+        // Width of the text preceding the caret gives its x; an empty range at 0
+        // yields a zero rect, so the caret sits at the leading edge.
+        let precedingWidth = caretLocation > 0
+            ? layoutManager.boundingRect(
+                forGlyphRange: NSRange(location: 0, length: caretLocation),
+                in: container
+            ).maxX
+            : 0
+
+        let origin = editor.textContainerOrigin
+        let xInEditor = origin.x + precedingWidth
+        let xInField = editor.convert(CGPoint(x: xInEditor, y: 0), to: self).x
+
+        let lineHeight = font.map { $0.ascender - $0.descender + $0.leading }
+            ?? bounds.height
+        let barHeight = lineHeight * Motion.Caret.heightScale
+        let y = (bounds.height - barHeight) / 2
+
+        return CGRect(x: xInField, y: y, width: Motion.Caret.width, height: barHeight)
+    }
+
+    // MARK: - Blink / solid-while-typing
+
+    private func registerTyping() {
+        caretLayer.removeAnimation(forKey: "blink")
+        caretLayer.opacity = 1
+        blinkResumeTimer?.invalidate()
+        blinkResumeTimer = Timer.scheduledTimer(
+            withTimeInterval: Motion.Caret.blinkResumeSeconds,
+            repeats: false
+        ) { [weak self] _ in
+            self?.startBlink()
+        }
+    }
+
+    private func startBlink() {
+        guard window?.firstResponder === currentEditor() else { return }
+        let blink = CAKeyframeAnimation(keyPath: "opacity")
+        blink.values = [1.0, 1.0, 0.0, 0.0, 1.0]
+        blink.keyTimes = [0.0, 0.45, 0.5, 0.95, 1.0]
+        blink.duration = Motion.Caret.blinkPeriodSeconds
+        blink.repeatCount = .infinity
+        blink.calculationMode = .cubic
+        caretLayer.add(blink, forKey: "blink")
+    }
+
+    // MARK: - Selection tracking
+
+    private func observeSelection() {
+        guard let editor = currentEditor() as? NSTextView else { return }
+        selectionObserver = NotificationCenter.default.addObserver(
+            forName: NSTextView.didChangeSelectionNotification,
+            object: editor,
+            queue: .main
+        ) { [weak self] _ in
+            self?.refreshCaret(animated: true)
+        }
+    }
+
+    private func stopObservingSelection() {
+        if let selectionObserver {
+            NotificationCenter.default.removeObserver(selectionObserver)
+            self.selectionObserver = nil
+        }
+    }
+}

--- a/bridge/ffi/Cargo.lock
+++ b/bridge/ffi/Cargo.lock
@@ -296,6 +296,7 @@ dependencies = [
  "look-answers",
  "look-engine",
  "look-indexing",
+ "look-lunar",
  "look-qactions",
  "look-ranking",
  "look-storage",
@@ -307,6 +308,13 @@ dependencies = [
 
 [[package]]
 name = "look-indexing"
+version = "0.1.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "look-lunar"
 version = "0.1.0"
 dependencies = [
  "serde",

--- a/bridge/ffi/Cargo.toml
+++ b/bridge/ffi/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 look-answers = { path = "../../core/answers" }
 look-engine = { path = "../../core/engine" }
 look-indexing = { path = "../../core/indexing" }
+look-lunar = { path = "../../core/lunar" }
 look-qactions = { path = "../../core/qactions" }
 look-ranking = { path = "../../core/ranking" }
 look-storage = { path = "../../core/storage" }

--- a/bridge/ffi/src/lib.rs
+++ b/bridge/ffi/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(unsafe_code)]
 
 mod answers_api;
+mod lunar_api;
 mod qactions_api;
 mod runtime_config;
 mod search_api;
@@ -111,6 +112,16 @@ pub extern "C" fn look_todo_save_json(json: *const c_char) -> bool {
         todo_api::look_todo_save_json_impl(json)
     }))
     .unwrap_or(false)
+}
+
+/// Lunar date JSON (`{day, month, year, leap}`) for a Gregorian `(year, month,
+/// day)` at UTC offset `tz` hours. Free the result with `look_free_cstring`.
+#[unsafe(no_mangle)]
+pub extern "C" fn look_lunar_date_json(year: i64, month: i64, day: i64, tz: f64) -> *mut c_char {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        lunar_api::look_lunar_date_json_impl(year, month, day, tz)
+    }))
+    .unwrap_or(std::ptr::null_mut())
 }
 
 #[unsafe(no_mangle)]

--- a/bridge/ffi/src/lunar_api.rs
+++ b/bridge/ffi/src/lunar_api.rs
@@ -1,0 +1,19 @@
+use crate::state::store_json_allocation;
+use look_lunar::solar_to_lunar;
+use std::ffi::CString;
+use std::os::raw::c_char;
+
+/// The JSON returned when the conversion cannot be serialized. The shell treats
+/// a `null` (or a null pointer) as "no lunar date", so it degrades gracefully.
+const NULL_JSON: &str = "null";
+
+/// Converts a Gregorian date to its lunar date at UTC offset `tz` (hours: 7 for
+/// the Vietnamese calendar, 8 for the Chinese one) and returns it as a JSON
+/// `LunarDate` object (`{day, month, year, leap}`). Free with `look_free_cstring`.
+pub(crate) fn look_lunar_date_json_impl(year: i64, month: i64, day: i64, tz: f64) -> *mut c_char {
+    let lunar = solar_to_lunar(year, month, day, tz);
+    let json = serde_json::to_string(&lunar).unwrap_or_else(|_| NULL_JSON.to_string());
+    let cstring =
+        CString::new(json).unwrap_or_else(|_| CString::new(NULL_JSON).expect("valid static json"));
+    store_json_allocation(cstring)
+}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added lunar calendar details to the Clock tile, including leap-month labeling.
  * Battery/info tile can now display either battery percent or system uptime when unavailable.

* **Enhancements**
  * Improved launcher animations with coordinated “spawn cascade” reveals for tiles and Quick Actions.
  * Updated selection visuals to glide smoothly across results.
  * Replaced search/command text inputs with a smoother, themed caret field.
  * Standardized uptime formatting across the launcher.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [x] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [ ] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [ ] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [ ] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [ ] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [ ] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

https://github.com/user-attachments/assets/1ee9fcaf-01a0-4cb9-93bd-85855807a0ae


## Checklist

- [x] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered
