### PR TITLE
fix: Large clipboard laggy

### DIFF
--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -249,6 +249,9 @@ enum AppConstants {
             static let maxEntriesLimit = 100
             static let historyLimitConfigKey = "clipboard_history_limit"
             static let maxStoredCharacters = 30_000
+            /// Row label length; longer clips are elided.
+            static let maxTitleCharacters = 80
+            static let emptyEntryTitle = "(Empty text)"
             static let foregroundPollInterval: TimeInterval = 0.35
             static let backgroundPollInterval: TimeInterval = 0.9
             static let burstPollInterval: TimeInterval = 0.08

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/ClipboardHistoryStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/ClipboardHistoryStore.swift
@@ -6,33 +6,34 @@ struct ClipboardHistoryEntry: Identifiable, Equatable {
     let id: UUID
     let content: String
     let capturedAt: Date
+    /// Derived once at capture time, not per render: rescanning full content on
+    /// every body evaluation stutters keyboard navigation.
+    let title: String
+    let lineCount: Int
+    let characterCount: Int
 
     init(id: UUID = UUID(), content: String, capturedAt: Date = Date()) {
         self.id = id
         self.content = content
         self.capturedAt = capturedAt
+        self.title = Self.makeTitle(from: content)
+        self.lineCount = max(1, content.split(whereSeparator: \.isNewline).count)
+        self.characterCount = content.count
     }
 
-    var title: String {
+    private static func makeTitle(from content: String) -> String {
         let collapsed = content
             .replacingOccurrences(of: "\r\n", with: "\n")
             .replacingOccurrences(of: "\n", with: " ")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         if collapsed.isEmpty {
-            return "(Empty text)"
+            return AppConstants.Launcher.Clipboard.emptyEntryTitle
         }
-        if collapsed.count <= 80 {
+        let limit = AppConstants.Launcher.Clipboard.maxTitleCharacters
+        if collapsed.count <= limit {
             return collapsed
         }
-        return String(collapsed.prefix(80)) + "…"
-    }
-
-    var lineCount: Int {
-        max(1, content.split(whereSeparator: \.isNewline).count)
-    }
-
-    var characterCount: Int {
-        content.count
+        return String(collapsed.prefix(limit)) + "…"
     }
 }
 

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/ClipboardHistoryStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/ClipboardHistoryStore.swift
@@ -17,8 +17,18 @@ struct ClipboardHistoryEntry: Identifiable, Equatable {
         self.content = content
         self.capturedAt = capturedAt
         self.title = Self.makeTitle(from: content)
-        self.lineCount = max(1, content.split(whereSeparator: \.isNewline).count)
+        self.lineCount = Self.makeLineCount(from: content)
         self.characterCount = content.count
+    }
+
+    /// Blank lines count, and a single trailing newline does not add one.
+    private static func makeLineCount(from content: String) -> Int {
+        var normalized = content.replacingOccurrences(of: "\r\n", with: "\n")
+        if normalized.hasSuffix("\n") {
+            normalized.removeLast()
+        }
+        guard !normalized.isEmpty else { return 1 }
+        return normalized.split(separator: "\n", omittingEmptySubsequences: false).count
     }
 
     private static func makeTitle(from content: String) -> String {

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/ClipboardHistoryStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/ClipboardHistoryStore.swift
@@ -21,9 +21,16 @@ struct ClipboardHistoryEntry: Identifiable, Equatable {
         self.characterCount = content.count
     }
 
+    /// CRLF and bare CR both read as one line break (terminal output carries CR).
+    private static func normalizedNewlines(_ content: String) -> String {
+        content
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+    }
+
     /// Blank lines count, and a single trailing newline does not add one.
     private static func makeLineCount(from content: String) -> Int {
-        var normalized = content.replacingOccurrences(of: "\r\n", with: "\n")
+        var normalized = normalizedNewlines(content)
         if normalized.hasSuffix("\n") {
             normalized.removeLast()
         }
@@ -32,8 +39,7 @@ struct ClipboardHistoryEntry: Identifiable, Equatable {
     }
 
     private static func makeTitle(from content: String) -> String {
-        let collapsed = content
-            .replacingOccurrences(of: "\r\n", with: "\n")
+        let collapsed = normalizedNewlines(content)
             .replacingOccurrences(of: "\n", with: " ")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         if collapsed.isEmpty {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/HighlightedTextView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/HighlightedTextView.swift
@@ -10,6 +10,18 @@ struct HighlightedTextView: NSViewRepresentable {
     let font: NSFont
     let defaultColor: NSColor
 
+    /// What was last pushed into the text storage. Re-setting it discards
+    /// TextKit's layout, so redundant updates have to be skipped.
+    final class Coordinator {
+        var applied: NSAttributedString?
+        var appliedFont: NSFont?
+        var appliedColor: NSColor?
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
     func makeNSView(context: Context) -> NSScrollView {
         let scroll = NSScrollView()
         scroll.hasVerticalScroller = false
@@ -37,6 +49,16 @@ struct HighlightedTextView: NSViewRepresentable {
     func updateNSView(_ nsView: NSScrollView, context: Context) {
         guard let text = nsView.documentView as? NSTextView,
               let storage = text.textStorage else { return }
+        let coordinator = context.coordinator
+        if let applied = coordinator.applied,
+           applied.isEqual(to: attributed),
+           coordinator.appliedFont == font,
+           coordinator.appliedColor == defaultColor {
+            return
+        }
+        coordinator.applied = attributed
+        coordinator.appliedFont = font
+        coordinator.appliedColor = defaultColor
         // Setting via textStorage avoids the perf cost of NSTextView's
         // `string` setter (which throws away typing attributes / undo).
         storage.setAttributedString(attributed)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
@@ -211,7 +211,9 @@ struct ResultsListView: View {
             }
             .onChange(of: selectedID) { _, newID in
                 guard let newID else { return }
-                withAnimation(.easeOut(duration: 0.12)) {
+                // Same curve as the selection pill, so the pill can't trail the
+                // list when rows differ in height.
+                withAnimation(Motion.Selection.glide) {
                     proxy.scrollTo(newID, anchor: .center)
                 }
             }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
@@ -255,6 +255,10 @@ struct ResultPreviewView: View {
         let capturedAt = result.clipboardCapturedAt.map { Self.clipboardDateFormatter.string(from: $0) } ?? "Unknown"
         let characterCount = result.clipboardCharacterCount ?? content.count
         let lineCount = result.clipboardLineCount ?? max(1, content.split(whereSeparator: \.isNewline).count)
+        let previewFont = NSFont.monospacedSystemFont(
+            ofSize: CGFloat(themeStore.settings.fontSize - 1),
+            weight: .regular
+        )
 
         return VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 10) {
@@ -302,14 +306,13 @@ struct ResultPreviewView: View {
                 .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .medium))
                 .foregroundStyle(themeStore.mutedTextColor())
 
-            ScrollView {
-                Text(content)
-                    .font(.system(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular, design: .monospaced))
-                    .foregroundStyle(themeStore.secondaryTextColor())
-                    .frame(maxWidth: .infinity, alignment: .topLeading)
-                    .textSelection(.enabled)
-                    .padding(10)
-            }
+            // TextKit, not SwiftUI Text: Text lays out the whole clip
+            // synchronously and drops frames on long content.
+            HighlightedTextView(
+                attributed: NSAttributedString(string: content),
+                font: previewFont,
+                defaultColor: NSColor(themeStore.secondaryTextColor())
+            )
             .background(themeStore.controlFillColor(), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
 
             InfoRow(label: "Kind", value: "Clipboard")


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Clipboard history entries now show clearer titles, including a placeholder for empty text and automatic elision for long/multiline content.

* **Bug Fixes**
  * Clipboard preview rendering was updated to use attributed, monospaced highlighted text for more consistent appearance.
  * Improved performance by avoiding unnecessary preview redraws and recalculations.

* **Style**
  * Selection scrolling now uses a smoother animation curve aligned with the selection indicator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Testing

  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Manual verification completed (if UI/behavior changed)


## Checklist

- [x] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


