### PR TITLE
fix: flaky behaviors while playing multiple tracks

### DIFF
--- a/apps/linows/src-tauri/src/nowplaying.rs
+++ b/apps/linows/src-tauri/src/nowplaying.rs
@@ -17,6 +17,9 @@ pub struct NowPlayingSnapshot {
     /// The owning app's display name (MPRIS `Identity`), e.g. "Firefox".
     pub app: Option<String>,
     pub is_playing: bool,
+    /// Handle passed back with a transport command so control drives this exact
+    /// player (MPRIS bus name). `None` on Windows (one implicit SMTC session).
+    pub player: Option<String>,
 }
 
 /// The current track, or `None` when nothing is playing. Runs the blocking
@@ -29,11 +32,12 @@ pub async fn now_playing_current() -> Option<NowPlayingSnapshot> {
         .flatten()
 }
 
-/// Send a transport command (`"playpause"`, `"next"`, `"previous"`) to the
-/// active player. Returns whether it was delivered.
+/// Send a transport command (`"playpause"`, `"next"`, `"previous"`) to a player.
+/// `player` is the handle from the snapshot being controlled; when omitted the
+/// active player is re-picked. Returns whether it was delivered.
 #[tauri::command]
-pub async fn now_playing_command(command: String) -> bool {
-    tauri::async_runtime::spawn_blocking(move || run_command(&command))
+pub async fn now_playing_command(command: String, player: Option<String>) -> bool {
+    tauri::async_runtime::spawn_blocking(move || run_command(&command, player.as_deref()))
         .await
         .unwrap_or(false)
 }
@@ -43,6 +47,7 @@ mod imp {
     use super::NowPlayingSnapshot;
     use crate::platform::linux::dbus;
     use std::collections::HashMap;
+    use std::sync::Mutex;
     use zbus::zvariant::{OwnedValue, Str};
 
     const MPRIS_PREFIX: &str = "org.mpris.MediaPlayer2.";
@@ -50,6 +55,10 @@ mod imp {
     const PLAYER_IFACE: &str = "org.mpris.MediaPlayer2.Player";
     const ROOT_IFACE: &str = "org.mpris.MediaPlayer2";
     const PLAYING: &str = "Playing";
+
+    /// The player the tile last locked onto, so a background player that starts
+    /// later can't steal it while the current one is still playing.
+    static LAST_ACTIVE: Mutex<Option<String>> = Mutex::new(None);
 
     pub fn current() -> Option<NowPlayingSnapshot> {
         let conn = dbus::session()?;
@@ -59,7 +68,7 @@ mod imp {
         })
     }
 
-    pub fn run_command(command: &str) -> bool {
+    pub fn run_command(command: &str, target: Option<&str>) -> bool {
         let method = match command {
             "playpause" => "PlayPause",
             "next" => "Next",
@@ -70,8 +79,12 @@ mod imp {
             return false;
         };
         dbus::runtime().block_on(async {
-            let Some((name, _)) = active_player(conn).await else {
-                return false;
+            let name = match target {
+                Some(name) => name.to_string(),
+                None => match active_player(conn).await {
+                    Some((name, _)) => name,
+                    None => return false,
+                },
             };
             let Some(proxy) = player_proxy(conn, &name, PLAYER_IFACE).await else {
                 return false;
@@ -101,9 +114,8 @@ mod imp {
             .ok()
     }
 
-    /// The player to display and drive, with its playback status: the one
-    /// currently playing, else the first that exports a status at all (paused /
-    /// stopped). Returning the status lets the caller skip re-reading it.
+    /// The player to display and drive, with its status. Skips uncontrollable
+    /// instances; remembers the pick so the next poll can favour it.
     async fn active_player(conn: &zbus::Connection) -> Option<(String, String)> {
         let reply = conn
             .call_method(
@@ -117,23 +129,53 @@ mod imp {
             .ok()?;
         let names: Vec<String> = reply.body().deserialize().ok()?;
 
-        let mut fallback = None;
+        let mut candidates: Vec<(String, String)> = Vec::new();
         for name in names.into_iter().filter(|n| n.starts_with(MPRIS_PREFIX)) {
-            match playback_status(conn, &name).await {
-                Some(status) if status == PLAYING => return Some((name, status)),
-                Some(status) if fallback.is_none() => fallback = Some((name, status)),
-                _ => {}
+            if let Some((status, true)) = player_state(conn, &name).await {
+                candidates.push((name, status));
             }
         }
-        fallback
+        if candidates.is_empty() {
+            return None;
+        }
+
+        let mut last = LAST_ACTIVE.lock().ok()?;
+        let name = pick_player(&candidates, last.as_deref());
+        let status = candidates
+            .iter()
+            .find(|(c, _)| *c == name)
+            .map(|(_, s)| s.clone())
+            .unwrap_or_default();
+        *last = Some(name.clone());
+        Some((name, status))
     }
 
-    async fn playback_status(conn: &zbus::Connection, name: &str) -> Option<String> {
-        player_proxy(conn, name, PLAYER_IFACE)
-            .await?
-            .get_property::<String>("PlaybackStatus")
+    /// Locked player if still playing, else any playing, else locked if still
+    /// present (keeps pause/resume put), else the first. `candidates` non-empty.
+    fn pick_player(candidates: &[(String, String)], locked: Option<&str>) -> String {
+        let playing = |name: &str| candidates.iter().any(|(c, s)| c == name && s == PLAYING);
+        if let Some(name) = locked.filter(|n| playing(n)) {
+            return name.to_string();
+        }
+        if let Some((name, _)) = candidates.iter().find(|(_, s)| s == PLAYING) {
+            return name.clone();
+        }
+        if let Some(name) = locked.filter(|n| candidates.iter().any(|(c, _)| c == n)) {
+            return name.to_string();
+        }
+        candidates[0].0.clone()
+    }
+
+    /// A player's `(PlaybackStatus, CanControl)` in one proxy. `CanControl`
+    /// defaults to `true` so a player that omits it isn't hidden.
+    async fn player_state(conn: &zbus::Connection, name: &str) -> Option<(String, bool)> {
+        let proxy = player_proxy(conn, name, PLAYER_IFACE).await?;
+        let status = proxy.get_property::<String>("PlaybackStatus").await.ok()?;
+        let can_control = proxy
+            .get_property::<bool>("CanControl")
             .await
-            .ok()
+            .unwrap_or(true);
+        Some((status, can_control))
     }
 
     async fn read_snapshot(
@@ -166,6 +208,7 @@ mod imp {
             artist,
             app,
             is_playing: status == PLAYING,
+            player: Some(name.to_string()),
         })
     }
 
@@ -247,10 +290,11 @@ mod imp {
             artist,
             app,
             is_playing,
+            player: None, // SMTC drives one implicit session.
         })
     }
 
-    pub fn run_command(command: &str) -> bool {
+    pub fn run_command(command: &str, _target: Option<&str>) -> bool {
         let Some(session) = active_session() else {
             return false;
         };
@@ -284,6 +328,6 @@ fn current() -> Option<NowPlayingSnapshot> {
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "windows")))]
-fn run_command(_command: &str) -> bool {
+fn run_command(_command: &str, _target: Option<&str>) -> bool {
     false
 }

--- a/apps/linows/src/js/components/superactions.js
+++ b/apps/linows/src/js/components/superactions.js
@@ -741,6 +741,8 @@ function setPlaying(playing) {
 
 // Reflect a track (or its absence) and the play/pause state on the transport.
 function renderMedia(np) {
+    // Handle the transport drives, so it hits the shown player, not a re-pick.
+    mediaEls.player = np?.player ?? null;
     setPlaying(!!np?.is_playing);
     if (!np?.title) {
         mediaEls.label.textContent = 'Nothing playing';
@@ -755,21 +757,22 @@ function renderMedia(np) {
 // Send a transport command to the active player. Play/Pause flips optimistically
 // and defers to the poll; next/previous re-read to show the new track promptly.
 async function transport(command) {
+    const player = mediaEls?.player ?? null;
     if (command === 'playpause' && mediaEls) {
-        // Optimistic flip; roll back only if the command errors. Don't re-read
-        // now: MPRIS PlaybackStatus lags the command and would flip back (flicker).
+        // Optimistic flip; roll back unless delivered. No re-read: MPRIS
+        // PlaybackStatus lags the command and would flip back (flicker).
         const wasPlaying = mediaEls.el.classList.contains('is-playing');
         setPlaying(!wasPlaying);
+        let delivered = false;
         try {
-            await nowPlayingCommand(command);
-        } catch (_) {
-            setPlaying(wasPlaying);
-        }
+            delivered = await nowPlayingCommand(command, player);
+        } catch (_) {}
+        if (!delivered) setPlaying(wasPlaying);
         return;
     }
     // next / previous: re-read so the new track shows without waiting for the poll.
     try {
-        await nowPlayingCommand(command);
+        await nowPlayingCommand(command, player);
     } catch (_) {}
     refreshNowPlaying((mediaToken += 1));
 }

--- a/apps/linows/src/js/ipc.js
+++ b/apps/linows/src/js/ipc.js
@@ -195,10 +195,10 @@ export async function nowPlayingCurrent() {
     return invoke('now_playing_current');
 }
 
-// Send a transport command ('playpause' | 'next' | 'previous') to the active
-// MPRIS player. Resolves to whether it was delivered.
-export async function nowPlayingCommand(command) {
-    return invoke('now_playing_command', { command });
+// Send a transport command ('playpause' | 'next' | 'previous') to `player` (the
+// handle from its snapshot). Resolves to whether it was delivered.
+export async function nowPlayingCommand(command, player) {
+    return invoke('now_playing_command', { command, player });
 }
 
 // Convert a local calendar date to its lunar date via the shared look-lunar core


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Playback controls now consistently target the player currently shown in the Now Playing view.
  * Play/pause, next, and previous commands are routed to the selected media player.
  * The interface now restores the correct playback state when a control command is not successfully delivered.
  * Improved handling for systems with multiple available media players, reducing unexpected control of another player.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [x] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)


## Checklist

- [x] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered

