### PR TITLE
feat: show, hide super actions

### DIFF
--- a/apps/linows/src-tauri/src/config.rs
+++ b/apps/linows/src-tauri/src/config.rs
@@ -142,6 +142,10 @@ fn default_config_contents() -> String {
          # disable all network answer features and run fully offline.\n\
          ai_enabled=true\n\
          \n\
+         # Super actions - empty-state launchpad of quick toggles / actions. Set\n\
+         # false to hide the strip and disable its keyboard accelerators.\n\
+         super_actions_enabled=true\n\
+         \n\
          # UI theme (empty = built-in default; pick one in Settings)\n\
          ui_theme=\n",
     );

--- a/apps/linows/src/html/screens/settings.html
+++ b/apps/linows/src/html/screens/settings.html
@@ -60,7 +60,12 @@
                         class="settings-toggle"
                         title="Show quick-actions launchpad on the empty home screen (Alt+letter)"
                     >
-                        <input type="checkbox" id="settings-super-actions" checked />
+                        <input
+                            type="checkbox"
+                            id="settings-super-actions"
+                            aria-label="Super Actions"
+                            checked
+                        />
                         <span class="settings-toggle-track"></span>
                     </label>
                 </div>

--- a/apps/linows/src/html/screens/settings.html
+++ b/apps/linows/src/html/screens/settings.html
@@ -55,6 +55,14 @@
                         <input type="checkbox" id="settings-running-apps" checked />
                         <span class="settings-toggle-track"></span>
                     </label>
+                    <span style="margin-left: 40px">Super Actions</span>
+                    <label
+                        class="settings-toggle"
+                        title="Show quick-actions launchpad on the empty home screen (Alt+letter)"
+                    >
+                        <input type="checkbox" id="settings-super-actions" checked />
+                        <span class="settings-toggle-track"></span>
+                    </label>
                 </div>
 
                 <div class="settings-divider"></div>

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -307,6 +307,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         runningApps.setEnabled(on);
         if (on) runningApps.refresh();
 
+        // Super actions launchpad: default ON. A disabled strip stays hidden on
+        // the empty home screen and its accelerators go inert (see superactions).
+        const superCfg = cfg.entries.find((e) => e.key === 'super_actions_enabled');
+        superactions.setEnabled(!superCfg || superCfg.value !== 'false');
+        syncControlStrip();
+
         // AI / web answers: default ON to match the default_config.txt setting
         // (and macOS, which ships aiEnabled=true). Honour the persisted value if
         // the user has flipped it. Propagated to both the controller (gates the
@@ -764,6 +770,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         runningApps.setEnabled(on);
         if (on) runningApps.refresh();
 
+        superactions.setEnabled(map.super_actions_enabled !== 'false');
+        syncControlStrip();
+
         const aiOn = map.ai_enabled !== 'false';
         aiAnswer.setEnabled(aiOn);
         search.setAiEnabled(aiOn);
@@ -774,6 +783,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         const enabled = e.detail.enabled;
         runningApps.setEnabled(enabled);
         if (enabled) runningApps.refresh();
+    });
+
+    // Live-update when the Settings → Appearance → Super Actions toggle changes.
+    document.addEventListener('look:super-actions-changed', (e) => {
+        superactions.setEnabled(e.detail.enabled);
+        syncControlStrip();
     });
 
     // Live-update when the Settings → Privacy & Logs → Web Answers toggle

--- a/apps/linows/src/js/components/superactions.js
+++ b/apps/linows/src/js/components/superactions.js
@@ -68,6 +68,9 @@ import * as banner from './banner.js';
 let container = null;
 let built = false;
 let visible = false;
+// User setting (Settings -> Appearance -> Super Actions). When off the strip
+// never shows and its accelerators never fire; setVisible collapses to hidden.
+let enabled = true;
 
 // The shared catalog layout. Rendered from, never mutated. Fetched lazily and
 // retried until it lands (see ensureLayout); layoutFetch is the in-flight request.
@@ -222,6 +225,8 @@ function ensureLayout() {
  */
 export function setVisible(show) {
     if (!container) return;
+    // A disabled strip is always hidden, so no summon can reveal it.
+    if (!enabled) show = false;
     if (show === visible) return;
     visible = show;
     container.hidden = !show;
@@ -267,6 +272,19 @@ export function armEntrance() {
 
 export function isVisible() {
     return visible;
+}
+
+// Apply the Super Actions setting. Turning it off hides the strip immediately so
+// its accelerators stop firing; turning it on lets the next syncControlStrip
+// reveal it on the empty home screen.
+export function setEnabled(on) {
+    if (enabled === on) return;
+    enabled = on;
+    if (!on) setVisible(false);
+}
+
+export function isEnabled() {
+    return enabled;
 }
 
 // Build (once) then reveal: read live state, start the timers, play the cascade.

--- a/apps/linows/src/js/screens/settings.js
+++ b/apps/linows/src/js/screens/settings.js
@@ -296,6 +296,18 @@ export function init(exitFn) {
         );
     });
 
+    // Super actions toggle (Appearance tab, next to Running Apps). Dispatches a
+    // custom event so app.js can show/hide the launchpad live.
+    document.getElementById('settings-super-actions').addEventListener('change', (e) => {
+        const enabled = e.target.checked;
+        saveConfig({ super_actions_enabled: enabled ? 'true' : 'false' });
+        document.dispatchEvent(
+            new CustomEvent('look:super-actions-changed', {
+                detail: { enabled },
+            }),
+        );
+    });
+
     // Extra scan dirs
     const extraDirsList = document.getElementById('settings-extra-dirs');
     extraDirsList.dataset.empty = 'No extra scan directories';
@@ -572,6 +584,10 @@ export function init(exitFn) {
                 .checked
                 ? 'right'
                 : 'none';
+            updates.super_actions_enabled = document.getElementById('settings-super-actions')
+                .checked
+                ? 'true'
+                : 'false';
             updates.ai_enabled = document.getElementById('settings-ai-enabled').checked
                 ? 'true'
                 : 'false';
@@ -906,6 +922,8 @@ async function loadConfig() {
             map.lazy_indexing_enabled !== 'false';
         document.getElementById('settings-running-apps').checked =
             (map.running_apps_placement || 'right') !== 'none';
+        document.getElementById('settings-super-actions').checked =
+            map.super_actions_enabled !== 'false';
         document.getElementById('settings-ai-enabled').checked = map.ai_enabled !== 'false';
         document.getElementById('settings-arch-disable-gpu').checked =
             map.arch_disable_gpu === 'true';

--- a/apps/macos/LauncherApp/look-app/Models/ThemeSettings.swift
+++ b/apps/macos/LauncherApp/look-app/Models/ThemeSettings.swift
@@ -182,5 +182,10 @@ struct ThemeSettings: Codable, Equatable {
     /// Which AI backend powers query understanding when `aiEnabled` is on.
     var aiProvider: AIProviderKind = .appleIntelligence
 
+    /// Whether the empty-state super actions launchpad is shown. Off hides the
+    /// strip and makes its ⌘-mnemonics inert. Persisted in `~/.look.config`
+    /// under `super_actions_enabled`.
+    var superActionsEnabled: Bool = true
+
     static let `default` = ThemeSettings()
 }

--- a/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
@@ -245,6 +245,9 @@ final class ThemeStore: ObservableObject {
         ConfigFileLines.upsert(&lines, key: "ai_enabled", value: settings.aiEnabled ? "true" : "false")
         ConfigFileLines.upsert(&lines, key: "ai_provider", value: settings.aiProvider.rawValue)
 
+        // Empty-state super actions launchpad
+        ConfigFileLines.upsert(&lines, key: "super_actions_enabled", value: settings.superActionsEnabled ? "true" : "false")
+
         do {
             try ConfigFileLines.render(lines).write(to: path, atomically: true, encoding: .utf8)
             _ = applyLaunchAtLoginSetting()
@@ -542,6 +545,10 @@ final class ThemeStore: ObservableObject {
             case "ai_provider":
                 if let parsed = AIProviderKind(rawValue: value) {
                     settings.aiProvider = parsed
+                }
+            case "super_actions_enabled":
+                if let parsed = parseBool(value) {
+                    settings.superActionsEnabled = parsed
                 }
             case "ui_background_image":
                 if !value.isEmpty {
@@ -874,6 +881,10 @@ inner_gap=0
 ai_enabled=true
 ai_provider=appleIntelligence
 
+# Super actions: empty-state launchpad of quick toggles / actions.
+# false hides the strip and disables its keyboard accelerators.
+super_actions_enabled=true
+
 # Search aliases (apps + System Settings). Format: alias_<keyword>=Term1|Term2|Term3
 alias_note=Notion|Obsidian|Notes|Apple Notes|Bear|Logseq
 alias_code=Visual Studio Code|VSCode|Cursor|Windsurf|IntelliJ IDEA|PyCharm|WebStorm|Neovim|Xcode|Zed
@@ -913,6 +924,9 @@ alias_brow=Safari|Arc|Google Chrome|Chrome|Firefox|Brave
         }
         if object["aiProvider"] == nil {
             object["aiProvider"] = ThemeSettings.default.aiProvider.rawValue
+        }
+        if object["superActionsEnabled"] == nil {
+            object["superActionsEnabled"] = ThemeSettings.default.superActionsEnabled
         }
 
         guard

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Launchpad.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Launchpad.swift
@@ -6,8 +6,10 @@ import Foundation
 /// interactive state lives in `LaunchpadController`.
 extension LauncherView {
     /// Decodes the shared launchpad layout once and wires the controller's
-    /// banner sink. Idempotent, so it is safe to call from `onAppear`.
+    /// banner sink. Idempotent, so it is safe to call from `onAppear`. Skipped
+    /// entirely while Settings → Appearance → Super Actions is off.
     func configureLaunchpadIfNeeded() {
+        guard themeStore.settings.superActionsEnabled else { return }
         if launchpadTiles.isEmpty {
             launchpadTiles = EngineBridge.shared.launchpadLayout()
             launchpadController.configure(tiles: launchpadTiles)
@@ -22,7 +24,17 @@ extension LauncherView {
     /// not in command mode / settings / help). Gates the Command-mnemonic keys so
     /// they only fire when the strip is actually shown.
     var isLaunchpadActive: Bool {
-        hidesResultsForEmptyQuery && !launchpadTiles.isEmpty
+        themeStore.settings.superActionsEnabled && hidesResultsForEmptyQuery && !launchpadTiles.isEmpty
+    }
+
+    /// Builds and refreshes the launchpad when the Super Actions setting is
+    /// switched on after the view already appeared, so the strip shows without a
+    /// relaunch.
+    func launchpadSettingChanged(enabled: Bool) {
+        guard enabled else { return }
+        configureLaunchpadIfNeeded()
+        Task { await launchpadController.refreshStates() }
+        Task { await launchpadController.refreshWeather() }
     }
 
     /// Routes a Command-mnemonic character to the launchpad. Returns true when a

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -631,8 +631,10 @@ struct LauncherView: View {
         .onAppear {
             refreshSearchResults()
             configureLaunchpadIfNeeded()
-            Task { await launchpadController.refreshStates() }
-            Task { await launchpadController.refreshWeather() }
+            if themeStore.settings.superActionsEnabled {
+                Task { await launchpadController.refreshStates() }
+                Task { await launchpadController.refreshWeather() }
+            }
             startKeyboardNavigationIfNeeded()
             focusActiveInput()
             refreshClipboardMonitoringMode()
@@ -646,6 +648,9 @@ struct LauncherView: View {
             recentURLTask?.cancel()
             keyboardMonitor.stop()
             clipboardStore.setMonitoringMode(.background)
+        }
+        .onChange(of: themeStore.settings.superActionsEnabled) { _, enabled in
+            launchpadSettingChanged(enabled: enabled)
         }
         .onChange(of: query) { _, _ in
             // Editing the query dismisses a pending Empty Trash confirmation,
@@ -906,7 +911,7 @@ struct LauncherView: View {
                 // Empty query while floating: the launchpad control strip sits
                 // below the top bar; a spacer keeps them pinned to the top. When
                 // the catalog fails to decode we fall back to the bare rest state.
-                if !launchpadTiles.isEmpty {
+                if isLaunchpadActive {
                     EmptyStateLaunchpadView(
                         tiles: launchpadTiles,
                         controller: launchpadController,

--- a/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Appearance.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Appearance.swift
@@ -30,6 +30,14 @@ extension ThemeSettingsView {
                     .labelsHidden()
                     .help("Show running apps in the right half of the search bar (⌘1-9 to switch)")
 
+                    Spacer().frame(width: 40)
+
+                    inlinePickerLabel("Super Actions")
+                    Toggle("Show super actions", isOn: $settings.superActionsEnabled)
+                        .toggleStyle(.switch)
+                        .labelsHidden()
+                        .help("Show the quick-actions launchpad on the empty home screen (⌘ + letter)")
+
                     Spacer(minLength: 0)
                 }
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a **Super Actions** toggle under Settings > Appearance (and restored its state on config reload).
  * When disabled, the Super Actions empty-state strip/launchpad stays hidden and related ⌘-shortcut behavior is inert.
  * Updated the launcher to only initialize and refresh Super Actions UI/activities when the setting is enabled.
  * Included tooltip/help text describing the Super Actions shortcut behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [ ] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

<img width="1023" height="267" alt="image" src="https://github.com/user-attachments/assets/4ede991c-2c8b-44c3-8f25-0ec6f9de1099" />

## Checklist

- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered


