### PR TITLE
feat: process fuzzy finding

### DIFF
--- a/apps/linows/src-tauri/Cargo.lock
+++ b/apps/linows/src-tauri/Cargo.lock
@@ -2527,6 +2527,7 @@ dependencies = [
  "look-answers",
  "look-engine",
  "look-lunar",
+ "look-matching",
  "look-qactions",
  "look-storage",
  "look-todo",

--- a/apps/linows/src-tauri/Cargo.toml
+++ b/apps/linows/src-tauri/Cargo.toml
@@ -11,6 +11,7 @@ tauri-plugin-single-instance = "2"
 look-answers = { path = "../../../core/answers" }
 look-engine = { path = "../../../core/engine" }
 look-lunar = { path = "../../../core/lunar" }
+look-matching = { path = "../../../core/matching" }
 look-qactions = { path = "../../../core/qactions" }
 look-storage = { path = "../../../core/storage" }
 look-todo = { path = "../../../core/todo" }

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -673,7 +673,6 @@ fn main() {
             sysinfo::get_system_info,
             sysinfo::system_uptime,
             process::list_processes,
-            process::list_processes_on_port,
             process::kill_process,
             process::search_processes,
             process::search_kill_targets,

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -673,6 +673,9 @@ fn main() {
             process::list_processes,
             process::list_processes_on_port,
             process::kill_process,
+            process::search_processes,
+            process::process_detail,
+            process::process_cpu,
             process::list_running_apps,
             process::activate_running_app,
             // Todo (shared look-todo store, same table macOS uses)

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -568,6 +568,8 @@ fn main() {
             if disable_gpu {
                 gpu::disable_gpu_acceleration(app);
             }
+            #[cfg(target_os = "linux")]
+            gpu::trim_memory_features(app);
 
             AppState::init_app_handle(app);
             app.state::<AppState>().start_bootstrap();
@@ -674,6 +676,7 @@ fn main() {
             process::list_processes_on_port,
             process::kill_process,
             process::search_processes,
+            process::search_kill_targets,
             process::process_detail,
             process::process_cpu,
             process::list_running_apps,

--- a/apps/linows/src-tauri/src/platform/linux/gpu.rs
+++ b/apps/linows/src-tauri/src/platform/linux/gpu.rs
@@ -106,6 +106,41 @@ pub fn disable_gpu_acceleration(app: &tauri::App) {
     }
 }
 
+/// Turn off WebKit subsystems this launcher never uses, so their per-web-process
+/// caches and init cost never land in `WebKitWebProcess` memory. All confirmed
+/// unused: no HTML5 media (audio is rodio in the backend), no WebGL (only a 2D
+/// canvas), no getUserMedia/WebRTC, no plugins, and no back/forward navigation
+/// to justify the page (bf) cache. localStorage and JavaScript stay on.
+///
+/// This trims baseline, not the irreducible engine footprint; WebKitGTK's shared
+/// libraries dominate and can't be unloaded.
+pub fn trim_memory_features(app: &tauri::App) {
+    if let Some(webview) = app.get_webview_window(consts::MAIN_WINDOW) {
+        let _ = webview.with_webview(|wv| {
+            use webkit2gtk::SettingsExt;
+            let inner = wv.inner();
+            if let Some(s) = webkit2gtk::WebViewExt::settings(&inner) {
+                // No page navigation in a single-view launcher.
+                s.set_enable_page_cache(false);
+                // GPU/graphics features unused by the UI (2D canvas is unaffected).
+                s.set_enable_webgl(false);
+                // Full HTML5 media stack: unused, audio goes through rodio.
+                s.set_enable_webaudio(false);
+                s.set_enable_media(false);
+                s.set_enable_mediasource(false);
+                s.set_enable_media_capabilities(false);
+                s.set_enable_encrypted_media(false);
+                s.set_enable_media_stream(false);
+                s.set_enable_webrtc(false);
+                // Legacy / privacy-noise features.
+                s.set_enable_offline_web_application_cache(false);
+                s.set_enable_hyperlink_auditing(false);
+                s.set_enable_dns_prefetching(false);
+            }
+        });
+    }
+}
+
 /// Disable WebKitGTK smooth scrolling on X11.
 ///
 /// Why: GTK3 issue #3287 - on X11 with GDK_SMOOTH_SCROLL_MASK enabled, the

--- a/apps/linows/src-tauri/src/platform/linux/process.rs
+++ b/apps/linows/src-tauri/src/platform/linux/process.rs
@@ -478,107 +478,6 @@ fn is_terminal_or_background(path: &str) -> bool {
     false
 }
 
-pub(crate) fn list_on_port(port: u16) -> Vec<RunningApp> {
-    // Parse /proc/net/tcp and /proc/net/tcp6 to find listening sockets on the given port
-    let mut pids: Vec<u32> = Vec::new();
-    let mut inodes: std::collections::HashSet<u64> = std::collections::HashSet::new();
-
-    for tcp_path in &["/proc/net/tcp", "/proc/net/tcp6"] {
-        if let Ok(content) = fs::read_to_string(tcp_path) {
-            for line in content.lines().skip(1) {
-                let fields: Vec<&str> = line.split_whitespace().collect();
-                if fields.len() < 10 {
-                    continue;
-                }
-                // State 0A = LISTEN
-                if fields[3] != "0A" {
-                    continue;
-                }
-                // local_address is hex IP:PORT
-                if let Some(port_hex) = fields[1].split(':').nth(1)
-                    && let Ok(p) = u16::from_str_radix(port_hex, 16)
-                    && p == port
-                    && let Ok(inode) = fields[9].parse::<u64>()
-                {
-                    inodes.insert(inode);
-                }
-            }
-        }
-    }
-
-    if inodes.is_empty() {
-        return Vec::new();
-    }
-
-    // Find PIDs owning these inodes by scanning /proc/[pid]/fd/
-    let my_uid = read_my_uid();
-    if let Ok(entries) = fs::read_dir("/proc") {
-        for entry in entries.flatten() {
-            let name = entry.file_name();
-            let name_str = name.to_string_lossy();
-            if !name_str.chars().all(|c| c.is_ascii_digit()) {
-                continue;
-            }
-            let pid: u32 = match name_str.parse() {
-                Ok(p) => p,
-                Err(_) => continue,
-            };
-            // Check ownership
-            let status_path = format!("/proc/{pid}/status");
-            if let Ok(status) = fs::read_to_string(&status_path) {
-                let proc_uid = parse_status_field(&status, "Uid:")
-                    .and_then(|v| v.parse::<u32>().ok())
-                    .unwrap_or(0);
-                if proc_uid != my_uid {
-                    continue;
-                }
-            } else {
-                continue;
-            }
-
-            let fd_dir = format!("/proc/{pid}/fd");
-            if let Ok(fds) = fs::read_dir(&fd_dir) {
-                for fd in fds.flatten() {
-                    if let Ok(link) = fs::read_link(fd.path())
-                        && let Some(inode_str) = link
-                            .to_string_lossy()
-                            .strip_prefix("socket:[")
-                            .and_then(|s| s.strip_suffix(']'))
-                        && let Ok(inode) = inode_str.parse::<u64>()
-                        && inodes.contains(&inode)
-                    {
-                        pids.push(pid);
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
-    pids.sort();
-    pids.dedup();
-
-    // Build RunningApp entries
-    pids.iter()
-        .map(|&pid| {
-            let name = fs::read_to_string(format!("/proc/{pid}/comm"))
-                .unwrap_or_default()
-                .trim()
-                .to_string();
-            RunningApp {
-                name: if name.is_empty() {
-                    format!("PID {pid}")
-                } else {
-                    name
-                },
-                pid,
-                desktop_id: None,
-                exec: None,
-            }
-        })
-        .collect()
-}
-
 /// True when a process owned by the current user has /proc Name: == `name`.
 /// Used by launch to detect cold-start cases (Steam) whose URL handling
 /// requires the main process to be running before the URL is issued.
@@ -907,7 +806,7 @@ pub(crate) fn list_all() -> Vec<ProcRow> {
 }
 
 /// Map every listening (state 0A) TCP socket inode to its port, from
-/// `/proc/net/tcp` + `tcp6`. The reverse of `list_on_port`'s port→inode lookup.
+/// `/proc/net/tcp` + `tcp6`. Feeds `ports_for_pid`, tagging each process row.
 fn listening_inode_ports() -> HashMap<u64, u16> {
     let mut map = HashMap::new();
     for tcp_path in ["/proc/net/tcp", "/proc/net/tcp6"] {

--- a/apps/linows/src-tauri/src/platform/linux/process.rs
+++ b/apps/linows/src-tauri/src/platform/linux/process.rs
@@ -1,11 +1,33 @@
 //! Linux process listing (via `/proc`) and kill (via `kill -9`).
 
-use crate::process::RunningApp;
+use crate::process::{ProcDetail, ProcRow, RunningApp};
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
-pub(crate) fn list() -> Vec<RunningApp> {
+/// Kernel tick rate assumed when converting `/proc` jiffies to seconds. Glibc
+/// exposes it via `sysconf(_SC_CLK_TCK)`, but it is 100 on every mainstream
+/// Linux, and reading it needs libc; hardcoding avoids the dependency.
+const CLK_TCK: u64 = 100;
+
+/// CPU sampling window: long enough for a stable delta, short enough to feel
+/// instant when triggered from `ps"` Enter.
+const CPU_SAMPLE_MS: u64 = 200;
+
+/// A running app: a `.desktop` entry matched to one or more live PIDs (all the
+/// processes whose normalized `/proc` name matched the entry's Exec).
+struct AppMatch {
+    display_name: String,
+    desktop_path: String,
+    exec: String,
+    /// Every matched process as (pid, rss_kb); the list picks the biggest.
+    pids: Vec<(u32, u64)>,
+}
+
+/// Match running user processes to `.desktop` entries. Shared by `list()` (which
+/// collapses each app to its heaviest PID) and `app_icon_sources()` (which wants
+/// every PID so all of an app's processes can wear its icon).
+fn match_running_apps() -> Vec<AppMatch> {
     let my_uid = read_my_uid();
 
     // 1. Collect running user processes: name → Vec<(pid, rss_kb)>
@@ -69,7 +91,7 @@ pub(crate) fn list() -> Vec<RunningApp> {
         let primary = bins.iter().any(|b| b.to_lowercase() == stem);
         (if primary { 0 } else { 1 }, stem)
     });
-    let mut apps: Vec<RunningApp> = Vec::new();
+    let mut matches: Vec<AppMatch> = Vec::new();
     let mut matched_keys: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     for de in &desktop_entries {
@@ -122,21 +144,50 @@ pub(crate) fn list() -> Vec<RunningApp> {
             });
             if let Some(pids) = pids {
                 matched_keys.insert(key);
-                let &(pid, _) = pids.iter().max_by_key(|(_, rss)| *rss).unwrap();
-                apps.push(RunningApp {
-                    name: de.name.clone(),
-                    pid,
-                    desktop_id: Some(format!("app:{}", de.path)),
-                    exec: Some(de.exec.clone()),
+                matches.push(AppMatch {
+                    display_name: de.name.clone(),
+                    desktop_path: de.path.clone(),
+                    exec: de.exec.clone(),
+                    pids: pids.clone(),
                 });
                 break;
             }
         }
     }
 
+    matches
+}
+
+pub(crate) fn list() -> Vec<RunningApp> {
+    let mut apps: Vec<RunningApp> = match_running_apps()
+        .into_iter()
+        .map(|m| {
+            let &(pid, _) = m.pids.iter().max_by_key(|(_, rss)| *rss).unwrap();
+            RunningApp {
+                name: m.display_name,
+                pid,
+                desktop_id: Some(format!("app:{}", m.desktop_path)),
+                exec: Some(m.exec),
+            }
+        })
+        .collect();
+
     // Sort alphabetically by name
     apps.sort_by_key(|a| a.name.to_lowercase());
     apps
+}
+
+/// PID → `.desktop` file path for every process that belongs to a matched app,
+/// so `ps"` can dress app processes in their real icon. All PIDs of an app map
+/// to its icon, not just the heaviest one `list()` keeps.
+fn app_icon_sources() -> HashMap<u32, String> {
+    let mut map = HashMap::new();
+    for m in match_running_apps() {
+        for (pid, _) in m.pids {
+            map.entry(pid).or_insert_with(|| m.desktop_path.clone());
+        }
+    }
+    map
 }
 
 /// Like `list()`, but filtered to only GUI apps with visible windows.
@@ -803,6 +854,209 @@ fn parse_status_field(status: &str, prefix: &str) -> Option<String> {
         .map(|s| s.to_string())
 }
 
+// --- ps" process finder ---
+
+/// Every process owned by the current user, by `/proc` `comm` name and PID.
+/// Unlike `list()`, this does no `.desktop` matching: background daemons,
+/// `node`, `python`, etc. all surface. One `status` read per PID.
+pub(crate) fn list_all() -> Vec<ProcRow> {
+    let my_uid = read_my_uid();
+    let icons = app_icon_sources();
+    // inode → listening port, built once; empty when nothing is listening, in
+    // which case the per-pid fd scan below is skipped entirely.
+    let inode_ports = listening_inode_ports();
+    let mut rows = Vec::new();
+    let Ok(entries) = fs::read_dir("/proc") else {
+        return rows;
+    };
+    for entry in entries.flatten() {
+        let fname = entry.file_name();
+        let fname_str = fname.to_string_lossy();
+        if !fname_str.chars().all(|c| c.is_ascii_digit()) {
+            continue;
+        }
+        let Ok(pid) = fname_str.parse::<u32>() else {
+            continue;
+        };
+        let Ok(status) = fs::read_to_string(format!("/proc/{pid}/status")) else {
+            continue;
+        };
+        let uid = parse_status_field(&status, "Uid:")
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(0);
+        if uid != my_uid {
+            continue;
+        }
+        let name = parse_status_field(&status, "Name:").unwrap_or_default();
+        if name.is_empty() {
+            continue;
+        }
+        let ports = if inode_ports.is_empty() {
+            Vec::new()
+        } else {
+            ports_for_pid(pid, &inode_ports)
+        };
+        rows.push(ProcRow {
+            name,
+            pid,
+            icon_source: icons.get(&pid).cloned(),
+            ports,
+        });
+    }
+    rows
+}
+
+/// Map every listening (state 0A) TCP socket inode to its port, from
+/// `/proc/net/tcp` + `tcp6`. The reverse of `list_on_port`'s port→inode lookup.
+fn listening_inode_ports() -> HashMap<u64, u16> {
+    let mut map = HashMap::new();
+    for tcp_path in ["/proc/net/tcp", "/proc/net/tcp6"] {
+        let Ok(content) = fs::read_to_string(tcp_path) else {
+            continue;
+        };
+        for line in content.lines().skip(1) {
+            let fields: Vec<&str> = line.split_whitespace().collect();
+            if fields.len() < 10 || fields[3] != "0A" {
+                continue;
+            }
+            if let Some(port_hex) = fields[1].split(':').nth(1)
+                && let Ok(port) = u16::from_str_radix(port_hex, 16)
+                && let Ok(inode) = fields[9].parse::<u64>()
+            {
+                map.insert(inode, port);
+            }
+        }
+    }
+    map
+}
+
+/// Listening ports for one PID: read its socket fds and look each inode up in
+/// the precomputed inode→port map. Sorted, deduped.
+fn ports_for_pid(pid: u32, inode_ports: &HashMap<u64, u16>) -> Vec<u16> {
+    let mut ports: Vec<u16> = Vec::new();
+    let Ok(fds) = fs::read_dir(format!("/proc/{pid}/fd")) else {
+        return ports;
+    };
+    for fd in fds.flatten() {
+        if let Ok(link) = fs::read_link(fd.path())
+            && let Some(inode_str) = link
+                .to_string_lossy()
+                .strip_prefix("socket:[")
+                .and_then(|s| s.strip_suffix(']'))
+            && let Ok(inode) = inode_str.parse::<u64>()
+            && let Some(&port) = inode_ports.get(&inode)
+            && !ports.contains(&port)
+        {
+            ports.push(port);
+        }
+    }
+    ports.sort_unstable();
+    ports
+}
+
+pub(crate) fn detail(pid: u32) -> Option<ProcDetail> {
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).ok()?;
+    let rss_kb = parse_status_field(&status, "VmRSS:")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    let ppid = parse_status_field(&status, "PPid:")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    let uid = parse_status_field(&status, "Uid:")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    let user = username_for_uid(uid).unwrap_or_else(|| uid.to_string());
+
+    // cmdline is NUL-separated argv; fall back to the bracketed comm name for
+    // kernel threads and zombies, which expose an empty cmdline.
+    let cmdline = fs::read(format!("/proc/{pid}/cmdline"))
+        .ok()
+        .map(|bytes| bytes_to_cmdline(&bytes))
+        .filter(|s| !s.is_empty())
+        .or_else(|| parse_status_field(&status, "Name:").map(|n| format!("[{n}]")))
+        .unwrap_or_default();
+
+    Some(ProcDetail {
+        cmdline,
+        rss_kb,
+        user,
+        ppid,
+        start_epoch: start_epoch(pid),
+    })
+}
+
+pub(crate) fn cpu(pid: u32) -> Option<f64> {
+    let before = proc_jiffies(pid)?;
+    let start = std::time::Instant::now();
+    std::thread::sleep(std::time::Duration::from_millis(CPU_SAMPLE_MS));
+    let after = proc_jiffies(pid)?;
+    let elapsed = start.elapsed().as_secs_f64();
+    if elapsed <= 0.0 {
+        return Some(0.0);
+    }
+    let delta = after.saturating_sub(before) as f64;
+    Some(100.0 * (delta / CLK_TCK as f64) / elapsed)
+}
+
+/// utime + stime (fields 14, 15) from `/proc/<pid>/stat`, in clock ticks. The
+/// comm field (2) is parenthesized and may contain spaces or `)`, so parsing
+/// resumes after the last `)`.
+fn proc_jiffies(pid: u32) -> Option<u64> {
+    let stat = fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let rest = &stat[stat.rfind(')')? + 1..];
+    let fields: Vec<&str> = rest.split_whitespace().collect();
+    // After ')' the next field is state (index 0), so utime is index 11, stime 12.
+    let utime: u64 = fields.get(11)?.parse().ok()?;
+    let stime: u64 = fields.get(12)?.parse().ok()?;
+    Some(utime + stime)
+}
+
+/// Wall-clock start time: system boot epoch (`btime` in `/proc/stat`) plus the
+/// process starttime (stat field 22) converted from ticks.
+fn start_epoch(pid: u32) -> Option<u64> {
+    let stat = fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let rest = &stat[stat.rfind(')')? + 1..];
+    let fields: Vec<&str> = rest.split_whitespace().collect();
+    let starttime: u64 = fields.get(19)?.parse().ok()?;
+    let btime = boot_epoch()?;
+    Some(btime + starttime / CLK_TCK)
+}
+
+fn boot_epoch() -> Option<u64> {
+    let stat = fs::read_to_string("/proc/stat").ok()?;
+    stat.lines()
+        .find_map(|l| l.strip_prefix("btime "))
+        .and_then(|v| v.trim().parse().ok())
+}
+
+fn bytes_to_cmdline(bytes: &[u8]) -> String {
+    let text = String::from_utf8_lossy(bytes);
+    text.split('\0')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+        .trim()
+        .to_string()
+}
+
+/// Resolve a UID to a username via `/etc/passwd`. Enough for a launcher; misses
+/// LDAP/NSS-only users, in which case the caller shows the numeric UID.
+fn username_for_uid(uid: u32) -> Option<String> {
+    let passwd = fs::read_to_string("/etc/passwd").ok()?;
+    for line in passwd.lines() {
+        // name:passwd:uid:...
+        let mut cols = line.split(':');
+        let (Some(name), Some(_pw), Some(entry_uid)) = (cols.next(), cols.next(), cols.next())
+        else {
+            continue;
+        };
+        if entry_uid.parse::<u32>() == Ok(uid) {
+            return Some(name.to_string());
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -962,5 +1216,34 @@ mod tests {
         );
         // Single-segment stems (e.g., `firefox.desktop`) yield None.
         assert_eq!(kebab_from_desktop_stem("/x/firefox.desktop"), None);
+    }
+
+    #[test]
+    fn cmdline_nul_separated_argv_joins_with_spaces() {
+        assert_eq!(
+            bytes_to_cmdline(b"node\0server.js\0--port\x003000\0"),
+            "node server.js --port 3000"
+        );
+        // Trailing/duplicate NULs don't leave empty args or edge whitespace.
+        assert_eq!(bytes_to_cmdline(b"vim\0\0"), "vim");
+        assert_eq!(bytes_to_cmdline(b""), "");
+    }
+
+    #[test]
+    fn self_process_surfaces_in_list_and_detail() {
+        let me = std::process::id();
+        assert!(
+            list_all().iter().any(|r| r.pid == me),
+            "own process must appear in the raw list"
+        );
+        let d = detail(me).expect("detail for self");
+        assert!(!d.cmdline.is_empty(), "self cmdline should not be empty");
+        assert!(d.start_epoch.is_some(), "self start time should resolve");
+    }
+
+    #[test]
+    fn self_cpu_samples_non_negative() {
+        let pct = cpu(std::process::id()).expect("cpu for self");
+        assert!(pct >= 0.0, "cpu percent must be non-negative, got {pct}");
     }
 }

--- a/apps/linows/src-tauri/src/platform/windows/process.rs
+++ b/apps/linows/src-tauri/src/platform/windows/process.rs
@@ -6,7 +6,7 @@
 //! is bypassed for any process that owns a visible window, so UWP apps like
 //! Windows Terminal still show up.
 
-use crate::process::RunningApp;
+use crate::process::{ProcRow, RunningApp};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::Mutex;
@@ -179,6 +179,23 @@ pub(crate) fn kill(pid: u32) -> Result<String, String> {
         terminate.map_err(|e| format!("TerminateProcess({pid}) failed: {e}"))?;
     }
     Ok(format!("Killed PID {pid}"))
+}
+
+/// Raw process list for the `ps"` finder. Every process (minus the idle/system
+/// PIDs and ourselves), by Toolhelp basename. `detail`/`cpu` are Linux-only for
+/// now, so the preview degrades to name + PID here.
+pub(crate) fn list_all() -> Vec<ProcRow> {
+    let current_pid = unsafe { GetCurrentProcessId() };
+    enumerate_processes()
+        .into_iter()
+        .filter(|(pid, _)| *pid != 0 && *pid != 4 && *pid != current_pid)
+        .map(|(pid, name)| ProcRow {
+            name,
+            pid,
+            icon_source: None,
+            ports: Vec::new(),
+        })
+        .collect()
 }
 
 // --- process enumeration ---

--- a/apps/linows/src-tauri/src/platform/windows/process.rs
+++ b/apps/linows/src-tauri/src/platform/windows/process.rs
@@ -1,7 +1,7 @@
 //! Windows process listing / kill. Mirrors the WinUI3 reference at
 //! apps/windows/LauncherApp/Commands/KillCommand.cs - EnumWindows tags every
 //! visible top-level window with its owning PID, Toolhelp32 walks the full
-//! process list, GetExtendedTcpTable does per-port lookups. Filtering
+//! process list, GetExtendedTcpTable maps PIDs to listening ports. Filtering
 //! (system-noise names, \WindowsApps\, \SystemApps\, \ImmersiveControlPanel\)
 //! is bypassed for any process that owns a visible window, so UWP apps like
 //! Windows Terminal still show up.
@@ -86,34 +86,6 @@ pub(crate) fn list() -> Vec<RunningApp> {
     apps
 }
 
-pub(crate) fn list_on_port(port: u16) -> Vec<RunningApp> {
-    let mut pids = collect_listening_pids(port);
-    let current_pid = unsafe { GetCurrentProcessId() };
-    pids.retain(|&pid| pid > 4 && pid != current_pid);
-    pids.sort();
-    pids.dedup();
-
-    let visible = enumerate_visible_windows();
-    let mut out = Vec::with_capacity(pids.len());
-    for pid in pids {
-        let exe_path = resolve_full_path(pid).unwrap_or_default();
-        let basename = Path::new(&exe_path)
-            .file_name()
-            .and_then(|s| s.to_str())
-            .unwrap_or("")
-            .to_string();
-        let title = visible.get(&pid).cloned().unwrap_or_default();
-        let display = resolve_display_name(&basename, &exe_path, &title);
-        out.push(RunningApp {
-            name: display,
-            pid,
-            desktop_id: (!exe_path.is_empty()).then(|| format!("app:{exe_path}")),
-            exec: (!exe_path.is_empty()).then(|| exe_path.clone()),
-        });
-    }
-    out
-}
-
 /// Switcher view: one entry per switchable top-level window. Unlike `list()`
 /// (the kill view), this surfaces UWP apps - Settings, Calculator, Photos, … -
 /// whose visible windows are owned by `ApplicationFrameHost.exe` while their
@@ -181,11 +153,13 @@ pub(crate) fn kill(pid: u32) -> Result<String, String> {
     Ok(format!("Killed PID {pid}"))
 }
 
-/// Raw process list for the `ps"` finder. Every process (minus the idle/system
-/// PIDs and ourselves), by Toolhelp basename. `detail`/`cpu` are Linux-only for
-/// now, so the preview degrades to name + PID here.
+/// Raw process list for the `ps"` and `kill` finders. Every process (minus the
+/// idle/system PIDs and ourselves), by Toolhelp basename, tagged with its
+/// listening TCP ports so a numeric query matches by port or PID. `detail`/`cpu`
+/// are Linux-only for now, so the preview degrades to name + PID here.
 pub(crate) fn list_all() -> Vec<ProcRow> {
     let current_pid = unsafe { GetCurrentProcessId() };
+    let mut ports_by_pid = listening_ports_by_pid();
     enumerate_processes()
         .into_iter()
         .filter(|(pid, _)| *pid != 0 && *pid != 4 && *pid != current_pid)
@@ -193,7 +167,7 @@ pub(crate) fn list_all() -> Vec<ProcRow> {
             name,
             pid,
             icon_source: None,
-            ports: Vec::new(),
+            ports: ports_by_pid.remove(&pid).unwrap_or_default(),
         })
         .collect()
 }
@@ -501,14 +475,21 @@ fn is_good_display_segment(value: &str) -> bool {
 
 // --- per-port listing ---
 
-fn collect_listening_pids(port: u16) -> Vec<u32> {
-    let mut pids = Vec::new();
-    collect_listening_pids_for(port, AF_INET, &mut pids);
-    collect_listening_pids_for(port, AF_INET6, &mut pids);
-    pids
+/// Map every PID to its listening TCP ports, built in one pass over the IPv4 and
+/// IPv6 tables. Ports are sorted and deduped so a process is tagged consistently
+/// regardless of the socket-table order.
+fn listening_ports_by_pid() -> HashMap<u32, Vec<u16>> {
+    let mut map: HashMap<u32, Vec<u16>> = HashMap::new();
+    collect_listening_into(AF_INET, &mut map);
+    collect_listening_into(AF_INET6, &mut map);
+    for ports in map.values_mut() {
+        ports.sort_unstable();
+        ports.dedup();
+    }
+    map
 }
 
-fn collect_listening_pids_for(port: u16, af: u32, pids: &mut Vec<u32>) {
+fn collect_listening_into(af: u32, map: &mut HashMap<u32, Vec<u16>>) {
     let mut size: u32 = 0;
     unsafe {
         GetExtendedTcpTable(None, &mut size, false, af, TCP_TABLE_OWNER_PID_LISTENER, 0);
@@ -534,8 +515,13 @@ fn collect_listening_pids_for(port: u16, af: u32, pids: &mut Vec<u32>) {
     // Layout: u32 dwNumEntries followed by MIB_TCP{,6}ROW_OWNER_PID[N].
     // The trailing row struct has u32 alignment, so the table starts at offset 4.
     let num_entries = u32::from_ne_bytes([buf[0], buf[1], buf[2], buf[3]]) as usize;
-    let target = port as u32;
     let listen = MIB_TCP_STATE_LISTEN.0 as u32;
+
+    let mut push = |pid: u32, port: u32| {
+        if let Ok(p) = u16::try_from(port) {
+            map.entry(pid).or_default().push(p);
+        }
+    };
 
     if af == AF_INET {
         let row_size = std::mem::size_of::<MIB_TCPROW_OWNER_PID>();
@@ -546,8 +532,8 @@ fn collect_listening_pids_for(port: u16, af: u32, pids: &mut Vec<u32>) {
             }
             let row: &MIB_TCPROW_OWNER_PID =
                 unsafe { &*(buf.as_ptr().add(off) as *const MIB_TCPROW_OWNER_PID) };
-            if row.dwState == listen && parse_port(row.dwLocalPort) == target {
-                pids.push(row.dwOwningPid);
+            if row.dwState == listen {
+                push(row.dwOwningPid, parse_port(row.dwLocalPort));
             }
         }
     } else {
@@ -559,8 +545,8 @@ fn collect_listening_pids_for(port: u16, af: u32, pids: &mut Vec<u32>) {
             }
             let row: &MIB_TCP6ROW_OWNER_PID =
                 unsafe { &*(buf.as_ptr().add(off) as *const MIB_TCP6ROW_OWNER_PID) };
-            if row.dwState == listen && parse_port(row.dwLocalPort) == target {
-                pids.push(row.dwOwningPid);
+            if row.dwState == listen {
+                push(row.dwOwningPid, parse_port(row.dwLocalPort));
             }
         }
     }

--- a/apps/linows/src-tauri/src/process.rs
+++ b/apps/linows/src-tauri/src/process.rs
@@ -3,6 +3,7 @@
 //! `platform::windows::process`.
 
 use serde::Serialize;
+use std::sync::{Mutex, OnceLock};
 
 #[derive(Serialize, Clone)]
 pub struct RunningApp {
@@ -10,6 +11,171 @@ pub struct RunningApp {
     pub pid: u32,
     pub desktop_id: Option<String>,
     pub exec: Option<String>,
+}
+
+/// One row in the `ps"` finder: a raw process, not desktop-matched like
+/// `RunningApp`. Kept minimal so enumeration stays cheap; richer fields are
+/// fetched per-selection via `process_detail`.
+#[derive(Serialize, Clone)]
+pub struct ProcRow {
+    pub name: String,
+    pub pid: u32,
+    /// `.desktop` path when this process belongs to a known app, so the finder
+    /// can show the app icon; `None` falls back to the generic process glyph.
+    pub icon_source: Option<String>,
+    /// Listening TCP ports owned by this process, sorted. Shown in the row and
+    /// matched against a numeric query so `ps"` doubles as a find-by-port.
+    pub ports: Vec<u16>,
+}
+
+/// Per-process detail for the `ps"` preview pane. All fields are cheap single
+/// `/proc` reads; `start_epoch` is Unix seconds (formatted on the frontend).
+#[derive(Serialize, Clone)]
+pub struct ProcDetail {
+    pub cmdline: String,
+    pub rss_kb: u64,
+    pub user: String,
+    pub ppid: u32,
+    pub start_epoch: Option<u64>,
+}
+
+/// Cap on rows returned to the finder: enough to scroll, few enough to render
+/// instantly. The raw snapshot behind it can hold every user process.
+const PROC_RESULT_LIMIT: usize = 50;
+
+/// Snapshot of every user process, enumerated once per `ps"` session (or after
+/// a kill) and re-scored per keystroke. Avoids walking `/proc` on every stroke.
+fn snapshot() -> &'static Mutex<Vec<ProcRow>> {
+    static SNAPSHOT: OnceLock<Mutex<Vec<ProcRow>>> = OnceLock::new();
+    SNAPSHOT.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+fn list_all_raw() -> Vec<ProcRow> {
+    #[cfg(target_os = "linux")]
+    {
+        crate::platform::linux::process::list_all()
+    }
+    #[cfg(target_os = "windows")]
+    {
+        crate::platform::windows::process::list_all()
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    {
+        Vec::new()
+    }
+}
+
+/// Scores for numeric-query matches, ranked above fuzzy name matches so an
+/// intentional port/PID lookup wins. Exact port beats a partial digit match.
+const PORT_EXACT_SCORE: i64 = i64::MAX / 2;
+const NUMERIC_PARTIAL_SCORE: i64 = i64::MAX / 4;
+/// PID-only matches rank below every name match (fuzzy scores are small).
+const PID_PARTIAL_SCORE: i64 = i64::MIN / 2;
+
+/// Fuzzy-find running processes for the `ps"` prefix. `refresh` re-enumerates
+/// `/proc` (mode entry or post-kill); otherwise the cached snapshot is scored.
+/// Matches on process name via `look-matching`; a numeric query also matches a
+/// listening port (find-by-port) or the PID. Async + `spawn_blocking` because a
+/// refresh scans socket fds and shouldn't touch the main thread.
+#[tauri::command]
+pub async fn search_processes(query: String, refresh: bool) -> Vec<ProcRow> {
+    tauri::async_runtime::spawn_blocking(move || search_processes_blocking(&query, refresh))
+        .await
+        .unwrap_or_default()
+}
+
+fn search_processes_blocking(query: &str, refresh: bool) -> Vec<ProcRow> {
+    let mut snap = snapshot().lock().unwrap();
+    if refresh || snap.is_empty() {
+        *snap = list_all_raw();
+    }
+
+    let trimmed = query.trim();
+    if trimmed.is_empty() {
+        let mut rows = snap.clone();
+        rows.sort_by_key(|r| r.name.to_lowercase());
+        rows.truncate(PROC_RESULT_LIMIT);
+        return rows;
+    }
+
+    let prepared = look_matching::prepare_query(trimmed);
+    let is_numeric = trimmed.chars().all(|c| c.is_ascii_digit());
+    let exact_port = trimmed.parse::<u16>().ok();
+
+    let mut scored: Vec<(i64, &ProcRow)> = snap
+        .iter()
+        .filter_map(|row| {
+            score_row(row, trimmed, &prepared, is_numeric, exact_port).map(|s| (s, row))
+        })
+        .collect();
+    scored.sort_by(|a, b| {
+        b.0.cmp(&a.0)
+            .then_with(|| a.1.name.to_lowercase().cmp(&b.1.name.to_lowercase()))
+    });
+    scored.truncate(PROC_RESULT_LIMIT);
+    scored.into_iter().map(|(_, row)| row.clone()).collect()
+}
+
+fn score_row(
+    row: &ProcRow,
+    trimmed: &str,
+    prepared: &look_matching::PreparedQuery<'_>,
+    is_numeric: bool,
+    exact_port: Option<u16>,
+) -> Option<i64> {
+    if is_numeric {
+        if exact_port.is_some_and(|p| row.ports.contains(&p)) {
+            return Some(PORT_EXACT_SCORE);
+        }
+        if row.ports.iter().any(|p| p.to_string().contains(trimmed)) {
+            return Some(NUMERIC_PARTIAL_SCORE);
+        }
+        if row.pid.to_string().contains(trimmed) {
+            return Some(PID_PARTIAL_SCORE);
+        }
+    }
+    // Name fuzzy still runs for numeric queries: a name can contain digits.
+    look_matching::fuzzy_score_prepared(prepared, &row.name)
+}
+
+#[tauri::command]
+pub fn process_detail(pid: u32) -> Option<ProcDetail> {
+    #[cfg(target_os = "linux")]
+    {
+        crate::platform::linux::process::detail(pid)
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let _ = pid;
+        None
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    {
+        let _ = pid;
+        None
+    }
+}
+
+/// Sample CPU usage for one process over a short interval. On-demand (bound to
+/// Enter in `ps"`), never per-selection, so the sampling cost is only paid when
+/// asked. Percentage is relative to a single core (may exceed 100, like `top`).
+/// Async + `spawn_blocking` so the sampling sleep never stalls the main thread.
+#[tauri::command]
+pub async fn process_cpu(pid: u32) -> Option<f64> {
+    tauri::async_runtime::spawn_blocking(move || {
+        #[cfg(target_os = "linux")]
+        {
+            crate::platform::linux::process::cpu(pid)
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = pid;
+            None
+        }
+    })
+    .await
+    .ok()
+    .flatten()
 }
 
 #[tauri::command]
@@ -160,5 +326,61 @@ pub fn kill_process(pid: u32) -> Result<String, String> {
     {
         let _ = pid;
         Err("kill not supported on this platform".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(name: &str, pid: u32, ports: &[u16]) -> ProcRow {
+        ProcRow {
+            name: name.to_string(),
+            pid,
+            icon_source: None,
+            ports: ports.to_vec(),
+        }
+    }
+
+    fn score(row: &ProcRow, query: &str) -> Option<i64> {
+        let trimmed = query.trim();
+        let prepared = look_matching::prepare_query(trimmed);
+        let is_numeric = trimmed.chars().all(|c| c.is_ascii_digit());
+        let exact_port = trimmed.parse::<u16>().ok();
+        score_row(row, trimmed, &prepared, is_numeric, exact_port)
+    }
+
+    #[test]
+    fn exact_port_beats_partial_and_name() {
+        let server = row("node", 4321, &[3000]);
+        let other = row("node", 30001, &[]); // "3000" is a PID substring only
+        let named = row("proc3000", 99, &[]); // name contains the digits
+        let s_exact = score(&server, "3000").unwrap();
+        assert_eq!(s_exact, PORT_EXACT_SCORE);
+        assert!(s_exact > score(&other, "3000").unwrap());
+        assert!(s_exact > score(&named, "3000").unwrap());
+    }
+
+    #[test]
+    fn partial_port_ranks_above_pid_only() {
+        let by_port = row("a", 1, &[3000]); // "300" is a substring of the port
+        let by_pid = row("b", 3009, &[]); // "300" is a substring of the PID
+        assert_eq!(score(&by_port, "300"), Some(NUMERIC_PARTIAL_SCORE));
+        assert_eq!(score(&by_pid, "300"), Some(PID_PARTIAL_SCORE));
+        assert!(score(&by_port, "300").unwrap() > score(&by_pid, "300").unwrap());
+    }
+
+    #[test]
+    fn name_query_still_fuzzy_matches() {
+        let ff = row("firefox", 100, &[]);
+        assert!(score(&ff, "fire").is_some());
+        assert!(score(&ff, "zzq").is_none());
+    }
+
+    #[test]
+    fn oversized_port_number_wont_panic_and_matches_nothing() {
+        // 99999 > u16::MAX: no exact port, no substring, no PID -> None.
+        let r = row("svc", 42, &[8080]);
+        assert_eq!(score(&r, "99999"), None);
     }
 }

--- a/apps/linows/src-tauri/src/process.rs
+++ b/apps/linows/src-tauri/src/process.rs
@@ -119,6 +119,34 @@ fn search_processes_blocking(query: &str, refresh: bool) -> Vec<ProcRow> {
     scored.into_iter().map(|(_, row)| row.clone()).collect()
 }
 
+/// Shared scoring for both process finders (`ps"` and `kill`). A numeric query
+/// matches a listening port (exact beats partial) or the PID; every query also
+/// fuzzy-matches the name. `None` when nothing matches. Pass an empty `ports`
+/// slice for sources that don't carry ports (e.g. desktop-app rows).
+fn score_process(
+    name: &str,
+    ports: &[u16],
+    pid: u32,
+    trimmed: &str,
+    prepared: &look_matching::PreparedQuery<'_>,
+    is_numeric: bool,
+    exact_port: Option<u16>,
+) -> Option<i64> {
+    if is_numeric {
+        if exact_port.is_some_and(|p| ports.contains(&p)) {
+            return Some(PORT_EXACT_SCORE);
+        }
+        if ports.iter().any(|p| p.to_string().contains(trimmed)) {
+            return Some(NUMERIC_PARTIAL_SCORE);
+        }
+        if pid.to_string().contains(trimmed) {
+            return Some(PID_PARTIAL_SCORE);
+        }
+    }
+    // Name fuzzy still runs for numeric queries: a name can contain digits.
+    look_matching::fuzzy_score_prepared(prepared, &name.to_lowercase())
+}
+
 fn score_row(
     row: &ProcRow,
     trimmed: &str,
@@ -126,19 +154,9 @@ fn score_row(
     is_numeric: bool,
     exact_port: Option<u16>,
 ) -> Option<i64> {
-    if is_numeric {
-        if exact_port.is_some_and(|p| row.ports.contains(&p)) {
-            return Some(PORT_EXACT_SCORE);
-        }
-        if row.ports.iter().any(|p| p.to_string().contains(trimmed)) {
-            return Some(NUMERIC_PARTIAL_SCORE);
-        }
-        if row.pid.to_string().contains(trimmed) {
-            return Some(PID_PARTIAL_SCORE);
-        }
-    }
-    // Name fuzzy still runs for numeric queries: a name can contain digits.
-    look_matching::fuzzy_score_prepared(prepared, &row.name.to_lowercase())
+    score_process(
+        &row.name, &row.ports, row.pid, trimmed, prepared, is_numeric, exact_port,
+    )
 }
 
 /// A row in the `kill` command: either a desktop app (nice name + icon) or a
@@ -181,7 +199,11 @@ fn rank_kill_targets(apps: Vec<RunningApp>, procs: Vec<ProcRow>, query: &str) ->
     // Capitalized ("Firefox") while queries are typed lowercase.
     let lowered = query.to_lowercase();
     let prepared = look_matching::prepare_query(&lowered);
+    let is_numeric = query.chars().all(|c| c.is_ascii_digit());
+    let exact_port = query.parse::<u16>().ok();
 
+    // Apps carry no ports, so they match by name only; a numeric port/PID query
+    // resolves through the process rows below (which own the port data).
     let mut app_pids = std::collections::HashSet::new();
     let mut app_hits: Vec<(i64, KillTarget)> = apps
         .into_iter()
@@ -199,8 +221,10 @@ fn rank_kill_targets(apps: Vec<RunningApp>, procs: Vec<ProcRow>, query: &str) ->
         .into_iter()
         .filter(|r| !app_pids.contains(&r.pid))
         .filter_map(|r| {
-            look_matching::fuzzy_score_prepared(&prepared, &r.name.to_lowercase())
-                .map(|s| (s, proc_target(r)))
+            score_process(
+                &r.name, &r.ports, r.pid, query, &prepared, is_numeric, exact_port,
+            )
+            .map(|s| (s, proc_target(r)))
         })
         .collect();
     proc_hits.sort_by(kill_hit_order);
@@ -286,25 +310,6 @@ pub fn list_processes() -> Vec<RunningApp> {
 
     #[cfg(not(any(target_os = "linux", target_os = "windows")))]
     {
-        Vec::new()
-    }
-}
-
-#[tauri::command]
-pub fn list_processes_on_port(port: u16) -> Vec<RunningApp> {
-    #[cfg(target_os = "linux")]
-    {
-        crate::platform::linux::process::list_on_port(port)
-    }
-
-    #[cfg(target_os = "windows")]
-    {
-        crate::platform::windows::process::list_on_port(port)
-    }
-
-    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
-    {
-        let _ = port;
         Vec::new()
     }
 }
@@ -505,5 +510,19 @@ mod tests {
     fn kill_targets_non_match_excluded() {
         let out = rank_kill_targets(vec![app("Firefox", 1)], vec![row("bash", 2, &[])], "zzq");
         assert!(out.is_empty());
+    }
+
+    #[test]
+    fn kill_targets_match_by_port_and_pid() {
+        let apps = vec![app("Firefox", 1)];
+        let procs = vec![row("node", 4321, &[3000]), row("bash", 900, &[])];
+        // A bare port number finds its owner via the process rows (no `:` prefix).
+        let by_port = rank_kill_targets(apps.clone(), procs.clone(), "3000");
+        assert_eq!(by_port.len(), 1);
+        assert_eq!(by_port[0].pid, 4321);
+        // A bare PID finds the process directly.
+        let by_pid = rank_kill_targets(apps, procs, "900");
+        assert_eq!(by_pid.len(), 1);
+        assert_eq!(by_pid[0].pid, 900);
     }
 }

--- a/apps/linows/src-tauri/src/process.rs
+++ b/apps/linows/src-tauri/src/process.rs
@@ -181,7 +181,11 @@ pub async fn search_kill_targets(query: String) -> Vec<KillTarget> {
     tauri::async_runtime::spawn_blocking(move || {
         let trimmed = query.trim();
         if trimmed.is_empty() {
-            return list_processes().into_iter().map(app_target).collect();
+            return list_processes()
+                .into_iter()
+                .take(KILL_RESULT_LIMIT)
+                .map(app_target)
+                .collect();
         }
         rank_kill_targets(list_processes(), list_all_raw(), trimmed)
     })

--- a/apps/linows/src-tauri/src/process.rs
+++ b/apps/linows/src-tauri/src/process.rs
@@ -98,7 +98,10 @@ fn search_processes_blocking(query: &str, refresh: bool) -> Vec<ProcRow> {
         return rows;
     }
 
-    let prepared = look_matching::prepare_query(trimmed);
+    // fuzzy_score is case-sensitive; lowercase both sides (title is lowercased
+    // in score_row), matching the engine's normalized-query convention.
+    let lowered = trimmed.to_lowercase();
+    let prepared = look_matching::prepare_query(&lowered);
     let is_numeric = trimmed.chars().all(|c| c.is_ascii_digit());
     let exact_port = trimmed.parse::<u16>().ok();
 
@@ -135,7 +138,98 @@ fn score_row(
         }
     }
     // Name fuzzy still runs for numeric queries: a name can contain digits.
-    look_matching::fuzzy_score_prepared(prepared, &row.name)
+    look_matching::fuzzy_score_prepared(prepared, &row.name.to_lowercase())
+}
+
+/// A row in the `kill` command: either a desktop app (nice name + icon) or a
+/// raw process. Apps rank above processes so `kill firefox` surfaces the app.
+#[derive(Serialize, Clone)]
+pub struct KillTarget {
+    pub name: String,
+    pub pid: u32,
+    pub is_app: bool,
+    pub desktop_id: Option<String>,
+    pub exec: Option<String>,
+}
+
+const KILL_RESULT_LIMIT: usize = 60;
+
+/// Fuzzy-find kill targets: apps first (matched on display name), then any other
+/// process (matched on `/proc` name), deduped by PID. Empty query lists apps
+/// only, matching the panel's default view. Async + `spawn_blocking`: it walks
+/// `/proc` fresh each query, so it stays off the main thread.
+#[tauri::command]
+pub async fn search_kill_targets(query: String) -> Vec<KillTarget> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let trimmed = query.trim();
+        if trimmed.is_empty() {
+            return list_processes().into_iter().map(app_target).collect();
+        }
+        rank_kill_targets(list_processes(), list_all_raw(), trimmed)
+    })
+    .await
+    .unwrap_or_default()
+}
+
+fn kill_hit_order(a: &(i64, KillTarget), b: &(i64, KillTarget)) -> std::cmp::Ordering {
+    b.0.cmp(&a.0)
+        .then_with(|| a.1.name.to_lowercase().cmp(&b.1.name.to_lowercase()))
+}
+
+fn rank_kill_targets(apps: Vec<RunningApp>, procs: Vec<ProcRow>, query: &str) -> Vec<KillTarget> {
+    // Lowercase both sides: fuzzy_score is case-sensitive and app names are
+    // Capitalized ("Firefox") while queries are typed lowercase.
+    let lowered = query.to_lowercase();
+    let prepared = look_matching::prepare_query(&lowered);
+
+    let mut app_pids = std::collections::HashSet::new();
+    let mut app_hits: Vec<(i64, KillTarget)> = apps
+        .into_iter()
+        .filter_map(|a| {
+            look_matching::fuzzy_score_prepared(&prepared, &a.name.to_lowercase()).map(|s| {
+                app_pids.insert(a.pid);
+                (s, app_target(a))
+            })
+        })
+        .collect();
+    app_hits.sort_by(kill_hit_order);
+
+    // Processes already shown as an app (its representative PID) are skipped.
+    let mut proc_hits: Vec<(i64, KillTarget)> = procs
+        .into_iter()
+        .filter(|r| !app_pids.contains(&r.pid))
+        .filter_map(|r| {
+            look_matching::fuzzy_score_prepared(&prepared, &r.name.to_lowercase())
+                .map(|s| (s, proc_target(r)))
+        })
+        .collect();
+    proc_hits.sort_by(kill_hit_order);
+
+    let mut out: Vec<KillTarget> = app_hits.into_iter().map(|(_, t)| t).collect();
+    out.extend(proc_hits.into_iter().map(|(_, t)| t));
+    out.truncate(KILL_RESULT_LIMIT);
+    out
+}
+
+fn app_target(a: RunningApp) -> KillTarget {
+    KillTarget {
+        name: a.name,
+        pid: a.pid,
+        is_app: true,
+        desktop_id: a.desktop_id,
+        exec: a.exec,
+    }
+}
+
+fn proc_target(r: ProcRow) -> KillTarget {
+    KillTarget {
+        name: r.name,
+        pid: r.pid,
+        is_app: false,
+        // App-backed processes still carry the app icon via their desktop path.
+        desktop_id: r.icon_source.map(|p| format!("app:{p}")),
+        exec: None,
+    }
 }
 
 #[tauri::command]
@@ -344,7 +438,8 @@ mod tests {
 
     fn score(row: &ProcRow, query: &str) -> Option<i64> {
         let trimmed = query.trim();
-        let prepared = look_matching::prepare_query(trimmed);
+        let lowered = trimmed.to_lowercase();
+        let prepared = look_matching::prepare_query(&lowered);
         let is_numeric = trimmed.chars().all(|c| c.is_ascii_digit());
         let exact_port = trimmed.parse::<u16>().ok();
         score_row(row, trimmed, &prepared, is_numeric, exact_port)
@@ -382,5 +477,33 @@ mod tests {
         // 99999 > u16::MAX: no exact port, no substring, no PID -> None.
         let r = row("svc", 42, &[8080]);
         assert_eq!(score(&r, "99999"), None);
+    }
+
+    fn app(name: &str, pid: u32) -> RunningApp {
+        RunningApp {
+            name: name.to_string(),
+            pid,
+            desktop_id: Some(format!("app:/x/{name}.desktop")),
+            exec: Some(name.to_string()),
+        }
+    }
+
+    #[test]
+    fn kill_targets_rank_apps_before_processes() {
+        let apps = vec![app("Firefox", 100)];
+        // pid 100 is the app's own PID (deduped); 200 is a stray "firefox" proc.
+        let procs = vec![row("firefox", 100, &[]), row("firefox", 200, &[])];
+        let out = rank_kill_targets(apps, procs, "fire");
+        assert_eq!(out.len(), 2, "app + the non-dup process");
+        assert!(out[0].is_app, "app ranks first");
+        assert_eq!(out[0].pid, 100);
+        assert!(!out[1].is_app);
+        assert_eq!(out[1].pid, 200);
+    }
+
+    #[test]
+    fn kill_targets_non_match_excluded() {
+        let out = rank_kill_targets(vec![app("Firefox", 1)], vec![row("bash", 2, &[])], "zzq");
+        assert!(out.is_empty());
     }
 }

--- a/apps/linows/src/css/components/preview.css
+++ b/apps/linows/src/css/components/preview.css
@@ -76,6 +76,9 @@
 .preview-badge.kind-clipboard {
     color: var(--accent-color);
 }
+.preview-badge.kind-process {
+    color: var(--color-info);
+}
 
 .preview-size {
     font-size: calc(var(--font-size) - 2px);

--- a/apps/linows/src/html/screens/commands/kill.html
+++ b/apps/linows/src/html/screens/commands/kill.html
@@ -4,7 +4,7 @@
         <input
             id="cmd-kill-input"
             type="text"
-            placeholder="Type app name, or :3000"
+            placeholder="Type app name, port, or PID"
             spellcheck="false"
             autocomplete="off"
         />

--- a/apps/linows/src/html/screens/help.html
+++ b/apps/linows/src/html/screens/help.html
@@ -90,12 +90,9 @@
             <div class="help-item">
                 <kbd>Alt+S / Alt+M</kbd><span>Start screensaver / mute mic</span>
             </div>
+            <div class="help-item"><kbd>Alt+P</kbd><span>Play/pause the current track</span></div>
             <div class="help-item">
-                <kbd>Alt+P</kbd><span>Play/pause the current track</span>
-            </div>
-            <div class="help-item">
-                <kbd>Alt+R / Alt+D</kbd
-                ><span>Restart / Shut Down (press twice to confirm)</span>
+                <kbd>Alt+R / Alt+D</kbd><span>Restart / Shut Down (press twice to confirm)</span>
             </div>
             <div class="help-item">
                 <kbd>Settings &rsaquo; Appearance</kbd
@@ -136,7 +133,9 @@
                 <kbd>Ctrl+N / Ctrl+S</kbd
                 ><span>In /todo: switch Tasks/Stats page, save changes</span>
             </div>
-            <div class="help-item"><kbd>:3000</kbd><span>Find process listening on port</span></div>
+            <div class="help-item">
+                <kbd>3000</kbd><span>In /kill: match by port or PID, not just name</span>
+            </div>
             <div class="help-item"><kbd>Up / Down</kbd><span>Select app in kill results</span></div>
             <div class="help-item"><kbd>Y / N</kbd><span>Confirm/cancel kill action</span></div>
         </div>

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -684,7 +684,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (runningApps.isEnabled()) runningApps.refresh();
     }
 
-    async function executeCommand(cmdId, input) {
+    async function executeCommand(cmdId, input, gen) {
         if (cmdId === 'calc-preview') {
             try {
                 const result = await evalCalc(input);
@@ -708,7 +708,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (cmdId === 'kill-search') {
             try {
                 const targets = await searchKillTargets(input);
-                commands.setProcessList(targets, input);
+                commands.setProcessList(targets, gen);
             } catch (err) {
                 commands.showFeedback(err || 'Search failed', true);
             }

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -59,6 +59,7 @@ const HINT_MAIN = 'Enter: Open \u2022 Ctrl+H: Help \u2022 Ctrl+/: Command mode';
 const HINT_TRANSLATE =
     'Enter: Translate \u2022 Copy per result \u2022 Ctrl+H: Help \u2022 Ctrl+/: Command mode';
 const HINT_CLIPBOARD = 'Enter: Copy clip \u2022 Ctrl+D: Remove clip';
+const HINT_PROCESS = 'Ctrl+D: Kill \u2022 Ctrl+C: Copy PID';
 // Discovery-menu hints \u2014 mirror macOS prefixSuggestion / commandSuggestion
 // hint bars (LauncherView.swift hintItems).
 const HINT_PREFIX_DISCOVERY =
@@ -520,6 +521,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (search.isClipboardMode()) {
             setHint(hintMessage, HINT_CLIPBOARD);
             results.setEmptyState({ mode: 'clipboard' });
+        } else if (search.isProcessMode()) {
+            setHint(hintMessage, HINT_PROCESS);
+            results.setEmptyState({ mode: 'default' });
         } else if (search.isPrefixHintMode() || search.isCommandHintMode()) {
             setHint(
                 hintMessage,
@@ -576,6 +580,11 @@ document.addEventListener('DOMContentLoaded', async () => {
                 openPath(urlTarget, 'browser', '');
                 recordUrlHit(urlTarget);
             });
+            return;
+        }
+        // Process row has no path to open; a click measures CPU like Enter.
+        if (item.kind === 'process') {
+            preview.measureCpu();
             return;
         }
 

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -32,7 +32,6 @@ import {
     runShellCommand,
     getSystemInfo,
     listProcesses,
-    listProcessesOnPort,
     searchKillTargets,
     killProcess,
     getIcon,
@@ -702,18 +701,6 @@ document.addEventListener('DOMContentLoaded', async () => {
                 commands.setProcessList(procs);
             } catch (err) {
                 commands.showFeedback(err || 'Failed to list processes', true);
-            }
-            return;
-        }
-
-        if (cmdId === 'kill-port') {
-            const port = parseInt(input);
-            if (!port) return;
-            try {
-                const procs = await listProcessesOnPort(port);
-                commands.setProcessList(procs, true);
-            } catch (err) {
-                commands.showFeedback(err || 'Failed to query port', true);
             }
             return;
         }

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -59,7 +59,7 @@ const HINT_MAIN = 'Enter: Open \u2022 Ctrl+H: Help \u2022 Ctrl+/: Command mode';
 const HINT_TRANSLATE =
     'Enter: Translate \u2022 Copy per result \u2022 Ctrl+H: Help \u2022 Ctrl+/: Command mode';
 const HINT_CLIPBOARD = 'Enter: Copy clip \u2022 Ctrl+D: Remove clip';
-const HINT_PROCESS = 'Ctrl+D: Kill \u2022 Ctrl+C: Copy PID';
+const HINT_PROCESS = 'Enter: CPU \u2022 Ctrl+D: Kill \u2022 Ctrl+C: Copy PID';
 // Discovery-menu hints \u2014 mirror macOS prefixSuggestion / commandSuggestion
 // hint bars (LauncherView.swift hintItems).
 const HINT_PREFIX_DISCOVERY =
@@ -708,7 +708,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (cmdId === 'kill-search') {
             try {
                 const targets = await searchKillTargets(input);
-                commands.setProcessList(targets, true);
+                commands.setProcessList(targets, input);
             } catch (err) {
                 commands.showFeedback(err || 'Search failed', true);
             }

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -33,6 +33,7 @@ import {
     getSystemInfo,
     listProcesses,
     listProcessesOnPort,
+    searchKillTargets,
     killProcess,
     getIcon,
     copyToClipboard,
@@ -713,6 +714,16 @@ document.addEventListener('DOMContentLoaded', async () => {
                 commands.setProcessList(procs, true);
             } catch (err) {
                 commands.showFeedback(err || 'Failed to query port', true);
+            }
+            return;
+        }
+
+        if (cmdId === 'kill-search') {
+            try {
+                const targets = await searchKillTargets(input);
+                commands.setProcessList(targets, true);
+            } catch (err) {
+                commands.showFeedback(err || 'Search failed', true);
             }
             return;
         }

--- a/apps/linows/src/js/catalog.js
+++ b/apps/linows/src/js/catalog.js
@@ -28,6 +28,7 @@ const PREFIX_ENTRIES = [
         description: 'Recent files/folders, newest first (optional filter)',
     },
     { prefix: 'r"', argHint: 'pattern', description: 'Regex search' },
+    { prefix: 'ps"', argHint: 'word', description: 'Find & kill running processes' },
     {
         prefix: 'c"',
         argHint: 'word',

--- a/apps/linows/src/js/catalog.js
+++ b/apps/linows/src/js/catalog.js
@@ -46,7 +46,7 @@ const COMMAND_ENTRIES = [
     {
         id: 'kill',
         title: 'kill (Ctrl+4)',
-        detail: 'Force kill app or process by port',
+        detail: 'Force kill app or process by name, port, or PID',
         icon: xCircle,
     },
     { id: 'shell', title: 'shell (Ctrl+5)', detail: 'Run a shell command', icon: terminal },

--- a/apps/linows/src/js/components/preview.js
+++ b/apps/linows/src/js/components/preview.js
@@ -338,23 +338,30 @@ function renderProcessPreview(result) {
     const setVal = (row, text) => {
         row.querySelector('.preview-info-value').textContent = text;
     };
-    processDetail(result.procPid).then((d) => {
+    // Platforms without detail support (Windows for now) and IPC failures
+    // (process exited between listing and preview) both degrade to name only.
+    const degrade = () => {
         if (currentPath !== cacheKey) return;
-        if (!d) {
-            // Platforms without detail support (Windows for now): name only.
-            cmdText.textContent = result.procName;
-            setVal(memRow, 'unavailable');
-            setVal(userRow, 'unavailable');
-            setVal(ppidRow, 'unavailable');
-            setVal(startRow, 'unavailable');
-            return;
-        }
-        cmdText.textContent = d.cmdline || result.procName;
-        setVal(memRow, d.rss_kb > 0 ? formatSize(d.rss_kb * 1024) : 'n/a');
-        setVal(userRow, d.user || 'n/a');
-        setVal(ppidRow, String(d.ppid));
-        setVal(startRow, formatStart(d.start_epoch));
-    });
+        cmdText.textContent = result.procName;
+        setVal(memRow, 'unavailable');
+        setVal(userRow, 'unavailable');
+        setVal(ppidRow, 'unavailable');
+        setVal(startRow, 'unavailable');
+    };
+    processDetail(result.procPid)
+        .then((d) => {
+            if (currentPath !== cacheKey) return;
+            if (!d) {
+                degrade();
+                return;
+            }
+            cmdText.textContent = d.cmdline || result.procName;
+            setVal(memRow, d.rss_kb > 0 ? formatSize(d.rss_kb * 1024) : 'n/a');
+            setVal(userRow, d.user || 'n/a');
+            setVal(ppidRow, String(d.ppid));
+            setVal(startRow, formatStart(d.start_epoch));
+        })
+        .catch(degrade);
 }
 
 // Sample CPU for the previewed process (bound to ps" Enter). No-op unless a

--- a/apps/linows/src/js/components/preview.js
+++ b/apps/linows/src/js/components/preview.js
@@ -6,10 +6,13 @@ import {
     highlightFile,
     listFolder,
     openPath,
+    processDetail,
+    processCpu,
 } from '../ipc.js';
 import {
     clipboard as clipboardIcon,
     trash as trashIcon,
+    cpu as cpuIcon,
     appIcon,
     fileIcon,
     folderIcon,
@@ -27,6 +30,10 @@ let panel = null;
 let currentPath = null;
 let onClipDelete = null;
 let highlightTimer = null;
+// PID of the process currently previewed, so the on-demand CPU measure (ps"
+// Enter) targets the right process and ignores a stale request after the
+// selection moved on.
+let currentProcPid = null;
 
 export function init(panelEl) {
     panel = panelEl;
@@ -55,12 +62,18 @@ export function update(result) {
     }
     panel.hidden = false;
     panel.innerHTML = '';
+    currentProcPid = null;
     // The panel was wiped: invalidate any in-flight Quick Actions render so a
     // late response can't append a stale section for the previous result.
     qactions.clear();
 
     if (result.kind === 'clipboard') {
         renderClipboardPreview(result);
+        return;
+    }
+
+    if (result.kind === 'process') {
+        renderProcessPreview(result);
         return;
     }
 
@@ -237,6 +250,139 @@ function renderClipboardPreview(result) {
     metaWrap.appendChild(infoRow('Kind', 'Clipboard'));
     metaWrap.appendChild(infoRow('Captured', result.clipDateMedium));
     panel.appendChild(metaWrap);
+}
+
+function renderProcessPreview(result) {
+    currentProcPid = result.procPid;
+    const cacheKey = result.path;
+
+    // Header: cpu glyph + process name + Process badge and PID
+    const header = document.createElement('div');
+    header.className = 'preview-header';
+
+    const iconWrap = document.createElement('div');
+    iconWrap.className = 'preview-icon';
+    iconWrap.innerHTML = cpuIcon;
+    iconWrap.style.background = 'var(--control-fill)';
+    iconWrap.style.color = 'var(--font-secondary)';
+    header.appendChild(iconWrap);
+
+    // App-backed process: swap the generic glyph for the real app icon.
+    if (result.iconPath) {
+        getIcon('app', result.iconPath, result.id).then((res) => {
+            if (res?.data_url && currentPath === cacheKey) {
+                const img = document.createElement('img');
+                img.src = res.data_url;
+                img.alt = '';
+                iconWrap.innerHTML = '';
+                iconWrap.style.background = 'none';
+                iconWrap.style.color = '';
+                iconWrap.appendChild(img);
+            }
+        });
+    }
+
+    const headerText = document.createElement('div');
+    headerText.className = 'preview-header-text';
+
+    const title = document.createElement('div');
+    title.className = 'preview-title';
+    title.textContent = result.procName;
+    headerText.appendChild(title);
+
+    const sub = document.createElement('div');
+    sub.className = 'preview-header-sub';
+    const badge = document.createElement('span');
+    badge.className = 'preview-badge kind-process';
+    badge.textContent = 'Process';
+    sub.appendChild(badge);
+    const pidSpan = document.createElement('span');
+    pidSpan.className = 'preview-size';
+    pidSpan.textContent = `PID ${result.procPid}`;
+    sub.appendChild(pidSpan);
+    headerText.appendChild(sub);
+
+    header.appendChild(headerText);
+    panel.appendChild(header);
+
+    // Command line: the disambiguator before a kill (many node/python share a name)
+    const cmdLabel = document.createElement('div');
+    cmdLabel.className = 'preview-clip-label';
+    cmdLabel.textContent = 'Command';
+    panel.appendChild(cmdLabel);
+    const cmdCard = document.createElement('div');
+    cmdCard.className = 'preview-clip-card';
+    const cmdText = document.createElement('pre');
+    cmdText.className = 'preview-clip-text';
+    cmdText.textContent = '…';
+    cmdCard.appendChild(cmdText);
+    panel.appendChild(cmdCard);
+
+    // Meta rows. CPU stays "Enter to measure" until the on-demand sample runs.
+    const metaWrap = document.createElement('div');
+    metaWrap.className = 'preview-meta';
+    const memRow = infoRow('Memory', '…');
+    const userRow = infoRow('User', '…');
+    const ppidRow = infoRow('Parent PID', '…');
+    const startRow = infoRow('Started', '…');
+    const cpuRow = infoRow('CPU', 'Enter to measure');
+    cpuRow.querySelector('.preview-info-value').classList.add('preview-proc-cpu-val');
+    metaWrap.append(memRow, userRow, ppidRow, startRow, cpuRow);
+    // Listening ports, only when the process holds any.
+    const ports = result.procPorts || [];
+    if (ports.length) {
+        metaWrap.appendChild(infoRow('Ports', ports.map((p) => `:${p}`).join('  ')));
+    }
+    panel.appendChild(metaWrap);
+
+    const setVal = (row, text) => {
+        row.querySelector('.preview-info-value').textContent = text;
+    };
+    processDetail(result.procPid).then((d) => {
+        if (currentPath !== cacheKey) return;
+        if (!d) {
+            // Platforms without detail support (Windows for now): name only.
+            cmdText.textContent = result.procName;
+            setVal(memRow, 'unavailable');
+            setVal(userRow, 'unavailable');
+            setVal(ppidRow, 'unavailable');
+            setVal(startRow, 'unavailable');
+            return;
+        }
+        cmdText.textContent = d.cmdline || result.procName;
+        setVal(memRow, d.rss_kb > 0 ? formatSize(d.rss_kb * 1024) : 'n/a');
+        setVal(userRow, d.user || 'n/a');
+        setVal(ppidRow, String(d.ppid));
+        setVal(startRow, formatStart(d.start_epoch));
+    });
+}
+
+// Sample CPU for the previewed process (bound to ps" Enter). No-op unless a
+// process is previewed; drops the result if the selection moved on.
+export async function measureCpu() {
+    if (currentProcPid == null) return;
+    const pid = currentProcPid;
+    const valEl = panel.querySelector('.preview-proc-cpu-val');
+    if (!valEl) return;
+    valEl.textContent = 'measuring…';
+    try {
+        const pct = await processCpu(pid);
+        if (currentProcPid !== pid) return;
+        valEl.textContent = pct == null ? 'n/a' : `${pct.toFixed(1)}%`;
+    } catch (err) {
+        console.error('CPU measure failed:', err);
+        if (currentProcPid === pid) valEl.textContent = 'n/a';
+    }
+}
+
+function formatStart(epoch) {
+    if (!epoch) return 'n/a';
+    return new Date(epoch * 1000).toLocaleString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+    });
 }
 
 function renderAppMeta(metaWrap, result, headerSub) {

--- a/apps/linows/src/js/components/results.js
+++ b/apps/linows/src/js/components/results.js
@@ -13,8 +13,29 @@ import { getSettingsIcon as getWindowsSettingsIcon } from '../settings-icons/win
 import { webSuggestionFromResultId } from '../catalog.js';
 import { isWindows } from '../platform.js';
 
+// LRU-bounded icon cache (cacheKey -> data URL | null). A plain Map keeps
+// insertion order, so re-inserting on a hit marks it most-recently-used and the
+// oldest key is always keys().next(). Bounds heap growth while browsing many
+// icons; evicted entries re-resolve instantly from the backend's own cache.
+const ICON_CACHE_MAX = 256;
 const iconCache = new Map();
 const pickedMap = new Map(); // key → result
+
+function iconCacheGet(key) {
+    if (!iconCache.has(key)) return undefined;
+    const val = iconCache.get(key);
+    iconCache.delete(key);
+    iconCache.set(key, val);
+    return val;
+}
+
+function iconCacheSet(key, val) {
+    iconCache.delete(key);
+    iconCache.set(key, val);
+    if (iconCache.size > ICON_CACHE_MAX) {
+        iconCache.delete(iconCache.keys().next().value);
+    }
+}
 
 let currentResults = [];
 let selectedIndex = -1;
@@ -376,24 +397,23 @@ function createRow(result, index) {
 function loadIcon(iconEl, kind, path, id) {
     const cacheKey = `${kind}:${path}`;
 
-    if (iconCache.has(cacheKey)) {
-        const dataUrl = iconCache.get(cacheKey);
-        if (dataUrl) {
-            applyIcon(iconEl, dataUrl);
-        }
+    const cached = iconCacheGet(cacheKey);
+    if (cached !== undefined) {
+        // null = known to have no icon; skip the re-fetch either way.
+        if (cached) applyIcon(iconEl, cached);
         return;
     }
 
     getIcon(kind, path, id)
         .then((result) => {
             const dataUrl = result?.data_url || null;
-            iconCache.set(cacheKey, dataUrl);
+            iconCacheSet(cacheKey, dataUrl);
             if (dataUrl) {
                 applyIcon(iconEl, dataUrl);
             }
         })
         .catch(() => {
-            iconCache.set(cacheKey, null);
+            iconCacheSet(cacheKey, null);
         });
 }
 

--- a/apps/linows/src/js/components/results.js
+++ b/apps/linows/src/js/components/results.js
@@ -2,6 +2,7 @@ import { getIcon } from '../ipc.js';
 import {
     clipboard as clipboardIcon,
     check as checkIcon,
+    cpu as cpuIcon,
     appIcon,
     fileIcon,
     folderIcon,
@@ -308,6 +309,7 @@ function createRow(result, index) {
         folder: folderIcon,
         setting: settingIcon,
         clipboard: clipboardIcon,
+        process: cpuIcon,
     };
     // Synthetic discovery rows (prefix/command menus) ship their own glyph in
     // result.iconSvg so the list scans visually; everything else falls back to
@@ -323,7 +325,18 @@ function createRow(result, index) {
     // Skip backend icon fetch for ms-settings entries - the Shell PNG would just
     // be the generic gear and would clobber our category-specific glyph. Same
     // applies to synthetic discovery rows whose `path` is empty.
-    if (result.kind !== 'clipboard' && !windowsSettingsSvg && !result.iconSvg && result.path) {
+    if (result.kind === 'process') {
+        // App-backed processes wear their app icon (loaded as an app path);
+        // the rest keep the generic process glyph from the fallback above.
+        if (result.iconPath) {
+            loadIcon(icon, 'app', result.iconPath, result.id);
+        }
+    } else if (
+        result.kind !== 'clipboard' &&
+        !windowsSettingsSvg &&
+        !result.iconSvg &&
+        result.path
+    ) {
         loadIcon(icon, result.kind, result.path, result.id);
     }
 

--- a/apps/linows/src/js/ipc.js
+++ b/apps/linows/src/js/ipc.js
@@ -73,10 +73,6 @@ export async function listProcesses() {
     return invoke('list_processes');
 }
 
-export async function listProcessesOnPort(port) {
-    return invoke('list_processes_on_port', { port });
-}
-
 export async function killProcess(pid) {
     return invoke('kill_process', { pid });
 }

--- a/apps/linows/src/js/ipc.js
+++ b/apps/linows/src/js/ipc.js
@@ -81,6 +81,18 @@ export async function killProcess(pid) {
     return invoke('kill_process', { pid });
 }
 
+export async function searchProcesses(query, refresh) {
+    return invoke('search_processes', { query, refresh });
+}
+
+export async function processDetail(pid) {
+    return invoke('process_detail', { pid });
+}
+
+export async function processCpu(pid) {
+    return invoke('process_cpu', { pid });
+}
+
 export async function listRunningApps() {
     return invoke('list_running_apps');
 }

--- a/apps/linows/src/js/ipc.js
+++ b/apps/linows/src/js/ipc.js
@@ -85,6 +85,10 @@ export async function searchProcesses(query, refresh) {
     return invoke('search_processes', { query, refresh });
 }
 
+export async function searchKillTargets(query) {
+    return invoke('search_kill_targets', { query });
+}
+
 export async function processDetail(pid) {
     return invoke('process_detail', { pid });
 }

--- a/apps/linows/src/js/keyboard.js
+++ b/apps/linows/src/js/keyboard.js
@@ -10,11 +10,13 @@ import {
     copyFilesToClipboard,
     copyToClipboard,
     deleteClipboardEntry,
+    killProcess,
     trashPaths,
     countTrashItems,
     emptyTrash,
     requestIndexRefresh,
 } from './ipc.js';
+import * as preview from './components/preview.js';
 import * as banner from './components/banner.js';
 import * as confirm from './components/confirm.js';
 import * as qactions from './components/qactions.js';
@@ -263,6 +265,10 @@ function handleKeyDown(e) {
                 if (text) translatePanel.perform(text);
             } else if (search.isClipboardMode()) {
                 copyClipboardEntry();
+            } else if (search.isProcessMode()) {
+                // ps": Enter measures CPU on demand (kill is Ctrl+D). Keeps
+                // selection instant by never sampling until asked.
+                preview.measureCpu();
             } else if (e.ctrlKey) {
                 searchWeb();
             } else if ((e.shiftKey || shiftHeld) && results.hasPickedItems()) {
@@ -277,6 +283,7 @@ function handleKeyDown(e) {
             if (
                 search.isClipboardMode() ||
                 search.isTranslateMode() ||
+                search.isProcessMode() ||
                 search.isPrefixHintMode() ||
                 search.isCommandHintMode()
             ) {
@@ -303,7 +310,11 @@ function handleKeyDown(e) {
             if (e.ctrlKey && !window.getSelection()?.toString()) {
                 e.preventDefault();
                 if (isDiscoveryMode()) break;
-                copySelectedPath();
+                if (search.isProcessMode()) {
+                    copySelectedPid();
+                } else {
+                    copySelectedPath();
+                }
             }
             break;
 
@@ -333,7 +344,9 @@ function handleKeyDown(e) {
             if (e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey) {
                 e.preventDefault();
                 if (isDiscoveryMode()) break;
-                if (search.isClipboardMode()) {
+                if (search.isProcessMode()) {
+                    killSelectedProcess();
+                } else if (search.isClipboardMode()) {
                     removeClipboardEntry();
                 } else {
                     handleTrashShortcut();
@@ -566,5 +579,30 @@ async function removeClipboardEntry() {
         search.handleQueryInput(queryInput.value);
     } catch (err) {
         console.error('Delete clipboard entry failed:', err);
+    }
+}
+
+async function copySelectedPid() {
+    const item = results.getSelected();
+    if (!item || item.kind !== 'process') return;
+    try {
+        await copyToClipboard(String(item.procPid));
+        banner.show(`Copied PID ${item.procPid}`, 'success', 1.0);
+    } catch (err) {
+        banner.show('Copy failed', 'error', 1.2);
+    }
+}
+
+async function killSelectedProcess() {
+    const item = results.getSelected();
+    if (!item || item.kind !== 'process') return;
+    try {
+        await killProcess(item.procPid);
+        banner.show(`Killed ${item.procName} (${item.procPid})`, 'success', 1.2);
+        // Force a fresh /proc walk so the killed row drops off next render.
+        search.forceProcessRefresh();
+        search.handleQueryInput(queryInput.value);
+    } catch (err) {
+        banner.show(`Kill failed: ${err}`, 'error', 1.6);
     }
 }

--- a/apps/linows/src/js/screens/commands/index.js
+++ b/apps/linows/src/js/screens/commands/index.js
@@ -173,8 +173,8 @@ export function showFeedback(text, isError = false) {
     if (mod.showFeedback) mod.showFeedback(text, isError);
 }
 
-export function setProcessList(procs, forQuery = null) {
-    kill.setProcessList(procs, forQuery);
+export function setProcessList(procs, gen = null) {
+    kill.setProcessList(procs, gen);
 }
 
 export function setSysInfo(sections) {

--- a/apps/linows/src/js/screens/commands/index.js
+++ b/apps/linows/src/js/screens/commands/index.js
@@ -173,8 +173,8 @@ export function showFeedback(text, isError = false) {
     if (mod.showFeedback) mod.showFeedback(text, isError);
 }
 
-export function setProcessList(procs, isPortResult = false) {
-    kill.setProcessList(procs, isPortResult);
+export function setProcessList(procs, forQuery = null) {
+    kill.setProcessList(procs, forQuery);
 }
 
 export function setSysInfo(sections) {

--- a/apps/linows/src/js/screens/commands/kill.js
+++ b/apps/linows/src/js/screens/commands/kill.js
@@ -21,6 +21,13 @@ let searchDebounce = null;
 // True while a backend fuzzy search is scheduled or in flight: the local
 // provisional filter may miss port/PID matches the backend still owns.
 let searchPending = false;
+// Monotonic per-keystroke generation. A search response is only applied when
+// its generation is still current, so a superseded request (even for the same
+// query text after foo -> bar -> foo) can never overwrite fresher results.
+let searchGen = 0;
+// True once initial enumeration has returned, so an empty base list reads as a
+// terminal "no processes" state rather than a perpetual "Loading...".
+let baseLoaded = false;
 
 export function init(executeFn, iconFn) {
     onExecute = executeFn;
@@ -44,6 +51,8 @@ export function enter() {
     panel.hidden = false;
     input.value = '';
     confirmPid = null;
+    baseLoaded = false;
+    searchPending = false;
     updateConfirmBar();
     requestAnimationFrame(() => input.focus());
     if (onExecute) onExecute('kill-load');
@@ -106,21 +115,21 @@ export function handleKey(e) {
     return false;
 }
 
-// `forQuery` is the query a backend search was fetched for; `null` marks the
+// `gen` is the generation a backend search was dispatched at; `null` marks the
 // base app list (mode entry / post-kill).
-export function setProcessList(procs, forQuery = null) {
-    const current = input ? input.value.trim() : '';
-    if (forQuery !== null) {
-        // Drop stale search hits: a response that lands after the box was
-        // cleared or retyped must not resurrect the old query's process list.
-        if (forQuery.trim() !== current) return;
+export function setProcessList(procs, gen = null) {
+    if (gen !== null) {
+        // Superseded response (a newer keystroke, retype, or clear advanced the
+        // generation): ignore it so only the latest request paints results.
+        if (gen !== searchGen) return;
         searchPending = false;
         processList = procs || [];
         filteredProcesses = [...processList];
     } else {
         baseProcessList = procs || [];
+        baseLoaded = true;
         processList = [...baseProcessList];
-        filterProcesses(current);
+        filterProcesses(input ? input.value.trim() : '');
     }
     selectedIndex = 0;
     confirmPid = null;
@@ -136,6 +145,9 @@ export function showFeedback(text, isError = false) {
 // --- Internal ---
 
 function filterProcesses(query) {
+    // Every intent change advances the generation, invalidating any in-flight
+    // search whose result has not landed yet.
+    searchGen += 1;
     if (!query) {
         clearTimeout(searchDebounce);
         searchPending = false;
@@ -149,8 +161,9 @@ function filterProcesses(query) {
         filteredProcesses = baseProcessList.filter((p) => p.name.toLowerCase().includes(q));
         clearTimeout(searchDebounce);
         searchPending = true;
+        const gen = searchGen;
         searchDebounce = setTimeout(() => {
-            if (onExecute) onExecute('kill-search', query);
+            if (onExecute) onExecute('kill-search', query, gen);
         }, SEARCH_DEBOUNCE_MS);
     }
     selectedIndex = Math.min(selectedIndex, Math.max(0, filteredProcesses.length - 1));
@@ -163,8 +176,9 @@ function renderList() {
     if (filteredProcesses.length === 0) {
         const query = input ? input.value.trim() : '';
         if (!query) {
-            // Empty query with nothing yet means the app list is still loading.
-            feedback.textContent = 'Loading...';
+            // Before enumeration returns, "Loading..."; once it has, an empty
+            // base list is a terminal state, not a perpetual spinner.
+            feedback.textContent = baseLoaded ? 'No running processes' : 'Loading...';
         } else {
             // A pending backend search can still return port/PID matches the
             // local name filter missed, so hold off on a definitive miss.

--- a/apps/linows/src/js/screens/commands/kill.js
+++ b/apps/linows/src/js/screens/commands/kill.js
@@ -1,5 +1,3 @@
-const MAX_PORT = 65535;
-const PORT_DEBOUNCE_MS = 200;
 const SEARCH_DEBOUNCE_MS = 140;
 
 let panel = null;
@@ -19,7 +17,6 @@ let processList = [];
 let filteredProcesses = [];
 let selectedIndex = 0;
 let confirmPid = null;
-let portDebounce = null;
 let searchDebounce = null;
 
 export function init(executeFn, iconFn) {
@@ -106,9 +103,9 @@ export function handleKey(e) {
     return false;
 }
 
-export function setProcessList(procs, isPortResult = false) {
+export function setProcessList(procs, isSearchResult = false) {
     const savedValue = input ? input.value : '';
-    if (isPortResult) {
+    if (isSearchResult) {
         processList = procs || [];
         filteredProcesses = [...processList];
     } else {
@@ -134,22 +131,10 @@ function filterProcesses(query) {
         clearTimeout(searchDebounce);
         processList = [...baseProcessList];
         filteredProcesses = [...processList];
-    } else if (query.startsWith(':')) {
-        clearTimeout(searchDebounce);
-        filteredProcesses = [];
-        selectedIndex = 0;
-        const port = parseInt(query.slice(1));
-        if (port > 0 && port <= MAX_PORT) {
-            clearTimeout(portDebounce);
-            portDebounce = setTimeout(() => {
-                if (onExecute) onExecute('kill-port', String(port));
-            }, PORT_DEBOUNCE_MS);
-        }
-        return;
     } else {
         // Instant provisional list from the loaded apps; the debounced backend
         // search then replaces it with the full fuzzy result (apps first) plus
-        // matching non-app processes.
+        // matching non-app processes, including port and PID matches.
         const q = query.toLowerCase();
         filteredProcesses = baseProcessList.filter((p) => p.name.toLowerCase().includes(q));
         clearTimeout(searchDebounce);
@@ -166,17 +151,9 @@ function renderList() {
 
     if (filteredProcesses.length === 0) {
         const query = input ? input.value.trim() : '';
-        if (query.startsWith(':')) {
-            const port = query.slice(1);
-            feedback.textContent =
-                processList.length === 0 && port
-                    ? `No process on port ${port}`
-                    : 'Searching port...';
-        } else {
-            // A non-empty query with no matches is a real miss; empty query with
-            // nothing yet means the app list is still loading.
-            feedback.textContent = query ? 'No matching processes' : 'Loading...';
-        }
+        // A non-empty query with no matches is a real miss; empty query with
+        // nothing yet means the app list is still loading.
+        feedback.textContent = query ? 'No matching processes' : 'Loading...';
         return;
     }
 

--- a/apps/linows/src/js/screens/commands/kill.js
+++ b/apps/linows/src/js/screens/commands/kill.js
@@ -1,5 +1,6 @@
 const MAX_PORT = 65535;
 const PORT_DEBOUNCE_MS = 200;
+const SEARCH_DEBOUNCE_MS = 140;
 
 let panel = null;
 let input = null;
@@ -19,6 +20,7 @@ let filteredProcesses = [];
 let selectedIndex = 0;
 let confirmPid = null;
 let portDebounce = null;
+let searchDebounce = null;
 
 export function init(executeFn, iconFn) {
     onExecute = executeFn;
@@ -129,9 +131,11 @@ export function showFeedback(text, isError = false) {
 
 function filterProcesses(query) {
     if (!query) {
+        clearTimeout(searchDebounce);
         processList = [...baseProcessList];
         filteredProcesses = [...processList];
     } else if (query.startsWith(':')) {
+        clearTimeout(searchDebounce);
         filteredProcesses = [];
         selectedIndex = 0;
         const port = parseInt(query.slice(1));
@@ -143,8 +147,15 @@ function filterProcesses(query) {
         }
         return;
     } else {
+        // Instant provisional list from the loaded apps; the debounced backend
+        // search then replaces it with the full fuzzy result (apps first) plus
+        // matching non-app processes.
         const q = query.toLowerCase();
         filteredProcesses = baseProcessList.filter((p) => p.name.toLowerCase().includes(q));
+        clearTimeout(searchDebounce);
+        searchDebounce = setTimeout(() => {
+            if (onExecute) onExecute('kill-search', query);
+        }, SEARCH_DEBOUNCE_MS);
     }
     selectedIndex = Math.min(selectedIndex, Math.max(0, filteredProcesses.length - 1));
 }
@@ -162,7 +173,9 @@ function renderList() {
                     ? `No process on port ${port}`
                     : 'Searching port...';
         } else {
-            feedback.textContent = processList.length > 0 ? 'No matching processes' : 'Loading...';
+            // A non-empty query with no matches is a real miss; empty query with
+            // nothing yet means the app list is still loading.
+            feedback.textContent = query ? 'No matching processes' : 'Loading...';
         }
         return;
     }

--- a/apps/linows/src/js/screens/commands/kill.js
+++ b/apps/linows/src/js/screens/commands/kill.js
@@ -18,6 +18,9 @@ let filteredProcesses = [];
 let selectedIndex = 0;
 let confirmPid = null;
 let searchDebounce = null;
+// True while a backend fuzzy search is scheduled or in flight: the local
+// provisional filter may miss port/PID matches the backend still owns.
+let searchPending = false;
 
 export function init(executeFn, iconFn) {
     onExecute = executeFn;
@@ -103,15 +106,21 @@ export function handleKey(e) {
     return false;
 }
 
-export function setProcessList(procs, isSearchResult = false) {
-    const savedValue = input ? input.value : '';
-    if (isSearchResult) {
+// `forQuery` is the query a backend search was fetched for; `null` marks the
+// base app list (mode entry / post-kill).
+export function setProcessList(procs, forQuery = null) {
+    const current = input ? input.value.trim() : '';
+    if (forQuery !== null) {
+        // Drop stale search hits: a response that lands after the box was
+        // cleared or retyped must not resurrect the old query's process list.
+        if (forQuery.trim() !== current) return;
+        searchPending = false;
         processList = procs || [];
         filteredProcesses = [...processList];
     } else {
         baseProcessList = procs || [];
         processList = [...baseProcessList];
-        filterProcesses(savedValue);
+        filterProcesses(current);
     }
     selectedIndex = 0;
     confirmPid = null;
@@ -129,6 +138,7 @@ export function showFeedback(text, isError = false) {
 function filterProcesses(query) {
     if (!query) {
         clearTimeout(searchDebounce);
+        searchPending = false;
         processList = [...baseProcessList];
         filteredProcesses = [...processList];
     } else {
@@ -138,6 +148,7 @@ function filterProcesses(query) {
         const q = query.toLowerCase();
         filteredProcesses = baseProcessList.filter((p) => p.name.toLowerCase().includes(q));
         clearTimeout(searchDebounce);
+        searchPending = true;
         searchDebounce = setTimeout(() => {
             if (onExecute) onExecute('kill-search', query);
         }, SEARCH_DEBOUNCE_MS);
@@ -151,9 +162,14 @@ function renderList() {
 
     if (filteredProcesses.length === 0) {
         const query = input ? input.value.trim() : '';
-        // A non-empty query with no matches is a real miss; empty query with
-        // nothing yet means the app list is still loading.
-        feedback.textContent = query ? 'No matching processes' : 'Loading...';
+        if (!query) {
+            // Empty query with nothing yet means the app list is still loading.
+            feedback.textContent = 'Loading...';
+        } else {
+            // A pending backend search can still return port/PID matches the
+            // local name filter missed, so hold off on a definitive miss.
+            feedback.textContent = searchPending ? 'Searching...' : 'No matching processes';
+        }
         return;
     }
 

--- a/apps/linows/src/js/search.js
+++ b/apps/linows/src/js/search.js
@@ -1,6 +1,7 @@
 import {
     search as ipcSearch,
     getClipboardHistory,
+    searchProcesses as ipcSearchProcesses,
     webSuggestions as ipcWebSuggestions,
     classifyUrl as ipcClassifyUrl,
     recentUrls as ipcRecentUrls,
@@ -30,6 +31,10 @@ let onResultsCallback = null;
 let clipboardMode = false;
 let translateMode = false;
 let recentMode = false;
+let processMode = false;
+// Set after a kill (or on mode entry) so the next process search re-enumerates
+// /proc instead of scoring the stale snapshot.
+let processRefreshPending = false;
 let prefixHintMode = false;
 let commandHintMode = false;
 let aiEnabled = true;
@@ -78,6 +83,16 @@ export function isRecentMode() {
     return recentMode;
 }
 
+export function isProcessMode() {
+    return processMode;
+}
+
+// Called after a kill so the next process search re-enumerates /proc. Callers
+// dispatch an input event to re-run the current query.
+export function forceProcessRefresh() {
+    processRefreshPending = true;
+}
+
 export function isPrefixHintMode() {
     return prefixHintMode;
 }
@@ -122,19 +137,23 @@ export function handleQueryInput(query) {
     // run before the t"/c"/rc" branches because the leading chars overlap.
     if (isPrefixSuggestionQuery(query)) {
         prefixHintMode = true;
-        commandHintMode = translateMode = clipboardMode = recentMode = false;
+        commandHintMode = translateMode = clipboardMode = recentMode = processMode = false;
         if (onResultsCallback) onResultsCallback(prefixSuggestionResults(query), query);
         return;
     }
     if (isCommandSuggestionQuery(query)) {
         commandHintMode = true;
-        prefixHintMode = translateMode = clipboardMode = recentMode = false;
+        prefixHintMode = translateMode = clipboardMode = recentMode = processMode = false;
         if (onResultsCallback) onResultsCallback(commandSuggestionResults(query), query);
         return;
     }
 
     prefixHintMode = false;
     commandHintMode = false;
+    // Default off; the ps" branch below re-arms it. Every early-return mode
+    // branch (t"/c"/rc") is reached with processMode already cleared here.
+    const wasProcessMode = processMode;
+    processMode = false;
 
     if (query.startsWith('t"')) {
         translateMode = true;
@@ -166,6 +185,17 @@ export function handleQueryInput(query) {
     }
 
     recentMode = false;
+
+    if (query.startsWith('ps"')) {
+        processMode = true;
+        // Re-enumerate on mode entry or after a kill; otherwise score the cached
+        // snapshot so typing never walks /proc.
+        const refresh = processRefreshPending || !wasProcessMode;
+        processRefreshPending = false;
+        const filter = query.slice(3);
+        debounceTimer = setTimeout(() => performProcessSearch(filter, refresh), DEBOUNCE_MS);
+        return;
+    }
 
     const myVersion = queryVersion;
     if (query.trim() === '') {
@@ -393,6 +423,33 @@ async function performClipboardSearch(filter) {
     } catch (err) {
         console.error('Clipboard search failed:', err);
         if (onResultsCallback) onResultsCallback([], `c"${filter}`);
+    }
+}
+
+async function performProcessSearch(filter, refresh) {
+    try {
+        const procs = await ipcSearchProcesses(filter.trim(), !!refresh);
+        const results = procs.map((p) => {
+            const ports = p.ports || [];
+            const portHint = ports.length ? ` \u2022 ${ports.map((x) => `:${x}`).join(' ')}` : '';
+            return {
+                id: `proc:${p.pid}`,
+                kind: 'process',
+                title: p.name,
+                subtitle: `PID ${p.pid}${portHint}`,
+                path: `process://${p.pid}`,
+                score: 0,
+                procPid: p.pid,
+                procName: p.name,
+                // .desktop path when the process belongs to an app; drives the icon.
+                iconPath: p.icon_source || null,
+                procPorts: ports,
+            };
+        });
+        if (onResultsCallback) onResultsCallback(results, `ps"${filter}`);
+    } catch (err) {
+        console.error('Process search failed:', err);
+        if (onResultsCallback) onResultsCallback([], `ps"${filter}`);
     }
 }
 

--- a/apps/linows/src/js/search.js
+++ b/apps/linows/src/js/search.js
@@ -193,7 +193,11 @@ export function handleQueryInput(query) {
         const refresh = processRefreshPending || !wasProcessMode;
         processRefreshPending = false;
         const filter = query.slice(3);
-        debounceTimer = setTimeout(() => performProcessSearch(filter, refresh), DEBOUNCE_MS);
+        const version = queryVersion;
+        debounceTimer = setTimeout(
+            () => performProcessSearch(filter, refresh, version),
+            DEBOUNCE_MS,
+        );
         return;
     }
 
@@ -426,9 +430,12 @@ async function performClipboardSearch(filter) {
     }
 }
 
-async function performProcessSearch(filter, refresh) {
+async function performProcessSearch(filter, refresh, version) {
     try {
         const procs = await ipcSearchProcesses(filter.trim(), !!refresh);
+        // A newer query or a mode switch may have landed while /proc was being
+        // walked; discard this response so it can't overwrite fresher results.
+        if (isStale(version)) return;
         const results = procs.map((p) => {
             const ports = p.ports || [];
             const portHint = ports.length ? ` \u2022 ${ports.map((x) => `:${x}`).join(' ')}` : '';
@@ -448,6 +455,7 @@ async function performProcessSearch(filter, refresh) {
         });
         if (onResultsCallback) onResultsCallback(results, `ps"${filter}`);
     } catch (err) {
+        if (isStale(version)) return;
         console.error('Process search failed:', err);
         if (onResultsCallback) onResultsCallback([], `ps"${filter}`);
     }

--- a/docs/process-finder-handoff.md
+++ b/docs/process-finder-handoff.md
@@ -1,0 +1,235 @@
+# Handoff: Process Finder (`ps"`) + Kill Fuzzy-Find — Windows & macOS
+
+Reference implementation landed in **linows** (`apps/linows/`). This document
+specifies the feature and what each other platform needs to reach parity.
+
+- **Windows** = the linows Tauri build (`apps/linows/`, shared JS + `src-tauri`).
+  Backend stubs need filling; the frontend is already shared and works as soon
+  as the backend returns real data.
+- **macOS** = the native SwiftUI app (`apps/macos/`), the design source of truth.
+  Needs a full native port: backend, frontend, and keyboard shortcuts.
+
+> The process code is intentionally **not** in `core/` — enumeration is
+> irreducibly OS-specific (`/proc` vs Win32 vs libproc), so each platform
+> implements its own. Only the fuzzy scoring is shared (`core/matching`).
+
+---
+
+## 1. What the feature is
+
+### `ps"` prefix — a live process finder
+Typing `ps"` enters a process mode (sibling of `c"` clipboard, `t"` translate):
+
+- **Empty query** → all of the user's processes, name + PID.
+- **Query** → fuzzy match on process name; a **numeric** query also matches a
+  **listening TCP port** (find-by-port) or the PID.
+- **Rows**: `Name` + `PID · :ports`. App-backed processes show the app icon;
+  others a generic process glyph.
+- **Preview**: Command line (argv), Memory, User, Parent PID, Started, CPU
+  (measured **on demand**, see below), Ports.
+- **Keys** (Linux/Windows use `Ctrl`, macOS uses `Cmd`):
+  - `Enter` → measure & show CPU% for the selected process (on-demand only).
+  - `Ctrl/Cmd+D` → kill (SIGKILL).
+  - `Ctrl/Cmd+C` → copy PID.
+  - `Esc` → clear query / leave mode.
+
+### Kill command — now a fuzzy finder over apps + processes
+The existing `kill` command (Ctrl+4 / Cmd+4) gained fuzzy search:
+
+- **Empty query** → apps only (unchanged default).
+- **Query** → apps that fuzzy-match rank **first**, then any other matching
+  process, deduped by PID. App-backed processes keep their app icon.
+- **`:port`** → unchanged port lookup.
+
+---
+
+## 2. Reference backend (linows `src-tauri/src/process.rs`)
+
+Tauri commands and their serialized payloads. **All names are `snake_case` over
+the IPC boundary** (serde) — match these field names on every platform so the
+shared frontend keeps working.
+
+```rust
+// Row in the ps" finder.
+struct ProcRow { name: String, pid: u32, icon_source: Option<String>, ports: Vec<u16> }
+
+// Per-selection preview detail. start_epoch is Unix seconds (frontend formats it).
+struct ProcDetail { cmdline: String, rss_kb: u64, user: String, ppid: u32, start_epoch: Option<u64> }
+
+// Row in the kill command (app or raw process).
+struct KillTarget { name: String, pid: u32, is_app: bool, desktop_id: Option<String>, exec: Option<String> }
+```
+
+| Command | Signature | Notes |
+|---|---|---|
+| `search_processes` | `(query: String, refresh: bool) -> Vec<ProcRow>` | **async**. Cached snapshot; `refresh` re-enumerates (mode entry + post-kill), else scores the cache. Limit 50. |
+| `process_detail` | `(pid: u32) -> Option<ProcDetail>` | sync; cheap per-selection reads. |
+| `process_cpu` | `(pid: u32) -> Option<f64>` | **async**; two-sample delta, ~200 ms. Percent of one core (may exceed 100, like `top`). |
+| `search_kill_targets` | `(query: String) -> Vec<KillTarget>` | **async**. Empty → apps; else apps-first then processes, deduped by PID. Limit 60. |
+| reused | `kill_process(pid)`, `copy_to_clipboard(text)`, `list_processes()` | already cross-platform. |
+
+### Scoring rules (must match on every platform)
+- **Name**: `look_matching::fuzzy_score_prepared`.
+- **Numeric query** (`ps"`): exact port > partial-port-substring > PID-substring,
+  all ranked **above** name matches; name fuzzy still runs (names can contain digits).
+- **Kill ranking**: all matching apps (by display name) first, then matching
+  processes, each group sorted by score then name.
+
+### ⚠️ Gotchas (cost real debugging time — honor them)
+1. **`look_matching::fuzzy_score` is CASE-SENSITIVE.** Lowercase **both** the
+   query and each title before scoring (the engine does the same via its
+   normalized-query path). App names are `Capitalized`; queries are typed
+   lowercase — skip this and app matches silently vanish.
+2. **CPU is on-demand (Enter), never per-selection.** Sampling needs a sleep;
+   doing it on every arrow-key would jank. Bind it to Enter only.
+3. **Anything that walks the process table or sleeps must run off the UI/main
+   thread** (Tauri: `async` + `spawn_blocking`). Same principle on every platform.
+4. **Snapshot caching**: enumerate once on mode entry / after a kill, then
+   re-score the cache per keystroke. Never walk the process table per keystroke.
+5. **Modifier**: `Ctrl` on Linux/Windows, `Cmd` on macOS.
+
+### Linux data sources (for translating field-by-field)
+| Field | Source |
+|---|---|
+| enumerate / name / uid | `/proc/[pid]/status` (`Name:`, `Uid:`), filter own uid |
+| cmdline | `/proc/[pid]/cmdline` (NUL-separated argv) |
+| rss_kb | `/proc/[pid]/status` `VmRSS:` |
+| ppid | `/proc/[pid]/status` `PPid:` |
+| user | uid → `/etc/passwd` |
+| start_epoch | `/proc/[pid]/stat` field 22 (starttime ticks) + `/proc/stat` `btime`, `CLK_TCK=100` |
+| cpu | `/proc/[pid]/stat` utime(14)+stime(15) sampled twice; `100·(Δticks/CLK_TCK)/Δsecs` |
+| ports | `/proc/net/tcp{,6}` LISTEN (state `0A`) → inode→port; `/proc/[pid]/fd/*` `socket:[inode]` → pid→ports |
+| icon_source | match `/proc` names to `.desktop` entries → pid → desktop path |
+
+### Reference frontend (shared JS — read before porting to SwiftUI)
+- `src/js/catalog.js` — `PREFIX_ENTRIES` entry `{ prefix: 'ps"', ... }`.
+- `src/js/search.js` — `processMode`, `forceProcessRefresh`, `performProcessSearch`.
+- `src/js/components/results.js` — process row + app-icon-or-glyph.
+- `src/js/components/preview.js` — `renderProcessPreview`, `measureCpu` (on Enter).
+- `src/js/keyboard.js` — Enter/Ctrl+D/Ctrl+C/Esc handling in process mode.
+- `src/js/screens/commands/kill.js` + `app.js` `kill-search` — kill fuzzy path.
+
+---
+
+## 3. Windows (linows Tauri) — fill the stubs
+
+File: `apps/linows/src-tauri/src/platform/windows/process.rs`.
+Win32 imports, `enumerate_processes() -> Vec<(u32, String)>`, `resolve_full_path`,
+`GetExtendedTcpTable`, `kill`, and `list()`/`list_on_port()` already exist.
+
+**Status:** `list_all()` works (Toolhelp) but returns `icon_source: None`,
+`ports: vec![]`. `process_detail` / `process_cpu` dispatch to `None` in
+`process.rs` (search across `#[cfg(target_os = "windows")]`).
+
+**TODO:**
+
+1. **`list_all()` — ports + icon.**
+   - Ports: generalize `collect_listening_pids_for` (already parses the
+     `GetExtendedTcpTable` `TCP_TABLE_OWNER_PID_LISTENER` table of
+     `MIB_TCP{,6}ROW_OWNER_PID`) to return `(pid, port)` pairs → build
+     `HashMap<pid, Vec<u16>>` once, attach per row. Port is big-endian in the
+     row (`u16::from_be`/swap bytes).
+   - `icon_source`: Windows apps have no `.desktop`; `list()` already emits
+     `desktop_id = "app:<exe_path>"`. Set `icon_source = Some(exe_path)` (from
+     `resolve_full_path(pid)`) so app-backed rows show the exe icon. The shared
+     frontend loads it via `getIcon('app', path)`.
+
+2. **`detail(pid) -> Option<ProcDetail>`** (new):
+   - `cmdline`: `NtQueryInformationProcess(ProcessBasicInformation)` → PEB →
+     `ProcessParameters.CommandLine` via `ReadProcessMemory`. Fallback to the
+     exe path (`resolve_full_path`) if the remote read is denied.
+   - `rss_kb`: `GetProcessMemoryInfo` → `WorkingSetSize / 1024`.
+   - `ppid`: Toolhelp `PROCESSENTRY32W.th32ParentProcessID` (build a pid→ppid
+     map in the existing `enumerate_processes` pass).
+   - `user`: `OpenProcessToken(TOKEN_QUERY)` → `GetTokenInformation(TokenUser)`
+     → `LookupAccountSidW`. Fallback to `""`.
+   - `start_epoch`: `GetProcessTimes` creation `FILETIME` → Unix seconds
+     (`(filetime - 116444736000000000) / 10_000_000`).
+
+3. **`cpu(pid) -> Option<f64>`** (new): `GetProcessTimes` kernel+user `FILETIME`
+   sampled twice around a ~200 ms sleep; `100·(Δ100ns / 1e7) / Δsecs`. Keep the
+   `spawn_blocking` wrapper (already in `process.rs`).
+
+4. **Wire dispatch** in `process.rs`: replace the two windows `None` arms of
+   `process_detail` / `process_cpu` with calls into the new functions.
+
+Frontend needs no changes — ports, detail, and CPU populate automatically once
+the backend returns them.
+
+---
+
+## 4. macOS (native SwiftUI `apps/macos/`) — full port
+
+Design source of truth. Match the linows layout (which was modeled on the macOS
+patterns — `LauncherView.swift`, `ResultPreviewView`, the command panels).
+
+### 4a. Architecture choice
+Process ops are OS-specific and are **not** in `core/`, so macOS reimplements
+them. Two options:
+- **Native Swift** (recommended): `libproc`/`sysctl` are C APIs trivially
+  callable from Swift; keeps it close to the SwiftUI layer.
+- **Rust module + FFI** (`bridge/ffi/`): only if you want to share the fuzzy
+  scoring path end-to-end. Note `core/matching` is already reachable — you can
+  call it over FFI for identical ranking while keeping enumeration native.
+
+### 4b. Backend (macOS APIs)
+| Field | API |
+|---|---|
+| enumerate | `proc_listallpids` (or `sysctl KERN_PROC_ALL`); filter to `getuid()` |
+| name | `proc_name` / comm |
+| cmdline (argv) | `sysctl KERN_PROCARGS2` |
+| memory (rss_kb) | `proc_pid_rusage(pid, RUSAGE_INFO_V2)` → `ri_resident_size` (or `ri_phys_footprint`) / 1024 |
+| cpu | `proc_pid_rusage` `ri_user_time + ri_system_time` (ns) sampled twice; `100·(Δns/1e9)/Δsecs` |
+| ppid / uid / start | `proc_pidinfo(PROC_PIDTBSDINFO)` → `pbi_ppid`, `pbi_uid`, `pbi_start_tvsec` (already Unix seconds → `start_epoch`) |
+| user | `getpwuid` |
+| ports | `proc_pidinfo(PROC_PIDLISTFDS)` → for `PROX_FDTYPE_SOCKET`, `proc_pidfdinfo(PROC_PIDFDSOCKETINFO)` → `socket_fdinfo`; keep TCP sockets in listen state (`soi_kind == SOCKINFO_TCP`, `tcpsi_state == TSI_S_LISTEN`), local port `insi_lport` (`ntohs`) |
+| icon | `NSWorkspace.shared.icon(forFile: bundleOrExePath)`; app-backed via `NSRunningApplication(processIdentifier:)` → `.bundleURL` |
+| kill | `kill(pid, SIGKILL)` |
+
+**⚠️ macOS-specific gotchas:**
+- **`task_for_pid` and reading other processes' info require elevated
+  privileges / an entitlement** under SIP. `proc_pid_rusage` and `proc_pidinfo`
+  work for the **current user's** processes without special entitlement — scope
+  the finder to own-uid processes (matches Linux `Uid:` filter). Killing other
+  users' processes needs privilege; surface a clear error rather than failing
+  silently.
+- Same on-demand-CPU and off-main-thread rules as §2 (use a background queue;
+  don't block the UI on the sampling sleep).
+- Same case-insensitive fuzzy rule — lowercase both sides.
+
+### 4c. Frontend (SwiftUI)
+- Detect the `ps"` prefix in the launcher input; enter a process mode alongside
+  the existing prefix modes.
+- Rows: `Name` + `PID` (append `· :port` when listening). App icon when
+  app-backed, else an SF Symbol (`cpu` / `gearshape`).
+- Preview pane mirroring linows: **Command** (argv), Memory, User, Parent PID,
+  Started, **CPU** (shows "Press Enter to measure" until requested), Ports.
+- Kill command: fuzzy over apps + processes, **apps first**, matching the
+  linows behavior; keep the existing confirm-before-kill flow.
+
+### 4d. Keyboard / shortkeys (macOS conventions — `Cmd`, not `Ctrl`)
+| Action | macOS | (linows equivalent) |
+|---|---|---|
+| Enter process mode | type `ps"` | same |
+| Measure CPU | `Enter` (on selected) | same |
+| Kill (SIGKILL) | **`Cmd+D`** | `Ctrl+D` |
+| Copy PID | **`Cmd+C`** | `Ctrl+C` |
+| Clear / leave mode | `Esc` | same |
+| Navigate | `↑` / `↓` | same |
+
+Hint bar: `Cmd+D: Kill • Cmd+C: Copy PID`.
+
+---
+
+## 5. Parity checklist
+
+- [ ] `ps"` prefix enters process mode; empty query lists own-user processes.
+- [ ] Numeric query matches exact port > partial port > PID; name fuzzy also runs.
+- [ ] Rows: Name + PID (+ ports); app-backed rows show the app icon.
+- [ ] Preview: cmdline, memory, user, ppid, started, ports; CPU on Enter only.
+- [ ] Kill/CopyPID on the platform modifier; Esc clears.
+- [ ] `kill` command: empty → apps; query → apps-first then processes, deduped.
+- [ ] Fuzzy is case-insensitive (lowercase both sides).
+- [ ] Enumeration/sleeps run off the UI thread; snapshot cached, refreshed on
+      entry + after a kill.
+- [ ] Kill failures on privileged processes report a clear error.


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added Process Finder mode via the `ps"` prefix to discover running processes by name, PID, or listening port.
  * Added process results with a dedicated preview (including ports) and on-demand CPU sampling (Enter), plus improved kill fuzzy search with app-first ranking and PID deduplication.
  * Added new process IPC commands (process search, kill targets, details, CPU); removed port-only process listing.

* **Bug Fixes**
  * Improved Linux stability/performance by trimming unused WebKitGTK memory/feature subsystems.

* **Documentation**
  * Added a cross-platform Process Finder + Kill parity handoff/spec.

* **Tests**
  * Added/extended coverage for ranking, cmdline parsing, list-all behavior, and detail/CPU outputs.

* **Style**
  * Improved process icon handling with bounded LRU caching; added process preview badge styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Why

#193 


## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [x] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)


## Checklist

- [x] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered

