### PR TITLE
fuzzy processes for macos

### DIFF
--- a/apps/linows/src-tauri/src/platform/linux/process.rs
+++ b/apps/linows/src-tauri/src/platform/linux/process.rs
@@ -855,11 +855,13 @@ fn ports_for_pid(pid: u32, inode_ports: &HashMap<u64, u16>) -> Vec<u16> {
 
 /// Private memory (USS = `Private_Clean` + `Private_Dirty`) from
 /// `/proc/<pid>/smaps_rollup` - the Linux analog of macOS `phys_footprint`;
-/// excludes shared pages, unlike the ~2x-larger `VmRSS`. Falls back to `VmRSS`
-/// when smaps_rollup is unavailable (kernels < 4.14).
+/// excludes shared pages, unlike the ~2x-larger `VmRSS`, which is the
+/// compatibility fallback whenever smaps_rollup can't be read or parsed
+/// (kernels < 4.14, permission denied, process exited mid-read).
 fn private_mem_kb(pid: u32, status: &str) -> u64 {
     if let Ok(rollup) = fs::read_to_string(format!("/proc/{pid}/smaps_rollup")) {
-        let field = |key: &str| parse_status_field(&rollup, key).and_then(|v| v.parse::<u64>().ok());
+        let field =
+            |key: &str| parse_status_field(&rollup, key).and_then(|v| v.parse::<u64>().ok());
         if let (Some(clean), Some(dirty)) = (field("Private_Clean:"), field("Private_Dirty:")) {
             return clean + dirty;
         }

--- a/apps/linows/src-tauri/src/platform/linux/process.rs
+++ b/apps/linows/src-tauri/src/platform/linux/process.rs
@@ -853,11 +853,25 @@ fn ports_for_pid(pid: u32, inode_ports: &HashMap<u64, u16>) -> Vec<u16> {
     ports
 }
 
+/// Private memory (USS = `Private_Clean` + `Private_Dirty`) from
+/// `/proc/<pid>/smaps_rollup` - the Linux analog of macOS `phys_footprint`;
+/// excludes shared pages, unlike the ~2x-larger `VmRSS`. Falls back to `VmRSS`
+/// when smaps_rollup is unavailable (kernels < 4.14).
+fn private_mem_kb(pid: u32, status: &str) -> u64 {
+    if let Ok(rollup) = fs::read_to_string(format!("/proc/{pid}/smaps_rollup")) {
+        let field = |key: &str| parse_status_field(&rollup, key).and_then(|v| v.parse::<u64>().ok());
+        if let (Some(clean), Some(dirty)) = (field("Private_Clean:"), field("Private_Dirty:")) {
+            return clean + dirty;
+        }
+    }
+    parse_status_field(status, "VmRSS:")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0)
+}
+
 pub(crate) fn detail(pid: u32) -> Option<ProcDetail> {
     let status = fs::read_to_string(format!("/proc/{pid}/status")).ok()?;
-    let rss_kb = parse_status_field(&status, "VmRSS:")
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(0);
+    let rss_kb = private_mem_kb(pid, &status);
     let ppid = parse_status_field(&status, "PPid:")
         .and_then(|v| v.parse().ok())
         .unwrap_or(0);

--- a/apps/linows/src-tauri/src/process.rs
+++ b/apps/linows/src-tauri/src/process.rs
@@ -140,7 +140,10 @@ fn score_process(
             return Some(NUMERIC_PARTIAL_SCORE);
         }
         if pid.to_string().contains(trimmed) {
-            return Some(PID_PARTIAL_SCORE);
+            // The PID tier ranks below every name hit, so it only applies when
+            // the name doesn't match.
+            return look_matching::fuzzy_score_prepared(prepared, &name.to_lowercase())
+                .or(Some(PID_PARTIAL_SCORE));
         }
     }
     // Name fuzzy still runs for numeric queries: a name can contain digits.
@@ -472,6 +475,14 @@ mod tests {
         assert_eq!(score(&by_port, "300"), Some(NUMERIC_PARTIAL_SCORE));
         assert_eq!(score(&by_pid, "300"), Some(PID_PARTIAL_SCORE));
         assert!(score(&by_port, "300").unwrap() > score(&by_pid, "300").unwrap());
+    }
+
+    #[test]
+    fn pid_substring_keeps_a_real_name_match() {
+        let named = row("proc300", 1300, &[]); // name and PID both hold "300"
+        let pid_only = row("b", 1300, &[]);
+        assert!(score(&named, "300").unwrap() > PID_PARTIAL_SCORE);
+        assert_eq!(score(&pid_only, "300"), Some(PID_PARTIAL_SCORE));
     }
 
     #[test]

--- a/apps/macos/LauncherApp/LauncherLogicTests/ProcessScoringTests.swift
+++ b/apps/macos/LauncherApp/LauncherLogicTests/ProcessScoringTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+@testable import LauncherLogic
+
+/// Parity tests for the process-finder ranking, mirroring the Rust reference
+/// tests in `apps/linows/src-tauri/src/process.rs`. The fuzzy name score is
+/// injected as a lightweight subsequence stub: the real `core/matching` DP is
+/// already covered by the Rust crate's own tests, and reused verbatim over FFI,
+/// so what needs testing here is the numeric-tier layering and the apps-first
+/// kill ordering - both pure Swift.
+final class ProcessScoringTests: XCTestCase {
+    /// Deterministic stand-in for `look_fuzzy_score`: a positive score when
+    /// `query` is a subsequence of `title`, else nil. Both are already
+    /// lowercased by the scorer, matching the FFI contract.
+    private func stubFuzzy(_ query: String) -> (String) -> Int? {
+        { title in
+            var qi = query.startIndex
+            for ch in title where qi < query.endIndex && ch == query[qi] {
+                qi = query.index(after: qi)
+            }
+            return qi == query.endIndex ? 100 : nil
+        }
+    }
+
+    private func score(_ candidate: ProcessScoring.Candidate, _ query: String) -> Int? {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        return ProcessScoring.score(
+            name: candidate.name,
+            ports: candidate.ports,
+            pid: candidate.pid,
+            trimmedQuery: trimmed,
+            isNumeric: ProcessScoring.isNumeric(trimmed),
+            exactPort: ProcessScoring.exactPort(trimmed),
+            fuzzy: stubFuzzy(trimmed.lowercased())
+        )
+    }
+
+    private func row(_ name: String, _ pid: Int32, _ ports: [Int]) -> ProcessScoring.Candidate {
+        ProcessScoring.Candidate(name: name, pid: pid, ports: ports)
+    }
+
+    // MARK: - score_process parity
+
+    func testExactPortBeatsPartialAndName() {
+        let server = row("node", 4321, [3000])
+        let other = row("node", 30001, []) // "3000" is a PID substring only
+        let named = row("proc3000", 99, []) // name contains the digits
+        let exact = score(server, "3000")
+        XCTAssertEqual(exact, ProcessScoring.portExactScore)
+        XCTAssertGreaterThan(exact!, score(other, "3000")!)
+        XCTAssertGreaterThan(exact!, score(named, "3000")!)
+    }
+
+    func testPartialPortRanksAbovePIDOnly() {
+        let byPort = row("a", 1, [3000]) // "300" is a substring of the port
+        let byPID = row("b", 3009, []) // "300" is a substring of the PID
+        XCTAssertEqual(score(byPort, "300"), ProcessScoring.numericPartialScore)
+        XCTAssertEqual(score(byPID, "300"), ProcessScoring.pidPartialScore)
+        XCTAssertGreaterThan(score(byPort, "300")!, score(byPID, "300")!)
+    }
+
+    func testNameQueryStillFuzzyMatches() {
+        let ff = row("firefox", 100, [])
+        XCTAssertNotNil(score(ff, "fire"))
+        XCTAssertNil(score(ff, "zzq"))
+    }
+
+    func testOversizedPortNumberMatchesNothing() {
+        // 99999 > u16::MAX: no exact port, no substring, no PID -> nil.
+        let r = row("svc", 42, [8080])
+        XCTAssertNil(score(r, "99999"))
+    }
+
+    func testNumericQueryStillFuzzyMatchesDigitName() {
+        // A name containing the digits still fuzzy-matches even for numeric queries.
+        let r = row("proc3000", 99, [])
+        XCTAssertNotNil(score(r, "3000"))
+    }
+
+    // MARK: - rank_kill_targets parity
+
+    func testKillTargetsRankAppsBeforeProcesses() {
+        let apps = [(name: "Firefox", pid: Int32(100))]
+        // pid 100 is the app's own PID (deduped); 200 is a stray "firefox" proc.
+        let procs = [row("firefox", 100, []), row("firefox", 200, [])]
+        let out = ProcessScoring.rankKillTargets(
+            apps: apps, procs: procs, query: "fire", fuzzy: stubFuzzy("fire"))
+        XCTAssertEqual(out.count, 2, "app + the non-dup process")
+        XCTAssertTrue(out[0].isApp, "app ranks first")
+        XCTAssertEqual(out[0].pid, 100)
+        XCTAssertFalse(out[1].isApp)
+        XCTAssertEqual(out[1].pid, 200)
+    }
+
+    func testKillTargetsNonMatchExcluded() {
+        let out = ProcessScoring.rankKillTargets(
+            apps: [(name: "Firefox", pid: 1)], procs: [row("bash", 2, [])],
+            query: "zzq", fuzzy: stubFuzzy("zzq"))
+        XCTAssertTrue(out.isEmpty)
+    }
+
+    func testKillTargetsMatchByPortAndPID() {
+        let apps = [(name: "Firefox", pid: Int32(1))]
+        let procs = [row("node", 4321, [3000]), row("bash", 900, [])]
+        // A bare port number finds its owner via the process rows.
+        let byPort = ProcessScoring.rankKillTargets(
+            apps: apps, procs: procs, query: "3000", fuzzy: stubFuzzy("3000"))
+        XCTAssertEqual(byPort.count, 1)
+        XCTAssertEqual(byPort[0].pid, 4321)
+        // A bare PID finds the process directly.
+        let byPID = ProcessScoring.rankKillTargets(
+            apps: apps, procs: procs, query: "900", fuzzy: stubFuzzy("900"))
+        XCTAssertEqual(byPID.count, 1)
+        XCTAssertEqual(byPID[0].pid, 900)
+    }
+}

--- a/apps/macos/LauncherApp/LauncherLogicTests/ProcessScoringTests.swift
+++ b/apps/macos/LauncherApp/LauncherLogicTests/ProcessScoringTests.swift
@@ -58,6 +58,13 @@ final class ProcessScoringTests: XCTestCase {
         XCTAssertGreaterThan(score(byPort, "300")!, score(byPID, "300")!)
     }
 
+    func testPIDSubstringKeepsARealNameMatch() {
+        let named = row("proc300", 1300, []) // name and PID both hold "300"
+        let pidOnly = row("b", 1300, [])
+        XCTAssertGreaterThan(score(named, "300")!, ProcessScoring.pidPartialScore)
+        XCTAssertEqual(score(pidOnly, "300"), ProcessScoring.pidPartialScore)
+    }
+
     func testNameQueryStillFuzzyMatches() {
         let ff = row("firefox", 100, [])
         XCTAssertNotNil(score(ff, "fire"))

--- a/apps/macos/LauncherApp/Package.swift
+++ b/apps/macos/LauncherApp/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
                 "Support/AppConstants.swift",
                 "Support/ConfigFileLines.swift",
                 "Support/Launcher/LauncherSearchLogic.swift",
+                "Support/Launcher/ProcessScoring.swift",
                 "Support/Launcher/DeleteTargetLogic.swift",
                 "Support/Launcher/BridgeErrorMapping.swift",
                 "Support/SingleInstanceLock.swift",

--- a/apps/macos/LauncherApp/look-app/Models/LauncherResult.swift
+++ b/apps/macos/LauncherApp/look-app/Models/LauncherResult.swift
@@ -5,6 +5,9 @@ enum LauncherResultKind: String, Codable {
     case file
     case folder
     case clipboard
+    /// A running process row from the `ps"` finder. Carries `processPID` /
+    /// `processPorts`; detail (cmdline, memory, …) loads per-selection.
+    case process
 }
 
 struct LauncherResult: Identifiable {
@@ -18,4 +21,7 @@ struct LauncherResult: Identifiable {
     var clipboardCapturedAt: Date? = nil
     var clipboardCharacterCount: Int? = nil
     var clipboardLineCount: Int? = nil
+    /// Set only for `.process` rows: the process id and its listening TCP ports.
+    var processPID: Int32? = nil
+    var processPorts: [Int]? = nil
 }

--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -87,6 +87,9 @@ enum AppConstants {
             // Translation prefixes (handled in LauncherView+Translation).
             static let translate = "t\""
             static let translateWord = "tw\""
+            // Live process finder (handled in LauncherView+Process): fuzzy over
+            // running processes, kill / copy-PID / measure-CPU from the results.
+            static let process = "ps\""
 
             // Typing a lone `"` opens the prefix-discovery menu (see
             // PrefixSuggestion.all / LauncherView.isPrefixSuggestionQuery).
@@ -151,6 +154,9 @@ enum AppConstants {
                 Entry(
                     prefix: QueryPrefix.translateWord, argHint: "word",
                     description: "Lookup panel with definitions"),
+                Entry(
+                    prefix: QueryPrefix.process, argHint: "word",
+                    description: "Find & kill running processes"),
             ]
 
             /// Recovers the query prefix encoded in a discovery-suggestion result
@@ -194,6 +200,16 @@ enum AppConstants {
                 guard resultID.hasPrefix(resultIDPrefix) else { return nil }
                 return String(resultID.dropFirst(resultIDPrefix.count))
             }
+        }
+
+        /// `ps"` process-finder constants. Logic lives in `LauncherProcessFeature`.
+        enum Process {
+            static let resultIDPrefix = "process:"
+            /// Row cap: enough to scroll, few enough to render instantly
+            /// (mirrors linows `PROC_RESULT_LIMIT`).
+            static let resultLimit = 50
+            /// Synthetic path so the row isn't treated as a filesystem target.
+            static let resultPath = "look://process"
         }
 
         enum Finder {
@@ -392,7 +408,7 @@ enum AppConstants {
             AppCommand(id: Command.calc, title: "calc (⌘1)", detail: "Evaluate math expression", placeholder: "Type math expression"),
             AppCommand(id: Command.pomo, title: "pomo (⌘2)", detail: "Pomodoro focus timer", placeholder: "Manage focus sessions"),
             AppCommand(id: Command.todo, title: "todo (⌘3)", detail: "Daily tasks & progress", placeholder: "Search tasks & dates"),
-            AppCommand(id: Command.kill, title: "kill (⌘4)", detail: "Force kill app or process by port", placeholder: "Type app name, or :3000"),
+            AppCommand(id: Command.kill, title: "kill (⌘4)", detail: "Force kill app or process by name, PID, or port", placeholder: "Type a name, PID, or port"),
             AppCommand(id: Command.shell, title: "shell (⌘5)", detail: "Run a shell command", placeholder: "Type shell command"),
             AppCommand(id: Command.sys, title: "sys (⌘6)", detail: "Show system information", placeholder: "View system info"),
         ]

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
@@ -28,6 +28,10 @@ private func look_request_index_refresh() -> Bool
 nonisolated
 private func look_translate_json(_ text: UnsafePointer<CChar>?, _ targetLang: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
 
+@_silgen_name("look_fuzzy_score")
+nonisolated
+private func look_fuzzy_score(_ query: UnsafePointer<CChar>?, _ title: UnsafePointer<CChar>?) -> Int64
+
 @_silgen_name("look_instant_answer_json")
 nonisolated
 private func look_instant_answer_json(_ query: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
@@ -235,6 +239,18 @@ final class EngineBridge: @unchecked Sendable {
         }
 
         return try? JSONDecoder().decode(TranslationResult.self, from: data)
+    }
+
+    /// Shared `core/matching` fuzzy score for `query` vs `title` (identical
+    /// ranking to linows), or nil on no match. Both sides must be pre-lowercased
+    /// by the caller (the scorer is case-sensitive). Cheap - safe while typing.
+    nonisolated func fuzzyScore(query: String, title: String) -> Int? {
+        let score = query.withCString { queryCstr in
+            title.withCString { titleCstr in
+                look_fuzzy_score(queryCstr, titleCstr)
+            }
+        }
+        return score == Int64.min ? nil : Int(score) // Int64.min = NO_MATCH sentinel
     }
 
     /// Network-free gate: whether `query` matches a shared instant-answer

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/HintText.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/HintText.swift
@@ -4,7 +4,7 @@ enum HintText {
     enum Launcher {
         static let normal = "Enter open  •  Cmd+F reveal  •  Cmd+H help  •  Cmd+/ command mode"
         static let command = "Tab select command  •  Cmd+1/2/3/4 switch  •  Enter run  •  Esc back  •  Cmd+Shift+, settings"
-        static let kill = "Up/Down results  •  Type :3000 for port  •  Cmd+1/2/3/4 switch  •  Y/N confirm"
+        static let kill = "Up/Down results  •  Name, PID, or port  •  Cmd+1/2/3/4 switch  •  Y/N confirm"
         static let sys = "Sys info view  •  Cmd+1/2/3/4 switch  •  Esc back"
     }
 

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/LauncherProcessFeature.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/LauncherProcessFeature.swift
@@ -1,0 +1,59 @@
+import AppKit
+import UniformTypeIdentifiers
+
+/// Query detection, row construction, and icon resolution for the `ps"` process
+/// finder. Mirrors `LauncherClipboardFeature`: `AppConstants.Launcher.Process`
+/// holds the constants, this owns the logic.
+enum LauncherProcessFeature {
+    static func isProcessQuery(_ query: String) -> Bool {
+        query.trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .hasPrefix(AppConstants.Launcher.QueryPrefix.process)
+    }
+
+    /// The text typed after `ps"` (empty when just the prefix is present), or
+    /// nil when `query` isn't a process query.
+    static func searchTerm(from query: String) -> String? {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let prefix = AppConstants.Launcher.QueryPrefix.process
+        guard trimmed.lowercased().hasPrefix(prefix) else { return nil }
+        return String(trimmed.dropFirst(prefix.count)).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// A results-list row for a process. Subtitle is `PID <pid>` plus `· :port`
+    /// per listening port (matches the linows row).
+    static func makeResult(_ candidate: ProcessScoring.Candidate) -> LauncherResult {
+        var subtitle = "PID \(candidate.pid)"
+        if !candidate.ports.isEmpty {
+            subtitle += " · " + candidate.ports.map { ":\($0)" }.joined(separator: " ")
+        }
+        var result = LauncherResult(
+            id: "\(AppConstants.Launcher.Process.resultIDPrefix)\(candidate.pid)",
+            kind: .process,
+            title: candidate.name.isEmpty ? "Process \(candidate.pid)" : candidate.name,
+            subtitle: subtitle,
+            path: AppConstants.Launcher.Process.resultPath,
+            score: 0
+        )
+        result.processPID = candidate.pid
+        result.processPorts = candidate.ports
+        return result
+    }
+
+    /// The pid encoded in a process-row id, or nil.
+    static func pid(fromResultID resultID: String) -> Int32? {
+        let prefix = AppConstants.Launcher.Process.resultIDPrefix
+        guard resultID.hasPrefix(prefix) else { return nil }
+        return Int32(resultID.dropFirst(prefix.count))
+    }
+
+    /// App-backed process → its app icon; otherwise a generic process glyph.
+    /// Single source for the row, preview, and `/kill` list.
+    static func icon(forPID pid: Int32) -> NSImage {
+        if let app = NSRunningApplication(processIdentifier: pid), let icon = app.icon {
+            return icon
+        }
+        return NSImage(systemSymbolName: "gearshape", accessibilityDescription: nil)
+            ?? NSWorkspace.shared.icon(for: .unixExecutable)
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/LauncherSearchLogic.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/LauncherSearchLogic.swift
@@ -92,7 +92,9 @@ enum LauncherSearchLogic {
             return "\(result.kind.rawValue):\(normalizedTitle)"
         case .file, .folder:
             return "\(result.kind.rawValue):\(normalizedPath)"
-        case .clipboard:
+        case .clipboard, .process:
+            // Clipboard entries and process rows are already unique by id
+            // (entry UUID / pid), so key on it rather than title/path.
             return result.id
         }
     }

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/ProcessFinderModel.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/ProcessFinderModel.swift
@@ -19,6 +19,13 @@ final class ProcessFinderModel: ObservableObject {
 
     private var snapshotLoaded = false
     private var refreshTask: Task<Void, Never>?
+    /// Detail loads in flight, so arrow-key nav doesn't stack duplicate fetches.
+    private var loadingDetail: Set<Int32> = []
+    /// Bumped on every snapshot swap; the ranking memo keys off it.
+    private var snapshotRevision = 0
+    private var rankedTerm: String?
+    private var rankedRevision = -1
+    private var rankedRows: [ProcessScoring.Candidate] = []
 
     /// Re-enumerate the process table. Called on mode entry and after a kill.
     /// Clears the detail/cpu caches since pids may have been reused.
@@ -30,10 +37,29 @@ final class ProcessFinderModel: ObservableObject {
             }.value
             guard !Task.isCancelled else { return }
             candidates = snapshot.map { .init(name: $0.name, pid: $0.pid, ports: $0.ports) }
+            snapshotRevision += 1
             details.removeAll()
             cpu.removeAll()
             snapshotLoaded = true
         }
+    }
+
+    /// Rows for `term`, memoized against the snapshot: the view reads this
+    /// several times per body pass and a miss costs one FFI call per candidate.
+    /// Empty term lists alphabetically.
+    func ranked(term: String, fuzzy: (String) -> Int?) -> [ProcessScoring.Candidate] {
+        if rankedTerm == term, rankedRevision == snapshotRevision { return rankedRows }
+
+        if term.isEmpty {
+            rankedRows = candidates.sorted {
+                $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+            }
+        } else {
+            rankedRows = ProcessScoring.rankProcesses(candidates, query: term, fuzzy: fuzzy)
+        }
+        rankedTerm = term
+        rankedRevision = snapshotRevision
+        return rankedRows
     }
 
     /// Enumerate once on first entry; later entries reuse the snapshot until an
@@ -46,11 +72,13 @@ final class ProcessFinderModel: ObservableObject {
     /// Load detail for a selected pid (cheap reads), caching the result. No-op
     /// if already cached.
     func loadDetail(pid: Int32) {
-        guard details[pid] == nil else { return }
+        guard details[pid] == nil, !loadingDetail.contains(pid) else { return }
+        loadingDetail.insert(pid)
         Task {
             let detail = await Task.detached(priority: .userInitiated) {
                 ProcessService.detail(pid: pid)
             }.value
+            loadingDetail.remove(pid)
             guard let detail else { return }
             details[pid] = detail
         }
@@ -84,6 +112,7 @@ final class ProcessFinderModel: ObservableObject {
     func invalidate() {
         refreshTask?.cancel()
         refreshTask = nil
+        loadingDetail.removeAll()
         snapshotLoaded = false
     }
 }

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/ProcessFinderModel.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/ProcessFinderModel.swift
@@ -1,0 +1,89 @@
+import Combine
+import Foundation
+
+/// Backing state for the `ps"` process finder: an enumerated snapshot re-scored
+/// per keystroke (never re-enumerated) plus per-selection detail and on-demand
+/// CPU caches. `ProcessService` calls run detached; results land on the main
+/// actor.
+@MainActor
+final class ProcessFinderModel: ObservableObject {
+    /// Scoring input, derived once per snapshot so per-keystroke scoring doesn't
+    /// rebuild it.
+    @Published private(set) var candidates: [ProcessScoring.Candidate] = []
+    /// Per-selection detail, cached by pid so arrow-key revisits are instant.
+    @Published private(set) var details: [Int32: ProcessDetail] = [:]
+    /// CPU% measured on-demand (Enter), cached by pid. Absent = not yet measured.
+    @Published private(set) var cpu: [Int32: Double] = [:]
+    /// True while a CPU sample is in flight, so the view can show a hint.
+    @Published private(set) var measuringCPU: Set<Int32> = []
+
+    private var snapshotLoaded = false
+    private var refreshTask: Task<Void, Never>?
+
+    /// Re-enumerate the process table. Called on mode entry and after a kill.
+    /// Clears the detail/cpu caches since pids may have been reused.
+    func refreshSnapshot() {
+        refreshTask?.cancel()
+        refreshTask = Task {
+            let snapshot = await Task.detached(priority: .userInitiated) {
+                ProcessService.enumerate()
+            }.value
+            guard !Task.isCancelled else { return }
+            candidates = snapshot.map { .init(name: $0.name, pid: $0.pid, ports: $0.ports) }
+            details.removeAll()
+            cpu.removeAll()
+            snapshotLoaded = true
+        }
+    }
+
+    /// Enumerate once on first entry; later entries reuse the snapshot until an
+    /// explicit `refreshSnapshot()`.
+    func loadSnapshotIfNeeded() {
+        guard !snapshotLoaded else { return }
+        refreshSnapshot()
+    }
+
+    /// Load detail for a selected pid (cheap reads), caching the result. No-op
+    /// if already cached.
+    func loadDetail(pid: Int32) {
+        guard details[pid] == nil else { return }
+        Task {
+            let detail = await Task.detached(priority: .userInitiated) {
+                ProcessService.detail(pid: pid)
+            }.value
+            guard let detail else { return }
+            details[pid] = detail
+        }
+    }
+
+    /// Sample CPU% for a pid over ~200 ms (on-demand, bound to Enter). Caches
+    /// the measurement; safe to call repeatedly (re-measures).
+    func measureCPU(pid: Int32) {
+        guard !measuringCPU.contains(pid) else { return }
+        measuringCPU.insert(pid)
+        Task {
+            let value = await Task.detached(priority: .userInitiated) {
+                ProcessService.cpu(pid: pid)
+            }.value
+            measuringCPU.remove(pid)
+            if let value { cpu[pid] = value }
+        }
+    }
+
+    /// SIGKILL a process, then refresh the snapshot so it drops from the list.
+    /// Returns the outcome for the caller to surface (banner).
+    func kill(pid: Int32) -> Result<String, ProcessKillError> {
+        let result = ProcessService.kill(pid: pid)
+        if case .success = result {
+            refreshSnapshot()
+        }
+        return result
+    }
+
+    /// Reset so the next entry re-enumerates fresh (called when leaving mode).
+    func invalidate() {
+        refreshTask?.cancel()
+        refreshTask = nil
+        snapshotLoaded = false
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/ProcessScoring.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/ProcessScoring.swift
@@ -1,0 +1,165 @@
+import Foundation
+
+/// Ranking for the `ps"` finder and `/kill`, ported field-for-field from the
+/// Rust reference (`apps/linows/src-tauri/src/process.rs`) so macOS ranks like
+/// linows. The fuzzy name score is injected as a closure (backed by the
+/// `look_fuzzy_score` FFI over `core/matching`), keeping this module pure and
+/// unit-testable. The caller lowercases the query once; this lowercases each
+/// candidate title before scoring.
+public enum ProcessScoring {
+    /// A process candidate for ranking: just the fields scoring needs. The UI
+    /// layer carries icons/detail separately, keyed by `pid`.
+    public struct Candidate: Equatable {
+        public let name: String
+        public let pid: Int32
+        /// Listening TCP ports, matched against a numeric query.
+        public let ports: [Int]
+
+        public init(name: String, pid: Int32, ports: [Int]) {
+            self.name = name
+            self.pid = pid
+            self.ports = ports
+        }
+    }
+
+    /// A ranked `/kill` target: an app (nice name + icon) or a raw process.
+    /// Apps rank above processes so `kill firefox` surfaces the app.
+    public struct KillTarget: Equatable {
+        public let name: String
+        public let pid: Int32
+        public let isApp: Bool
+
+        public init(name: String, pid: Int32, isApp: Bool) {
+            self.name = name
+            self.pid = pid
+            self.isApp = isApp
+        }
+    }
+
+    // Scores for numeric-query matches, ranked above fuzzy name matches so an
+    // intentional port/PID lookup wins. Exact port beats a partial digit match.
+    // Mirror the Rust i64 constants (Int is 64-bit on macOS).
+    public static let portExactScore = Int.max / 2
+    public static let numericPartialScore = Int.max / 4
+    /// PID-only matches rank below every name match (fuzzy scores are small).
+    public static let pidPartialScore = Int.min / 2
+
+    /// True when `query` is all ASCII digits (a port/PID lookup). Mirrors the
+    /// Rust `chars().all(is_ascii_digit)`; an empty string is not numeric.
+    public static func isNumeric(_ query: String) -> Bool {
+        !query.isEmpty && query.allSatisfy { $0.isASCII && $0.isNumber }
+    }
+
+    /// The exact port a numeric query names, or nil if it overflows a u16.
+    /// Mirrors Rust `trimmed.parse::<u16>().ok()`, so `99999` yields nil (and
+    /// then matches nothing, rather than panicking).
+    public static func exactPort(_ query: String) -> Int? {
+        UInt16(query).map(Int.init)
+    }
+
+    /// Shared scoring for both process finders. A numeric query matches a
+    /// listening port (exact beats partial) or the PID; every query also
+    /// fuzzy-matches the name. nil when nothing matches. Pass an empty `ports`
+    /// array for sources that carry no ports (e.g. app rows).
+    ///
+    /// `fuzzy` scores an already-lowercased title against the (already
+    /// lowercased) query the caller closed over.
+    public static func score(
+        name: String,
+        ports: [Int],
+        pid: Int32,
+        trimmedQuery: String,
+        isNumeric: Bool,
+        exactPort: Int?,
+        fuzzy: (String) -> Int?
+    ) -> Int? {
+        if isNumeric {
+            if let port = exactPort, ports.contains(port) {
+                return portExactScore
+            }
+            if ports.contains(where: { String($0).contains(trimmedQuery) }) {
+                return numericPartialScore
+            }
+            if String(pid).contains(trimmedQuery) {
+                return pidPartialScore
+            }
+        }
+        // Name fuzzy still runs for numeric queries: a name can contain digits.
+        return fuzzy(name.lowercased())
+    }
+
+    /// Order two scored hits: score descending, then name ascending
+    /// (case-insensitive) - the tiebreak used everywhere in the reference.
+    /// `key` is the pre-lowercased name, so the sort doesn't re-lowercase on
+    /// every comparison.
+    private static func hitOrder<T>(
+        _ a: (score: Int, key: String, value: T),
+        _ b: (score: Int, key: String, value: T)
+    ) -> Bool {
+        if a.score != b.score { return a.score > b.score }
+        return a.key < b.key
+    }
+
+    /// Rank `ps"` rows for a non-empty query: score each candidate, drop
+    /// non-matches, sort by score then name. (The empty-query case is a plain
+    /// alphabetical listing handled by the caller.)
+    public static func rankProcesses(
+        _ candidates: [Candidate],
+        query: String,
+        fuzzy: (String) -> Int?
+    ) -> [Candidate] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let numeric = isNumeric(trimmed)
+        let port = exactPort(trimmed)
+
+        let scored: [(score: Int, key: String, value: Candidate)] = candidates.compactMap { row in
+            guard let s = score(
+                name: row.name, ports: row.ports, pid: row.pid,
+                trimmedQuery: trimmed, isNumeric: numeric, exactPort: port, fuzzy: fuzzy
+            ) else { return nil }
+            return (s, row.name.lowercased(), row)
+        }
+        return scored.sorted(by: hitOrder).map(\.value)
+    }
+
+    /// Rank `/kill` targets: apps first (matched on display name), then any
+    /// other process (matched on process name + numeric port/PID), deduped by
+    /// PID. Mirrors `rank_kill_targets`.
+    ///
+    /// `apps` are (display name, pid); `procs` are process candidates. `fuzzy`
+    /// scores an already-lowercased title against the caller's lowered query.
+    public static func rankKillTargets(
+        apps: [(name: String, pid: Int32)],
+        procs: [Candidate],
+        query: String,
+        fuzzy: (String) -> Int?
+    ) -> [KillTarget] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let numeric = isNumeric(trimmed)
+        let port = exactPort(trimmed)
+
+        // Apps carry no ports, so they match by name only; a numeric port/PID
+        // query resolves through the process rows below (which own the ports).
+        var appPIDs = Set<Int32>()
+        let appHits: [(score: Int, key: String, value: KillTarget)] = apps.compactMap { app in
+            let lowerName = app.name.lowercased()
+            guard let s = fuzzy(lowerName) else { return nil }
+            appPIDs.insert(app.pid)
+            return (s, lowerName, KillTarget(name: app.name, pid: app.pid, isApp: true))
+        }
+        let sortedApps = appHits.sorted(by: hitOrder)
+
+        // Processes already shown as an app (its representative PID) are skipped.
+        let procHits: [(score: Int, key: String, value: KillTarget)] = procs.compactMap { row in
+            guard !appPIDs.contains(row.pid) else { return nil }
+            guard let s = score(
+                name: row.name, ports: row.ports, pid: row.pid,
+                trimmedQuery: trimmed, isNumeric: numeric, exactPort: port, fuzzy: fuzzy
+            ) else { return nil }
+            return (s, row.name.lowercased(), KillTarget(name: row.name, pid: row.pid, isApp: false))
+        }
+        let sortedProcs = procHits.sorted(by: hitOrder)
+
+        return sortedApps.map(\.value) + sortedProcs.map(\.value)
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/ProcessScoring.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/ProcessScoring.swift
@@ -81,7 +81,9 @@ public enum ProcessScoring {
                 return numericPartialScore
             }
             if String(pid).contains(trimmedQuery) {
-                return pidPartialScore
+                // The PID tier ranks below every name hit, so it only applies
+                // when the name doesn't match.
+                return fuzzy(name.lowercased()) ?? pidPartialScore
             }
         }
         // Name fuzzy still runs for numeric queries: a name can contain digits.

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/ProcessService.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/ProcessService.swift
@@ -1,0 +1,281 @@
+import Darwin
+import Foundation
+
+/// One row in the `ps"` finder: a raw process. Kept minimal so enumeration stays
+/// cheap; richer fields load per-selection via `ProcessService.detail`. Mirrors
+/// the linows `ProcRow` (`apps/linows/src-tauri/src/process.rs`), minus the
+/// icon: macOS resolves that in the view via `NSRunningApplication`.
+struct ProcessRow: Identifiable, Equatable {
+    let pid: Int32
+    let name: String
+    /// Listening TCP ports owned by this process, sorted. Shown in the row and
+    /// matched against a numeric query so `ps"` doubles as a find-by-port.
+    let ports: [Int]
+
+    var id: Int32 { pid }
+}
+
+/// Per-process detail for the `ps"` preview pane. All fields are cheap single
+/// reads; `startEpoch` is Unix seconds (formatted in the view).
+struct ProcessDetail: Equatable {
+    let cmdline: String
+    /// Memory footprint in KB. Uses `ri_phys_footprint` (the app's private
+    /// memory) to match Activity Monitor's "Memory" column, rather than
+    /// `ri_resident_size` (RSS), which counts shared pages and reads much higher.
+    let memoryKB: UInt64
+    let user: String
+    let ppid: Int32
+    let startEpoch: UInt64?
+}
+
+/// Native process enumeration / detail / CPU / kill for the macOS `ps"` finder,
+/// scoped to the current user (own-uid reads need no SIP entitlement; killing
+/// another user's process needs privilege and surfaces a clear error).
+/// `nonisolated` so callers can run it on a detached task - it walks the process
+/// table and sleeps, so it must stay off the main thread.
+nonisolated enum ProcessService {
+    /// Own-user processes: pid, name, listening ports. Uses `sysctl
+    /// KERN_PROC_ALL` (what `ps` uses), **not** `proc_listallpids` - the latter
+    /// is silently throttled in hardened contexts and returns a partial list
+    /// (~146 of ~584 procs), which hid the user's own apps.
+    static func enumerate() -> [ProcessRow] {
+        let ownUID = getuid()
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_ALL, 0]
+
+        // Size the table, then fill it with slack (it can grow between calls).
+        // Retry once on ENOMEM if it grew past even the padded buffer.
+        var procs: [kinfo_proc] = []
+        for _ in 0..<3 {
+            var size = 0
+            guard sysctl(&mib, 4, nil, &size, nil, 0) == 0, size > 0 else { return [] }
+            let stride = MemoryLayout<kinfo_proc>.stride
+            let capacity = size / stride + 64 // slack for newly-spawned processes
+            procs = [kinfo_proc](repeating: kinfo_proc(), count: capacity)
+            var filled = capacity * stride
+            let rc = sysctl(&mib, 4, &procs, &filled, nil, 0)
+            if rc == 0 {
+                procs.removeLast(procs.count - filled / stride)
+                break
+            }
+            if errno != ENOMEM { return [] } // real error; retry only on "grew"
+            procs = []
+        }
+
+        var rows: [ProcessRow] = []
+        rows.reserveCapacity(procs.count)
+        for var proc in procs {
+            let pid = proc.kp_proc.p_pid
+            guard pid > 0, proc.kp_eproc.e_ucred.cr_uid == ownUID else { continue }
+            // p_comm is truncated to 16 chars; proc_name gives the full name.
+            let name = processName(pid: pid, commFallback: cString(from: &proc.kp_proc.p_comm))
+            rows.append(ProcessRow(pid: pid, name: name, ports: listeningPorts(pid: pid)))
+        }
+        return rows
+    }
+
+    /// Per-selection detail. Cheap reads; safe to call on arrow-key selection.
+    static func detail(pid: Int32) -> ProcessDetail? {
+        guard let info = bsdInfo(pid: pid) else { return nil }
+        let user = userName(uid: info.pbi_uid)
+        let start = info.pbi_start_tvsec == 0 ? nil : UInt64(info.pbi_start_tvsec)
+        return ProcessDetail(
+            cmdline: commandLine(pid: pid) ?? processName(pid: pid, commFallback: comm(from: info)),
+            memoryKB: memoryFootprintKB(pid: pid),
+            user: user,
+            ppid: Int32(bitPattern: info.pbi_ppid),
+            startEpoch: start
+        )
+    }
+
+    /// CPU% over ~200 ms (two `proc_pid_rusage` reads). On-demand (bound to
+    /// Enter), never per-selection - the sampling sleep would jank arrow-key
+    /// nav. Percent of one core (may exceed 100, like `top`).
+    static func cpu(pid: Int32) -> Double? {
+        guard let first = cpuTimeNs(pid: pid) else { return nil }
+        let intervalNs: UInt64 = 200_000_000
+        var ts = timespec(tv_sec: 0, tv_nsec: Int(intervalNs))
+        nanosleep(&ts, nil)
+        guard let second = cpuTimeNs(pid: pid) else { return nil }
+
+        let deltaCPU = Double(second >= first ? second - first : 0)
+        let deltaWall = Double(intervalNs)
+        guard deltaWall > 0 else { return nil }
+        return 100.0 * (deltaCPU / deltaWall)
+    }
+
+    /// SIGKILL a process. Native `kill(2)` rather than shelling out; EPERM
+    /// (another user's / protected process) surfaces a clear message instead of
+    /// failing silently.
+    static func kill(pid: Int32) -> Result<String, ProcessKillError> {
+        if Darwin.kill(pid, SIGKILL) == 0 {
+            return .success("Killed PID \(pid)")
+        }
+        let err = errno
+        switch err {
+        case EPERM:
+            return .failure(.permissionDenied)
+        case ESRCH:
+            return .failure(.noSuchProcess)
+        default:
+            return .failure(.other(String(cString: strerror(err))))
+        }
+    }
+
+    // MARK: - BSD info
+
+    private static func bsdInfo(pid: Int32) -> proc_bsdinfo? {
+        var info = proc_bsdinfo()
+        let size = Int32(MemoryLayout<proc_bsdinfo>.size)
+        let rc = proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info, size)
+        return rc == size ? info : nil
+    }
+
+    /// Full process name via `proc_name`, falling back to a caller-supplied
+    /// short name (the 16-char `comm`) when `proc_name` is unavailable. Never
+    /// returns empty for a live process, so enumeration never drops a row just
+    /// because `proc_name` failed.
+    private static func processName(pid: Int32, commFallback: String) -> String {
+        var buf = [CChar](repeating: 0, count: 2 * Int(MAXPATHLEN))
+        let n = proc_name(pid, &buf, UInt32(buf.count))
+        if n > 0 {
+            let name = String(cString: buf)
+            if !name.isEmpty { return name }
+        }
+        return commFallback.isEmpty ? "Process \(pid)" : commFallback
+    }
+
+    /// The 16-char `comm` from a `proc_bsdinfo` (prefers the longer `pbi_name`).
+    private static func comm(from info: proc_bsdinfo) -> String {
+        var info = info
+        let name = cString(from: &info.pbi_name)
+        return name.isEmpty ? cString(from: &info.pbi_comm) : name
+    }
+
+    /// Read a fixed-size C `char[]` tuple (imported as a Swift tuple) as a String.
+    private static func cString<T>(from tuple: inout T) -> String {
+        withUnsafeBytes(of: &tuple) {
+            String(cString: $0.bindMemory(to: CChar.self).baseAddress!)
+        }
+    }
+
+    private static func userName(uid: UInt32) -> String {
+        guard let pw = getpwuid(uid) else { return "" }
+        return String(cString: pw.pointee.pw_name)
+    }
+
+    // MARK: - Memory / CPU
+
+    private static func rusage(pid: Int32) -> rusage_info_v2? {
+        var usage = rusage_info_v2()
+        let rc = withUnsafeMutablePointer(to: &usage) { ptr in
+            ptr.withMemoryRebound(to: rusage_info_t?.self, capacity: 1) {
+                proc_pid_rusage(pid, RUSAGE_INFO_V2, $0)
+            }
+        }
+        return rc == 0 ? usage : nil
+    }
+
+    /// Memory footprint (`ri_phys_footprint`) in KB, matching Activity Monitor's
+    /// "Memory" column. RSS (`ri_resident_size`) would over-count shared pages.
+    private static func memoryFootprintKB(pid: Int32) -> UInt64 {
+        (rusage(pid: pid)?.ri_phys_footprint ?? 0) / 1024
+    }
+
+    private static func cpuTimeNs(pid: Int32) -> UInt64? {
+        rusage(pid: pid).map { $0.ri_user_time &+ $0.ri_system_time }
+    }
+
+    // MARK: - Command line (argv)
+
+    /// Full argv via `sysctl KERN_PROCARGS2`. Layout: `Int32 argc`, then the
+    /// exec path (NUL-terminated), NUL padding, then `argc` NUL-separated argv
+    /// strings. We skip the exec path and join the argv strings with spaces.
+    private static func commandLine(pid: Int32) -> String? {
+        var argmax: Int = 0
+        var sizeMax = MemoryLayout<Int>.size
+        var mibMax = [CTL_KERN, KERN_ARGMAX]
+        guard sysctl(&mibMax, 2, &argmax, &sizeMax, nil, 0) == 0, argmax > 0 else { return nil }
+
+        var buffer = [CChar](repeating: 0, count: argmax)
+        var size = argmax
+        var mib = [CTL_KERN, KERN_PROCARGS2, Int32(pid)]
+        guard sysctl(&mib, 3, &buffer, &size, nil, 0) == 0, size > MemoryLayout<Int32>.size else {
+            return nil
+        }
+
+        return buffer.withUnsafeBufferPointer { raw -> String? in
+            let base = raw.baseAddress!
+            var argc: Int32 = 0
+            memcpy(&argc, base, MemoryLayout<Int32>.size)
+            guard argc > 0 else { return nil }
+
+            var cursor = MemoryLayout<Int32>.size
+            let end = size
+
+            // Skip the exec path (NUL-terminated) then any NUL padding before argv[0].
+            while cursor < end && base[cursor] != 0 { cursor += 1 }
+            while cursor < end && base[cursor] == 0 { cursor += 1 }
+
+            var args: [String] = []
+            var collected: Int32 = 0
+            while cursor < end && collected < argc {
+                let startIdx = cursor
+                while cursor < end && base[cursor] != 0 { cursor += 1 }
+                let arg = String(cString: Array(raw[startIdx..<cursor]) + [0])
+                if !arg.isEmpty { args.append(arg) }
+                collected += 1
+                cursor += 1 // step over the NUL separator
+            }
+            return args.isEmpty ? nil : args.joined(separator: " ")
+        }
+    }
+
+    // MARK: - Ports
+
+    /// Listening TCP ports for a process: walk its fd table for socket fds, keep
+    /// TCP sockets in the LISTEN state, collect the local port. Mirrors the
+    /// linows `/proc/[pid]/fd` + socket-inode scan.
+    private static func listeningPorts(pid: Int32) -> [Int] {
+        let bufferSize = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, nil, 0)
+        guard bufferSize > 0 else { return [] }
+
+        let count = Int(bufferSize) / MemoryLayout<proc_fdinfo>.stride
+        var fds = [proc_fdinfo](repeating: proc_fdinfo(), count: count)
+        let filled = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, &fds, bufferSize)
+        guard filled > 0 else { return [] }
+        let actual = Int(filled) / MemoryLayout<proc_fdinfo>.stride
+
+        var ports = Set<Int>()
+        for i in 0..<actual {
+            guard fds[i].proc_fdtype == UInt32(PROX_FDTYPE_SOCKET) else { continue }
+            var socketInfo = socket_fdinfo()
+            let size = Int32(MemoryLayout<socket_fdinfo>.size)
+            let rc = proc_pidfdinfo(pid, fds[i].proc_fd, PROC_PIDFDSOCKETINFO, &socketInfo, size)
+            guard rc == size else { continue }
+            guard socketInfo.psi.soi_kind == SOCKINFO_TCP else { continue }
+            let tcp = socketInfo.psi.soi_proto.pri_tcp
+            guard tcp.tcpsi_state == Int32(TSI_S_LISTEN) else { continue }
+            // insi_lport is network byte order; ntohs -> host order.
+            let netPort = UInt16(truncatingIfNeeded: tcp.tcpsi_ini.insi_lport)
+            let port = Int(CFSwapInt16BigToHost(netPort))
+            if port > 0 { ports.insert(port) }
+        }
+        return ports.sorted()
+    }
+}
+
+/// Why a kill failed, so the UI can show a clear reason rather than a silent
+/// no-op (per the handoff's "surface a clear error" rule for privileged kills).
+enum ProcessKillError: Error, Equatable {
+    case permissionDenied
+    case noSuchProcess
+    case other(String)
+
+    var message: String {
+        switch self {
+        case .permissionDenied: return "permission denied (protected or another user's process)"
+        case .noSuchProcess: return "process no longer exists"
+        case .other(let detail): return detail
+        }
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/ProcessService.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/ProcessService.swift
@@ -93,12 +93,15 @@ nonisolated enum ProcessService {
     static func cpu(pid: Int32) -> Double? {
         guard let first = cpuTimeNs(pid: pid) else { return nil }
         let intervalNs: UInt64 = 200_000_000
+        let startNs = clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW)
         var ts = timespec(tv_sec: 0, tv_nsec: Int(intervalNs))
         nanosleep(&ts, nil)
         guard let second = cpuTimeNs(pid: pid) else { return nil }
 
+        // Measured elapsed, not the requested interval: nanosleep can overshoot
+        // or return early on EINTR.
         let deltaCPU = Double(second >= first ? second - first : 0)
-        let deltaWall = Double(intervalNs)
+        let deltaWall = Double(clock_gettime_nsec_np(CLOCK_MONOTONIC_RAW) - startNs)
         guard deltaWall > 0 else { return nil }
         return 100.0 * (deltaCPU / deltaWall)
     }
@@ -138,7 +141,9 @@ nonisolated enum ProcessService {
         var buf = [CChar](repeating: 0, count: 2 * Int(MAXPATHLEN))
         let n = proc_name(pid, &buf, UInt32(buf.count))
         if n > 0 {
-            let name = String(cString: buf)
+            let name = buf.withUnsafeBytes {
+                String(decoding: $0.prefix(while: { $0 != 0 }), as: UTF8.self)
+            }
             if !name.isEmpty { return name }
         }
         return commFallback.isEmpty ? "Process \(pid)" : commFallback
@@ -151,10 +156,12 @@ nonisolated enum ProcessService {
         return name.isEmpty ? cString(from: &info.pbi_comm) : name
     }
 
-    /// Read a fixed-size C `char[]` tuple (imported as a Swift tuple) as a String.
+    /// Read a fixed-size C `char[]` tuple (imported as a Swift tuple) as a
+    /// String. The scan stays inside the tuple: an unterminated field would
+    /// make `String(cString:)` read past it.
     private static func cString<T>(from tuple: inout T) -> String {
-        withUnsafeBytes(of: &tuple) {
-            String(cString: $0.bindMemory(to: CChar.self).baseAddress!)
+        withUnsafeBytes(of: &tuple) { buffer in
+            String(decoding: buffer.prefix(while: { $0 != 0 }), as: UTF8.self)
         }
     }
 

--- a/apps/macos/LauncherApp/look-app/Views/Commands/KillCommand.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/KillCommand.swift
@@ -3,6 +3,9 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct KillCommand {
+    /// Row cap for the fuzzy query path (mirrors linows `KILL_RESULT_LIMIT`).
+    private static let resultLimit = 60
+
     struct Candidate: Identifiable {
         let id: String
         let displayName: String
@@ -31,116 +34,61 @@ struct KillCommand {
         }
     }
 
-    private static func parsePort(from searchTerm: String) -> Int? {
+    /// Strips the optional `:` / `port ` port-search affordance so `:3000` and
+    /// `3000` resolve identically through the one numeric path (exact port >
+    /// partial > PID) rather than a separate lsof lookup.
+    private static func normalize(_ searchTerm: String) -> String {
         let trimmed = searchTerm.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.hasPrefix(":") {
-            return Int(trimmed.dropFirst())
+            return String(trimmed.dropFirst()).trimmingCharacters(in: .whitespacesAndNewlines)
         }
-        let lower = trimmed.lowercased()
-        if lower.hasPrefix("port ") {
-            return Int(lower.dropFirst(5).trimmingCharacters(in: .whitespacesAndNewlines))
+        if trimmed.lowercased().hasPrefix("port ") {
+            return String(trimmed.dropFirst(5)).trimmingCharacters(in: .whitespacesAndNewlines)
         }
-        return nil
+        return trimmed
     }
 
-    private static func isPortQuery(_ searchTerm: String) -> Bool {
-        let trimmed = searchTerm.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        return trimmed.hasPrefix(":") || trimmed.hasPrefix("port ")
-    }
-
-    private static func commandName(for pid: Int32) -> String {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/ps")
-        process.arguments = ["-p", "\(pid)", "-o", "comm="]
-        let outputPipe = Pipe()
-        process.standardOutput = outputPipe
-        process.standardError = Pipe()
-
-        do {
-            try process.run()
-            process.waitUntilExit()
-            let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
-            let value = String(data: data, encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            return (value?.isEmpty == false) ? value! : "Process \(pid)"
-        } catch {
-            return "Process \(pid)"
-        }
-    }
-
-    private static func processCandidates(onPort port: Int) -> [Candidate] {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
-        process.arguments = ["-nP", "-iTCP:\(port)", "-sTCP:LISTEN", "-t"]
-        let outputPipe = Pipe()
-        process.standardOutput = outputPipe
-        process.standardError = Pipe()
-
-        do {
-            try process.run()
-            process.waitUntilExit()
-        } catch {
-            return []
+    static func suggestions(searchTerm: String) -> [Candidate] {
+        let term = normalize(searchTerm)
+        let apps = getRunningApps()
+        // Empty query lists apps only (the panel's default view).
+        if term.isEmpty {
+            return appCandidates(from: apps)
         }
 
-        let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
-        guard let output = String(data: data, encoding: .utf8) else { return [] }
-        let pids = output
-            .split(separator: "\n")
-            .compactMap { Int32($0.trimmingCharacters(in: .whitespacesAndNewlines)) }
+        // Non-empty query: fuzzy over apps + processes, apps first, deduped by
+        // PID (ProcessScoring mirrors the Rust `rank_kill_targets`; the fuzzy
+        // score is the same `core/matching` scorer over FFI).
+        let appPairs = apps.map { (name: $0.localizedName ?? "Unknown", pid: $0.processIdentifier) }
+        let procs = ProcessService.enumerate().map {
+            ProcessScoring.Candidate(name: $0.name, pid: $0.pid, ports: $0.ports)
+        }
+        let lowered = term.lowercased()
+        let ranked = ProcessScoring.rankKillTargets(
+            apps: appPairs, procs: procs, query: term
+        ) { title in
+            EngineBridge.shared.fuzzyScore(query: lowered, title: title)
+        }
 
-        var seen = Set<Int32>()
-        let uniquePIDs = pids.filter { seen.insert($0).inserted }
-
-        return uniquePIDs.enumerated().map { index, pid in
-            let name = commandName(for: pid)
-            return Candidate(
-                id: "port-\(port)-\(pid)-\(index)",
-                displayName: name,
-                pid: pid,
-                icon: NSWorkspace.shared.icon(forFile: name),
+        return ranked.prefix(resultLimit).enumerated().map { index, target in
+            Candidate(
+                id: "\(target.isApp ? "app" : "proc")-\(target.pid)-\(index)",
+                displayName: target.name,
+                pid: target.pid,
+                icon: LauncherProcessFeature.icon(forPID: target.pid),
                 number: index + 1,
-                detail: "PID: \(pid)  •  Port: \(port)"
+                detail: "PID: \(target.pid)"
             )
         }
     }
 
-    static func suggestions(searchTerm: String) -> [Candidate] {
-        if isPortQuery(searchTerm) {
-            guard let port = parsePort(from: searchTerm), (1...65_535).contains(port) else {
-                return []
-            }
-            return processCandidates(onPort: port)
-        }
-
-        let apps = getRunningApps()
-        let candidates = appCandidates(from: apps)
-        if searchTerm.isEmpty {
-            return candidates
-        }
-
-        if let num = Int(searchTerm), num > 0 && num <= candidates.count {
-            return [candidates[num - 1]]
-        }
-
-        return candidates.filter { $0.displayName.lowercased().contains(searchTerm.lowercased()) }
-    }
-
+    /// SIGKILL a process, routed through the native `ProcessService.kill`.
     static func kill(pid: Int32, name: String, completion: @escaping (String) -> Void) {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/kill")
-        process.arguments = ["-9", "\(pid)"]
-
-        do {
-            try process.run()
-            process.waitUntilExit()
-            if process.terminationStatus == 0 {
-                completion("Killed: \(name) (PID: \(pid))")
-            } else {
-                completion("Failed to kill \(name): permission denied")
-            }
-        } catch {
-            completion("Error: \(error.localizedDescription)")
+        switch ProcessService.kill(pid: pid) {
+        case .success:
+            completion("Killed: \(name) (PID: \(pid))")
+        case .failure(let error):
+            completion("Failed to kill \(name): \(error.message)")
         }
     }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Commands/KillCommand.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Commands/KillCommand.swift
@@ -48,7 +48,9 @@ struct KillCommand {
         return trimmed
     }
 
-    static func suggestions(searchTerm: String) -> [Candidate] {
+    /// `processes` is the cached `ProcessFinderModel` snapshot: this runs in a
+    /// SwiftUI body, so it must never walk the process table itself.
+    static func suggestions(searchTerm: String, processes: [ProcessScoring.Candidate]) -> [Candidate] {
         let term = normalize(searchTerm)
         let apps = getRunningApps()
         // Empty query lists apps only (the panel's default view).
@@ -60,12 +62,9 @@ struct KillCommand {
         // PID (ProcessScoring mirrors the Rust `rank_kill_targets`; the fuzzy
         // score is the same `core/matching` scorer over FFI).
         let appPairs = apps.map { (name: $0.localizedName ?? "Unknown", pid: $0.processIdentifier) }
-        let procs = ProcessService.enumerate().map {
-            ProcessScoring.Candidate(name: $0.name, pid: $0.pid, ports: $0.ports)
-        }
         let lowered = term.lowercased()
         let ranked = ProcessScoring.rankKillTargets(
-            apps: appPairs, procs: procs, query: term
+            apps: appPairs, procs: processes, query: term
         ) { title in
             EngineBridge.shared.fuzzyScore(query: lowered, title: title)
         }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
@@ -56,6 +56,10 @@ struct LauncherRowView: View {
                 ?? NSWorkspace.shared.icon(for: .plainText)
         }
 
+        if result.kind == .process, let pid = result.processPID {
+            return LauncherProcessFeature.icon(forPID: pid)
+        }
+
         if result.id.hasPrefix("setting:") {
             let settingsPath = "/System/Applications/System Settings.app"
             if FileManager.default.fileExists(atPath: settingsPath) {
@@ -93,6 +97,8 @@ struct LauncherRowView: View {
             return "Folder"
         case .clipboard:
             return "Clipboard"
+        case .process:
+            return "Process"
         }
     }
 
@@ -101,6 +107,10 @@ struct LauncherRowView: View {
             return result.subtitle ?? ""
         }
         if result.kind == .clipboard {
+            return result.subtitle ?? kindLabel
+        }
+        if result.kind == .process {
+            // "PID 1234 · :3000" - carries the pid and any listening ports.
             return result.subtitle ?? kindLabel
         }
         if result.kind == .app {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
@@ -532,7 +532,7 @@ private enum LauncherHelpContent {
     static let commandMode: [(String, String)] = [
         ("Tab / Shift+Tab", "Switch command"),
         ("Cmd+1 / Cmd+2 / Cmd+3 / Cmd+4", "Switch command"),
-        (":3000", "Find process listening on port"),
+        ("3000", "Find process by port or PID"),
         ("Up / Down", "Select app in kill results"),
         ("Y / N", "Confirm/cancel kill action"),
     ]

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+CommandMode.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+CommandMode.swift
@@ -162,11 +162,7 @@ extension LauncherView {
             logUIEvent("kill action search='\(searchTerm)' matches=\(matched.count)")
 
             if matched.isEmpty {
-                if searchTerm.hasPrefix(":") || searchTerm.lowercased().hasPrefix("port ") {
-                    commandFeedback = "No process listening on this port"
-                } else {
-                    commandFeedback = "No matching apps. /kill to list all. Use :3000 to search by port."
-                }
+                commandFeedback = "No matching processes"
             } else if searchTerm.isEmpty {
                 let appList = matched.map { candidate in
                     "\(candidate.number). \(candidate.displayName) (PID: \(candidate.pid))"
@@ -292,11 +288,7 @@ extension LauncherView {
                         // owns its own card-style backdrops where wanted.
 
                     if activeCommandID == AppConstants.Launcher.Command.kill {
-                        let killSearchTerm = commandArgsPart.trimmingCharacters(in: .whitespacesAndNewlines)
-                        let portQuery = killSearchTerm.hasPrefix(":") || killSearchTerm.lowercased().hasPrefix("port ")
-                        let defaultKillEmptyMessage = portQuery
-                            ? "No process listening on this port"
-                            : "No matches. Type an app name or use :3000"
+                        let defaultKillEmptyMessage = "No matching processes"
 
                         KillCommandView(
                             suggestions: Array(killSuggestions),

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+CommandMode.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+CommandMode.swift
@@ -3,6 +3,8 @@ import SwiftUI
 
 extension LauncherView {
     func scheduleKillListRefresh() {
+        // Drop the killed process from the shared snapshot; the ticks re-read it.
+        processModel.refreshSnapshot()
         killListRefreshTick &+= 1
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
             killListRefreshTick &+= 1
@@ -158,7 +160,7 @@ extension LauncherView {
             }
         case AppConstants.Launcher.Command.kill:
             let searchTerm = commandArgsPart.trimmingCharacters(in: .whitespacesAndNewlines)
-            let matched = KillCommand.suggestions(searchTerm: searchTerm)
+            let matched = KillCommand.suggestions(searchTerm: searchTerm, processes: processModel.candidates)
             logUIEvent("kill action search='\(searchTerm)' matches=\(matched.count)")
 
             if matched.isEmpty {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Process.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Process.swift
@@ -1,0 +1,90 @@
+import AppKit
+import SwiftUI
+
+/// `ps"` process-finder mode: fuzzy-matches running processes and drives the
+/// per-selection preview, on-demand CPU (Enter), kill (Cmd+D), and copy-PID
+/// (Cmd+C). Keys follow macOS conventions (Cmd, not Ctrl).
+extension LauncherView {
+    var isProcessQuery: Bool { LauncherProcessFeature.isProcessQuery(query) }
+
+    /// Scored process rows. Empty query → alphabetical listing; otherwise ranked
+    /// by `ProcessScoring` (numeric port/PID tiers above fuzzy name matches),
+    /// capped at the result limit. Scored against the cached snapshot.
+    var processResults: [LauncherResult] {
+        guard let term = LauncherProcessFeature.searchTerm(from: query) else { return [] }
+        let candidates = processModel.candidates
+        let limit = AppConstants.Launcher.Process.resultLimit
+
+        let ranked: [ProcessScoring.Candidate]
+        if term.isEmpty {
+            ranked = candidates.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        } else {
+            let lowered = term.lowercased()
+            ranked = ProcessScoring.rankProcesses(candidates, query: term) { title in
+                bridge.fuzzyScore(query: lowered, title: title)
+            }
+        }
+        return ranked.prefix(limit).map(LauncherProcessFeature.makeResult)
+    }
+
+    /// The pid of the currently selected process row, or nil when the selection
+    /// isn't a process.
+    var selectedProcessPID: Int32? {
+        guard isProcessQuery, let selectedResultID else { return nil }
+        return LauncherProcessFeature.pid(fromResultID: selectedResultID)
+    }
+
+    func loadProcessDetailForSelection() {
+        guard let pid = selectedProcessPID else { return }
+        processModel.loadDetail(pid: pid)
+    }
+
+    func processDetail(for result: LauncherResult) -> ProcessDetail? {
+        guard let pid = result.processPID else { return nil }
+        return processModel.details[pid]
+    }
+
+    func processCPU(for result: LauncherResult) -> Double? {
+        guard let pid = result.processPID else { return nil }
+        return processModel.cpu[pid]
+    }
+
+    func isMeasuringCPU(for result: LauncherResult) -> Bool {
+        guard let pid = result.processPID else { return false }
+        return processModel.measuringCPU.contains(pid)
+    }
+
+    /// Enter measures the selected process's CPU% on demand (see `ProcessService.cpu`).
+    func measureCPUForSelectedProcess() {
+        guard let pid = selectedProcessPID else { return }
+        processModel.measureCPU(pid: pid)
+    }
+
+    /// Cmd+D sends SIGKILL, surfacing a clear error on failure (protected /
+    /// another user's process) rather than a silent no-op.
+    func killSelectedProcess() {
+        guard let selected = displayedResults.first(where: { $0.id == selectedResultID }),
+              let pid = selected.processPID
+        else { return }
+        let name = selected.title
+        switch processModel.kill(pid: pid) {
+        case .success:
+            showBanner("Killed \(name) (PID \(pid))", style: .success, duration: 1.6)
+            DispatchQueue.main.async {
+                if !displayedResults.contains(where: { $0.id == selectedResultID }) {
+                    selectedResultID = displayedResults.first?.id
+                }
+            }
+        case .failure(let error):
+            showBanner("Could not kill \(name): \(error.message)", style: .error, duration: 2.6)
+        }
+    }
+
+    /// Cmd+C copies the selected process's PID.
+    func copySelectedProcessPID() {
+        guard let pid = selectedProcessPID else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(String(pid), forType: .string)
+        showBanner("Copied PID \(pid)", style: .success, duration: 1.2)
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Process.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Process.swift
@@ -12,19 +12,11 @@ extension LauncherView {
     /// capped at the result limit. Scored against the cached snapshot.
     var processResults: [LauncherResult] {
         guard let term = LauncherProcessFeature.searchTerm(from: query) else { return [] }
-        let candidates = processModel.candidates
-        let limit = AppConstants.Launcher.Process.resultLimit
-
-        let ranked: [ProcessScoring.Candidate]
-        if term.isEmpty {
-            ranked = candidates.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
-        } else {
-            let lowered = term.lowercased()
-            ranked = ProcessScoring.rankProcesses(candidates, query: term) { title in
-                bridge.fuzzyScore(query: lowered, title: title)
-            }
+        let lowered = term.lowercased()
+        let ranked = processModel.ranked(term: term) { title in
+            bridge.fuzzyScore(query: lowered, title: title)
         }
-        return ranked.prefix(limit).map(LauncherProcessFeature.makeResult)
+        return ranked.prefix(AppConstants.Launcher.Process.resultLimit).map(LauncherProcessFeature.makeResult)
     }
 
     /// The pid of the currently selected process row, or nil when the selection
@@ -70,13 +62,17 @@ extension LauncherView {
         switch processModel.kill(pid: pid) {
         case .success:
             showBanner("Killed \(name) (PID \(pid))", style: .success, duration: 1.6)
-            DispatchQueue.main.async {
-                if !displayedResults.contains(where: { $0.id == selectedResultID }) {
-                    selectedResultID = displayedResults.first?.id
-                }
-            }
         case .failure(let error):
             showBanner("Could not kill \(name): \(error.message)", style: .error, duration: 2.6)
+        }
+    }
+
+    /// Move the selection off a row the latest snapshot dropped (killed or
+    /// exited). Driven by `candidates`, so it runs when the refresh lands.
+    func repairProcessSelection() {
+        guard isProcessQuery, selectedResultID != nil else { return }
+        if !displayedResults.contains(where: { $0.id == selectedResultID }) {
+            selectedResultID = displayedResults.first?.id
         }
     }
 

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
@@ -71,6 +71,9 @@ extension LauncherView {
                 style: .success,
                 duration: AppConstants.Launcher.Clipboard.copiedBannerDuration
             )
+        case .process:
+            // Enter measures CPU on demand and keeps the launcher open.
+            measureCPUForSelectedProcess()
         }
     }
 
@@ -202,6 +205,8 @@ extension LauncherView {
                 style: .info,
                 duration: AppConstants.Launcher.Clipboard.infoBannerDuration
             )
+        case .process:
+            showBanner("Processes can't be revealed in Finder", style: .info, duration: 1.2)
         }
     }
 
@@ -293,6 +298,12 @@ extension LauncherView {
               let selected = displayedResults.first(where: { $0.id == selectedID })
         else { return false }
 
+        // In `ps"` mode, Cmd+C copies the selected process's PID.
+        if selected.kind == .process {
+            copySelectedProcessPID()
+            return true
+        }
+
         guard selected.kind == .file || selected.kind == .folder else { return false }
 
         let targetURL = URL(fileURLWithPath: selected.path)
@@ -380,6 +391,12 @@ extension LauncherView {
     /// it's permanent.
     func requestDeleteSelection() {
         guard !isCommandMode, !appUIState.showsThemeSettings, !showsHelpScreen else { return }
+        // In `ps"` mode, Cmd+D kills the selected process (SIGKILL) instead of
+        // trashing a file.
+        if isProcessQuery, selectedProcessPID != nil {
+            killSelectedProcess()
+            return
+        }
         // Don't stack an Empty Trash confirmation, nor start work while a
         // previous trash/empty is still running (recycle / Finder are async).
         guard pendingEmptyTrashCount == nil, !isDeleteInFlight else { return }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -619,7 +619,7 @@ struct LauncherView: View {
     var killSuggestions: [KillCommand.Candidate] {
         _ = killListRefreshTick
         let searchTerm = commandArgsPart.trimmingCharacters(in: .whitespacesAndNewlines)
-        return KillCommand.suggestions(searchTerm: searchTerm)
+        return KillCommand.suggestions(searchTerm: searchTerm, processes: processModel.candidates)
             .filter { !recentlyKilledPIDs.contains($0.pid) }
     }
 
@@ -711,9 +711,14 @@ struct LauncherView: View {
             // invalidates so the next entry re-enumerates fresh.
             if entering {
                 processModel.loadSnapshotIfNeeded()
-            } else {
+            } else if activeCommandID != AppConstants.Launcher.Command.kill {
+                // /kill scores the same snapshot; don't drop it when the query
+                // switches straight into that panel.
                 processModel.invalidate()
             }
+        }
+        .onChange(of: processModel.candidates) { _, _ in
+            repairProcessSelection()
         }
         .onReceive(clipboardStore.$entries) { _ in
             refreshClipboardSelectionIfNeeded()
@@ -735,6 +740,10 @@ struct LauncherView: View {
         }
         .onChange(of: activeCommandID) { _, newID in
             if let newID { appUIState.lastCommandID = newID }
+            // /kill ranks the same cached snapshot; take a fresh one on entry.
+            if newID == AppConstants.Launcher.Command.kill {
+                processModel.refreshSnapshot()
+            }
         }
         .onChange(of: appUIState.showsThemeSettings) { _, showsSettings in
             if showsSettings {
@@ -777,6 +786,11 @@ struct LauncherView: View {
                 window === launcherWindow()
             else { return }
             refreshQuickActions()
+            // The query survives hide/show: re-entering `ps"` must not keep
+            // scoring pids that exited while hidden.
+            if isProcessQuery {
+                processModel.refreshSnapshot()
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: .lookReloadConfigRequested)) { _ in
             reloadConfig()

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -99,6 +99,7 @@ struct LauncherView: View {
     @State var lookupDefinition: LookupDefinition?
     @State var pidToRestoreOnHide: pid_t?
     @StateObject var runningAppsService = RunningAppsService()
+    @StateObject var processModel = ProcessFinderModel()
 
     /// Live size of the whole panel, captured so a background image can be
     /// cropped into each floating tile at its correct window position (the tiles
@@ -397,6 +398,7 @@ struct LauncherView: View {
         if isPrefixSuggestionQuery { return prefixSuggestionResults }
         if isCommandSuggestionQuery { return commandSuggestionResults }
         if isClipboardQuery { return clipboardResults }
+        if isProcessQuery { return processResults }
         // Recent URLs interleave with local results by frecency; web-search rows
         // stay last.
         let ranked = mergeByScore(backendFilteredResults, recentURLResults)
@@ -501,6 +503,12 @@ struct LauncherView: View {
             return ["Enter copy clip", "Cmd+D remove clip"]
         }
 
+        // Mirrors the linows ps" hint (Cmd instead of Ctrl); Enter/CPU dropped
+        // to keep it on one line.
+        if isProcessQuery {
+            return ["Cmd+D kill", "Cmd+C copy PID"]
+        }
+
         // The home screen replaces the "Cmd+/ command mode" hint with a
         // clickable today done/total quick view (see todoQuickView), so it
         // is intentionally omitted here.
@@ -514,7 +522,7 @@ struct LauncherView: View {
         guard !appUIState.showsThemeSettings, !isCommandMode, !showsHelpScreen else { return false }
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         if extractTranslationQuery(from: trimmed) != nil { return false }
-        if isPrefixSuggestionQuery || isCommandSuggestionQuery || isClipboardQuery { return false }
+        if isPrefixSuggestionQuery || isCommandSuggestionQuery || isClipboardQuery || isProcessQuery { return false }
         return true
     }
 
@@ -668,12 +676,13 @@ struct LauncherView: View {
                 if showsHelpScreen {
                     showsHelpScreen = false
                 }
-                if isClipboardQuery || isPrefixSuggestionQuery || isCommandSuggestionQuery || isTranslationQuery {
+                if isClipboardQuery || isPrefixSuggestionQuery || isCommandSuggestionQuery || isTranslationQuery || isProcessQuery {
                     // These render their own panels (clip history / prefix menu /
-                    // command menu / translation), not backend results. Skip the
-                    // search + AI answer entirely - otherwise a background AI
-                    // activation flips the floating layout and flashes the old
-                    // backdrop while typing. Translation only fires on Enter.
+                    // command menu / translation / process finder), not backend
+                    // results. Skip the search + AI answer entirely - otherwise a
+                    // background AI activation flips the floating layout and
+                    // flashes the old backdrop while typing. Translation only
+                    // fires on Enter.
                     aiAnswer.cancel()
                     setInitialSelection()
                 } else {
@@ -693,6 +702,18 @@ struct LauncherView: View {
         .onChange(of: selectedResultID) { _, _ in
             // Load Quick Actions + read their live state for the new selection.
             refreshQuickActions()
+            // Prefetch process detail for the newly selected process row so the
+            // preview pane fills in (cheap per-selection reads, cached by pid).
+            loadProcessDetailForSelection()
+        }
+        .onChange(of: isProcessQuery) { _, entering in
+            // Enumerate the process table once on entering `ps"` mode; leaving
+            // invalidates so the next entry re-enumerates fresh.
+            if entering {
+                processModel.loadSnapshotIfNeeded()
+            } else {
+                processModel.invalidate()
+            }
         }
         .onReceive(clipboardStore.$entries) { _ in
             refreshClipboardSelectionIfNeeded()
@@ -1088,7 +1109,10 @@ struct LauncherView: View {
                     },
                     onDeleteClipboard: selectedResult.kind == .clipboard
                         ? { deleteClipboardResult(resultID: selectedResult.id) }
-                        : nil
+                        : nil,
+                    processDetail: processDetail(for: selectedResult),
+                    processCPU: processCPU(for: selectedResult),
+                    isMeasuringProcessCPU: isMeasuringCPU(for: selectedResult)
                 )
             }
         }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
@@ -19,6 +19,10 @@ struct ResultPreviewView: View {
     var onRunQuickAction: (QuickActionDescriptor, ActionIntent) -> Void = { _, _ in }
     var onActivateQuickActionItem: (QuickActionDescriptor, QuickActionListItem) -> Void = { _, _ in }
     var onDeleteClipboard: (() -> Void)? = nil
+    /// Process-finder preview inputs (only set for `.process` results).
+    var processDetail: ProcessDetail? = nil
+    var processCPU: Double? = nil
+    var isMeasuringProcessCPU: Bool = false
 
     @State private var folderListing: FolderListing?
     @State private var trashItemCount: Int?
@@ -122,7 +126,9 @@ struct ResultPreviewView: View {
     }
 
     var body: some View {
-        if result.kind == .clipboard {
+        if result.kind == .process {
+            processPreview
+        } else if result.kind == .clipboard {
             clipboardPreview
         } else {
         let info = bundleInfo
@@ -317,6 +323,86 @@ struct ResultPreviewView: View {
 
             InfoRow(label: "Kind", value: "Clipboard")
             InfoRow(label: "Captured", value: capturedAt)
+
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    // MARK: - Process preview
+
+    private var processIcon: NSImage {
+        result.processPID.map(LauncherProcessFeature.icon) ?? NSWorkspace.shared.icon(for: .unixExecutable)
+    }
+
+    private func formattedStart(_ epoch: UInt64) -> String {
+        Self.modifiedDateFormatter.string(from: Date(timeIntervalSince1970: TimeInterval(epoch)))
+    }
+
+    private var cpuValueText: String {
+        if let processCPU {
+            return String(format: "%.1f%%", processCPU)
+        }
+        return isMeasuringProcessCPU ? "Measuring…" : "Press Enter to measure"
+    }
+
+    private var portsText: String {
+        let ports = result.processPorts ?? []
+        return ports.isEmpty ? "None" : ports.map { ":\($0)" }.joined(separator: "  ")
+    }
+
+    private var processPreview: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 12) {
+                Image(nsImage: processIcon)
+                    .resizable()
+                    .frame(width: 40, height: 40)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(result.title)
+                        .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize + 2), weight: .semibold))
+                        .foregroundStyle(themeStore.fontColor())
+                        .lineLimit(2)
+                    HStack(spacing: 6) {
+                        KindBadge(kind: "process")
+                        if let pid = result.processPID {
+                            Text("PID \(pid)")
+                                .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular))
+                                .foregroundStyle(themeStore.secondaryTextColor())
+                        }
+                    }
+                }
+                Spacer()
+            }
+
+            // Command line (argv).
+            if let detail = processDetail, !detail.cmdline.isEmpty {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Command")
+                        .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular))
+                        .foregroundStyle(themeStore.mutedTextColor())
+                    Text(detail.cmdline)
+                        .font(.system(size: CGFloat(themeStore.settings.fontSize - 2), design: .monospaced))
+                        .foregroundStyle(themeStore.secondaryTextColor())
+                        .lineLimit(4)
+                        .textSelection(.enabled)
+                }
+            }
+
+            if let detail = processDetail {
+                InfoRow(label: "Memory", value: formatFileSize(Int64(detail.memoryKB) * 1024))
+                if !detail.user.isEmpty {
+                    InfoRow(label: "User", value: detail.user)
+                }
+                InfoRow(label: "Parent PID", value: String(detail.ppid))
+                if let start = detail.startEpoch {
+                    InfoRow(label: "Started", value: formattedStart(start))
+                }
+            }
+
+            InfoRow(label: "CPU", value: cpuValueText)
+            InfoRow(label: "Ports", value: portsText)
 
             Spacer(minLength: 0)
         }

--- a/bridge/ffi/Cargo.lock
+++ b/bridge/ffi/Cargo.lock
@@ -297,6 +297,7 @@ dependencies = [
  "look-engine",
  "look-indexing",
  "look-lunar",
+ "look-matching",
  "look-qactions",
  "look-ranking",
  "look-storage",

--- a/bridge/ffi/Cargo.toml
+++ b/bridge/ffi/Cargo.toml
@@ -12,6 +12,7 @@ look-answers = { path = "../../core/answers" }
 look-engine = { path = "../../core/engine" }
 look-indexing = { path = "../../core/indexing" }
 look-lunar = { path = "../../core/lunar" }
+look-matching = { path = "../../core/matching" }
 look-qactions = { path = "../../core/qactions" }
 look-ranking = { path = "../../core/ranking" }
 look-storage = { path = "../../core/storage" }

--- a/bridge/ffi/examples/search_json_bench.rs
+++ b/bridge/ffi/examples/search_json_bench.rs
@@ -54,11 +54,7 @@ fn bench(label: &'static str, iterations: usize, mut f: impl FnMut() -> usize) -
     } else {
         total_us / samples.len() as u128
     };
-    let avg_payload_bytes = if iterations == 0 {
-        0
-    } else {
-        total_bytes / iterations
-    };
+    let avg_payload_bytes = total_bytes.checked_div(iterations).unwrap_or(0);
 
     BenchStats {
         label,

--- a/bridge/ffi/src/lib.rs
+++ b/bridge/ffi/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod answers_api;
 mod lunar_api;
+mod matching_api;
 mod qactions_api;
 mod runtime_config;
 mod search_api;
@@ -151,6 +152,17 @@ pub extern "C" fn look_instant_answer_json(query: *const c_char) -> *mut c_char 
         answers_api::look_instant_answer_json_impl(query)
     }))
     .unwrap_or(std::ptr::null_mut())
+}
+
+/// Shared `core/matching` fuzzy score for `query` vs `title` (both pre-lowercased
+/// by the caller). Returns `matching_api::NO_MATCH` (`i64::MIN`) on no match, so
+/// callers reproduce the linows ranking without porting the algorithm.
+#[unsafe(no_mangle)]
+pub extern "C" fn look_fuzzy_score(query: *const c_char, title: *const c_char) -> i64 {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        matching_api::look_fuzzy_score_impl(query, title)
+    }))
+    .unwrap_or(matching_api::NO_MATCH)
 }
 
 /// Network-free check of whether `query` matches an instant-answer provider.

--- a/bridge/ffi/src/matching_api.rs
+++ b/bridge/ffi/src/matching_api.rs
@@ -1,0 +1,47 @@
+//! C-ABI wrapper over `look_matching::fuzzy_score` so macOS ranks identically to
+//! linows. The numeric port/PID tiers are process-finder specific and layered on
+//! top natively in Swift, not here.
+
+use crate::state::cstr_to_string;
+use std::os::raw::c_char;
+
+/// No-match sentinel. `fuzzy_score` never returns a negative score, so `i64::MIN`
+/// is unambiguous; the Swift wrapper maps it back to `nil`.
+pub(crate) const NO_MATCH: i64 = i64::MIN;
+
+/// `look_matching::fuzzy_score`, adapted to the C ABI. Both arguments must be
+/// pre-lowercased by the caller (`fuzzy_score` is case-sensitive).
+pub(crate) fn look_fuzzy_score_impl(query: *const c_char, title: *const c_char) -> i64 {
+    let query = cstr_to_string(query);
+    let title = cstr_to_string(title);
+    look_matching::fuzzy_score(&query, &title).unwrap_or(NO_MATCH)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    fn score(query: &str, title: &str) -> i64 {
+        let q = CString::new(query).unwrap();
+        let t = CString::new(title).unwrap();
+        look_fuzzy_score_impl(q.as_ptr(), t.as_ptr())
+    }
+
+    #[test]
+    fn exact_and_prefix_and_subsequence_match() {
+        assert_eq!(score("ghostty", "ghostty"), 2_000, "exact match");
+        assert!(score("firefox", "firefox gpu helper") > 0, "prefix match");
+        assert!(score("firefox", ".firefox-old") > 0, "substring/subsequence");
+        assert_eq!(score("zzq", "ghostty"), NO_MATCH, "no match -> sentinel");
+    }
+
+    #[test]
+    fn null_pointers_do_not_crash() {
+        assert_eq!(
+            look_fuzzy_score_impl(std::ptr::null(), std::ptr::null()),
+            2_000,
+            "two empty strings compare equal"
+        );
+    }
+}

--- a/bridge/ffi/src/matching_api.rs
+++ b/bridge/ffi/src/matching_api.rs
@@ -32,7 +32,10 @@ mod tests {
     fn exact_and_prefix_and_subsequence_match() {
         assert_eq!(score("ghostty", "ghostty"), 2_000, "exact match");
         assert!(score("firefox", "firefox gpu helper") > 0, "prefix match");
-        assert!(score("firefox", ".firefox-old") > 0, "substring/subsequence");
+        assert!(
+            score("firefox", ".firefox-old") > 0,
+            "substring/subsequence"
+        );
         assert_eq!(score("zzq", "ghostty"), NO_MATCH, "no match -> sentinel");
     }
 

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -880,14 +880,14 @@ mod tests {
     fn app_scan_roots_include_finder_embedded_apps() {
         let roots = default_app_scan_roots();
         assert!(
-            roots.iter().any(
-                |root| root == &"/System/Library/CoreServices/Finder.app/Contents/Applications"
-            )
+            roots
+                .iter()
+                .any(|root| root == "/System/Library/CoreServices/Finder.app/Contents/Applications")
         );
         assert!(
             roots
                 .iter()
-                .any(|root| root == &"/System/Library/CoreServices/Applications")
+                .any(|root| root == "/System/Library/CoreServices/Applications")
         );
     }
 

--- a/docs/process-finder-handoff.md
+++ b/docs/process-finder-handoff.md
@@ -89,11 +89,12 @@ struct KillTarget { name: String, pid: u32, is_app: bool, desktop_id: Option<Str
 5. **Modifier**: `Ctrl` on Linux/Windows, `Cmd` on macOS.
 
 ### Linux data sources (for translating field-by-field)
+
 | Field | Source |
 |---|---|
 | enumerate / name / uid | `/proc/[pid]/status` (`Name:`, `Uid:`), filter own uid |
 | cmdline | `/proc/[pid]/cmdline` (NUL-separated argv) |
-| rss_kb | **USS** = `Private_Clean` + `Private_Dirty` from `/proc/[pid]/smaps_rollup` (private memory, matches macOS `phys_footprint`); falls back to `/proc/[pid]/status` `VmRSS:` on kernels < 4.14. Do not report bare `VmRSS` — it counts shared pages and reads ~2× higher. |
+| rss_kb | **USS** = `Private_Clean` + `Private_Dirty` from `/proc/[pid]/smaps_rollup` (private memory, matches macOS `phys_footprint`). `VmRSS:` from `/proc/[pid]/status` is the compatibility fallback whenever smaps_rollup can't be read or parsed (kernels < 4.14, permission denied, process exited mid-read); it counts shared pages and reads ~2× higher, so never prefer it. |
 | ppid | `/proc/[pid]/status` `PPid:` |
 | user | uid → `/etc/passwd` |
 | start_epoch | `/proc/[pid]/stat` field 22 (starttime ticks) + `/proc/stat` `btime`, `CLK_TCK=100` |
@@ -136,10 +137,10 @@ still returns `icon_source: None`. `process_detail` / `process_cpu` dispatch to
      `ProcessParameters.CommandLine` via `ReadProcessMemory`. Fallback to the
      exe path (`resolve_full_path`) if the remote read is denied.
    - `rss_kb`: `GetProcessMemoryInfo` with `PROCESS_MEMORY_COUNTERS_EX` →
-     **`PrivateUsage / 1024`** (private commit), *not* `WorkingSetSize`. This
-     matches Task Manager's default "Memory" (private working set) and the
-     macOS `phys_footprint` / Linux USS choice; `WorkingSetSize` counts shared
-     pages and reads much higher.
+     **`PrivateUsage / 1024`** (private commit charge: Task Manager's "Commit
+     size", Process Explorer's "Private Bytes"), *not* `WorkingSetSize`. It is
+     the closest Windows analog to macOS `phys_footprint` / Linux USS, excluding
+     the shared pages that make `WorkingSetSize` read much higher.
    - `ppid`: Toolhelp `PROCESSENTRY32W.th32ParentProcessID` (build a pid→ppid
      map in the existing `enumerate_processes` pass).
    - `user`: `OpenProcessToken(TOKEN_QUERY)` → `GetTokenInformation(TokenUser)`
@@ -198,6 +199,7 @@ them. Two options:
   **(This is what shipped: native enumeration, FFI for the fuzzy score only.)**
 
 ### 4b. Backend (macOS APIs)
+
 | Field | API |
 |---|---|
 | enumerate | **`sysctl KERN_PROC_ALL`** (gives pid + uid + comm in one call); filter to `getuid()`. **Do NOT use `proc_listallpids`** — it is silently throttled in hardened/restricted contexts and returns only a partial list (observed ~146 of ~584 procs, dropping the user's own apps). |
@@ -232,7 +234,8 @@ them. Two options:
 - Kill command: fuzzy over apps + processes, **apps first**, matching the
   linows behavior; keep the existing confirm-before-kill flow.
 
-### 4d. Keyboard / shortkeys (macOS conventions — `Cmd`, not `Ctrl`)
+### 4d. Keyboard / shortkeys (macOS conventions, `Cmd` not `Ctrl`)
+
 | Action | macOS | (linows equivalent) |
 |---|---|---|
 | Enter process mode | type `ps"` | same |
@@ -248,8 +251,9 @@ Hint bar: `Cmd+D: Kill • Cmd+C: Copy PID`.
 
 ## 5. Parity checklist
 
-**macOS: all items below met** (see §4). **Windows: remaining** — `icon_source`,
-`process_detail`, `process_cpu` (ports already done).
+The boxes are the reference list every port must satisfy, not a per-platform
+tracker, so they stay unchecked. **macOS meets every item** (see §4); **Windows
+still owes** `icon_source`, `process_detail`, `process_cpu` (ports already done).
 
 - [ ] `ps"` prefix enters process mode; empty query lists own-user processes.
 - [ ] Numeric query matches exact port > partial port > PID; name fuzzy also runs.

--- a/docs/process-finder-handoff.md
+++ b/docs/process-finder-handoff.md
@@ -93,7 +93,7 @@ struct KillTarget { name: String, pid: u32, is_app: bool, desktop_id: Option<Str
 |---|---|
 | enumerate / name / uid | `/proc/[pid]/status` (`Name:`, `Uid:`), filter own uid |
 | cmdline | `/proc/[pid]/cmdline` (NUL-separated argv) |
-| rss_kb | `/proc/[pid]/status` `VmRSS:` |
+| rss_kb | **USS** = `Private_Clean` + `Private_Dirty` from `/proc/[pid]/smaps_rollup` (private memory, matches macOS `phys_footprint`); falls back to `/proc/[pid]/status` `VmRSS:` on kernels < 4.14. Do not report bare `VmRSS` — it counts shared pages and reads ~2× higher. |
 | ppid | `/proc/[pid]/status` `PPid:` |
 | user | uid → `/etc/passwd` |
 | start_epoch | `/proc/[pid]/stat` field 22 (starttime ticks) + `/proc/stat` `btime`, `CLK_TCK=100` |
@@ -117,18 +117,15 @@ File: `apps/linows/src-tauri/src/platform/windows/process.rs`.
 Win32 imports, `enumerate_processes() -> Vec<(u32, String)>`, `resolve_full_path`,
 `GetExtendedTcpTable`, `kill`, and `list()`/`list_on_port()` already exist.
 
-**Status:** `list_all()` works (Toolhelp) but returns `icon_source: None`,
-`ports: vec![]`. `process_detail` / `process_cpu` dispatch to `None` in
-`process.rs` (search across `#[cfg(target_os = "windows")]`).
+**Status:** `list_all()` works (Toolhelp) and now **attaches listening ports**
+(`listening_ports_by_pid()` parses the `GetExtendedTcpTable`
+`TCP_TABLE_OWNER_PID_LISTENER` table, big-endian port via `parse_port`), but
+still returns `icon_source: None`. `process_detail` / `process_cpu` dispatch to
+`None` in `process.rs` (search across `#[cfg(target_os = "windows")]`).
 
 **TODO:**
 
-1. **`list_all()` — ports + icon.**
-   - Ports: generalize `collect_listening_pids_for` (already parses the
-     `GetExtendedTcpTable` `TCP_TABLE_OWNER_PID_LISTENER` table of
-     `MIB_TCP{,6}ROW_OWNER_PID`) to return `(pid, port)` pairs → build
-     `HashMap<pid, Vec<u16>>` once, attach per row. Port is big-endian in the
-     row (`u16::from_be`/swap bytes).
+1. **`list_all()` — icon.** (Ports are already done — see Status.)
    - `icon_source`: Windows apps have no `.desktop`; `list()` already emits
      `desktop_id = "app:<exe_path>"`. Set `icon_source = Some(exe_path)` (from
      `resolve_full_path(pid)`) so app-backed rows show the exe icon. The shared
@@ -138,7 +135,11 @@ Win32 imports, `enumerate_processes() -> Vec<(u32, String)>`, `resolve_full_path
    - `cmdline`: `NtQueryInformationProcess(ProcessBasicInformation)` → PEB →
      `ProcessParameters.CommandLine` via `ReadProcessMemory`. Fallback to the
      exe path (`resolve_full_path`) if the remote read is denied.
-   - `rss_kb`: `GetProcessMemoryInfo` → `WorkingSetSize / 1024`.
+   - `rss_kb`: `GetProcessMemoryInfo` with `PROCESS_MEMORY_COUNTERS_EX` →
+     **`PrivateUsage / 1024`** (private commit), *not* `WorkingSetSize`. This
+     matches Task Manager's default "Memory" (private working set) and the
+     macOS `phys_footprint` / Linux USS choice; `WorkingSetSize` counts shared
+     pages and reads much higher.
    - `ppid`: Toolhelp `PROCESSENTRY32W.th32ParentProcessID` (build a pid→ppid
      map in the existing `enumerate_processes` pass).
    - `user`: `OpenProcessToken(TOKEN_QUERY)` → `GetTokenInformation(TokenUser)`
@@ -158,10 +159,33 @@ the backend returns them.
 
 ---
 
-## 4. macOS (native SwiftUI `apps/macos/`) — full port
+## 4. macOS (native SwiftUI `apps/macos/`) — ✅ implemented
 
-Design source of truth. Match the linows layout (which was modeled on the macOS
-patterns — `LauncherView.swift`, `ResultPreviewView`, the command panels).
+Design source of truth. Matches the linows layout (which was modeled on the
+macOS patterns — `LauncherView.swift`, `ResultPreviewView`, the command panels).
+
+**Status: done.** Implemented natively; see the files below. Chosen approach:
+**native Swift enumeration + `core/matching` fuzzy over a new FFI export** (the
+hybrid recommended in 4a), so ranking is identical to linows without porting the
+DP scorer.
+
+New/changed files:
+- `bridge/ffi/src/matching_api.rs` + `look_fuzzy_score` export in `lib.rs` —
+  exposes `look_matching::fuzzy_score` over the C ABI (Swift decl + `fuzzyScore`
+  wrapper in `EngineBridge.swift`). `look-matching` added to `bridge/ffi/Cargo.toml`.
+- `Support/Launcher/ProcessScoring.swift` — pure port of `score_process` /
+  `rank_kill_targets` (numeric port/PID tiers + apps-first kill ordering), fuzzy
+  injected as a closure so it's unit-testable. Parity tests in
+  `LauncherLogicTests/ProcessScoringTests.swift` mirror the Rust tests.
+- `Support/Launcher/ProcessService.swift` — native `libproc`/`sysctl`
+  enumeration, detail, on-demand CPU, ports, SIGKILL (off-main).
+- `Support/Launcher/ProcessFinderModel.swift` — snapshot cache + detail/CPU
+  caches, refreshed on mode entry / after a kill.
+- `Views/Launcher/LauncherView+Process.swift` — `ps"` mode: results, preview,
+  measure-CPU (Enter), kill (Cmd+D), copy-PID (Cmd+C). Rows/preview/kind wired
+  through `LauncherResult.process` in the existing results/preview views.
+- `KillCommand.swift` — `/kill` upgraded to fuzzy over apps + processes
+  (apps-first, deduped); empty → apps, `:port` unchanged.
 
 ### 4a. Architecture choice
 Process ops are OS-specific and are **not** in `core/`, so macOS reimplements
@@ -171,14 +195,15 @@ them. Two options:
 - **Rust module + FFI** (`bridge/ffi/`): only if you want to share the fuzzy
   scoring path end-to-end. Note `core/matching` is already reachable — you can
   call it over FFI for identical ranking while keeping enumeration native.
+  **(This is what shipped: native enumeration, FFI for the fuzzy score only.)**
 
 ### 4b. Backend (macOS APIs)
 | Field | API |
 |---|---|
-| enumerate | `proc_listallpids` (or `sysctl KERN_PROC_ALL`); filter to `getuid()` |
+| enumerate | **`sysctl KERN_PROC_ALL`** (gives pid + uid + comm in one call); filter to `getuid()`. **Do NOT use `proc_listallpids`** — it is silently throttled in hardened/restricted contexts and returns only a partial list (observed ~146 of ~584 procs, dropping the user's own apps). |
 | name | `proc_name` / comm |
 | cmdline (argv) | `sysctl KERN_PROCARGS2` |
-| memory (rss_kb) | `proc_pid_rusage(pid, RUSAGE_INFO_V2)` → `ri_resident_size` (or `ri_phys_footprint`) / 1024 |
+| memory | `proc_pid_rusage(pid, RUSAGE_INFO_V2)` → **`ri_phys_footprint`** / 1024. Use footprint, not `ri_resident_size` (RSS): footprint matches Activity Monitor's "Memory" column, while RSS counts shared pages and reads ~2× higher (confusing when users cross-check). |
 | cpu | `proc_pid_rusage` `ri_user_time + ri_system_time` (ns) sampled twice; `100·(Δns/1e9)/Δsecs` |
 | ppid / uid / start | `proc_pidinfo(PROC_PIDTBSDINFO)` → `pbi_ppid`, `pbi_uid`, `pbi_start_tvsec` (already Unix seconds → `start_epoch`) |
 | user | `getpwuid` |
@@ -222,6 +247,9 @@ Hint bar: `Cmd+D: Kill • Cmd+C: Copy PID`.
 ---
 
 ## 5. Parity checklist
+
+**macOS: all items below met** (see §4). **Windows: remaining** — `icon_source`,
+`process_detail`, `process_cpu` (ports already done).
 
 - [ ] `ps"` prefix enters process mode; empty query lists own-user processes.
 - [ ] Numeric query matches exact port > partial port > PID; name fuzzy also runs.


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a live process finder on macOS with fuzzy search by name, PID, or port, including process previews (CPU/memory/command/ports).
  * Added `/kill` flow improvements to rank and target matching processes, plus copy-PID and kill actions.
* **Bug Fixes**
  * Linux process memory (`rss_kb`) now prefers private memory (USS) via `/proc/<pid>/smaps_rollup`, with fallback to prior `VmRSS` parsing.
* **Documentation**
  * Updated parity guidance for the process finder and kill behavior across platforms.
* **Tests**
  * Added macOS process scoring coverage, including fuzzy and ranking precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

#193 

## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [x] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)


## Checklist

- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered
