### PR TITLE
windows: run apps as admin

### DIFF
--- a/apps/linows/src-tauri/src/commands.rs
+++ b/apps/linows/src-tauri/src/commands.rs
@@ -103,6 +103,7 @@ pub fn open_path(
     path: String,
     kind: Option<String>,
     #[cfg_attr(not(target_os = "linux"), allow(unused_variables))] id: Option<String>,
+    #[cfg_attr(not(target_os = "windows"), allow(unused_variables))] elevated: Option<bool>,
 ) -> Result<(), String> {
     // Windows classic applets: look-cmd://program[?args].
     // - `program` alone (e.g. "devmgmt.msc", "appwiz.cpl", "regedit.exe") →
@@ -227,6 +228,21 @@ pub fn open_path(
         });
         Ok(())
     } else {
+        // Windows: elevated launch via the shell `runas` verb. Only meaningful
+        // for a real executable (.exe / .lnk); the frontend gates the gesture to
+        // app rows. UAC prompt is modal, so run off-thread after hide().
+        #[cfg(target_os = "windows")]
+        if elevated == Some(true) {
+            let _ = window.hide();
+            let path = path.clone();
+            std::thread::spawn(move || {
+                if let Err(e) = crate::platform::windows::launch::run_as_admin(&path) {
+                    eprintln!("[open_path] runas {path:?} failed: {e}");
+                }
+            });
+            return Ok(());
+        }
+
         // Windows: before launching a fresh instance, try to raise an existing
         // window for the same .exe / .lnk / UWP AUMID. Must run while Look
         // still holds foreground - SetForegroundWindow fails after hide().

--- a/apps/linows/src-tauri/src/commands.rs
+++ b/apps/linows/src-tauri/src/commands.rs
@@ -103,7 +103,6 @@ pub fn open_path(
     path: String,
     kind: Option<String>,
     #[cfg_attr(not(target_os = "linux"), allow(unused_variables))] id: Option<String>,
-    #[cfg_attr(not(target_os = "windows"), allow(unused_variables))] elevated: Option<bool>,
 ) -> Result<(), String> {
     // Windows classic applets: look-cmd://program[?args].
     // - `program` alone (e.g. "devmgmt.msc", "appwiz.cpl", "regedit.exe") →
@@ -228,21 +227,6 @@ pub fn open_path(
         });
         Ok(())
     } else {
-        // Windows: elevated launch via the shell `runas` verb. Only meaningful
-        // for a real executable (.exe / .lnk); the frontend gates the gesture to
-        // app rows. UAC prompt is modal, so run off-thread after hide().
-        #[cfg(target_os = "windows")]
-        if elevated == Some(true) {
-            let _ = window.hide();
-            let path = path.clone();
-            std::thread::spawn(move || {
-                if let Err(e) = crate::platform::windows::launch::run_as_admin(&path) {
-                    eprintln!("[open_path] runas {path:?} failed: {e}");
-                }
-            });
-            return Ok(());
-        }
-
         // Windows: before launching a fresh instance, try to raise an existing
         // window for the same .exe / .lnk / UWP AUMID. Must run while Look
         // still holds foreground - SetForegroundWindow fails after hide().
@@ -289,6 +273,38 @@ pub fn open_path(
             }
         });
         Ok(())
+    }
+}
+
+/// Windows: `runas` launch. Async because the UAC prompt is modal and a sync
+/// command would block the main thread; resolves only once the launch is
+/// confirmed, so usage is never recorded for a declined prompt.
+#[tauri::command]
+pub async fn open_elevated(
+    window: tauri::WebviewWindow,
+    #[cfg_attr(not(target_os = "windows"), allow(unused_variables))] path: String,
+) -> Result<(), String> {
+    #[cfg(target_os = "windows")]
+    {
+        let _ = window.hide();
+        let result = tauri::async_runtime::spawn_blocking(move || {
+            let (program, args) = crate::platform::windows::launch::split_target(&path);
+            crate::platform::windows::launch::run_as_admin(program, args)
+        })
+        .await
+        .map_err(|e| e.to_string())?;
+        if let Err(e) = &result {
+            // Declined or refused: don't leave Look hidden.
+            eprintln!("[open_elevated] {e}");
+            let _ = window.show();
+            let _ = window.set_focus();
+        }
+        result
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = window;
+        Err("elevated launch is Windows only".into())
     }
 }
 

--- a/apps/linows/src-tauri/src/commands.rs
+++ b/apps/linows/src-tauri/src/commands.rs
@@ -292,9 +292,9 @@ pub async fn open_elevated(
             crate::platform::windows::launch::run_as_admin(program, args)
         })
         .await
-        .map_err(|e| e.to_string())?;
+        .unwrap_or_else(|e| Err(e.to_string()));
         if let Err(e) = &result {
-            // Declined or refused: don't leave Look hidden.
+            // Declined, refused, or the task died: don't leave Look hidden.
             eprintln!("[open_elevated] {e}");
             let _ = window.show();
             let _ = window.set_focus();

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -638,6 +638,7 @@ fn main() {
             commands::search,
             commands::record_usage,
             commands::open_path,
+            commands::open_elevated,
             commands::reveal_path,
             commands::reload_config,
             commands::request_index_refresh,

--- a/apps/linows/src-tauri/src/platform/windows/launch.rs
+++ b/apps/linows/src-tauri/src/platform/windows/launch.rs
@@ -1,0 +1,31 @@
+//! Elevated launch via the shell `runas` verb, which triggers the UAC prompt.
+//! `open::that` uses the default `open` verb; only `ShellExecuteW` with `runas`
+//! requests elevation for the target.
+
+use windows::Win32::UI::Shell::ShellExecuteW;
+use windows::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
+use windows::core::{HSTRING, PCWSTR};
+
+/// Launch `path` elevated. Returns `Err` when the user declines the UAC prompt
+/// (ERROR_CANCELLED) or the shell fails to start the target.
+pub fn run_as_admin(path: &str) -> Result<(), String> {
+    let verb = HSTRING::from("runas");
+    let file = HSTRING::from(path);
+    // ShellExecuteW returns an HINSTANCE that is only an error indicator: a value
+    // greater than 32 means success, anything else is a failure code.
+    let hinst = unsafe {
+        ShellExecuteW(
+            None,
+            &verb,
+            &file,
+            PCWSTR::null(),
+            PCWSTR::null(),
+            SW_SHOWNORMAL,
+        )
+    };
+    if hinst.0 as isize > 32 {
+        Ok(())
+    } else {
+        Err(format!("runas failed (code {})", hinst.0 as isize))
+    }
+}

--- a/apps/linows/src-tauri/src/platform/windows/launch.rs
+++ b/apps/linows/src-tauri/src/platform/windows/launch.rs
@@ -6,11 +6,24 @@ use windows::Win32::UI::Shell::ShellExecuteW;
 use windows::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
 use windows::core::{HSTRING, PCWSTR};
 
-/// Launch `path` elevated. Returns `Err` when the user declines the UAC prompt
-/// (ERROR_CANCELLED) or the shell fails to start the target.
-pub fn run_as_admin(path: &str) -> Result<(), String> {
+const ERROR_CANCELLED: isize = 1223;
+
+/// `look-cmd://program[?args]` → (program, args); anything else is the exe itself.
+pub fn split_target(path: &str) -> (&str, Option<&str>) {
+    match path.strip_prefix("look-cmd://") {
+        Some(rest) => match rest.split_once('?') {
+            Some((program, args)) => (program, Some(args)),
+            None => (rest, None),
+        },
+        None => (path, None),
+    }
+}
+
+/// Blocks until the UAC prompt is answered. `Err` on decline or launch failure.
+pub fn run_as_admin(program: &str, args: Option<&str>) -> Result<(), String> {
     let verb = HSTRING::from("runas");
-    let file = HSTRING::from(path);
+    let file = HSTRING::from(program);
+    let params = args.map(HSTRING::from);
     // ShellExecuteW returns an HINSTANCE that is only an error indicator: a value
     // greater than 32 means success, anything else is a failure code.
     let hinst = unsafe {
@@ -18,14 +31,34 @@ pub fn run_as_admin(path: &str) -> Result<(), String> {
             None,
             &verb,
             &file,
-            PCWSTR::null(),
+            params
+                .as_ref()
+                .map_or(PCWSTR::null(), |p| PCWSTR(p.as_ptr())),
             PCWSTR::null(),
             SW_SHOWNORMAL,
         )
     };
-    if hinst.0 as isize > 32 {
-        Ok(())
-    } else {
-        Err(format!("runas failed (code {})", hinst.0 as isize))
+    match hinst.0 as isize {
+        code if code > 32 => Ok(()),
+        ERROR_CANCELLED => Err("elevation declined".into()),
+        code => Err(format!("runas {program:?} failed (code {code})")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::split_target;
+
+    #[test]
+    fn splits_look_cmd_targets() {
+        assert_eq!(split_target("look-cmd://regedit.exe"), ("regedit.exe", None));
+        assert_eq!(
+            split_target("look-cmd://rundll32.exe?sysdm.cpl,EditEnvironmentVariables"),
+            ("rundll32.exe", Some("sysdm.cpl,EditEnvironmentVariables"))
+        );
+        assert_eq!(
+            split_target(r"C:\Windows\notepad.exe"),
+            (r"C:\Windows\notepad.exe", None)
+        );
     }
 }

--- a/apps/linows/src-tauri/src/platform/windows/launch.rs
+++ b/apps/linows/src-tauri/src/platform/windows/launch.rs
@@ -51,7 +51,10 @@ mod tests {
 
     #[test]
     fn splits_look_cmd_targets() {
-        assert_eq!(split_target("look-cmd://regedit.exe"), ("regedit.exe", None));
+        assert_eq!(
+            split_target("look-cmd://regedit.exe"),
+            ("regedit.exe", None)
+        );
         assert_eq!(
             split_target("look-cmd://rundll32.exe?sysdm.cpl,EditEnvironmentVariables"),
             ("rundll32.exe", Some("sysdm.cpl,EditEnvironmentVariables"))

--- a/apps/linows/src-tauri/src/platform/windows/mod.rs
+++ b/apps/linows/src-tauri/src/platform/windows/mod.rs
@@ -17,6 +17,7 @@ pub mod effects;
 pub mod fonts;
 pub mod icons;
 pub mod known_folders;
+pub mod launch;
 pub mod process;
 pub mod recycle_bin;
 pub mod sysinfo;

--- a/apps/linows/src-tauri/tauri.conf.json
+++ b/apps/linows/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicoverbruggen/tauri-v2-schema/main/schema.json",
   "productName": "Look",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "identifier": "com.look.desktop",
   "build": {
     "frontendDist": "../src",

--- a/apps/linows/src/js/components/preview.js
+++ b/apps/linows/src/js/components/preview.js
@@ -25,6 +25,7 @@ import {
     WEB_URL_OPEN_SUBTITLE,
 } from '../catalog.js';
 import * as qactions from './qactions.js';
+import { isWindows } from '../platform.js';
 
 let panel = null;
 let currentPath = null;
@@ -404,6 +405,9 @@ function renderAppMeta(metaWrap, result, headerSub) {
 
     metaWrap.appendChild(infoRow('Kind', 'App'));
     metaWrap.appendChild(infoRow('Path', result.path));
+    if (isWindows()) {
+        metaWrap.appendChild(infoRow('Run as admin', 'Ctrl+Shift+Enter'));
+    }
 }
 
 function renderFileMeta(metaWrap, previewSlot, result, headerSub) {

--- a/apps/linows/src/js/components/preview.js
+++ b/apps/linows/src/js/components/preview.js
@@ -25,7 +25,7 @@ import {
     WEB_URL_OPEN_SUBTITLE,
 } from '../catalog.js';
 import * as qactions from './qactions.js';
-import { isWindows } from '../platform.js';
+import { canRunElevated } from '../platform.js';
 
 let panel = null;
 let currentPath = null;
@@ -405,7 +405,7 @@ function renderAppMeta(metaWrap, result, headerSub) {
 
     metaWrap.appendChild(infoRow('Kind', 'App'));
     metaWrap.appendChild(infoRow('Path', result.path));
-    if (isWindows()) {
+    if (canRunElevated(result)) {
         metaWrap.appendChild(infoRow('Run as admin', 'Ctrl+Shift+Enter'));
     }
 }

--- a/apps/linows/src/js/ipc.js
+++ b/apps/linows/src/js/ipc.js
@@ -9,8 +9,8 @@ export async function recordUsage(candidateId, action) {
     return invoke('record_usage', { candidateId, action });
 }
 
-export async function openPath(path, kind, id) {
-    return invoke('open_path', { path, kind, id });
+export async function openPath(path, kind, id, elevated = false) {
+    return invoke('open_path', { path, kind, id, elevated });
 }
 
 export async function revealPath(path) {

--- a/apps/linows/src/js/ipc.js
+++ b/apps/linows/src/js/ipc.js
@@ -9,8 +9,13 @@ export async function recordUsage(candidateId, action) {
     return invoke('record_usage', { candidateId, action });
 }
 
-export async function openPath(path, kind, id, elevated = false) {
-    return invoke('open_path', { path, kind, id, elevated });
+export async function openPath(path, kind, id) {
+    return invoke('open_path', { path, kind, id });
+}
+
+// Windows only. Rejects when UAC is declined, so await before recording usage.
+export async function openElevated(path) {
+    return invoke('open_elevated', { path });
 }
 
 export async function revealPath(path) {

--- a/apps/linows/src/js/keyboard.js
+++ b/apps/linows/src/js/keyboard.js
@@ -3,6 +3,7 @@ import * as search from './search.js';
 import * as translatePanel from './components/translate.js';
 import {
     openPath,
+    openElevated,
     recordUsage,
     recordUrlHit,
     revealPath,
@@ -22,7 +23,7 @@ import * as confirm from './components/confirm.js';
 import * as qactions from './components/qactions.js';
 import * as superactions from './components/superactions.js';
 import * as runningApps from './components/running-apps.js';
-import { isWindows } from './platform.js';
+import { canRunElevated } from './platform.js';
 import { trash as trashIcon } from './icons.js';
 import {
     prefixFromResultId,
@@ -273,8 +274,7 @@ function handleKeyDown(e) {
             } else if (
                 e.ctrlKey &&
                 (e.shiftKey || shiftHeld) &&
-                isWindows() &&
-                results.getSelected()?.kind === 'app'
+                canRunElevated(results.getSelected())
             ) {
                 // Ctrl+Shift+Enter: launch the selected app elevated (UAC).
                 openSelected(true);
@@ -517,7 +517,11 @@ async function openSelected(elevated = false) {
     }
 
     try {
-        await openPath(item.path, item.kind, item.id, elevated && item.kind === 'app');
+        if (elevated) {
+            await openElevated(item.path);
+        } else {
+            await openPath(item.path, item.kind, item.id);
+        }
         const actionMap = { app: 'open_app', file: 'open_file', folder: 'open_folder' };
         const action = actionMap[item.kind] || 'open_file';
         await recordUsage(item.id, action);

--- a/apps/linows/src/js/keyboard.js
+++ b/apps/linows/src/js/keyboard.js
@@ -22,6 +22,7 @@ import * as confirm from './components/confirm.js';
 import * as qactions from './components/qactions.js';
 import * as superactions from './components/superactions.js';
 import * as runningApps from './components/running-apps.js';
+import { isWindows } from './platform.js';
 import { trash as trashIcon } from './icons.js';
 import {
     prefixFromResultId,
@@ -269,6 +270,14 @@ function handleKeyDown(e) {
                 // ps": Enter measures CPU on demand (kill is Ctrl+D). Keeps
                 // selection instant by never sampling until asked.
                 preview.measureCpu();
+            } else if (
+                e.ctrlKey &&
+                (e.shiftKey || shiftHeld) &&
+                isWindows() &&
+                results.getSelected()?.kind === 'app'
+            ) {
+                // Ctrl+Shift+Enter: launch the selected app elevated (UAC).
+                openSelected(true);
             } else if (e.ctrlKey) {
                 searchWeb();
             } else if ((e.shiftKey || shiftHeld) && results.hasPickedItems()) {
@@ -468,7 +477,7 @@ export async function openAllPicked() {
     results.clearPicks();
 }
 
-async function openSelected() {
+async function openSelected(elevated = false) {
     const item = results.getSelected();
     if (!item) return;
 
@@ -508,7 +517,7 @@ async function openSelected() {
     }
 
     try {
-        await openPath(item.path, item.kind, item.id);
+        await openPath(item.path, item.kind, item.id, elevated && item.kind === 'app');
         const actionMap = { app: 'open_app', file: 'open_file', folder: 'open_folder' };
         const action = actionMap[item.kind] || 'open_file';
         await recordUsage(item.id, action);

--- a/apps/linows/src/js/platform.js
+++ b/apps/linows/src/js/platform.js
@@ -68,6 +68,12 @@ export function isLinux() {
     return info?.os === 'linux';
 }
 
+// Ctrl+Shift+Enter target: exes and look-cmd:// applets. ms-settings: pages
+// have no elevated form, so neither gesture nor hint is offered for them.
+export function canRunElevated(item) {
+    return isWindows() && item?.kind === 'app' && !item.path?.startsWith('ms-settings:');
+}
+
 // Windows calls it the Recycle Bin; Linux/macOS call it the Trash. Used for
 // user-facing strings so the banner/confirm copy matches the OS.
 export function trashLabel() {


### PR DESCRIPTION

## Summary of changes

* **New Features**
  * On Windows, **Ctrl+Shift+Enter** now opens the selected item with administrator privileges when eligible.
  * App previews show a **“Run as admin”** hint for eligible apps.
* **Bug Fixes**
  * If the administrator prompt is declined or the elevated launch fails, the window automatically restores visibility and focus to avoid UI lockups.
* **Other**
  * Elevated launching now correctly handles special “look-cmd://” targets in addition to standard paths.


## Why

#298 

## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [ ] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)


## Checklist

- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


