### PR TITLE
feat: super actions on i3

### DIFF
--- a/apps/linows/src/css/components/superactions.css
+++ b/apps/linows/src/css/components/superactions.css
@@ -31,14 +31,10 @@ html.controls-open #hint-bar {
     max-height: 260px;
 }
 
-/* No transparency / square corners (bare X11/i3): the space below the bento is
- * an opaque dead box the floating layout would leave see-through. Stack a
- * todo-stats panel under the bento to fill it - the grid sizes to its natural
- * height at the top, the stats panel takes the rest. */
-/* :not([hidden]) is load-bearing: the strip hides on the first keystroke via
- * the `hidden` attribute (UA `[hidden]{display:none}`), and a bare
- * `display:flex` here outranks it, pinning the bento open under the results.
- * Only take over the layout while the strip is actually shown. */
+/* Opaque panel: stack a todo-stats panel under the bento to fill the dead space.
+ * :not([hidden]) is load-bearing: the strip hides on the first keystroke via the
+ * `hidden` attribute, and a bare display:flex here outranks it and pins the bento
+ * open under the results. */
 html[data-transparent="false"] .control-strip:not([hidden]) {
     display: flex;
     flex-direction: column;
@@ -49,9 +45,8 @@ html[data-transparent="false"] .control-strip-grid {
     flex: 0 0 auto;
 }
 
-/* Heatmap + insights, spread to fill the leftover height (the charts can't
- * grow - square heatmap cells, fixed insight row - so the section gaps widen
- * evenly instead, mirroring the /todo Stats page). */
+/* Charts can't grow (square heatmap cells, fixed insight row), so spread them
+ * to fill the leftover height. */
 .control-strip-stats {
     flex: 1 1 auto;
     min-height: 0;

--- a/apps/linows/src/css/components/superactions.css
+++ b/apps/linows/src/css/components/superactions.css
@@ -31,6 +31,38 @@ html.controls-open #hint-bar {
     max-height: 260px;
 }
 
+/* No transparency / square corners (bare X11/i3): the space below the bento is
+ * an opaque dead box the floating layout would leave see-through. Stack a
+ * todo-stats panel under the bento to fill it - the grid sizes to its natural
+ * height at the top, the stats panel takes the rest. */
+/* :not([hidden]) is load-bearing: the strip hides on the first keystroke via
+ * the `hidden` attribute (UA `[hidden]{display:none}`), and a bare
+ * `display:flex` here outranks it, pinning the bento open under the results.
+ * Only take over the layout while the strip is actually shown. */
+html[data-transparent="false"] .control-strip:not([hidden]) {
+    display: flex;
+    flex-direction: column;
+}
+
+html[data-transparent="false"] .control-strip-grid {
+    height: auto;
+    flex: 0 0 auto;
+}
+
+/* Heatmap + insights, spread to fill the leftover height (the charts can't
+ * grow - square heatmap cells, fixed insight row - so the section gaps widen
+ * evenly instead, mirroring the /todo Stats page). */
+.control-strip-stats {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    gap: 8px;
+    margin-top: var(--content-padding);
+    overflow: hidden;
+}
+
 /* Entrance: each tile eases up + fades in, staggered by its grid index (--i)
  * so the launchpad cascades in when summoned. `backwards` fill holds the tile
  * hidden through its delay, then hands transform back to the base rule so

--- a/apps/linows/src/js/components/superactions.js
+++ b/apps/linows/src/js/components/superactions.js
@@ -63,11 +63,18 @@ import {
     snapshot as pomoSnapshot,
     formatTime as formatPomoTime,
 } from '../screens/commands/pomo.js';
+import { statsWidgetHtml } from '../screens/commands/todo.js';
+import * as platform from '../platform.js';
 import * as banner from './banner.js';
 
 let container = null;
 let built = false;
 let visible = false;
+// Todo-stats panel (year heatmap + insights) appended below the bento on the
+// no-transparency classic panel, to fill the space the floating layout leaves
+// see-through. Null on transparent/floating platforms - the surplus there is
+// the desktop showing through, so nothing to fill. Populated by refreshTodo.
+let statsEl = null;
 // User setting (Settings -> Appearance -> Super Actions). When off the strip
 // never shows and its accelerators never fire; setVisible collapses to hidden.
 let enabled = true;
@@ -694,6 +701,16 @@ async function refreshTodo() {
     openTasks = mine.filter((t) => !t.done).map((t) => t.name);
     taskCursor = 0;
     renderSlot();
+    renderStatsWidget(tasks);
+}
+
+// Fill the no-transparency stats panel from the same todoList() rows the
+// priority slot just read. Heatmap cells scale to the card's content width, so
+// measure it live (minus the card chrome: 2x14 padding + 2x1 border = 30px).
+function renderStatsWidget(tasks) {
+    if (!statsEl) return;
+    const width = Math.max(280, statsEl.clientWidth - 30);
+    statsEl.innerHTML = statsWidgetHtml(tasks || [], width);
 }
 
 // Rotate through the open tasks so a long day's list all gets a turn, matching
@@ -859,6 +876,18 @@ function render(tiles) {
 
     container.innerHTML = '';
     container.appendChild(grid);
+
+    // On the opaque classic panel (no transparency / square corners) the space
+    // below the bento is a dead box. Fill it with a todo-stats panel; refreshTodo
+    // populates it from the same todoList() read the priority slot uses. Gated on
+    // real transparency so floating/rounded platforms (whose surplus is see-through)
+    // are untouched.
+    statsEl = null;
+    if (!platform.hasCompositor()) {
+        statsEl = document.createElement('div');
+        statsEl.className = 'control-strip-stats';
+        container.appendChild(statsEl);
+    }
 }
 
 function buildTile(tile) {

--- a/apps/linows/src/js/components/superactions.js
+++ b/apps/linows/src/js/components/superactions.js
@@ -70,10 +70,8 @@ import * as banner from './banner.js';
 let container = null;
 let built = false;
 let visible = false;
-// Todo-stats panel (year heatmap + insights) appended below the bento on the
-// no-transparency classic panel, to fill the space the floating layout leaves
-// see-through. Null on transparent/floating platforms - the surplus there is
-// the desktop showing through, so nothing to fill. Populated by refreshTodo.
+// Todo-stats panel filling the dead space below the bento on the opaque
+// (no-transparency) panel. Null elsewhere. Populated by refreshTodo.
 let statsEl = null;
 // User setting (Settings -> Appearance -> Super Actions). When off the strip
 // never shows and its accelerators never fire; setVisible collapses to hidden.
@@ -704,9 +702,8 @@ async function refreshTodo() {
     renderStatsWidget(tasks);
 }
 
-// Fill the no-transparency stats panel from the same todoList() rows the
-// priority slot just read. Heatmap cells scale to the card's content width, so
-// measure it live (minus the card chrome: 2x14 padding + 2x1 border = 30px).
+// Reuses the priority slot's todoList() rows. width = card content (minus 30px
+// chrome: 2x14 padding + 2x1 border) so the heatmap cells scale to fit.
 function renderStatsWidget(tasks) {
     if (!statsEl) return;
     const width = Math.max(280, statsEl.clientWidth - 30);
@@ -877,11 +874,8 @@ function render(tiles) {
     container.innerHTML = '';
     container.appendChild(grid);
 
-    // On the opaque classic panel (no transparency / square corners) the space
-    // below the bento is a dead box. Fill it with a todo-stats panel; refreshTodo
-    // populates it from the same todoList() read the priority slot uses. Gated on
-    // real transparency so floating/rounded platforms (whose surplus is see-through)
-    // are untouched.
+    // Opaque panel only: fill the dead space below the bento with todo stats.
+    // Transparent/floating panels leave it see-through, so nothing to fill.
     statsEl = null;
     if (!platform.hasCompositor()) {
         statsEl = document.createElement('div');

--- a/apps/linows/src/js/screens/commands/todo.js
+++ b/apps/linows/src/js/screens/commands/todo.js
@@ -823,12 +823,9 @@ function insightsHtml(trend) {
         .join('<div class="cmd-todo-insight-sep"></div>');
 }
 
-// Compact stats widget (year heatmap + 30-day insights) for embedding in the
-// super-actions strip on the no-transparency classic panel, where it fills the
-// space the floating layout leaves see-through. Pure: derives its own day
-// counts from the raw todo rows (todoList output), so it never touches the
-// /todo page's in-memory store or its dirty/loaded lifecycle. `width` is the
-// pixel width available to the heatmap card's content.
+// Year heatmap + 30-day insights for the super-actions strip. Pure: builds its
+// own counts from raw todoList() rows, so it ignores the /todo page's store.
+// width is the heatmap card's content width in px.
 export function statsWidgetHtml(rows, width) {
     const counts = new Map();
     for (const r of rows || []) {

--- a/apps/linows/src/js/screens/commands/todo.js
+++ b/apps/linows/src/js/screens/commands/todo.js
@@ -823,6 +823,28 @@ function insightsHtml(trend) {
         .join('<div class="cmd-todo-insight-sep"></div>');
 }
 
+// Compact stats widget (year heatmap + 30-day insights) for embedding in the
+// super-actions strip on the no-transparency classic panel, where it fills the
+// space the floating layout leaves see-through. Pure: derives its own day
+// counts from the raw todo rows (todoList output), so it never touches the
+// /todo page's in-memory store or its dirty/loaded lifecycle. `width` is the
+// pixel width available to the heatmap card's content.
+export function statsWidgetHtml(rows, width) {
+    const counts = new Map();
+    for (const r of rows || []) {
+        const c = counts.get(r.due_date) || { done: 0, total: 0 };
+        c.total += 1;
+        if (r.done) c.done += 1;
+        counts.set(r.due_date, c);
+    }
+    const trend = trendData(counts);
+    return `
+    <div class="cmd-todo-section-title">${calendar} ACTIVITY · LAST YEAR${heatLegendHtml()}</div>
+    <div class="cmd-todo-card">${heatmapHtml(counts, width)}</div>
+    <div class="cmd-todo-section-title">${zap} INSIGHTS · LAST ${TREND_DAYS} DAYS (TASKS)</div>
+    <div class="cmd-todo-card cmd-todo-insights">${insightsHtml(trend)}</div>`;
+}
+
 // Leftover panel height is split between the trend chart (which grows a
 // little) and the section gaps (which widen evenly), so the page fills the
 // panel without any one chart ballooning. The heatmap can't grow: its


### PR DESCRIPTION
## Summary

- i3(x11) and some DE types don't have right transparency, corner... effects. We need to show app panel fullsize. -> 
we have to fullfill the app panel while only super actions appear. 
(temp solution: bring 2 charts from todo analytics screen)

## Why

#288 

## Testing

  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

<img width="721" height="507" alt="image" src="https://github.com/user-attachments/assets/a3f63f35-2bb0-4cb2-8309-a3928f2d19cf" />


## Checklist

- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “todo activity statistics” widget to the Super Actions area on classic, non-transparent layouts.
  * Displays last-year activity in a heatmap and highlights recent task insights (completed vs. total), updating as the todo view refreshes.

* **Style**
  * Improved the control strip layout for opaque modes so the statistics section expands to use available space cleanly, with better sizing and spacing for readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->