### PR TITLE
chore: Fix nowplaying pomo, message box width

### DIFF
--- a/apps/linows/src/css/components/confirm.css
+++ b/apps/linows/src/css/components/confirm.css
@@ -1,7 +1,9 @@
 .confirm-bar {
     position: fixed;
-    left: 10px;
-    right: 10px;
+    /* Inset to match the content rhythm (top bar margin, floating tiles) so the
+     * bar never overhangs the window's rounded corners or the floating tiles. */
+    left: var(--content-padding);
+    right: var(--content-padding);
     bottom: 38px;
     z-index: 1000;
     display: flex;
@@ -17,6 +19,13 @@
 
 .confirm-bar[hidden] {
     display: none;
+}
+
+/* Floating grid moves the hints into the card footers and hides the bottom
+ * hint bar, so drop the confirm bar to the content edge instead of clearing a
+ * bar that is no longer there. */
+.floating-grid .confirm-bar {
+    bottom: var(--content-padding);
 }
 
 body.confirm-active .hint-bar > span:first-child {

--- a/apps/linows/src/js/components/superactions.js
+++ b/apps/linows/src/js/components/superactions.js
@@ -62,6 +62,8 @@ import {
 import {
     snapshot as pomoSnapshot,
     formatTime as formatPomoTime,
+    musicSnapshot,
+    musicCommand,
 } from '../screens/commands/pomo.js';
 import { statsWidgetHtml } from '../screens/commands/todo.js';
 import * as platform from '../platform.js';
@@ -112,6 +114,9 @@ let weatherEls = null;
 let mediaEls = null;
 let weatherToken = 0;
 let mediaToken = 0;
+// 'internal' (pomo) or 'mpris': the source that last actually played. Breaks the
+// tie when both are paused so the tile resumes whichever the user last used.
+let mediaLastSource = null;
 
 // Bumped on every refresh so a late async state read for a stale summon is
 // dropped; guards against clobbering the optimistic value a press just set.
@@ -753,8 +758,21 @@ async function refreshWeather(myToken) {
 
 // --- Now Playing (active MPRIS player) --------------------------------------
 
+// The pomo background player is app-internal (rodio), so it never appears on
+// MPRIS. Shape its snapshot like an MPRIS one for renderMedia.
+function internalMedia(m) {
+    return { title: m.track, artist: 'Pomodoro', is_playing: m.playing, internal: true };
+}
+
 async function refreshNowPlaying(myToken) {
     if (!mediaEls) return;
+    const internal = musicSnapshot();
+    // Pomo actively playing outranks any MPRIS player.
+    if (internal?.playing) {
+        mediaLastSource = 'internal';
+        renderMedia(internalMedia(internal));
+        return;
+    }
     let np;
     try {
         np = await nowPlayingCurrent();
@@ -762,6 +780,19 @@ async function refreshNowPlaying(myToken) {
         return;
     }
     if (myToken !== mediaToken || !mediaEls) return;
+    // A real player that is actually playing beats a paused pomo track.
+    if (np?.title && np.is_playing) {
+        mediaLastSource = 'mpris';
+        renderMedia(np);
+        return;
+    }
+    // Nothing is playing: keep whichever source last played, so a paused pomo
+    // does not hijack a just-paused MPRIS player (and vice versa). Fall back to
+    // pomo when the MPRIS player is gone entirely.
+    if (internal && (mediaLastSource !== 'mpris' || !np?.title)) {
+        renderMedia(internalMedia(internal));
+        return;
+    }
     renderMedia(np);
 }
 
@@ -775,6 +806,7 @@ function setPlaying(playing) {
 function renderMedia(np) {
     // Handle the transport drives, so it hits the shown player, not a re-pick.
     mediaEls.player = np?.player ?? null;
+    mediaEls.internal = !!np?.internal;
     setPlaying(!!np?.is_playing);
     if (!np?.title) {
         mediaEls.label.textContent = 'Nothing playing';
@@ -789,6 +821,18 @@ function renderMedia(np) {
 // Send a transport command to the active player. Play/Pause flips optimistically
 // and defers to the poll; next/previous re-read to show the new track promptly.
 async function transport(command) {
+    // Internal pomo player: state flips synchronously, so re-read at once.
+    if (mediaEls?.internal) {
+        // Flip the glyph now so pausing feels instant; pausing then re-reads
+        // MPRIS (an await), which would otherwise lag the glyph. The re-read
+        // reconciles either way.
+        if (command === 'playpause') {
+            setPlaying(!mediaEls.el.classList.contains('is-playing'));
+        }
+        musicCommand(command);
+        refreshNowPlaying((mediaToken += 1));
+        return;
+    }
     const player = mediaEls?.player ?? null;
     if (command === 'playpause' && mediaEls) {
         // Optimistic flip; roll back unless delivered. No re-read: MPRIS

--- a/apps/linows/src/js/screens/commands/pomo.js
+++ b/apps/linows/src/js/screens/commands/pomo.js
@@ -845,6 +845,21 @@ function stopEndPoll() {
     }
 }
 
+// Home Now Playing tile reads this: the background player is app-internal
+// (rodio) so it never appears on MPRIS. Null when no track is loaded.
+export function musicSnapshot() {
+    if (musicIndex < 0 || musicTracks.length === 0) return null;
+    return { playing: musicPlaying, track: trackName(musicTracks[musicIndex]) };
+}
+
+// Drive that same player from the home tile transport.
+export function musicCommand(cmd) {
+    if (musicTracks.length === 0) return;
+    if (cmd === 'playpause') musicToggle();
+    else if (cmd === 'next') musicNext();
+    else if (cmd === 'previous') musicPrev();
+}
+
 function updateMusicUI() {
     if (!musicTrackEl) return;
 


### PR DESCRIPTION
## Summary

- Now playing shows pomo music
- Reduce message box width (while app sets inner gap)


## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [ ] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [ ] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [ ] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [ ] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [ ] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [ ] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

<img width="1016" height="172" alt="image" src="https://github.com/user-attachments/assets/66caec5d-895a-4e44-81dd-49e8fc7fa8d4" />


## Checklist

- [x] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the Home “Now Playing” tile to support internal Pomodoro music alongside external media players.
  * Added playback controls for internal music, including play/pause, next, and previous track actions.
  * Improved fallback behavior when external media players are unavailable.

* **Bug Fixes**
  * Prevented paused playback sources from incorrectly overriding the currently displayed player.
  * Aligned the confirmation bar with content spacing and rounded corners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->