### PR TITLE
sync old crate with gpl license

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,12 @@ Built-in: Catppuccin, Tokyo Night, Rose Pine, Gruvbox, Dracula, Kanagawa, plus C
 
 ## License
 
-GPLv3 - see [LICENSE](LICENSE).
+Copyright (C) 2026 kunkka19xx
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version. See [LICENSE](LICENSE) for the full text.
 
 ## Contributors
 

--- a/apps/linows/src-tauri/Cargo.toml
+++ b/apps/linows/src-tauri/Cargo.toml
@@ -2,7 +2,8 @@
 name = "lookapp"
 version = "0.1.0"
 edition = "2024"
-license = "MIT"
+license = "GPL-3.0-or-later"
+authors = ["kunkka19xx <nobita079x@gmail.com>"]
 
 [dependencies]
 tauri = { version = "2.11.1", features = ["protocol-asset"] }

--- a/bridge/ffi/Cargo.toml
+++ b/bridge/ffi/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "look-ffi"
 edition = "2024"
-license = "MIT"
+license = "GPL-3.0-or-later"
+authors = ["kunkka19xx <nobita079x@gmail.com>"]
 version = "0.1.0"
 
 [lib]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,5 +14,6 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-license = "MIT"
+license = "GPL-3.0-or-later"
+authors = ["kunkka19xx <nobita079x@gmail.com>"]
 version = "0.1.0"

--- a/core/answers/Cargo.toml
+++ b/core/answers/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "look-answers"
 edition = "2024"
-license = "MIT"
+license.workspace = true
+authors.workspace = true
 version = "0.1.0"
 
 [dependencies]

--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "look-engine"
 edition = "2024"
-license = "MIT"
+license.workspace = true
+authors.workspace = true
 version = "0.1.0"
 
 [dependencies]

--- a/core/indexing/Cargo.toml
+++ b/core/indexing/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "look-indexing"
 edition = "2024"
-license = "MIT"
+license.workspace = true
+authors.workspace = true
 version = "0.1.0"
 
 [dependencies]

--- a/core/lunar/Cargo.toml
+++ b/core/lunar/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "look-lunar"
 edition = "2024"
-license = "MIT"
+license.workspace = true
+authors.workspace = true
 version = "0.1.0"
 
 [dependencies]

--- a/core/matching/Cargo.toml
+++ b/core/matching/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "look-matching"
 edition = "2024"
-license = "MIT"
+license.workspace = true
+authors.workspace = true
 version = "0.1.0"

--- a/core/qactions/Cargo.toml
+++ b/core/qactions/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "look-qactions"
 edition = "2024"
-license = "MIT"
+license.workspace = true
+authors.workspace = true
 version = "0.1.0"
 
 [dependencies]

--- a/core/ranking/Cargo.toml
+++ b/core/ranking/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "look-ranking"
 edition = "2024"
-license = "MIT"
+license.workspace = true
+authors.workspace = true
 version = "0.1.0"
 
 [dependencies]

--- a/core/storage/Cargo.toml
+++ b/core/storage/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "look-storage"
 edition = "2024"
-license = "MIT"
+license.workspace = true
+authors.workspace = true
 version = "0.1.0"
 
 [dependencies]

--- a/core/todo/Cargo.toml
+++ b/core/todo/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "look-todo"
 edition = "2024"
-license = "MIT"
+license.workspace = true
+authors.workspace = true
 version = "0.1.0"
 
 [dependencies]

--- a/tools/perf/Cargo.toml
+++ b/tools/perf/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "look-perf-tools"
 edition = "2024"
-license = "MIT"
+license = "GPL-3.0-or-later"
+authors = ["kunkka19xx <nobita079x@gmail.com>"]
 version = "0.1.0"
 publish = false
 description = "Perf and stress benches for look's index refresh / watcher path. Not shipped in any app bundle."


### PR DESCRIPTION
## Summary

- This app was originally under MIT license, but this was changed to GPL months ago.
-> just sync old crate with the current license



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the license documentation with the full GPLv3 redistribution and modification notice.
  - Added copyright information for 2026.

- **Chores**
  - Updated project and package metadata to use GPL-3.0-or-later licensing.
  - Standardized author information across packages.
  - Consolidated package license and author details through shared workspace configuration.
  - Updated storage tooling configuration to support bundled SQLite and indexing integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->