### PR TITLE
Theme: kindle like theme

### DIFF
--- a/apps/macos/LauncherApp/look-app/Components/VisualEffectBlur.swift
+++ b/apps/macos/LauncherApp/look-app/Components/VisualEffectBlur.swift
@@ -3,12 +3,15 @@ import SwiftUI
 
 struct VisualEffectBlur: NSViewRepresentable {
     var material: NSVisualEffectView.Material
+    /// Pinned per theme: materials otherwise follow the system light/dark setting.
+    var appearance: ThemeAppearance = .dark
 
     func makeNSView(context: Context) -> NSVisualEffectView {
         let view = NSVisualEffectView()
         view.material = material
         view.blendingMode = .withinWindow
         view.state = .active
+        view.appearance = NSAppearance(named: appearance.nsAppearanceName)
         return view
     }
 
@@ -18,6 +21,9 @@ struct VisualEffectBlur: NSViewRepresentable {
         // hasn't actually changed.
         if nsView.material != material {
             nsView.material = material
+        }
+        if nsView.appearance?.name != appearance.nsAppearanceName {
+            nsView.appearance = NSAppearance(named: appearance.nsAppearanceName)
         }
     }
 }

--- a/apps/macos/LauncherApp/look-app/Models/ThemeSettings.swift
+++ b/apps/macos/LauncherApp/look-app/Models/ThemeSettings.swift
@@ -147,7 +147,10 @@ struct ThemeSettings: Codable, Equatable {
     var borderOpacity: Double = 0.12
 
     var themeName: String = ""
-    var uiTheme: BuiltinThemePreset = .catppuccin
+
+    /// Preset shown in the Settings picker. Custom by default because the values
+    /// above are no preset's; `ThemeStore` re-detects it whenever config is read.
+    var uiTheme: BuiltinThemePreset = .custom
 
     // Background image
     var backgroundImagePath: String?

--- a/apps/macos/LauncherApp/look-app/Support/ThemeStore+Appearance.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ThemeStore+Appearance.swift
@@ -1,6 +1,18 @@
 import SwiftUI
 
 extension ThemeStore {
+    /// Bases for the opaque command-mode surfaces. Dark adds the tint to a
+    /// near-black base; on paper that would clip past white, so light mixes.
+    private enum CommandSurface {
+        static let darkBackgroundBase = 0.18
+        static let darkBackgroundBlueBase = 0.20
+        static let darkPanelBase = 0.13
+        static let darkPanelBlueBase = 0.15
+        static let lightBackgroundBase = 0.94
+        static let lightPanelBase = 0.87
+        static let tintWeight = 0.25
+    }
+
     // MARK: - Appearance Tokens
 
     func fontColor(opacityMultiplier: Double = 1.0) -> Color {
@@ -117,23 +129,50 @@ extension ThemeStore {
     // - the card is just a few points darker, like a subtle recess.
 
     func commandModeBackgroundColor() -> Color {
-        Color(
-            .sRGB,
-            red: 0.18 + settings.tintRed * 0.25,
-            green: 0.18 + settings.tintGreen * 0.25,
-            blue: 0.20 + settings.tintBlue * 0.25,
-            opacity: 1.0
+        commandSurfaceColor(
+            darkBase: ThemeRGB(
+                red: CommandSurface.darkBackgroundBase,
+                green: CommandSurface.darkBackgroundBase,
+                blue: CommandSurface.darkBackgroundBlueBase
+            ),
+            lightBase: CommandSurface.lightBackgroundBase
         )
     }
 
     func commandModePanelColor() -> Color {
-        Color(
-            .sRGB,
-            red: 0.13 + settings.tintRed * 0.25,
-            green: 0.13 + settings.tintGreen * 0.25,
-            blue: 0.15 + settings.tintBlue * 0.25,
-            opacity: 1.0
+        commandSurfaceColor(
+            darkBase: ThemeRGB(
+                red: CommandSurface.darkPanelBase,
+                green: CommandSurface.darkPanelBase,
+                blue: CommandSurface.darkPanelBlueBase
+            ),
+            lightBase: CommandSurface.lightPanelBase
         )
+    }
+
+    /// Wash that seats a pane on the backdrop: darkens on dark, lightens on paper.
+    func scrimColor(opacity: Double) -> Color {
+        switch themeAppearance() {
+        case .dark:
+            return .black.opacity(opacity)
+        case .light:
+            return .white.opacity(opacity)
+        }
+    }
+
+    /// The inverse of `scrimColor`, for chips and badges that must stand off
+    /// the backdrop: white on dark, ink on paper.
+    func liftColor(opacity: Double) -> Color {
+        switch themeAppearance() {
+        case .dark:
+            return .white.opacity(opacity)
+        case .light:
+            return .black.opacity(opacity)
+        }
+    }
+
+    func themeAppearance() -> ThemeAppearance {
+        activeAppearanceStyle()?.appearance ?? .dark
     }
 
     func borderColor() -> Color {
@@ -153,18 +192,17 @@ extension ThemeStore {
 
     func applyBuiltinTheme(_ preset: BuiltinThemePreset) {
         guard let style = preset.style else {
+            // Custom owns no palette: clearing the name is what makes the
+            // semantic tokens fall back to being derived from the user's colors.
+            settings.themeName = ""
             return
         }
         style.apply(to: &settings)
     }
 
     func detectBuiltinTheme(for settings: ThemeSettings) -> BuiltinThemePreset {
-        if !settings.themeName.isEmpty {
-            for preset in BuiltinThemePreset.allCases where preset != .custom {
-                if preset.style?.themeName.lowercased() == settings.themeName.lowercased() {
-                    return preset
-                }
-            }
+        if let named = BuiltinThemePreset.preset(forThemeName: settings.themeName) {
+            return named
         }
         for preset in BuiltinThemePreset.allCases where preset != .custom {
             if let style = preset.style, style.matches(settings) {
@@ -172,6 +210,31 @@ extension ThemeStore {
             }
         }
         return .custom
+    }
+
+    private func commandSurfaceColor(darkBase: ThemeRGB, lightBase: Double) -> Color {
+        switch themeAppearance() {
+        case .dark:
+            return Color(
+                .sRGB,
+                red: darkBase.red + settings.tintRed * CommandSurface.tintWeight,
+                green: darkBase.green + settings.tintGreen * CommandSurface.tintWeight,
+                blue: darkBase.blue + settings.tintBlue * CommandSurface.tintWeight,
+                opacity: 1.0
+            )
+        case .light:
+            return Color(
+                .sRGB,
+                red: mixedWithTint(lightBase, settings.tintRed),
+                green: mixedWithTint(lightBase, settings.tintGreen),
+                blue: mixedWithTint(lightBase, settings.tintBlue),
+                opacity: 1.0
+            )
+        }
+    }
+
+    private func mixedWithTint(_ base: Double, _ tint: Double) -> Double {
+        base * (1 - CommandSurface.tintWeight) + tint * CommandSurface.tintWeight
     }
 
     private func activeAppearanceStyle() -> BuiltinThemeStyle? {

--- a/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
@@ -119,16 +119,9 @@ final class ThemeStore: ObservableObject {
                         }
                     }
                 case "ui_theme":
-                    if !value.isEmpty {
-                        let themeValue = value.lowercased()
-                        let validThemes = ["catppuccin", "tokyonight", "rosepine", "gruvbox", "dracula", "kanagawa"]
-                        if validThemes.contains(themeValue) {
-                            let preset = BuiltinThemePreset(rawValue: themeValue) ?? .custom
-                            settings.uiTheme = preset
-                            applyBuiltinTheme(preset)
-                        } else {
-                            warnings.append("theme '\(value)' not found")
-                        }
+                    // Only validated here; applyThemeOverridesFromConfigFile applies it.
+                    if !value.isEmpty, BuiltinThemePreset.preset(forThemeName: value) == nil {
+                        warnings.append("theme '\(value)' not found")
                     }
                 default:
                     break
@@ -184,6 +177,7 @@ final class ThemeStore: ObservableObject {
         }
         var lines = ConfigFileLines.parse(raw)
 
+        ConfigFileLines.upsert(&lines, key: "ui_theme", value: savedThemeName())
         ConfigFileLines.upsert(&lines, key: "ui_tint_red", value: String(format: "%.2f", settings.tintRed))
         ConfigFileLines.upsert(&lines, key: "ui_tint_green", value: String(format: "%.2f", settings.tintGreen))
         ConfigFileLines.upsert(&lines, key: "ui_tint_blue", value: String(format: "%.2f", settings.tintBlue))
@@ -408,6 +402,15 @@ final class ThemeStore: ObservableObject {
         UserDefaults.standard.set(data, forKey: defaultsKey)
     }
 
+    /// Value for `ui_theme`. Recorded only while the values still match the
+    /// preset, since reading applies it over the individual keys. Empty = Custom.
+    private func savedThemeName() -> String {
+        guard let style = detectBuiltinTheme(for: settings).style, style.matches(settings) else {
+            return ""
+        }
+        return style.themeName
+    }
+
     private func applyThemeOverridesFromConfigFile() {
         guard let raw = try? String(contentsOf: Self.configPath(), encoding: .utf8) else {
             return
@@ -436,7 +439,10 @@ final class ThemeStore: ObservableObject {
 
             switch key {
             case "ui_theme":
-                settings.themeName = value
+                // Empty means "no preset", not "forget the picker's choice".
+                if !value.isEmpty {
+                    settings.themeName = value
+                }
             case "ui_tint_red":
                 if let parsed = parseUnitDouble(value) {
                     settings.tintRed = parsed
@@ -585,6 +591,17 @@ final class ThemeStore: ObservableObject {
                 continue
             }
         }
+
+        // Applied last, overriding the individual ui_* keys: every config file
+        // carries a full set of them, so the other order would ignore a
+        // hand-written `ui_theme=kindle`. See savedThemeName.
+        if let themeValue = ConfigFileLines.keyValues(raw)["ui_theme"],
+           let preset = BuiltinThemePreset.preset(forThemeName: themeValue) {
+            applyBuiltinTheme(preset)
+        }
+
+        // Keeps the Settings picker in step when the config file is what changed.
+        settings.uiTheme = detectBuiltinTheme(for: settings)
     }
 
     private static func configPath() -> URL {
@@ -809,6 +826,9 @@ launch_at_login=true
 skip_dir_names=node_modules,target,build,dist,library,applications,old firefox data,deriveddata,pods,vendor,out,coverage,tmp,cache,venv
 
 # UI theme
+# Preset: catppuccin, tokyoNight, rosePine, gruvbox, dracula, kanagawa, kindle.
+# A preset overrides every ui_* value below. Leave it empty to use them as written.
+ui_theme=
 ui_tint_red=0.08
 ui_tint_green=0.10
 ui_tint_blue=0.12

--- a/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
@@ -439,10 +439,9 @@ final class ThemeStore: ObservableObject {
 
             switch key {
             case "ui_theme":
-                // Empty means "no preset", not "forget the picker's choice".
-                if !value.isEmpty {
-                    settings.themeName = value
-                }
+                // Empty is Custom, and must clear a preset the file no longer
+                // names - the ui_* keys below are then the whole theme.
+                settings.themeName = value
             case "ui_tint_red":
                 if let parsed = parseUnitDouble(value) {
                     settings.tintRed = parsed

--- a/apps/macos/LauncherApp/look-app/Themes/BuiltinThemePreset.swift
+++ b/apps/macos/LauncherApp/look-app/Themes/BuiltinThemePreset.swift
@@ -8,6 +8,7 @@ enum BuiltinThemePreset: String, CaseIterable, Identifiable, Codable {
     case gruvbox
     case dracula
     case kanagawa
+    case kindle
 
     var id: String { rawValue }
 
@@ -20,6 +21,7 @@ enum BuiltinThemePreset: String, CaseIterable, Identifiable, Codable {
         case .gruvbox: return "Gruvbox"
         case .dracula: return "Dracula"
         case .kanagawa: return "Kanagawa"
+        case .kindle: return "Kindle"
         }
     }
 }

--- a/apps/macos/LauncherApp/look-app/Themes/BuiltinThemeStyle.swift
+++ b/apps/macos/LauncherApp/look-app/Themes/BuiltinThemeStyle.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 
 struct ThemeRGB {
@@ -6,14 +7,32 @@ struct ThemeRGB {
     let blue: Double
 }
 
+/// Surface a preset paints on. Drives the pinned window/blur appearance and the
+/// opaque command-mode colors, neither of which can be derived from the tokens.
+enum ThemeAppearance {
+    case dark
+    case light
+
+    var nsAppearanceName: NSAppearance.Name {
+        switch self {
+        case .dark: return .darkAqua
+        case .light: return .aqua
+        }
+    }
+}
+
 struct BuiltinThemeStyle {
     let themeName: String
+    let appearance: ThemeAppearance
     let tintRed: Double
     let tintGreen: Double
     let tintBlue: Double
     let tintOpacity: Double
     let blurMaterial: LauncherBlurMaterial
     let blurOpacity: Double
+    /// nil keeps the app default. An unavailable family falls back to the
+    /// system font via `ThemeStore.uiFont`.
+    let fontName: String?
     let fontRed: Double
     let fontGreen: Double
     let fontBlue: Double
@@ -23,17 +42,8 @@ struct BuiltinThemeStyle {
     let borderBlue: Double
     let borderOpacity: Double
 
-    // Semantic color adjustments (relative to main text color when theme applied)
-    // -1.0 = black, 0 = same, +1.0 = white
-    let textSecondaryAdjust: Double = -0.18
-    let textMutedAdjust: Double = -0.35
-    let panelFillAdjust: Double = -0.85
-    let controlFillAdjust: Double = -0.80
-    let dividerAdjust: Double = -0.70
-    let selectionFillAdjust: Double = -0.55
-    let accentAdjust: Double = 0.0  // will use actual accent color
-
-    // Absolute semantic colors (override adjustments when set)
+    // Semantic colors. Left nil, `ThemeStore` derives the token from the main
+    // text color instead.
     let textSecondary: ThemeRGB?
     let textMuted: ThemeRGB?
     let panelFill: ThemeRGB?
@@ -52,12 +62,14 @@ struct BuiltinThemeStyle {
 
 init(
         themeName: String = "",
+        appearance: ThemeAppearance = .dark,
         tintRed: Double = 0.08,
         tintGreen: Double = 0.10,
         tintBlue: Double = 0.12,
         tintOpacity: Double = 0.55,
         blurMaterial: LauncherBlurMaterial = .hudWindow,
         blurOpacity: Double = 0.95,
+        fontName: String? = nil,
         fontRed: Double = 0.96,
         fontGreen: Double = 0.96,
         fontBlue: Double = 0.98,
@@ -83,12 +95,14 @@ init(
         danger: ThemeRGB? = nil
     ) {
         self.themeName = themeName
+        self.appearance = appearance
         self.tintRed = tintRed
         self.tintGreen = tintGreen
         self.tintBlue = tintBlue
         self.tintOpacity = tintOpacity
         self.blurMaterial = blurMaterial
         self.blurOpacity = blurOpacity
+        self.fontName = fontName
         self.fontRed = fontRed
         self.fontGreen = fontGreen
         self.fontBlue = fontBlue
@@ -122,6 +136,7 @@ init(
         settings.tintOpacity = tintOpacity
         settings.blurMaterial = blurMaterial
         settings.blurOpacity = blurOpacity
+        settings.fontName = fontName ?? ThemeSettings.default.fontName
         settings.fontRed = fontRed
         settings.fontGreen = fontGreen
         settings.fontBlue = fontBlue
@@ -134,7 +149,8 @@ init(
     }
 
     func matches(_ settings: ThemeSettings, tolerance: Double = 0.01) -> Bool {
-        abs(settings.tintRed - tintRed) <= tolerance
+        settings.fontName == (fontName ?? ThemeSettings.default.fontName)
+            && abs(settings.tintRed - tintRed) <= tolerance
             && abs(settings.tintGreen - tintGreen) <= tolerance
             && abs(settings.tintBlue - tintBlue) <= tolerance
             && abs(settings.tintOpacity - tintOpacity) <= tolerance

--- a/apps/macos/LauncherApp/look-app/Themes/KindleTheme.swift
+++ b/apps/macos/LauncherApp/look-app/Themes/KindleTheme.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Kindle Paperwhite: warm paper, near-black ink, greyscale semantics, and a
+/// high tint opacity so it reads matte rather than frosted. Charter is the
+/// stand-in for Bookerly, which Amazon ships only on its own readers.
+enum KindleTheme {
+    static let style = BuiltinThemeStyle(
+        themeName: "kindle",
+        appearance: .light,
+        tintRed: 0.97,
+        tintGreen: 0.95,
+        tintBlue: 0.90,
+        tintOpacity: 0.93,
+        blurMaterial: .menu,
+        blurOpacity: 0.98,
+        fontName: "Charter",
+        fontRed: 0.13,
+        fontGreen: 0.12,
+        fontBlue: 0.10,
+        fontOpacity: 1.0,
+        borderRed: 0.42,
+        borderGreen: 0.38,
+        borderBlue: 0.32,
+        borderOpacity: 0.26,
+        textSecondary: ThemeRGB(red: 0.24, green: 0.22, blue: 0.19),
+        textMuted: ThemeRGB(red: 0.30, green: 0.28, blue: 0.24),
+        panelFill: ThemeRGB(red: 1.0, green: 0.99, blue: 0.96),
+        panelFillOpacity: 0.55,
+        controlFill: ThemeRGB(red: 0.85, green: 0.82, blue: 0.76),
+        controlFillOpacity: 0.55,
+        divider: ThemeRGB(red: 0.40, green: 0.37, blue: 0.32),
+        dividerOpacity: 0.30,
+        selectionFill: ThemeRGB(red: 0.24, green: 0.22, blue: 0.19),
+        selectionFillOpacity: 0.16,
+        accent: ThemeRGB(red: 0.18, green: 0.17, blue: 0.15),
+        onAccent: ThemeRGB(red: 0.97, green: 0.95, blue: 0.90),
+        success: ThemeRGB(red: 0.16, green: 0.42, blue: 0.22),
+        warning: ThemeRGB(red: 0.52, green: 0.35, blue: 0.03),
+        danger: ThemeRGB(red: 0.62, green: 0.15, blue: 0.13)
+    )
+}

--- a/apps/macos/LauncherApp/look-app/Themes/ThemePresetRegistry.swift
+++ b/apps/macos/LauncherApp/look-app/Themes/ThemePresetRegistry.swift
@@ -17,6 +17,20 @@ extension BuiltinThemePreset {
             return DraculaTheme.style
         case .kanagawa:
             return KanagawaTheme.style
+        case .kindle:
+            return KindleTheme.style
         }
+    }
+}
+
+extension BuiltinThemePreset {
+    /// Resolves the `ui_theme` config value in any casing. Matches on the
+    /// style's `themeName`, not the enum raw value, so `tokyoNight` resolves.
+    static func preset(forThemeName name: String) -> BuiltinThemePreset? {
+        let needle = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !needle.isEmpty else {
+            return nil
+        }
+        return allCases.first { $0.style?.themeName.lowercased() == needle }
     }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/AIAnswerCardView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/AIAnswerCardView.swift
@@ -42,7 +42,7 @@ struct AIAnswerCardView: View {
         )
         .overlay(
             RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .strokeBorder(.white.opacity(0.08), lineWidth: 1)
+                .strokeBorder(themeStore.liftColor(opacity: 0.08), lineWidth: 1)
         )
     }
 

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ActionPanelView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ActionPanelView.swift
@@ -77,11 +77,11 @@ struct ActionPanelView: View {
     private func pill(_ text: String, on: Bool) -> some View {
         Text(text)
             .font(themeStore.uiFont(size: CGFloat(max(11, themeStore.settings.fontSize - 2)), weight: .semibold))
-            .foregroundStyle(on ? Color.white : themeStore.fontColor())
+            .foregroundStyle(on ? themeStore.onSuccessColor() : themeStore.fontColor())
             .padding(.horizontal, 10)
             .padding(.vertical, 3)
             .background(
-                (on ? Color.green.opacity(0.75) : themeStore.dividerColor().opacity(0.6)),
+                (on ? themeStore.successColor() : themeStore.dividerColor().opacity(0.6)),
                 in: Capsule()
             )
     }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
@@ -563,8 +563,11 @@ private let launchpadAlertBorderOpacity = 0.3
 func frostedTile(themeStore: ThemeStore, tint: Color? = nil, tintOpacity: Double = 0) -> some View {
     let radius = AppConstants.Launcher.Launchpad.cornerRadius
     return ZStack {
-        VisualEffectBlur(material: themeStore.settings.blurMaterial.material)
-        Color.black.opacity(launchpadTileScrimOpacity)
+        VisualEffectBlur(
+            material: themeStore.settings.blurMaterial.material,
+            appearance: themeStore.themeAppearance()
+        )
+        themeStore.scrimColor(opacity: launchpadTileScrimOpacity)
         themeStore.controlFillColor()
         if let tint {
             tint.opacity(tintOpacity)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Background.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Background.swift
@@ -30,7 +30,10 @@ extension LauncherView {
                     .opacity(themeStore.settings.backgroundImageOpacity)
             }
 
-            VisualEffectBlur(material: themeStore.settings.blurMaterial.material)
+            VisualEffectBlur(
+                material: themeStore.settings.blurMaterial.material,
+                appearance: themeStore.themeAppearance()
+            )
                 .opacity(
                     min(
                         1,

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -108,6 +108,9 @@ struct LauncherView: View {
     @State private var panelSize: CGSize = .zero
     static let panelCoordinateSpace = "launcherPanel"
 
+    static let floatingTileScrimOpacity = 0.30
+    static let attachedPanelScrimOpacity = 0.16
+
     var runningAppsPlacement: RunningAppsPlacement {
         themeStore.settings.runningAppsPlacement
     }
@@ -839,6 +842,9 @@ struct LauncherView: View {
     @ViewBuilder
     private func borderedPanel(windowCornerRadius: CGFloat, contentSpacing: CGFloat, contentPadding: CGFloat) -> some View {
         ZStack {
+            WindowAppearancePin(appearance: themeStore.themeAppearance())
+                .frame(width: 0, height: 0)
+
             // When the content floats free (floating panes, or resting on an empty
             // query) the blur + tint backdrop box is dropped so the tiles sit on
             // the bare desktop. A background image, if set, is cropped into each
@@ -858,7 +864,10 @@ struct LauncherView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             .font(themeStore.uiFont())
             .foregroundStyle(themeStore.fontColor())
-            .background(.black.opacity(barFloatsFree ? 0 : 0.16), in: RoundedRectangle(cornerRadius: windowCornerRadius, style: .continuous))
+            .background(
+                themeStore.scrimColor(opacity: barFloatsFree ? 0 : Self.attachedPanelScrimOpacity),
+                in: RoundedRectangle(cornerRadius: windowCornerRadius, style: .continuous)
+            )
             .contentShape(Rectangle())
             .onTapGesture { focusActiveInput() }
         }
@@ -1007,7 +1016,7 @@ struct LauncherView: View {
                 .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .semibold))
                 .padding(.horizontal, 8)
                 .padding(.vertical, 3)
-                .background(.white.opacity(0.18), in: Capsule())
+                .background(themeStore.controlFillColor(), in: Capsule())
             }
         }
         .padding(.horizontal, 10)
@@ -1308,9 +1317,12 @@ struct LauncherView: View {
                 if let image = themeStore.backgroundImage {
                     croppedBackgroundImage(image)
                 } else {
-                    VisualEffectBlur(material: themeStore.settings.blurMaterial.material)
+                    VisualEffectBlur(
+                        material: themeStore.settings.blurMaterial.material,
+                        appearance: themeStore.themeAppearance()
+                    )
                 }
-                Color.black.opacity(0.30)
+                themeStore.scrimColor(opacity: Self.floatingTileScrimOpacity)
                 themeStore.controlFillColor()
             }
             .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
@@ -1408,7 +1420,7 @@ struct LauncherView: View {
 
     private var resultsDivider: some View {
         Rectangle()
-            .fill(.white.opacity(0.08))
+            .fill(themeStore.dividerColor())
             .frame(width: 1)
             .padding(.vertical, 4)
     }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/RunningAppsStripView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/RunningAppsStripView.swift
@@ -103,7 +103,7 @@ private struct RunningAppIconItem: View {
             .frame(width: 14, height: 14)
             .background(
                 RoundedRectangle(cornerRadius: 7)
-                    .fill(Color.black.opacity(0.72))
+                    .fill(themeStore.scrimColor(opacity: 0.72))
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 7)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/WebSuggestionPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/WebSuggestionPreviewView.swift
@@ -32,7 +32,7 @@ struct WebSuggestionPreviewView: View {
                     .fontWeight(.semibold)
                     .padding(.horizontal, 6)
                     .padding(.vertical, 1)
-                    .background(.white.opacity(0.12), in: RoundedRectangle(cornerRadius: 4, style: .continuous))
+                    .background(themeStore.liftColor(opacity: 0.12), in: RoundedRectangle(cornerRadius: 4, style: .continuous))
                 Text("to search the web")
             }
             .font(themeStore.uiFont(size: fontSize - 2, weight: .regular))

--- a/apps/macos/LauncherApp/look-app/Views/Settings/AppUpdateStatusView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Settings/AppUpdateStatusView.swift
@@ -62,9 +62,9 @@ struct AppUpdateStatusView: View {
                 .foregroundStyle(themeStore.fontColor())
                 .padding(.horizontal, 10)
                 .padding(.vertical, 4)
-                .background(.white.opacity(0.16), in: Capsule())
+                .background(themeStore.liftColor(opacity: 0.16), in: Capsule())
                 .overlay(
-                    Capsule().strokeBorder(.white.opacity(0.22), lineWidth: 1)
+                    Capsule().strokeBorder(themeStore.liftColor(opacity: 0.22), lineWidth: 1)
                 )
         }
         .buttonStyle(.plain)

--- a/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Advanced.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Advanced.swift
@@ -65,7 +65,7 @@ extension ThemeSettingsView {
                     }
 
                     Divider()
-                        .overlay(.white.opacity(0.1))
+                        .overlay(themeStore.dividerColor())
                         .padding(.vertical, 4)
 
                     Text("Background")
@@ -114,7 +114,7 @@ extension ThemeSettingsView {
                     LabeledSlider(title: "Image Blur", value: $settings.backgroundImageBlur, range: 0...30)
 
                     Divider()
-                        .overlay(.white.opacity(0.1))
+                        .overlay(themeStore.dividerColor())
                         .padding(.vertical, 4)
 
                     Text("Indexing")
@@ -238,7 +238,7 @@ extension ThemeSettingsView {
                                             .foregroundStyle(themeStore.secondaryTextColor())
                                             .padding(.horizontal, 9)
                                             .padding(.vertical, 5)
-                                            .background(.white.opacity(0.12), in: Capsule())
+                                            .background(themeStore.liftColor(opacity: 0.12), in: Capsule())
                                         }
                                     }
                                 }
@@ -289,7 +289,7 @@ extension ThemeSettingsView {
                                             .foregroundStyle(themeStore.secondaryTextColor())
                                             .padding(.horizontal, 9)
                                             .padding(.vertical, 5)
-                                            .background(.white.opacity(0.12), in: Capsule())
+                                            .background(themeStore.liftColor(opacity: 0.12), in: Capsule())
                                         }
                                     }
                                 }
@@ -301,7 +301,7 @@ extension ThemeSettingsView {
                     }
 
                     Divider()
-                        .overlay(.white.opacity(0.1))
+                        .overlay(themeStore.dividerColor())
                         .padding(.vertical, 4)
 
                     Text("Privacy & Logs")
@@ -331,7 +331,7 @@ extension ThemeSettingsView {
                     }
 
                     Divider()
-                        .overlay(.white.opacity(0.1))
+                        .overlay(themeStore.dividerColor())
                         .padding(.vertical, 4)
 
                     Text("Startup")
@@ -352,7 +352,7 @@ extension ThemeSettingsView {
                     }
 
                     Divider()
-                        .overlay(.white.opacity(0.1))
+                        .overlay(themeStore.dividerColor())
                         .padding(.vertical, 4)
 
                     Text("Config file")
@@ -379,7 +379,7 @@ extension ThemeSettingsView {
                     }
 
                     Divider()
-                        .overlay(.white.opacity(0.1))
+                        .overlay(themeStore.dividerColor())
                         .padding(.vertical, 4)
 
                     aboutSection

--- a/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Appearance.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Appearance.swift
@@ -42,7 +42,7 @@ extension ThemeSettingsView {
                 }
 
                 Divider()
-                    .overlay(.white.opacity(0.1))
+                    .overlay(themeStore.dividerColor())
                     .padding(.vertical, 4)
 
                 sectionHeader("Layout")
@@ -196,10 +196,10 @@ extension ThemeSettingsView {
         }
         .frame(width: 240, height: 320, alignment: .topLeading)
         .scrollIndicators(.hidden)
-        .background(.black.opacity(0.72), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .background(themeStore.scrimColor(opacity: 0.72), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .stroke(.white.opacity(0.12), lineWidth: 1)
+                .stroke(themeStore.liftColor(opacity: 0.12), lineWidth: 1)
         )
         .shadow(color: .black.opacity(0.25), radius: 8, y: 4)
     }

--- a/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Shortcuts.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Shortcuts.swift
@@ -126,7 +126,7 @@ struct ShortcutSection: View {
                         .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular))
                         .padding(.horizontal, 8)
                         .padding(.vertical, 3)
-                        .background(.white.opacity(0.14), in: Capsule())
+                        .background(themeStore.liftColor(opacity: 0.14), in: Capsule())
                     Text(item.action)
                         .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular))
                         .foregroundStyle(themeStore.secondaryTextColor())

--- a/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView.swift
@@ -7,6 +7,9 @@ struct ThemeSettingsView: View {
         case fontName
     }
 
+    static let activeTabFillOpacity = 0.16
+    static let inactiveTabFillOpacity = 0.06
+
     @EnvironmentObject var appUIState: AppUIState
     @EnvironmentObject var themeStore: ThemeStore
     @ObservedObject var updateChecker = UpdateChecker.shared
@@ -36,10 +39,10 @@ struct ThemeSettingsView: View {
                 if let saveMessage {
                     Text(saveMessage)
                         .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .semibold))
-                        .foregroundStyle(.white)
+                        .foregroundStyle(themeStore.onSuccessColor())
                         .padding(.horizontal, 10)
                         .padding(.vertical, 5)
-                        .background(.green.opacity(0.42), in: Capsule())
+                        .background(themeStore.successColor(), in: Capsule())
                 }
 
                 Button("Save Config") {
@@ -148,7 +151,7 @@ struct ThemeSettingsView: View {
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 7)
                 .background(
-                    (isActive ? .white.opacity(0.16) : .white.opacity(0.06)),
+                    themeStore.liftColor(opacity: isActive ? Self.activeTabFillOpacity : Self.inactiveTabFillOpacity),
                     in: RoundedRectangle(cornerRadius: 8, style: .continuous)
                 )
         }

--- a/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView.swift
@@ -7,6 +7,13 @@ struct ThemeSettingsView: View {
         case fontName
     }
 
+    /// Outcome carried with the text so a failed save cannot be styled as a
+    /// success by a stale flag.
+    struct SaveMessage {
+        let text: String
+        let succeeded: Bool
+    }
+
     static let activeTabFillOpacity = 0.16
     static let inactiveTabFillOpacity = 0.06
 
@@ -15,7 +22,7 @@ struct ThemeSettingsView: View {
     @ObservedObject var updateChecker = UpdateChecker.shared
     @Binding var settings: ThemeSettings
     @State var selectedTab = 0
-    @State var saveMessage: String?
+    @State var saveMessage: SaveMessage?
     @State var fontSuggestions: [String] = []
     @State var showsFontSuggestions = false
     @State var isPickingFontSuggestion = false
@@ -37,19 +44,22 @@ struct ThemeSettingsView: View {
                 Spacer()
 
                 if let saveMessage {
-                    Text(saveMessage)
+                    Text(saveMessage.text)
                         .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .semibold))
-                        .foregroundStyle(themeStore.onSuccessColor())
+                        .foregroundStyle(saveMessage.succeeded ? themeStore.onSuccessColor() : themeStore.onDangerColor())
                         .padding(.horizontal, 10)
                         .padding(.vertical, 5)
-                        .background(themeStore.successColor(), in: Capsule())
+                        .background(
+                            saveMessage.succeeded ? themeStore.successColor() : themeStore.dangerColor(),
+                            in: Capsule()
+                        )
                 }
 
                 Button("Save Config") {
                     applyFileScanDepthInput()
                     applyFileScanLimitInput()
                     let ok = themeStore.saveCurrentConfigToFile()
-                    saveMessage = ok ? "Saved" : "Save failed"
+                    saveMessage = SaveMessage(text: ok ? "Saved" : "Save failed", succeeded: ok)
                     if ok {
                         NotificationCenter.default.post(name: .lookReloadConfigRequested, object: nil)
                     }

--- a/apps/macos/LauncherApp/look-app/Window/WindowAppearancePin.swift
+++ b/apps/macos/LauncherApp/look-app/Window/WindowAppearancePin.swift
@@ -1,0 +1,34 @@
+import AppKit
+import SwiftUI
+
+/// Pins the window's NSAppearance to the theme's. Pickers, text fields and
+/// sliders colour themselves from the window, not from the theme tokens: a light
+/// theme otherwise drew a black text field and an unreadable popup on paper.
+struct WindowAppearancePin: NSViewRepresentable {
+    var appearance: ThemeAppearance
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        DispatchQueue.main.async {
+            apply(to: view)
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        DispatchQueue.main.async {
+            apply(to: nsView)
+        }
+    }
+
+    private func apply(to view: NSView) {
+        guard let window = view.window else {
+            return
+        }
+        let name = appearance.nsAppearanceName
+        guard window.appearance?.name != name else {
+            return
+        }
+        window.appearance = NSAppearance(named: name)
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -352,6 +352,7 @@ Available themes (selected via Settings > Appearance):
 | Gruvbox | Retro warm tones |
 | Dracula | Classic purple-accented dark |
 | Kanagawa | Japanese-inspired dark theme |
+| Kindle | Paper and ink, e-reader light theme (Charter serif) |
 | Custom | Auto-derived semantic colors from tint |
 
 Themes are defined in `Themes/` folder:
@@ -359,12 +360,19 @@ Themes are defined in `Themes/` folder:
 - `BuiltinThemePreset`: Dropdown selection enum
 - Individual theme files: `CatppuccinTheme.swift`, `TokyoNightTheme.swift`, etc.
 
+A preset declares its `ThemeAppearance` (`.dark` or `.light`). It pins the
+NSVisualEffectView appearance, so a preset frosts the same way whether macOS is
+in Light or Dark mode, and it picks how the opaque command-mode surfaces and the
+pane scrims are mixed: dark themes darken, light themes lighten. A preset may
+also declare a `fontName`; presets that do not reset the font to the app default
+when applied.
+
 ### Config File Integration
 
 All settings are persisted to `.look.config`:
 
 **UI Theme:**
-- `ui_theme` - theme name (catppuccin, tokyoNight, rosePine, gruvbox, dracula, kanagawa)
+- `ui_theme` - theme name (catppuccin, tokyoNight, rosePine, gruvbox, dracula, kanagawa, kindle). Matched case-insensitively, and applied after the individual `ui_*` keys below, so a preset overrides them. Empty means Custom. Save Config writes a preset name only while the values still match that preset, so a theme you have tweaked is stored as its literal values.
 
 **Appearance:**
 - `ui_tint_red`, `ui_tint_green`, `ui_tint_blue`, `ui_tint_opacity` - background tint (0-1)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -212,9 +212,14 @@ Built-in theme presets are available:
 | Gruvbox     | Retro warm tones                  |
 | Dracula     | Classic purple-accented dark      |
 | Kanagawa    | Japanese-inspired dark theme      |
+| Kindle      | Paper and ink e-reader look       |
 | Custom      | Your own colors derived from tint |
 
-Theme is saved as `ui_theme=<name>` in config.
+Theme is saved as `ui_theme=<name>` in config, and a name written there overrides
+the individual `ui_*` values. Kindle is the one light preset: it also switches the
+frosted panels to a light material and the font to Charter, macOS' stand-in for
+Bookerly. Picking a preset overwrites your tint, text color, border and font;
+`Custom` keeps the current values and derives the rest from them.
 
 **Running Apps**: a switch that shows running-app icons in the right half of the search bar. When on, the search field shrinks to the left half and the running apps fill the right half (right-aligned, growing leftward as more apps open). Each icon has a corner number badge; pressing the modifier + the badge digit on the home screen activates that app - `Cmd+1`..`Cmd+9` on macOS, `Alt+1`..`Alt+9` on Linux and Windows. When off, the search bar spans the full width and the switcher shortcut is disabled. The launcher window stays the same size either way.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -216,10 +216,13 @@ Built-in theme presets are available:
 | Custom      | Your own colors derived from tint |
 
 Theme is saved as `ui_theme=<name>` in config, and a name written there overrides
-the individual `ui_*` values. Kindle is the one light preset: it also switches the
-frosted panels to a light material and the font to Charter, macOS' stand-in for
-Bookerly. Picking a preset overwrites your tint, text color, border and font;
-`Custom` keeps the current values and derives the rest from them.
+the individual `ui_*` values. Save Config writes the preset name only while every
+value still matches that preset; once you tweak one, it writes `ui_theme=` and
+your literal `ui_*` values instead, so the edit survives a reload. Kindle is the
+one light preset: it also switches the frosted panels to a light material and the
+font to Charter, macOS' stand-in for Bookerly. Picking a preset overwrites your
+tint, text color, border and font; `Custom` keeps the current values and derives
+the rest from them.
 
 **Running Apps**: a switch that shows running-app icons in the right half of the search bar. When on, the search field shrinks to the left half and the running apps fill the right half (right-aligned, growing leftward as more apps open). Each icon has a corner number badge; pressing the modifier + the badge digit on the home screen activates that app - `Cmd+1`..`Cmd+9` on macOS, `Alt+1`..`Alt+9` on Linux and Windows. When off, the search bar spans the full width and the switcher shortcut is disabled. The launcher window stays the same size either way.
 


### PR DESCRIPTION
## Summary

- Add kindle theme
- Clean some old UI code

Hope every one like this theme :) 

## Testing

  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

<img width="872" height="354" alt="image" src="https://github.com/user-attachments/assets/758bc0a0-dc4f-41e3-9bba-386fa78977f5" />


## Checklist

- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Kindle built-in theme with a warm, light reading-focused appearance and Charter typography.
  * Added theme-aware light/dark appearance handling for windows, blur effects, panels, controls, and overlays.
  * Improved theme preset detection, configuration loading, and custom theme preservation.

* **Bug Fixes**
  * Corrected save-status styling so failed theme saves display the appropriate error appearance.
  * Updated interface elements to use consistent theme-derived colors across the launcher and settings.

* **Documentation**
  * Expanded theme configuration guidance, including Kindle, Custom themes, appearance behavior, and preset matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->