### PR TITLE
Fix/empty hiding app

### DIFF
--- a/apps/linows/src/js/keyboard.js
+++ b/apps/linows/src/js/keyboard.js
@@ -158,10 +158,7 @@ function handleKeyDown(e) {
     // Ctrl+Shift+H: hide the selected app from Look
     if (e.ctrlKey && (e.shiftKey || shiftHeld) && (e.key === 'H' || e.key === 'h')) {
         e.preventDefault();
-        if (settingsModule?.isActive()) return;
-        if (helpScreen && !helpScreen.hidden) return;
-        if (commandMode?.isActive()) return;
-        void handleHideSelectApp();
+        if(allowShortcut()) handleHideSelectApp();
         return;
     }
 
@@ -387,6 +384,22 @@ function handleKeyDown(e) {
             }
             break;
     }
+}
+
+// Shared gate for result-based shortcuts: disable them while another launcher
+// surface owns the UI, while the query is empty, or while the search input is
+// in a non-result mode such as discovery, translate, or clipboard.
+function allowShortcut() {
+    return (
+        !settingsModule?.isActive() &&
+        !(helpScreen && !helpScreen.hidden) &&
+        !commandMode?.isActive() &&
+        !isDiscoveryMode() &&
+        !search.isTranslateMode() &&
+        !search.isClipboardMode() &&
+        !search.isProcessMode() &&
+        queryInput.value.trim() !== ''
+    );
 }
 
 // The letter behind an Alt chord. Prefer e.key so it respects the layout (like

--- a/apps/linows/src/js/keyboard.js
+++ b/apps/linows/src/js/keyboard.js
@@ -398,7 +398,7 @@ function allowShortcut() {
         !search.isTranslateMode() &&
         !search.isClipboardMode() &&
         !search.isProcessMode() &&
-        queryInput.value.trim() !== ''
+        queryInput.value !== ''
     );
 }
 

--- a/apps/macos/LauncherApp/LauncherLogicTests/HideAppShortcutLogicTests.swift
+++ b/apps/macos/LauncherApp/LauncherLogicTests/HideAppShortcutLogicTests.swift
@@ -12,7 +12,8 @@ final class HideAppShortcutLogicTests: XCTestCase {
                 isPrefixSuggestionQuery: false,
                 isCommandSuggestionQuery: false,
                 isTranslationQuery: false,
-                isClipboardQuery: false
+                isClipboardQuery: false,
+                isProcessQuery: false
             )
         )
         XCTAssertFalse(
@@ -24,7 +25,8 @@ final class HideAppShortcutLogicTests: XCTestCase {
                 isPrefixSuggestionQuery: false,
                 isCommandSuggestionQuery: false,
                 isTranslationQuery: false,
-                isClipboardQuery: false
+                isClipboardQuery: false,
+                isProcessQuery: false
             )
         )
         XCTAssertFalse(
@@ -36,7 +38,8 @@ final class HideAppShortcutLogicTests: XCTestCase {
                 isPrefixSuggestionQuery: false,
                 isCommandSuggestionQuery: false,
                 isTranslationQuery: false,
-                isClipboardQuery: false
+                isClipboardQuery: false,
+                isProcessQuery: false
             )
         )
     }
@@ -51,7 +54,8 @@ final class HideAppShortcutLogicTests: XCTestCase {
                 isPrefixSuggestionQuery: false,
                 isCommandSuggestionQuery: false,
                 isTranslationQuery: false,
-                isClipboardQuery: false
+                isClipboardQuery: false,
+                isProcessQuery: false
             )
         )
     }
@@ -66,7 +70,8 @@ final class HideAppShortcutLogicTests: XCTestCase {
                 isPrefixSuggestionQuery: true,
                 isCommandSuggestionQuery: false,
                 isTranslationQuery: false,
-                isClipboardQuery: false
+                isClipboardQuery: false,
+                isProcessQuery: false
             )
         )
         XCTAssertFalse(
@@ -78,7 +83,8 @@ final class HideAppShortcutLogicTests: XCTestCase {
                 isPrefixSuggestionQuery: false,
                 isCommandSuggestionQuery: true,
                 isTranslationQuery: false,
-                isClipboardQuery: false
+                isClipboardQuery: false,
+                isProcessQuery: false
             )
         )
         XCTAssertFalse(
@@ -90,7 +96,8 @@ final class HideAppShortcutLogicTests: XCTestCase {
                 isPrefixSuggestionQuery: false,
                 isCommandSuggestionQuery: false,
                 isTranslationQuery: true,
-                isClipboardQuery: false
+                isClipboardQuery: false,
+                isProcessQuery: false
             )
         )
         XCTAssertFalse(
@@ -102,7 +109,21 @@ final class HideAppShortcutLogicTests: XCTestCase {
                 isPrefixSuggestionQuery: false,
                 isCommandSuggestionQuery: false,
                 isTranslationQuery: false,
-                isClipboardQuery: true
+                isClipboardQuery: true,
+                isProcessQuery: false
+            )
+        )
+        XCTAssertFalse(
+            HideAppShortcutLogic.allowsKeyboardHideApp(
+                showsThemeSettings: false,
+                isCommandMode: false,
+                showsHelpScreen: false,
+                hidesResultsForEmptyQuery: false,
+                isPrefixSuggestionQuery: false,
+                isCommandSuggestionQuery: false,
+                isTranslationQuery: false,
+                isClipboardQuery: false,
+                isProcessQuery: true
             )
         )
     }
@@ -117,7 +138,8 @@ final class HideAppShortcutLogicTests: XCTestCase {
                 isPrefixSuggestionQuery: false,
                 isCommandSuggestionQuery: false,
                 isTranslationQuery: false,
-                isClipboardQuery: false
+                isClipboardQuery: false,
+                isProcessQuery: false
             )
         )
     }

--- a/apps/macos/LauncherApp/LauncherLogicTests/HideAppShortcutLogicTests.swift
+++ b/apps/macos/LauncherApp/LauncherLogicTests/HideAppShortcutLogicTests.swift
@@ -1,0 +1,124 @@
+import XCTest
+@testable import LauncherLogic
+
+final class HideAppShortcutLogicTests: XCTestCase {
+    func testDisablesShortcutWhileAnotherLauncherSurfaceOwnsUI() {
+        XCTAssertFalse(
+            HideAppShortcutLogic.allowsKeyboardHideApp(
+                showsThemeSettings: true,
+                isCommandMode: false,
+                showsHelpScreen: false,
+                hidesResultsForEmptyQuery: false,
+                isPrefixSuggestionQuery: false,
+                isCommandSuggestionQuery: false,
+                isTranslationQuery: false,
+                isClipboardQuery: false
+            )
+        )
+        XCTAssertFalse(
+            HideAppShortcutLogic.allowsKeyboardHideApp(
+                showsThemeSettings: false,
+                isCommandMode: true,
+                showsHelpScreen: false,
+                hidesResultsForEmptyQuery: false,
+                isPrefixSuggestionQuery: false,
+                isCommandSuggestionQuery: false,
+                isTranslationQuery: false,
+                isClipboardQuery: false
+            )
+        )
+        XCTAssertFalse(
+            HideAppShortcutLogic.allowsKeyboardHideApp(
+                showsThemeSettings: false,
+                isCommandMode: false,
+                showsHelpScreen: true,
+                hidesResultsForEmptyQuery: false,
+                isPrefixSuggestionQuery: false,
+                isCommandSuggestionQuery: false,
+                isTranslationQuery: false,
+                isClipboardQuery: false
+            )
+        )
+    }
+
+    func testDisablesShortcutOnEmptyHome() {
+        XCTAssertFalse(
+            HideAppShortcutLogic.allowsKeyboardHideApp(
+                showsThemeSettings: false,
+                isCommandMode: false,
+                showsHelpScreen: false,
+                hidesResultsForEmptyQuery: true,
+                isPrefixSuggestionQuery: false,
+                isCommandSuggestionQuery: false,
+                isTranslationQuery: false,
+                isClipboardQuery: false
+            )
+        )
+    }
+
+    func testDisablesShortcutInNonResultModes() {
+        XCTAssertFalse(
+            HideAppShortcutLogic.allowsKeyboardHideApp(
+                showsThemeSettings: false,
+                isCommandMode: false,
+                showsHelpScreen: false,
+                hidesResultsForEmptyQuery: false,
+                isPrefixSuggestionQuery: true,
+                isCommandSuggestionQuery: false,
+                isTranslationQuery: false,
+                isClipboardQuery: false
+            )
+        )
+        XCTAssertFalse(
+            HideAppShortcutLogic.allowsKeyboardHideApp(
+                showsThemeSettings: false,
+                isCommandMode: false,
+                showsHelpScreen: false,
+                hidesResultsForEmptyQuery: false,
+                isPrefixSuggestionQuery: false,
+                isCommandSuggestionQuery: true,
+                isTranslationQuery: false,
+                isClipboardQuery: false
+            )
+        )
+        XCTAssertFalse(
+            HideAppShortcutLogic.allowsKeyboardHideApp(
+                showsThemeSettings: false,
+                isCommandMode: false,
+                showsHelpScreen: false,
+                hidesResultsForEmptyQuery: false,
+                isPrefixSuggestionQuery: false,
+                isCommandSuggestionQuery: false,
+                isTranslationQuery: true,
+                isClipboardQuery: false
+            )
+        )
+        XCTAssertFalse(
+            HideAppShortcutLogic.allowsKeyboardHideApp(
+                showsThemeSettings: false,
+                isCommandMode: false,
+                showsHelpScreen: false,
+                hidesResultsForEmptyQuery: false,
+                isPrefixSuggestionQuery: false,
+                isCommandSuggestionQuery: false,
+                isTranslationQuery: false,
+                isClipboardQuery: true
+            )
+        )
+    }
+
+    func testEnablesShortcutOnNormalResultsSurface() {
+        XCTAssertTrue(
+            HideAppShortcutLogic.allowsKeyboardHideApp(
+                showsThemeSettings: false,
+                isCommandMode: false,
+                showsHelpScreen: false,
+                hidesResultsForEmptyQuery: false,
+                isPrefixSuggestionQuery: false,
+                isCommandSuggestionQuery: false,
+                isTranslationQuery: false,
+                isClipboardQuery: false
+            )
+        )
+    }
+}

--- a/apps/macos/LauncherApp/Package.swift
+++ b/apps/macos/LauncherApp/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
                 "Support/Launcher/HintText.swift",
                 "Support/AppConstants.swift",
                 "Support/ConfigFileLines.swift",
+                "Support/Launcher/HideAppShortcutLogic.swift",
                 "Support/Launcher/LauncherSearchLogic.swift",
                 "Support/Launcher/ProcessScoring.swift",
                 "Support/Launcher/DeleteTargetLogic.swift",

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/HideAppShortcutLogic.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/HideAppShortcutLogic.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+enum HideAppShortcutLogic {
+    static func allowsKeyboardHideApp(
+        showsThemeSettings: Bool,
+        isCommandMode: Bool,
+        showsHelpScreen: Bool,
+        hidesResultsForEmptyQuery: Bool,
+        isPrefixSuggestionQuery: Bool,
+        isCommandSuggestionQuery: Bool,
+        isTranslationQuery: Bool,
+        isClipboardQuery: Bool
+    ) -> Bool {
+        !showsThemeSettings
+            && !isCommandMode
+            && !showsHelpScreen
+            && !hidesResultsForEmptyQuery
+            && !isPrefixSuggestionQuery
+            && !isCommandSuggestionQuery
+            && !isTranslationQuery
+            && !isClipboardQuery
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/HideAppShortcutLogic.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/HideAppShortcutLogic.swift
@@ -9,7 +9,8 @@ enum HideAppShortcutLogic {
         isPrefixSuggestionQuery: Bool,
         isCommandSuggestionQuery: Bool,
         isTranslationQuery: Bool,
-        isClipboardQuery: Bool
+        isClipboardQuery: Bool,
+        isProcessQuery: Bool
     ) -> Bool {
         !showsThemeSettings
             && !isCommandMode
@@ -19,5 +20,6 @@ enum HideAppShortcutLogic {
             && !isCommandSuggestionQuery
             && !isTranslationQuery
             && !isClipboardQuery
+            && !isProcessQuery
     }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+AppHiding.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+AppHiding.swift
@@ -62,7 +62,8 @@ extension LauncherView {
             isPrefixSuggestionQuery: isPrefixSuggestionQuery,
             isCommandSuggestionQuery: isCommandSuggestionQuery,
             isTranslationQuery: isTranslationQuery,
-            isClipboardQuery: isClipboardQuery
+            isClipboardQuery: isClipboardQuery,
+            isProcessQuery: isProcessQuery
         )
     }
 

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+AppHiding.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+AppHiding.swift
@@ -5,7 +5,7 @@ extension LauncherView {
     /// False when another screen owns the launcher, so the caller can leave the
     /// key alone instead of swallowing it into a no-op.
     func hideSelectedApp() -> Bool {
-        guard !isCommandMode, !appUIState.showsThemeSettings, !showsHelpScreen else { return false }
+        guard allowsHideAppShortcut() else { return false }
         guard pendingEmptyTrashCount == nil else { return false }
 
         guard let selectedResultID,
@@ -51,6 +51,19 @@ extension LauncherView {
 
     func cancelHideSelectedApp() {
         pendingHideAppResult = nil
+    }
+
+    private func allowsHideAppShortcut() -> Bool {
+        HideAppShortcutLogic.allowsKeyboardHideApp(
+            showsThemeSettings: appUIState.showsThemeSettings,
+            isCommandMode: isCommandMode,
+            showsHelpScreen: showsHelpScreen,
+            hidesResultsForEmptyQuery: hidesResultsForEmptyQuery,
+            isPrefixSuggestionQuery: isPrefixSuggestionQuery,
+            isCommandSuggestionQuery: isCommandSuggestionQuery,
+            isTranslationQuery: isTranslationQuery,
+            isClipboardQuery: isClipboardQuery
+        )
     }
 
     private enum AppExcludeResult {


### PR DESCRIPTION
## Summary

- block the hide-app shortcut outside normal result contexts

## Why

- #334 

## Changes

- disable the hide-app shortcut on empty home so it cannot act on background auto-selection
- disable the hide-app shortcut in non-result modes such as discovery, translation, clipboard, and process views

## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [x] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [ ] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

- No Macos devices to manual test 🥲️

## Checklist

- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the hide-app keyboard shortcut so it is unavailable while settings, help, command, discovery, translation, clipboard, or process modes are active.
  * Prevented the shortcut from triggering when there is no active query or result set.
  * Reduced shortcut conflicts while entering commands, suggestions, or other specialized searches.
  * Confirmed the shortcut remains available during normal search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->