### PR TITLE
chore: adjust script to match the README

### DIFF
--- a/apps/linows/BUILDING.md
+++ b/apps/linows/BUILDING.md
@@ -189,10 +189,10 @@ yay -S look-bin
 
 ```bash
 # Run directly
-nix run github:kunkka19xx/look?dir=apps/linows
+nix run 'github:kunkka19xx/look?dir=apps/linows'
 
 # Install to profile
-nix profile install github:kunkka19xx/look?dir=apps/linows
+nix profile install 'github:kunkka19xx/look?dir=apps/linows'
 
 # Build locally
 cd apps/linows


### PR DESCRIPTION
## Summary

- Quote the Nix GitHub flake URL in the build instructions.

## Why

- The ?dir=apps/linows query must be passed as part of the flake URL. Without quotes, some shells may interpret ? as a wildcard.

## Changes

- Updated the `nix run`, `nix profile install` command.
- Kept the commands consistent with the README.


## Checklist

- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Nix command examples to correctly quote the flake URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->