### PR TITLE
fix: empty query selection

### DIFF
--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -504,7 +504,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         search.handleQueryInput(value);
         const translating = search.isTranslateMode();
-        layout.setQuery({ empty: value === '', translate: translating });
+        layout.setQuery({ empty: layout.isEmptyQuery(value), translate: translating });
         syncControlStrip();
         resultsList.hidden = translating;
         runningApps.setSuspended(translating);

--- a/apps/linows/src/js/components/results.js
+++ b/apps/linows/src/js/components/results.js
@@ -12,6 +12,7 @@ import {
 import { getSettingsIcon as getWindowsSettingsIcon } from '../settings-icons/windows.js';
 import { webSuggestionFromResultId } from '../catalog.js';
 import { isWindows } from '../platform.js';
+import * as layout from '../layout.js';
 
 // LRU-bounded icon cache (cacheKey -> data URL | null). A plain Map keeps
 // insertion order, so re-inserting on a hit marks it most-recently-used and the
@@ -61,13 +62,6 @@ let emptyState = { mode: 'default' };
 // the gate the cursor follows it there instead of resting on the top result.
 let userNavigated = false;
 let lastRenderQuery = null;
-
-function hidesResultsForEmptyQuery() {
-    return (
-        document.documentElement.classList.contains('controls-open') ||
-        document.getElementById('app')?.classList.contains('resting')
-    );
-}
 
 export function init(containerEl) {
     container = containerEl;
@@ -158,7 +152,7 @@ export function render(results, query = null) {
         if (idx >= 0) nextIndex = idx;
     }
 
-    if (hidesResultsForEmptyQuery()) {
+    if (layout.hidesResultsForEmptyQuery()) {
         // No rows on screen. A seeded selection here is one the user cannot
         // see, and Enter / Ctrl+D / Ctrl+Shift+H would still act on it.
         selectedIndex = -1;

--- a/apps/linows/src/js/components/results.js
+++ b/apps/linows/src/js/components/results.js
@@ -152,7 +152,7 @@ export function render(results, query = null) {
         if (idx >= 0) nextIndex = idx;
     }
 
-    if (layout.hidesResultsForEmptyQuery()) {
+    if (layout.isEmptyQuery(query) && layout.hidesResultsForEmptyQuery()) {
         // No rows on screen. A seeded selection here is one the user cannot
         // see, and Enter / Ctrl+D / Ctrl+Shift+H would still act on it.
         selectedIndex = -1;

--- a/apps/linows/src/js/components/results.js
+++ b/apps/linows/src/js/components/results.js
@@ -62,6 +62,13 @@ let emptyState = { mode: 'default' };
 let userNavigated = false;
 let lastRenderQuery = null;
 
+function hidesResultsForEmptyQuery() {
+    return (
+        document.documentElement.classList.contains('controls-open') ||
+        document.getElementById('app')?.classList.contains('resting')
+    );
+}
+
 export function init(containerEl) {
     container = containerEl;
 }
@@ -150,6 +157,14 @@ export function render(results, query = null) {
         const idx = results.findIndex((r) => r.id === prevSelectedId);
         if (idx >= 0) nextIndex = idx;
     }
+
+    if (hidesResultsForEmptyQuery()) {
+        // No rows on screen. A seeded selection here is one the user cannot
+        // see, and Enter / Ctrl+D / Ctrl+Shift+H would still act on it.
+        selectedIndex = -1;
+        return;
+    }
+
     select(nextIndex);
 }
 

--- a/apps/linows/src/js/layout.js
+++ b/apps/linows/src/js/layout.js
@@ -17,7 +17,6 @@ let innerGap = 0;
 let queryEmpty = true;
 let translateQuery = false;
 let recentEmptyQuery = false;
-let resting = false;
 
 // Modal screens that suspend the floating home layout entirely.
 const modal = { command: false, settings: false, help: false };
@@ -124,11 +123,21 @@ function drawnImageRect(winRect) {
     return { x: 0, y: 0, w: winRect.width, h: winRect.height };
 }
 
-/** True when the results row is off screen: the empty-query rest state, or the
- *  controls strip covering it. The strip ignores the floating-support gate, so
- *  it can hide the row when `resting` is false. */
+/** One rule for "empty query", shared by the layout gate and by the search and
+ *  selection guards below. Whitespace still searches, so it is not empty. */
+export function isEmptyQuery(query) {
+    return query === '';
+}
+
+/** True when an empty query leaves the results row off screen: the rest state,
+ *  or the controls strip covering it. The strip ignores the floating-support
+ *  gate, so it can hide the row when floating is unavailable.
+ *
+ *  Derived from mode state only, never the cached `queryEmpty`: app.js updates
+ *  layout after handing the new query to search.js, and the discovery menus
+ *  publish rows synchronously from there. Callers gate on the query itself. */
 export function hidesResultsForEmptyQuery() {
-    return resting || superactions.isVisible();
+    return onHome() && (platform.floatingSupported() || superactions.isEnabled());
 }
 
 // Re-evaluate the floating gate after environment state changes at runtime
@@ -137,15 +146,20 @@ export function refresh() {
     apply();
 }
 
+// Modal screens suspend the floating home layout; every gate below is off there.
+function onHome() {
+    return !modal.command && !modal.settings && !modal.help;
+}
+
 function apply() {
     if (!win) return;
     // Degraded-rendering environments keep the classic framed panel: both the
     // gaps and the resting bar depend on real transparency. Still coarse -
     // platform info is static and the attribute only flips from settings.
     const supported = platform.floatingSupported();
-    const onHome = !modal.command && !modal.settings && !modal.help;
-    const floating = supported && innerGap > 0 && onHome; // showsFloatingCards
-    resting = supported && queryEmpty && onHome; // hidesResultsForEmptyQuery
+    const home = onHome();
+    const floating = supported && innerGap > 0 && home; // showsFloatingCards
+    const resting = supported && queryEmpty && home; // macOS hidesResultsForEmptyQuery, as a CSS state
     const barFree = floating || resting; // barFloatsFree
     const floatingGrid = floating && !translateQuery && !recentEmptyQuery;
 

--- a/apps/linows/src/js/layout.js
+++ b/apps/linows/src/js/layout.js
@@ -8,6 +8,7 @@
 // command/settings/help), never query text or result counts.
 
 import * as platform from './platform.js';
+import * as superactions from './components/superactions.js';
 
 const GAP_MIN = 0;
 const GAP_MAX = 24;
@@ -16,6 +17,7 @@ let innerGap = 0;
 let queryEmpty = true;
 let translateQuery = false;
 let recentEmptyQuery = false;
+let resting = false;
 
 // Modal screens that suspend the floating home layout entirely.
 const modal = { command: false, settings: false, help: false };
@@ -122,6 +124,13 @@ function drawnImageRect(winRect) {
     return { x: 0, y: 0, w: winRect.width, h: winRect.height };
 }
 
+/** True when the results row is off screen: the empty-query rest state, or the
+ *  controls strip covering it. The strip ignores the floating-support gate, so
+ *  it can hide the row when `resting` is false. */
+export function hidesResultsForEmptyQuery() {
+    return resting || superactions.isVisible();
+}
+
 // Re-evaluate the floating gate after environment state changes at runtime
 // (the settings blur-fallback toggle flips data-disable-blur).
 export function refresh() {
@@ -136,7 +145,7 @@ function apply() {
     const supported = platform.floatingSupported();
     const onHome = !modal.command && !modal.settings && !modal.help;
     const floating = supported && innerGap > 0 && onHome; // showsFloatingCards
-    const resting = supported && queryEmpty && onHome; // hidesResultsForEmptyQuery
+    resting = supported && queryEmpty && onHome; // hidesResultsForEmptyQuery
     const barFree = floating || resting; // barFloatsFree
     const floatingGrid = floating && !translateQuery && !recentEmptyQuery;
 

--- a/apps/linows/src/js/search.js
+++ b/apps/linows/src/js/search.js
@@ -213,6 +213,7 @@ export function handleQueryInput(query) {
         // The rest screen shows no rows, and the engine answers an empty query
         // by scoring the whole index. Clear instead of searching for nothing.
         if (hidesResultsForEmptyQuery()) {
+            if (onResultsCallback) onResultsCallback([], query);
             return;
         }
         performSearch('', myVersion);

--- a/apps/linows/src/js/search.js
+++ b/apps/linows/src/js/search.js
@@ -206,7 +206,7 @@ export function handleQueryInput(query) {
     if (query.trim() === '') {
         // The rest screen shows no rows, and the engine answers an empty query
         // by scoring the whole index. Clear instead of searching for nothing.
-        if (layout.hidesResultsForEmptyQuery()) {
+        if (layout.isEmptyQuery(query) && layout.hidesResultsForEmptyQuery()) {
             if (onResultsCallback) onResultsCallback([], query);
             return;
         }

--- a/apps/linows/src/js/search.js
+++ b/apps/linows/src/js/search.js
@@ -17,6 +17,7 @@ import {
     WEB_URL_OPEN_SUBTITLE,
     WEB_URL_RECENT_SUBTITLE,
 } from './catalog.js';
+import * as layout from './layout.js';
 
 const DEBOUNCE_MS = 70;
 const MIN_QUICK_FOLDER_PREFIX = 2;
@@ -58,13 +59,6 @@ let webInFlight = false;
 // web suggestions need) and refilled by fetchUrlRows.
 let lastUrlMatch = null;
 let lastRecentUrls = [];
-
-function hidesResultsForEmptyQuery() {
-    return (
-        document.documentElement.classList.contains('controls-open') ||
-        document.getElementById('app')?.classList.contains('resting')
-    );
-}
 
 /** Resolved by the backend (Windows: SHGetKnownFolderPath; *nix: $HOME/<name>).
  *  Empty until setQuickFolders is called at boot. */
@@ -212,7 +206,7 @@ export function handleQueryInput(query) {
     if (query.trim() === '') {
         // The rest screen shows no rows, and the engine answers an empty query
         // by scoring the whole index. Clear instead of searching for nothing.
-        if (hidesResultsForEmptyQuery()) {
+        if (layout.hidesResultsForEmptyQuery()) {
             if (onResultsCallback) onResultsCallback([], query);
             return;
         }

--- a/apps/linows/src/js/search.js
+++ b/apps/linows/src/js/search.js
@@ -59,6 +59,13 @@ let webInFlight = false;
 let lastUrlMatch = null;
 let lastRecentUrls = [];
 
+function hidesResultsForEmptyQuery() {
+    return (
+        document.documentElement.classList.contains('controls-open') ||
+        document.getElementById('app')?.classList.contains('resting')
+    );
+}
+
 /** Resolved by the backend (Windows: SHGetKnownFolderPath; *nix: $HOME/<name>).
  *  Empty until setQuickFolders is called at boot. */
 let quickFolders = [];
@@ -203,6 +210,11 @@ export function handleQueryInput(query) {
 
     const myVersion = queryVersion;
     if (query.trim() === '') {
+        // The rest screen shows no rows, and the engine answers an empty query
+        // by scoring the whole index. Clear instead of searching for nothing.
+        if (hidesResultsForEmptyQuery()) {
+            return;
+        }
         performSearch('', myVersion);
         return;
     }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Search.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Search.swift
@@ -20,6 +20,14 @@ extension LauncherView {
             setInitialSelection()
             return
         }
+        // The rest screen shows no rows, and the engine answers an empty query
+        // by scoring the whole index. Clear instead of searching for nothing.
+        guard !hidesResultsForEmptyQuery else {
+            invalidateSearchRequests()
+            backendResults = []
+            setInitialSelection()
+            return
+        }
 
         let currentQuery = query
         let searchLimit = AppConstants.Launcher.defaultSearchLimit

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
@@ -9,6 +9,10 @@ extension LauncherView {
             } else {
                 selectedCommandID = filteredCommands.first?.id
             }
+        } else if hidesResultsForEmptyQuery {
+            // No rows on screen. A seeded selection here is one the user cannot
+            // see, and Enter / Cmd+D / Cmd+Shift+H would still act on it.
+            selectedResultID = nil
         } else {
             selectedResultID = displayedResults.first?.id
         }


### PR DESCRIPTION
## Summary

- Fix the empty-query hidden-selection bug on both macOS and linows.
- Prevent the launcher from keeping actionable results selected while the home screen is hiding the results UI.

## Why

- On macOS, the empty home/rest screen could still keep backend results and a seeded selection alive.
- On linows, the same issue existed in the hidden-results state on the empty home screen.
- That let keyboard actions target an item the user could not see.

## Changes

- macOS:
  - Skip empty-query search when hidesResultsForEmptyQuery is active.
  - Clear the hidden results state instead of searching an empty query.
  - Avoid seeding selectedResultID while rows are hidden.
- linows:
  - Add the equivalent empty-query guard in search.js.
  - Avoid seeding selectedIndex in results.js when the empty home screen is hiding rows.

## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved empty-query behavior when controls are open or the app is idle.
  * Prevented hidden results from being searched, displayed, or selected.
  * Cleared stale results and selections when the results panel is hidden.
  * Improved consistency between search, result display, and selection states.
  * Prevented unnecessary full-index searches when no results should be visible.
  * Ensured pending searches are canceled and the interface resets cleanly when results are hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->