### PR TITLE
fix: ranking when app and quick folder have same name

### DIFF
--- a/apps/linows/src/js/search.js
+++ b/apps/linows/src/js/search.js
@@ -475,20 +475,36 @@ function prependQuickFolders(results, query) {
     const q = query.toLowerCase().trim();
     if (q.length < MIN_QUICK_FOLDER_PREFIX) return results;
 
-    const matched = [];
+    const merged = [...results];
+    let insertAt = 0;
+
     for (const folder of quickFolders) {
         if (!folder.title.toLowerCase().startsWith(q)) continue;
-        if (results.some((r) => r.path === folder.path)) continue;
+        if (merged.some((r) => r.path === folder.path)) continue;
+
         const isTrash = folder.title === 'Trash' || folder.title === 'Recycle Bin';
-        matched.push({
+        const quickFolderResult = {
             id: `quickfolder:${folder.title.toLowerCase()}`,
             kind: 'folder',
             title: folder.title,
             subtitle: isTrash ? 'Pinned · Ctrl+D to empty' : 'Pinned home folder',
             path: folder.path,
             score: 999999,
-        });
+        };
+
+        // A same-titled app already won the backend's type-priority ranking -
+        // don't let the pin bump it out of first place. Surface the folder
+        // right below it instead of dropping it, so it's still reachable.
+        const rivalAppIndex = merged.findIndex(
+            (r) => r.kind === 'app' && r.title.toLowerCase() === folder.title.toLowerCase()
+        );
+        if (rivalAppIndex === -1) {
+            merged.splice(insertAt, 0, quickFolderResult);
+            insertAt += 1;
+        } else {
+            merged.splice(rivalAppIndex + 1, 0, quickFolderResult);
+        }
     }
 
-    return [...matched, ...results];
+    return merged;
 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -267,9 +267,17 @@ struct LauncherView: View {
             let alreadyPresent = sourceResults.contains { item in
                 item.kind == .folder && item.path == quickFolder.path
             }
-            if !alreadyPresent {
-                sourceResults.insert(quickFolder, at: 0)
+            guard !alreadyPresent else { continue }
+
+            // A same-titled app (e.g. Apple Music.app vs the ~/Music quick folder)
+            // already won the backend's type-priority ranking - don't let the pin
+            // bump it out of first place. Surface the folder right below it instead
+            // of dropping it, so it's still reachable.
+            let rivalAppIndex = sourceResults.firstIndex { item in
+                item.kind == .app
+                    && item.title.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == quickFolder.title.lowercased()
             }
+            sourceResults.insert(quickFolder, at: rivalAppIndex.map { $0 + 1 } ?? 0)
         }
 
         if shouldInjectFinderResult {


### PR DESCRIPTION
## Summary

- fix ranking when app and quick folder have same name. Eg: Music, Photo...


## Testing


- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)


## Checklist

- [x] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quick-folder result placement when an app with the same name is also found.
  * Prevented pinned folders from unnecessarily displacing equally ranked app results.
  * Enhanced duplicate handling for quick-folder entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->