### PR TITLE
chore: make the message more user-friendly

### DIFF
--- a/apps/linows/src/js/keyboard.js
+++ b/apps/linows/src/js/keyboard.js
@@ -518,7 +518,7 @@ async function handleHideSelectApp() {
     const item = results.getSelected();
     // Only real launcher apps carry a path; synthetic rows must not be excluded.
     if (!item || item.kind !== 'app' || !item.path || isSyntheticResultId(item.id)) {
-        banner.show('Select an app first', 'warning', 1.2);
+        banner.show('Select an app to hide', 'warning', 1.2);
         return;
     }
 

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+AppHiding.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+AppHiding.swift
@@ -14,7 +14,7 @@ extension LauncherView {
               !selected.path.isEmpty,
               selected.path.hasSuffix(Self.appBundleExtension)
         else {
-            showBanner("Select an app first", style: .info, duration: 1.2)
+            showBanner("Select an app to hide", style: .info, duration: 1.2)
             return true
         }
 


### PR DESCRIPTION
## Summary

- Change message hide app more user-friendly

## Why

- Old message  make me confuse 

## Changes

- Change message log `Select an app first` to `Select an app to hide` 


## Screenshots / Recordings (if UI changed)

### Before
<img width="852" height="372" alt="image" src="https://github.com/user-attachments/assets/ee3c607e-656b-44cf-9a8d-5f39977b5d0d" />


### After
<img width="858" height="407" alt="image" src="https://github.com/user-attachments/assets/85468166-990c-44f8-9066-0da1228592f6" />


## Risks / Notes

- None

## Checklist

- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the app-hiding warning to clearly prompt users to select an app to hide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->