### PR TITLE
chore: add Ctrl+Shift+Enter shortcut to help panel

### DIFF
--- a/apps/linows/src/html/screens/help.html
+++ b/apps/linows/src/html/screens/help.html
@@ -15,6 +15,9 @@
                 <kbd>Enter</kbd
                 ><span>Open selected app/file/folder or copy selected clipboard item</span>
             </div>
+            <div class="help-item help-windows-only">
+                <kbd>Ctrl+Shift+Enter</kbd><span>Run selected app as administrator</span>
+            </div>
             <div class="help-item">
                 <kbd>Ctrl+C</kbd><span>Copy selected file/folder to clipboard</span>
             </div>


### PR DESCRIPTION
## Summary
- Add missing `Ctrl+Shift+Enter` (Run as administrator) shortcut to the Ctrl+H help panel.
## Why
- Issue #345: The shortcut was implemented in code but not listed in the help panel, so users had no way to discover it.
## Changes
- `apps/linows/src/html/screens/help.html`: Add a new `help-windows-only` entry for `Ctrl+Shift+Enter` in the Main section.

## Testing

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

### Before

### After

## Risks / Notes

-

## Checklist

- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Windows-specific help guidance for using `Ctrl+Shift+Enter` to run the selected app with administrator privileges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->