### PR TITLE
chore: improve now playing on macos

### DIFF
--- a/apps/macos/LauncherApp/look-app/Support/QuickActions/SystemNowPlaying.swift
+++ b/apps/macos/LauncherApp/look-app/Support/QuickActions/SystemNowPlaying.swift
@@ -1,77 +1,113 @@
 import Foundation
 import OSLog
 
-/// A snapshot of the system-wide "now playing" media, whatever app owns it
-/// (a browser tab, Spotify, Apple Music, Look's own Pomodoro player, ...).
+/// A snapshot of the current now-playing media, whatever app owns it.
 struct NowPlayingSnapshot: Equatable {
     let title: String?
     let artist: String?
-    /// The owning app's display name, e.g. "Firefox", "Spotify".
     let app: String?
     let isPlaying: Bool
+    /// Serialized `MRPlayerPath` identifying the player (not the track), so it
+    /// stays valid across track changes.
+    let playerPath: Data?
 
     var hasTrack: Bool { title?.isEmpty == false }
 }
 
-/// Reads and controls the system-wide now-playing media via Apple's private
-/// MediaRemote framework.
+/// Reads and controls system-wide now-playing via Apple's private MediaRemote
+/// framework.
 ///
-/// macOS 15.4+ blocks a normal app from reading now-playing directly (the
-/// `mediaremoted` daemon checks for an Apple-only entitlement), so the READ is
-/// delegated to `/usr/bin/osascript`, a system binary that *is* entitled; its
-/// bundled JXA loads MediaRemote and prints the track as JSON. Sending transport
-/// commands was never gated, so that path calls `MRMediaRemoteSendCommand`
-/// directly. This is a private-API path (not App Store safe) and could break on
-/// a future macOS update; it is used only for this read-only glance + transport.
-final class SystemNowPlaying: Sendable {
+/// macOS 15.4+ lets only Apple-entitled binaries read now-playing, so the work
+/// is delegated to `/usr/bin/osascript`, which is entitled. Not App Store safe,
+/// and liable to break on a macOS update.
+///
+/// Commands must be addressed to a specific player, as the Linux/Windows app
+/// does with an MPRIS bus name (`apps/linows/src-tauri/src/nowplaying.rs`). The
+/// untargeted `MRMediaRemoteSendCommand` reports success but is answered by
+/// Look's own `MPRemoteCommandCenter`, so it resumes Pomodoro music instead of
+/// the tab on screen.
+///
+/// `nonisolated` because the target defaults to `MainActor` isolation, which
+/// would make even closure literals here main-actor bound and trap the
+/// concurrency runtime when reached from the background queue below.
+nonisolated final class SystemNowPlaying: Sendable {
     static let shared = SystemNowPlaying()
 
-    /// `MRMediaRemoteSendCommand` command codes (stable for years).
+    /// `MRMediaRemoteSendCommand` command codes.
     enum Command: Int32 {
         case togglePlayPause = 2
         case nextTrack = 4
         case previousTrack = 5
     }
 
-    private static let mediaRemotePath =
-        "/System/Library/PrivateFrameworks/MediaRemote.framework/MediaRemote"
-    /// Kill the `osascript` read if it hangs past this, so the poll never stalls.
-    private static let readTimeout: TimeInterval = 4
-
-    private typealias SendCommand = @convention(c) (Int32, CFDictionary?) -> Bool
-    private let sendCommand: SendCommand?
+    private static let mediaRemoteBundlePath =
+        "/System/Library/PrivateFrameworks/MediaRemote.framework/"
+    /// Kill a hung `osascript` so the poll never stalls.
+    private static let scriptTimeout: TimeInterval = 4
+    private static let commandPathEnvKey = "LOOK_NOWPLAYING_COMMAND_PATH"
+    private static let commandCodeEnvKey = "LOOK_NOWPLAYING_COMMAND_CODE"
+    private static let sendSuccessMarker = "ok"
 
     private let log = Logger(subsystem: "noah-code.Look", category: "nowplaying")
 
-    private init() {
-        if let handle = dlopen(Self.mediaRemotePath, RTLD_NOW),
-           let symbol = dlsym(handle, "MRMediaRemoteSendCommand") {
-            sendCommand = unsafeBitCast(symbol, to: SendCommand.self)
-        } else {
-            sendCommand = nil
-        }
-    }
+    private init() {}
 
-    /// Sends a transport command to whichever app owns now-playing.
-    @discardableResult
-    func send(_ command: Command) -> Bool {
-        sendCommand?(command.rawValue, nil) ?? false
-    }
+    // MARK: Reading
 
-    /// Reads the current now-playing track, or nil when nothing is playing or the
-    /// read fails. Runs `osascript` off the main thread.
+    /// The current track, or nil when nothing is playing or the read fails.
     func current() async -> NowPlayingSnapshot? {
         await withCheckedContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async {
-                continuation.resume(returning: self.readViaOSAScript())
+                continuation.resume(returning: self.read())
             }
         }
     }
 
-    private func readViaOSAScript() -> NowPlayingSnapshot? {
+    private func read() -> NowPlayingSnapshot? {
+        guard let output = runScript(Self.readScript, environment: [:]),
+              let result = try? JSONDecoder().decode(ReadResult.self, from: output),
+              result.hasTrack else {
+            return nil
+        }
+        return NowPlayingSnapshot(
+            title: result.title,
+            artist: result.artist,
+            app: result.appName,
+            isPlaying: result.isPlaying ?? false,
+            playerPath: result.path.flatMap { Data(base64Encoded: $0) }
+        )
+    }
+
+    // MARK: Sending
+
+    /// Sends a transport command to the player `playerPath` identifies.
+    @discardableResult
+    func send(_ command: Command, to playerPath: Data?) async -> Bool {
+        guard let playerPath else { return false }
+        return await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(returning: self.sendTargeted(command, to: playerPath))
+            }
+        }
+    }
+
+    private func sendTargeted(_ command: Command, to playerPath: Data) -> Bool {
+        let environment = [
+            Self.commandPathEnvKey: playerPath.base64EncodedString(),
+            Self.commandCodeEnvKey: String(command.rawValue),
+        ]
+        guard let output = runScript(Self.sendScript, environment: environment) else { return false }
+        let text = String(decoding: output, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+        return text == Self.sendSuccessMarker
+    }
+
+    // MARK: osascript plumbing
+
+    private func runScript(_ script: String, environment: [String: String]) -> Data? {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
         process.arguments = ["-l", "JavaScript", "-"]
+        process.environment = ProcessInfo.processInfo.environment.merging(environment) { _, new in new }
         let input = Pipe()
         let output = Pipe()
         process.standardInput = input
@@ -80,78 +116,132 @@ final class SystemNowPlaying: Sendable {
 
         do {
             try process.run()
-            input.fileHandleForWriting.write(Data(Self.readScript.utf8))
+            input.fileHandleForWriting.write(Data(script.utf8))
             input.fileHandleForWriting.closeFile()
 
-            // Guard against a hung osascript: terminate it after the timeout so
-            // the pipe closes, the blocking read returns, and current()'s
-            // continuation always resumes rather than stalling the poll.
+            // Terminate on timeout so the pipe closes and the blocking read
+            // below returns instead of hanging the caller.
             let terminator = DispatchWorkItem {
                 if process.isRunning { process.terminate() }
             }
-            DispatchQueue.global().asyncAfter(deadline: .now() + Self.readTimeout, execute: terminator)
+            DispatchQueue.global().asyncAfter(deadline: .now() + Self.scriptTimeout, execute: terminator)
 
             let data = output.fileHandleForReading.readDataToEndOfFile()
             process.waitUntilExit()
             terminator.cancel()
-            return Self.parse(data)
+            guard process.terminationStatus == 0 else { return nil }
+            return data
         } catch {
-            log.error("now-playing read failed: \(error.localizedDescription, privacy: .public)")
+            log.error("now-playing script failed: \(error.localizedDescription, privacy: .public)")
             return nil
         }
     }
 
-    private static func parse(_ data: Data) -> NowPlayingSnapshot? {
-        guard let result = try? JSONDecoder().decode(ReadResult.self, from: data) else { return nil }
-        guard result.track == true, let title = result.title, !title.isEmpty else { return nil }
-        return NowPlayingSnapshot(
-            title: title,
-            artist: result.artist,
-            app: result.app,
-            isPlaying: result.isPlaying ?? false
-        )
-    }
+    // MARK: Decoding
 
     private struct ReadResult: Decodable {
-        let track: Bool?
         let title: String?
         let artist: String?
-        let app: String?
+        let displayName: String?
         let isPlaying: Bool?
-    }
+        /// Base64 `MRPlayerPath`.
+        let path: String?
 
-    /// JXA run under `osascript` (an Apple-entitled binary): loads MediaRemote,
-    /// reads `MRNowPlayingRequest`, and prints the track as JSON. Kept minimal and
-    /// defensive so any failure yields parseable output rather than a crash.
-    private static let readScript = """
+        var hasTrack: Bool { title?.isEmpty == false }
+
+        var appName: String? { displayName?.isEmpty == false ? displayName : nil }
+    }
+}
+
+// MARK: - Scripts
+
+private nonisolated extension SystemNowPlaying {
+    /// Reports the elected player as JSON.
+    ///
+    /// The track and the owning app come from two independent calls, and the
+    /// system can hand the slot to another app in between, pairing one app's
+    /// track with another's name. The path is read on both sides and the result
+    /// discarded if it moved.
+    static let readScript = """
     function run() {
         try {
-            const MediaRemote = $.NSBundle.bundleWithPath('/System/Library/PrivateFrameworks/MediaRemote.framework/');
-            MediaRemote.load;
+            const bundle = $.NSBundle.bundleWithPath('\(mediaRemoteBundlePath)');
+            bundle.load;
             const Req = $.NSClassFromString('MRNowPlayingRequest');
-            if (!Req) return JSON.stringify({ track: false });
+            if (!Req) return JSON.stringify({});
+
+            const unwrap = (v) => (v && !v.isNil()) ? ObjC.unwrap(v) : null;
+            const pathData = () => {
+                const p = Req.localNowPlayingPlayerPath;
+                if (!p || p.isNil()) return null;
+                try { return unwrap(p.data.base64EncodedStringWithOptions(0)); } catch (e) { return null; }
+            };
+
+            const before = pathData();
             const item = Req.localNowPlayingItem;
-            if (!item || item.isNil()) return JSON.stringify({ track: false });
+            if (!item || item.isNil()) return JSON.stringify({});
             const info = item.nowPlayingInfo;
+            if (!info || info.isNil()) return JSON.stringify({});
+            const after = pathData();
+            if (before !== after) return JSON.stringify({});
+
             const get = (k) => {
                 const v = info.valueForKey(k);
                 return (v && !v.isNil()) ? ObjC.deepUnwrap(v) : null;
             };
-            let app = null;
-            try {
-                const client = Req.localNowPlayingPlayerPath.client;
-                if (client && !client.isNil()) app = ObjC.unwrap(client.displayName);
-            } catch (e) {}
-            const rate = get('kMRMediaRemoteNowPlayingInfoPlaybackRate');
-            return JSON.stringify({
-                track: true,
+            const out = {
                 title: get('kMRMediaRemoteNowPlayingInfoTitle'),
                 artist: get('kMRMediaRemoteNowPlayingInfoArtist'),
-                app: app,
-                isPlaying: (typeof rate === 'number') ? rate > 0 : false
-            });
+                isPlaying: false,
+                path: after
+            };
+            const rate = get('kMRMediaRemoteNowPlayingInfoPlaybackRate');
+            if (typeof rate === 'number') out.isPlaying = rate > 0;
+
+            const path = Req.localNowPlayingPlayerPath;
+            if (path && !path.isNil()) {
+                try {
+                    const client = path.client;
+                    if (client && !client.isNil()) {
+                        out.displayName = unwrap(client.displayName);
+                    }
+                } catch (e) {}
+            }
+            return JSON.stringify(out);
         } catch (e) {
-            return JSON.stringify({ track: false });
+            return JSON.stringify({});
+        }
+    }
+    """
+
+    /// Rebuilds a player path and sends one transport command to it.
+    static let sendScript = """
+    function run() {
+        const env = $.NSProcessInfo.processInfo.environment;
+        const envValue = (key) => {
+            const v = env.objectForKey(key);
+            return (v && !v.isNil()) ? ObjC.unwrap(v) : null;
+        };
+        try {
+            const bundle = $.NSBundle.bundleWithPath('\(mediaRemoteBundlePath)');
+            bundle.load;
+            const encoded = envValue('\(commandPathEnvKey)');
+            const code = parseInt(envValue('\(commandCodeEnvKey)'), 10);
+            if (!encoded || isNaN(code)) return '';
+
+            const raw = $.NSData.alloc.initWithBase64EncodedStringOptions(encoded, 0);
+            const PathClass = $.NSClassFromString('MRPlayerPath');
+            const path = PathClass.alloc.initWithData(raw);
+            if (!path || path.isNil()) return '';
+
+            const Req = $.NSClassFromString('MRNowPlayingRequest');
+            const request = Req.alloc.initWithPlayerPath(path);
+            if (!request || request.isNil()) return '';
+
+            request.sendCommandOptionsQueueCompletion(code, $(), $(), $());
+            return '\(sendSuccessMarker)';
+        } catch (e) {
+            return '';
         }
     }
     """

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LaunchpadController.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LaunchpadController.swift
@@ -42,6 +42,9 @@ final class LaunchpadController {
     @ObservationIgnored private var expectationDeadline = Date.distantPast
     @ObservationIgnored private var nowPlayingReconcile: Task<Void, Never>?
 
+    /// Stops an earlier read resuming last over a newer one, as `stateGeneration` does.
+    @ObservationIgnored private var nowPlayingGeneration: UInt64 = 0
+
     private static let nowPlayingSettleNanos: UInt64 = 300_000_000
     /// Cap on holding the expected state, so a command that never lands cannot
     /// freeze the tile.
@@ -94,7 +97,10 @@ final class LaunchpadController {
     /// Reads the current now-playing track. While a command is still settling,
     /// fresh metadata is adopted but the expected play state is kept.
     func refreshNowPlaying() async {
+        nowPlayingGeneration &+= 1
+        let generation = nowPlayingGeneration
         let fresh = await SystemNowPlaying.shared.current()
+        guard generation == nowPlayingGeneration else { return }
 
         guard let expected = expectedIsPlaying, Date() < expectationDeadline else {
             expectedIsPlaying = nil
@@ -106,15 +112,16 @@ final class LaunchpadController {
             nowPlaying = fresh
             return
         }
-        nowPlaying = fresh.map {
-            NowPlayingSnapshot(
-                title: $0.title,
-                artist: $0.artist,
-                app: $0.app,
-                isPlaying: expected,
-                playerPath: $0.playerPath
-            )
-        }
+        // Reads come back empty when the player moves mid-read. Blanking here
+        // would strip the path the next press needs.
+        guard let fresh else { return }
+        nowPlaying = NowPlayingSnapshot(
+            title: fresh.title,
+            artist: fresh.artist,
+            app: fresh.app,
+            isPlaying: expected,
+            playerPath: fresh.playerPath
+        )
     }
 
     /// Toggles play/pause on the player the tile is showing. Flips optimistically
@@ -147,7 +154,13 @@ final class LaunchpadController {
         let target = nowPlaying?.playerPath
         nowPlayingReconcile?.cancel()
         nowPlayingReconcile = Task {
-            await SystemNowPlaying.shared.send(command, to: target)
+            guard await SystemNowPlaying.shared.send(command, to: target) else {
+                // Undelivered, so no change is coming: drop the optimistic flip
+                // now rather than polling to the deadline.
+                expectedIsPlaying = nil
+                await refreshNowPlaying()
+                return
+            }
             while !Task.isCancelled {
                 try? await Task.sleep(nanoseconds: Self.nowPlayingSettleNanos)
                 guard !Task.isCancelled else { return }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LaunchpadController.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LaunchpadController.swift
@@ -35,16 +35,17 @@ final class LaunchpadController {
     /// The system-wide now-playing track (any app), or nil when nothing plays.
     private(set) var nowPlaying: NowPlayingSnapshot?
 
-    /// When the last transport command was issued. A background poll ignores a
-    /// read for this long afterward so it cannot clobber the optimistic update
-    /// before the command has settled; the forced reconcile applies the truth.
-    @ObservationIgnored private var lastNowPlayingCommandAt = Date.distantPast
+    /// The play state a just-issued command should produce, held until a read
+    /// agrees. Commands apply asynchronously, so without this the tile flips
+    /// three times per press: optimistic, stale read, then the truth.
+    @ObservationIgnored private var expectedIsPlaying: Bool?
+    @ObservationIgnored private var expectationDeadline = Date.distantPast
     @ObservationIgnored private var nowPlayingReconcile: Task<Void, Never>?
 
-    /// Delay before re-reading after a command (commands apply asynchronously).
-    private static let nowPlayingSettleNanos: UInt64 = 350_000_000
-    /// A poll read is skipped when a command was issued within this window.
-    private static let nowPlayingCommandGuard: TimeInterval = 0.4
+    private static let nowPlayingSettleNanos: UInt64 = 300_000_000
+    /// Cap on holding the expected state, so a command that never lands cannot
+    /// freeze the tile.
+    private static let nowPlayingSettleTimeout: TimeInterval = 2.5
 
     /// The destructive tile currently awaiting an inline confirm, or nil.
     private(set) var pendingConfirmActionID: String?
@@ -90,29 +91,46 @@ final class LaunchpadController {
         weather = await weatherService.currentWeather()
     }
 
-    /// Reads the current system-wide now-playing track. `force` bypasses the
-    /// post-command guard and is used by the reconcile after a transport command;
-    /// the periodic poll passes `force: false` so it never overrides a fresh
-    /// optimistic update mid-flight.
-    func refreshNowPlaying(force: Bool = false) async {
-        if !force, Date().timeIntervalSince(lastNowPlayingCommandAt) < Self.nowPlayingCommandGuard {
+    /// Reads the current now-playing track. While a command is still settling,
+    /// fresh metadata is adopted but the expected play state is kept.
+    func refreshNowPlaying() async {
+        let fresh = await SystemNowPlaying.shared.current()
+
+        guard let expected = expectedIsPlaying, Date() < expectationDeadline else {
+            expectedIsPlaying = nil
+            nowPlaying = fresh
             return
         }
-        nowPlaying = await SystemNowPlaying.shared.current()
-    }
-
-    /// Toggles play/pause on whatever app owns system now-playing.
-    func nowPlayingToggle() {
-        // Optimistic: flip immediately so the button responds without waiting for
-        // the read; the reconcile confirms the real state shortly after.
-        if let current = nowPlaying {
-            nowPlaying = NowPlayingSnapshot(
-                title: current.title,
-                artist: current.artist,
-                app: current.app,
-                isPlaying: !current.isPlaying
+        if fresh?.isPlaying == expected {
+            expectedIsPlaying = nil
+            nowPlaying = fresh
+            return
+        }
+        nowPlaying = fresh.map {
+            NowPlayingSnapshot(
+                title: $0.title,
+                artist: $0.artist,
+                app: $0.app,
+                isPlaying: expected,
+                playerPath: $0.playerPath
             )
         }
+    }
+
+    /// Toggles play/pause on the player the tile is showing. Flips optimistically
+    /// so the button responds without waiting for the read.
+    func nowPlayingToggle() {
+        guard let current = nowPlaying else { return }
+        let target = !current.isPlaying
+        nowPlaying = NowPlayingSnapshot(
+            title: current.title,
+            artist: current.artist,
+            app: current.app,
+            isPlaying: target,
+            playerPath: current.playerPath
+        )
+        expectedIsPlaying = target
+        expectationDeadline = Date().addingTimeInterval(Self.nowPlayingSettleTimeout)
         issueNowPlayingCommand(.togglePlayPause)
     }
 
@@ -122,15 +140,20 @@ final class LaunchpadController {
     /// Returns the current system media to the previous track.
     func nowPlayingPrevious() { issueNowPlayingCommand(.previousTrack) }
 
-    /// Sends a transport command, then re-reads once the change has settled.
+    /// Sends a command to the player on the tile, then re-reads until it lands.
+    /// Targeting that exact player is what stops "pause, then play" from
+    /// resuming Pomodoro music instead of the browser.
     private func issueNowPlayingCommand(_ command: SystemNowPlaying.Command) {
-        lastNowPlayingCommandAt = Date()
-        SystemNowPlaying.shared.send(command)
+        let target = nowPlaying?.playerPath
         nowPlayingReconcile?.cancel()
         nowPlayingReconcile = Task {
-            try? await Task.sleep(nanoseconds: Self.nowPlayingSettleNanos)
-            guard !Task.isCancelled else { return }
-            await refreshNowPlaying(force: true)
+            await SystemNowPlaying.shared.send(command, to: target)
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: Self.nowPlayingSettleNanos)
+                guard !Task.isCancelled else { return }
+                await refreshNowPlaying()
+                guard expectedIsPlaying != nil else { return }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- improve now playing on macos 
  - pause / play behavior with multiple sources
  - icon react instantly



## Testing

- `apps/linows`
  
  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Manual verification completed (if UI/behavior changed)

## Checklist

- [x] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media playback controls by targeting commands to the active player.
  * Added more reliable play/pause state updates, including immediate feedback while system state synchronizes.
  * Added safeguards for command timeouts, invalid responses, cancelled operations, and unavailable players.
  * Improved reconciliation so displayed playback state settles correctly after commands complete or fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->