### PR TITLE
fix: blur, transparent after adding kindle theme

### DIFF
--- a/apps/macos/LauncherApp/look-app/Components/ThemedBackdrop.swift
+++ b/apps/macos/LauncherApp/look-app/Components/ThemedBackdrop.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// Blur plus tint at the opacities set in Settings. Shared by the window backdrop
+/// and every floating tile so both sliders reach all of them.
+struct ThemedBackdrop: View {
+    @ObservedObject var themeStore: ThemeStore
+    /// Thins the blur only, for the settings overlay.
+    var blurOpacityMultiplier: Double = 1
+
+    var body: some View {
+        ZStack {
+            VisualEffectBlur(
+                material: themeStore.settings.blurMaterial.material,
+                appearance: themeStore.themeAppearance()
+            )
+            .opacity(
+                clamped(
+                    themeStore.settings.blurOpacity
+                        * themeStore.settings.blurMaterial.blurOpacityScale
+                        * blurOpacityMultiplier
+                )
+            )
+
+            Color(
+                .sRGB,
+                red: themeStore.settings.tintRed,
+                green: themeStore.settings.tintGreen,
+                blue: themeStore.settings.tintBlue,
+                opacity: clamped(
+                    themeStore.settings.tintOpacity * themeStore.settings.blurMaterial.tintOpacityScale
+                )
+            )
+        }
+    }
+
+    private func clamped(_ value: Double) -> Double {
+        min(1, max(0, value))
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
@@ -544,9 +544,6 @@ private struct LaunchpadMediaTile: View {
 
 // MARK: - Shared tile chrome
 
-/// Scrim opacity layered over the blur, matching `LauncherView.tileBackground`
-/// so launchpad tiles read with the same depth as the rest of the floating UI.
-private let launchpadTileScrimOpacity = 0.30
 private let launchpadOnTintOpacity = 0.22
 /// Backs both the red confirm state and the amber muted-mic state, so the tile
 /// takes its hue from `tint` rather than baking one in here.
@@ -560,19 +557,13 @@ private let launchpadStateBorderWidth: CGFloat = 1
 private let launchpadOnBorderOpacity = 0.35
 private let launchpadAlertBorderOpacity = 0.3
 
-/// The frosted surface every launchpad tile sits on: the same
-/// blur + dark-scrim + control-fill stack the app uses for its floating tiles
-/// (`LauncherView.tileBackground(floats:)`), so opacity and material stay
-/// unified. An optional tint (accent for on-state toggles, caution for a
-/// confirming/muted action) layers on top.
+/// The frosted surface every launchpad tile sits on: the same backdrop +
+/// control-fill stack as `LauncherView.tileBackground(floats:)`. An optional tint
+/// (accent for on-state toggles, caution for a confirming/muted action) layers on top.
 func frostedTile(themeStore: ThemeStore, tint: Color? = nil, tintOpacity: Double = 0) -> some View {
     let radius = AppConstants.Launcher.Launchpad.cornerRadius
     return ZStack {
-        VisualEffectBlur(
-            material: themeStore.settings.blurMaterial.material,
-            appearance: themeStore.themeAppearance()
-        )
-        themeStore.scrimColor(opacity: launchpadTileScrimOpacity)
+        ThemedBackdrop(themeStore: themeStore)
         themeStore.controlFillColor()
         if let tint {
             tint.opacity(tintOpacity)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Background.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Background.swift
@@ -30,34 +30,9 @@ extension LauncherView {
                     .opacity(themeStore.settings.backgroundImageOpacity)
             }
 
-            VisualEffectBlur(
-                material: themeStore.settings.blurMaterial.material,
-                appearance: themeStore.themeAppearance()
-            )
-                .opacity(
-                    min(
-                        1,
-                        max(
-                            0,
-                            themeStore.settings.blurOpacity
-                                * themeStore.settings.blurMaterial.blurOpacityScale
-                                * (appUIState.showsThemeSettings ? appUIState.settingsBlurMultiplier : 1.0)
-                        )
-                    )
-                )
-
-            Color(
-                .sRGB,
-                red: themeStore.settings.tintRed,
-                green: themeStore.settings.tintGreen,
-                blue: themeStore.settings.tintBlue,
-                opacity: min(
-                    1,
-                    max(
-                        0,
-                        themeStore.settings.tintOpacity * themeStore.settings.blurMaterial.tintOpacityScale
-                    )
-                )
+            ThemedBackdrop(
+                themeStore: themeStore,
+                blurOpacityMultiplier: appUIState.showsThemeSettings ? appUIState.settingsBlurMultiplier : 1.0
             )
         }
     }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -1338,21 +1338,20 @@ struct LauncherView: View {
     /// The frosted surface shared by every floating tile (top bar + columns). When
     /// a background image is set, each tile shows its own aligned slice of that
     /// image (cropped to the tile's window position) instead of a blurred desktop,
-    /// so the tiles read as separate windows onto one image. A dark scrim + tint
-    /// on top keeps the tile content legible.
+    /// so the tiles read as separate windows onto one image. Otherwise it takes the
+    /// themed backdrop, at the same blur and tint opacities as the window.
     @ViewBuilder
     private func tileBackground(cornerRadius: CGFloat, floats: Bool) -> some View {
         if floats {
             ZStack {
                 if let image = themeStore.backgroundImage {
                     croppedBackgroundImage(image)
+                    // Only the opaque image needs a scrim; the blur path is
+                    // covered by the tint.
+                    themeStore.scrimColor(opacity: Self.floatingTileScrimOpacity)
                 } else {
-                    VisualEffectBlur(
-                        material: themeStore.settings.blurMaterial.material,
-                        appearance: themeStore.themeAppearance()
-                    )
+                    ThemedBackdrop(themeStore: themeStore)
                 }
-                themeStore.scrimColor(opacity: Self.floatingTileScrimOpacity)
                 themeStore.controlFillColor()
             }
             .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved launcher background and tile appearance with consistent theme-aware blur and tint effects.
  * Applied configurable blur intensity and opacity settings across launcher surfaces.
  * Preserved custom background images while improving their overlay treatment.
  * Ensured visual effects remain within valid opacity limits for a more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Testing
  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

## Checklist

- [x] I have read and agree to the CLA (CLA.md)
- [ ] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


