### PR TITLE
macos: liquid glass

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Full reference: [docs/user-guide.md](docs/user-guide.md).
 
 ## Themes
 
-Built-in: Catppuccin, Tokyo Night, Rose Pine, Gruvbox, Dracula, Kanagawa, Kindle, plus Custom. Kindle is the one light preset - paper, ink, and a serif face. Switch in `Settings > Appearance`.
+Built-in: Catppuccin, Tokyo Night, Rose Pine, Gruvbox, Dracula, Kanagawa, Kindle, Liquid, plus Custom. Kindle is the one light preset - paper, ink, and a serif face. Liquid renders on macOS 26's Liquid Glass and is hidden on older releases. Switch in `Settings > Appearance`.
 
 <p align="center">
   <img src="assets/look-ui/1.png" width="45%" />

--- a/apps/macos/LauncherApp/look-app/Components/GlassEffectBackdrop.swift
+++ b/apps/macos/LauncherApp/look-app/Components/GlassEffectBackdrop.swift
@@ -3,19 +3,14 @@ import SwiftUI
 
 /// AppKit's Liquid Glass surface, wrapped the same way as `VisualEffectBlur`.
 ///
-/// SwiftUI's `glassEffect` refracts only what sits behind it *inside its own
-/// view tree*. Look's window is transparent (`WindowConfigurator` sets
-/// `isOpaque = false` with a clear background), so in the SwiftUI tree there is
-/// nothing behind the backdrop and the effect renders as very nearly nothing.
-/// `NSGlassEffectView` is the window-level primitive and composites the way the
-/// system's own glass surfaces do, which is what a launcher floating over the
-/// desktop needs.
+/// Not SwiftUI's `glassEffect`: that refracts only what sits behind it inside
+/// its own view tree, and Look's window is transparent, so it renders as nearly
+/// nothing. `NSGlassEffectView` composites at the window level.
 @available(macOS 26.0, *)
 struct GlassEffectBackdrop: NSViewRepresentable {
     var cornerRadius: CGFloat
-    /// The theme tint, handed to the glass rather than layered over it. A flat
-    /// colour wash on top at any usable opacity cancels the refraction and the
-    /// surface collapses back to looking like a plain blur.
+    /// Handed to the glass rather than layered over it: a colour wash on top at
+    /// any usable opacity cancels the refraction.
     var tint: NSColor?
 
     func makeNSView(context: Context) -> NSGlassEffectView {
@@ -23,16 +18,13 @@ struct GlassEffectBackdrop: NSViewRepresentable {
         view.style = .regular
         view.cornerRadius = cornerRadius
         view.tintColor = tint
-        // The view exists to embed a content view in glass, and draws nothing
-        // when it has none. Look wants the material on its own as a backdrop
-        // layer, so it gets an empty transparent view to wrap.
+        // Draws nothing without a content view to embed.
         view.contentView = NSView()
         return view
     }
 
     func updateNSView(_ nsView: NSGlassEffectView, context: Context) {
-        // Reassigning an unchanged value makes the glass recompute and flash,
-        // the same reason `VisualEffectBlur` guards its material.
+        // Reassigning an unchanged value makes the glass recompute and flash.
         if nsView.cornerRadius != cornerRadius {
             nsView.cornerRadius = cornerRadius
         }

--- a/apps/macos/LauncherApp/look-app/Components/GlassEffectBackdrop.swift
+++ b/apps/macos/LauncherApp/look-app/Components/GlassEffectBackdrop.swift
@@ -1,0 +1,43 @@
+import AppKit
+import SwiftUI
+
+/// AppKit's Liquid Glass surface, wrapped the same way as `VisualEffectBlur`.
+///
+/// SwiftUI's `glassEffect` refracts only what sits behind it *inside its own
+/// view tree*. Look's window is transparent (`WindowConfigurator` sets
+/// `isOpaque = false` with a clear background), so in the SwiftUI tree there is
+/// nothing behind the backdrop and the effect renders as very nearly nothing.
+/// `NSGlassEffectView` is the window-level primitive and composites the way the
+/// system's own glass surfaces do, which is what a launcher floating over the
+/// desktop needs.
+@available(macOS 26.0, *)
+struct GlassEffectBackdrop: NSViewRepresentable {
+    var cornerRadius: CGFloat
+    /// The theme tint, handed to the glass rather than layered over it. A flat
+    /// colour wash on top at any usable opacity cancels the refraction and the
+    /// surface collapses back to looking like a plain blur.
+    var tint: NSColor?
+
+    func makeNSView(context: Context) -> NSGlassEffectView {
+        let view = NSGlassEffectView()
+        view.style = .regular
+        view.cornerRadius = cornerRadius
+        view.tintColor = tint
+        // The view exists to embed a content view in glass, and draws nothing
+        // when it has none. Look wants the material on its own as a backdrop
+        // layer, so it gets an empty transparent view to wrap.
+        view.contentView = NSView()
+        return view
+    }
+
+    func updateNSView(_ nsView: NSGlassEffectView, context: Context) {
+        // Reassigning an unchanged value makes the glass recompute and flash,
+        // the same reason `VisualEffectBlur` guards its material.
+        if nsView.cornerRadius != cornerRadius {
+            nsView.cornerRadius = cornerRadius
+        }
+        if nsView.tintColor != tint {
+            nsView.tintColor = tint
+        }
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Components/ThemedBackdrop.swift
+++ b/apps/macos/LauncherApp/look-app/Components/ThemedBackdrop.swift
@@ -4,16 +4,15 @@ import SwiftUI
 /// Blur plus tint at the opacities set in Settings. Shared by the window backdrop
 /// and every floating tile so both sliders reach all of them.
 ///
-/// Liquid Glass takes a different route through this view: the glass carries the
-/// tint itself and no wash is drawn over it, because a flat colour layer at any
-/// usable opacity cancels the refraction. See `GlassEffectBackdrop`.
+/// On Liquid Glass the glass carries the tint itself and no wash is drawn over
+/// it. See `GlassEffectBackdrop`.
 struct ThemedBackdrop: View {
     @ObservedObject var themeStore: ThemeStore
     /// Thins the blur only, for the settings overlay.
     var blurOpacityMultiplier: Double = 1
-    /// Corner the Liquid Glass surface is cut to. Callers already clip this view,
-    /// but glass draws its own specular edge and needs the corner up front or
-    /// that edge lands outside the clip and is lost. Ignored by the blur path.
+    /// Corner the glass is cut to. Callers clip this view, but glass draws its
+    /// own specular edge and needs the corner up front or it lands outside the
+    /// clip. Ignored by the blur path.
     var cornerRadius: CGFloat = 0
 
     private var tintOpacity: Double {
@@ -22,11 +21,9 @@ struct ThemedBackdrop: View {
 
     var body: some View {
         backdrop
-            // The backdrop never animates. It is nested inside the panel, so it
-            // inherits any ambient transaction: arrow-key nav wraps its selection
-            // assignment in a global `withAnimation` (LauncherView+Selection), and
-            // re-compositing an NSVisualEffectView or NSGlassEffectView inside that
-            // transaction flickers the entire window on every keypress.
+            // Never animates: nav wraps its selection assignment in a global
+            // `withAnimation`, and re-compositing the effect view inside that
+            // transaction flickers the whole window on every keypress.
             .transaction { $0.animation = nil }
     }
 
@@ -34,10 +31,7 @@ struct ThemedBackdrop: View {
     private var backdrop: some View {
         ZStack {
             if themeStore.settings.blurMaterial == .liquidGlass, #available(macOS 26.0, *) {
-                // Glass on its own, no blur substrate. A blur underneath was
-                // tried and read as *less* liquid: the opaque frost plus a tint
-                // wash sits in front of the refraction and flattens it. The
-                // glass carries the tint itself instead.
+                // No blur substrate: frost in front of the refraction flattens it.
                 GlassEffectBackdrop(cornerRadius: cornerRadius, tint: tintColor)
                     .opacity(clamped(blurOpacityMultiplier))
             } else {
@@ -64,8 +58,8 @@ struct ThemedBackdrop: View {
         }
     }
 
-    /// The theme tint as an `NSColor` for the glass to absorb. nil at zero
-    /// opacity so the glass stays untinted rather than multiplying by clear.
+    /// nil at zero opacity, so the glass stays untinted rather than
+    /// multiplying by clear.
     private var tintColor: NSColor? {
         guard tintOpacity > 0 else { return nil }
         return NSColor(

--- a/apps/macos/LauncherApp/look-app/Components/ThemedBackdrop.swift
+++ b/apps/macos/LauncherApp/look-app/Components/ThemedBackdrop.swift
@@ -21,10 +21,23 @@ struct ThemedBackdrop: View {
     }
 
     var body: some View {
+        backdrop
+            // The backdrop never animates. It is nested inside the panel, so it
+            // inherits any ambient transaction: arrow-key nav wraps its selection
+            // assignment in a global `withAnimation` (LauncherView+Selection), and
+            // re-compositing an NSVisualEffectView or NSGlassEffectView inside that
+            // transaction flickers the entire window on every keypress.
+            .transaction { $0.animation = nil }
+    }
+
+    @ViewBuilder
+    private var backdrop: some View {
         ZStack {
             if themeStore.settings.blurMaterial == .liquidGlass, #available(macOS 26.0, *) {
-                // No blur-opacity term: dimming glass makes it ghostly rather
-                // than lighter. Only the settings-overlay multiplier applies.
+                // Glass on its own, no blur substrate. A blur underneath was
+                // tried and read as *less* liquid: the opaque frost plus a tint
+                // wash sits in front of the refraction and flattens it. The
+                // glass carries the tint itself instead.
                 GlassEffectBackdrop(cornerRadius: cornerRadius, tint: tintColor)
                     .opacity(clamped(blurOpacityMultiplier))
             } else {

--- a/apps/macos/LauncherApp/look-app/Components/ThemedBackdrop.swift
+++ b/apps/macos/LauncherApp/look-app/Components/ThemedBackdrop.swift
@@ -1,36 +1,66 @@
+import AppKit
 import SwiftUI
 
 /// Blur plus tint at the opacities set in Settings. Shared by the window backdrop
 /// and every floating tile so both sliders reach all of them.
+///
+/// Liquid Glass takes a different route through this view: the glass carries the
+/// tint itself and no wash is drawn over it, because a flat colour layer at any
+/// usable opacity cancels the refraction. See `GlassEffectBackdrop`.
 struct ThemedBackdrop: View {
     @ObservedObject var themeStore: ThemeStore
     /// Thins the blur only, for the settings overlay.
     var blurOpacityMultiplier: Double = 1
+    /// Corner the Liquid Glass surface is cut to. Callers already clip this view,
+    /// but glass draws its own specular edge and needs the corner up front or
+    /// that edge lands outside the clip and is lost. Ignored by the blur path.
+    var cornerRadius: CGFloat = 0
+
+    private var tintOpacity: Double {
+        clamped(themeStore.settings.tintOpacity * themeStore.settings.blurMaterial.tintOpacityScale)
+    }
 
     var body: some View {
         ZStack {
-            VisualEffectBlur(
-                material: themeStore.settings.blurMaterial.material,
-                appearance: themeStore.themeAppearance()
-            )
-            .opacity(
-                clamped(
-                    themeStore.settings.blurOpacity
-                        * themeStore.settings.blurMaterial.blurOpacityScale
-                        * blurOpacityMultiplier
+            if themeStore.settings.blurMaterial == .liquidGlass, #available(macOS 26.0, *) {
+                // No blur-opacity term: dimming glass makes it ghostly rather
+                // than lighter. Only the settings-overlay multiplier applies.
+                GlassEffectBackdrop(cornerRadius: cornerRadius, tint: tintColor)
+                    .opacity(clamped(blurOpacityMultiplier))
+            } else {
+                VisualEffectBlur(
+                    material: themeStore.settings.blurMaterial.material,
+                    appearance: themeStore.themeAppearance()
                 )
-            )
+                .opacity(
+                    clamped(
+                        themeStore.settings.blurOpacity
+                            * themeStore.settings.blurMaterial.blurOpacityScale
+                            * blurOpacityMultiplier
+                    )
+                )
 
-            Color(
-                .sRGB,
-                red: themeStore.settings.tintRed,
-                green: themeStore.settings.tintGreen,
-                blue: themeStore.settings.tintBlue,
-                opacity: clamped(
-                    themeStore.settings.tintOpacity * themeStore.settings.blurMaterial.tintOpacityScale
+                Color(
+                    .sRGB,
+                    red: themeStore.settings.tintRed,
+                    green: themeStore.settings.tintGreen,
+                    blue: themeStore.settings.tintBlue,
+                    opacity: tintOpacity
                 )
-            )
+            }
         }
+    }
+
+    /// The theme tint as an `NSColor` for the glass to absorb. nil at zero
+    /// opacity so the glass stays untinted rather than multiplying by clear.
+    private var tintColor: NSColor? {
+        guard tintOpacity > 0 else { return nil }
+        return NSColor(
+            srgbRed: themeStore.settings.tintRed,
+            green: themeStore.settings.tintGreen,
+            blue: themeStore.settings.tintBlue,
+            alpha: tintOpacity
+        )
     }
 
     private func clamped(_ value: Double) -> Double {

--- a/apps/macos/LauncherApp/look-app/Models/ThemeSettings.swift
+++ b/apps/macos/LauncherApp/look-app/Models/ThemeSettings.swift
@@ -30,9 +30,8 @@ enum LauncherBlurMaterial: String, CaseIterable, Codable, Identifiable {
         }
     }
 
-    /// The `NSVisualEffectView` material this renders through. Liquid Glass does
-    /// not use one (see `ThemedBackdrop`); it names the material it degrades to
-    /// on macOS 15, where the glass effect does not exist.
+    /// Liquid Glass does not render through one; it names what it degrades to
+    /// on macOS 15. See `ThemedBackdrop`.
     var material: NSVisualEffectView.Material {
         switch self {
         case .hudWindow: return .hudWindow
@@ -53,9 +52,8 @@ enum LauncherBlurMaterial: String, CaseIterable, Codable, Identifiable {
         }
     }
 
-    /// Glass carries its own depth, so the theme tint sits lighter on it than on
-    /// a flat blur. Anything near the other materials' weight reads as muddy and
-    /// cancels the refraction.
+    /// Glass carries its own depth, so the tint sits lighter on it: anything
+    /// near the other materials' weight cancels the refraction.
     var tintOpacityScale: Double {
         switch self {
         case .hudWindow: return 1.16
@@ -66,8 +64,7 @@ enum LauncherBlurMaterial: String, CaseIterable, Codable, Identifiable {
         }
     }
 
-    /// False where the material needs an OS newer than the one running, so the
-    /// settings picker can omit it rather than offer a silent fallback.
+    /// False where the material needs an OS newer than the one running.
     var isSupported: Bool {
         switch self {
         case .liquidGlass:
@@ -80,8 +77,8 @@ enum LauncherBlurMaterial: String, CaseIterable, Codable, Identifiable {
         }
     }
 
-    /// Materials offered in Settings on this machine. A value persisted on a
-    /// newer machine still decodes and degrades at render time.
+    /// Offered in Settings on this machine. A value persisted on a newer one
+    /// still decodes and degrades at render time.
     static var selectable: [LauncherBlurMaterial] {
         allCases.filter(\.isSupported)
     }

--- a/apps/macos/LauncherApp/look-app/Models/ThemeSettings.swift
+++ b/apps/macos/LauncherApp/look-app/Models/ThemeSettings.swift
@@ -6,6 +6,7 @@ enum LauncherBlurMaterial: String, CaseIterable, Codable, Identifiable {
     case sidebar
     case menu
     case underWindowBackground
+    case liquidGlass
 
     var id: String { rawValue }
 
@@ -15,6 +16,7 @@ enum LauncherBlurMaterial: String, CaseIterable, Codable, Identifiable {
         case .sidebar: return "Soft"
         case .menu: return "Balanced"
         case .underWindowBackground: return "Subtle"
+        case .liquidGlass: return "Liquid Glass"
         }
     }
 
@@ -24,15 +26,20 @@ enum LauncherBlurMaterial: String, CaseIterable, Codable, Identifiable {
         case .sidebar: return "Light and gentle blur"
         case .menu: return "Neutral default look"
         case .underWindowBackground: return "Most transparent feel"
+        case .liquidGlass: return "Refracts the desktop behind the window"
         }
     }
 
+    /// The `NSVisualEffectView` material this renders through. Liquid Glass does
+    /// not use one (see `ThemedBackdrop`); it names the material it degrades to
+    /// on macOS 15, where the glass effect does not exist.
     var material: NSVisualEffectView.Material {
         switch self {
         case .hudWindow: return .hudWindow
         case .sidebar: return .sidebar
         case .menu: return .menu
         case .underWindowBackground: return .underWindowBackground
+        case .liquidGlass: return .hudWindow
         }
     }
 
@@ -42,16 +49,41 @@ enum LauncherBlurMaterial: String, CaseIterable, Codable, Identifiable {
         case .sidebar: return 0.86
         case .menu: return 1.0
         case .underWindowBackground: return 0.72
+        case .liquidGlass: return 1.0
         }
     }
 
+    /// Glass carries its own depth, so the theme tint sits lighter on it than on
+    /// a flat blur. Anything near the other materials' weight reads as muddy and
+    /// cancels the refraction.
     var tintOpacityScale: Double {
         switch self {
         case .hudWindow: return 1.16
         case .sidebar: return 0.84
         case .menu: return 1.0
         case .underWindowBackground: return 0.68
+        case .liquidGlass: return 0.55
         }
+    }
+
+    /// False where the material needs an OS newer than the one running, so the
+    /// settings picker can omit it rather than offer a silent fallback.
+    var isSupported: Bool {
+        switch self {
+        case .liquidGlass:
+            if #available(macOS 26.0, *) {
+                return true
+            }
+            return false
+        case .hudWindow, .sidebar, .menu, .underWindowBackground:
+            return true
+        }
+    }
+
+    /// Materials offered in Settings on this machine. A value persisted on a
+    /// newer machine still decodes and degrades at render time.
+    static var selectable: [LauncherBlurMaterial] {
+        allCases.filter(\.isSupported)
     }
 }
 

--- a/apps/macos/LauncherApp/look-app/Models/ThemeSettings.swift
+++ b/apps/macos/LauncherApp/look-app/Models/ThemeSettings.swift
@@ -62,7 +62,7 @@ enum LauncherBlurMaterial: String, CaseIterable, Codable, Identifiable {
         case .sidebar: return 0.84
         case .menu: return 1.0
         case .underWindowBackground: return 0.68
-        case .liquidGlass: return 0.55
+        case .liquidGlass: return 0.42
         }
     }
 

--- a/apps/macos/LauncherApp/look-app/Models/ThemeSettings.swift
+++ b/apps/macos/LauncherApp/look-app/Models/ThemeSettings.swift
@@ -77,10 +77,28 @@ enum LauncherBlurMaterial: String, CaseIterable, Codable, Identifiable {
         }
     }
 
-    /// Offered in Settings on this machine. A value persisted on a newer one
-    /// still decodes and degrades at render time.
-    static var selectable: [LauncherBlurMaterial] {
-        allCases.filter(\.isSupported)
+    /// True when this renders as glass, which has no blur to thin.
+    var rendersGlass: Bool {
+        self == .liquidGlass && isSupported
+    }
+
+    /// Title in Settings. An unsupported value can still be the current
+    /// selection, so it says why it is inert rather than looking broken.
+    var pickerTitle: String {
+        isSupported ? title : "\(title) \(AppConstants.ThemeUI.unsupportedSuffix)"
+    }
+
+    /// Offered in Settings on this machine, plus `current` when that is a value
+    /// this OS cannot render (a config written on a newer machine). Keeping it
+    /// in the list is deliberate: a `Picker` whose selection matches no tag
+    /// renders blank, and rewriting the value here would destroy the user's
+    /// setting the next time they open the same config on a newer machine.
+    static func options(including current: LauncherBlurMaterial) -> [LauncherBlurMaterial] {
+        var options = allCases.filter(\.isSupported)
+        if !options.contains(current) {
+            options.append(current)
+        }
+        return options
     }
 }
 

--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -502,6 +502,9 @@ enum AppConstants {
     enum ThemeUI {
         static let labelWidth: CGFloat = 150
         static let pickerWidth: CGFloat = 140
+        /// Dimming for a control the active theme has taken over, so the value
+        /// stays readable while reading as not-yours-to-set.
+        static let disabledControlOpacity: Double = 0.4
     }
 
     enum FileScan {

--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -505,6 +505,9 @@ enum AppConstants {
         /// Dimming for a control the active theme has taken over, so the value
         /// stays readable while reading as not-yours-to-set.
         static let disabledControlOpacity: Double = 0.4
+        /// Appended to a picker entry this OS cannot render, so a value carried
+        /// over from a newer machine reads as inert rather than broken.
+        static let unsupportedSuffix = "(needs macOS 26)"
     }
 
     enum FileScan {

--- a/apps/macos/LauncherApp/look-app/Support/RowIconCache.swift
+++ b/apps/macos/LauncherApp/look-app/Support/RowIconCache.swift
@@ -1,0 +1,41 @@
+import AppKit
+import Foundation
+
+/// Cache for result-row icons, keyed by the path they were resolved from.
+///
+/// `NSWorkspace.icon(forFile:)` returns a fresh `NSImage` on every call, and the
+/// row resolves its icon inside `body`. Without a cache, any redraw of the list
+/// (selecting a different row redraws all of them) hands SwiftUI a new image
+/// instance per visible row, which it treats as a changed image and redraws:
+/// every icon in the list visibly flickers on each keypress. Returning the same
+/// instance for the same path keeps them still.
+nonisolated enum RowIconCache {
+    // NSCache is documented thread-safe; mark nonisolated(unsafe) to satisfy
+    // Swift 6 strict-concurrency without an actor wrapper, matching
+    // `HighlightedTextCache`.
+    nonisolated(unsafe) private static let cache: NSCache<NSString, NSImage> = {
+        let c = NSCache<NSString, NSImage>()
+        // Comfortably more than a screenful of rows, so scrolling a long result
+        // list does not evict icons that are about to come back into view.
+        c.countLimit = 256
+        return c
+    }()
+
+    /// The icon for `path`, resolving and caching it on first use.
+    static func icon(forFile path: String) -> NSImage {
+        image(key: path) {
+            NSWorkspace.shared.icon(forFile: path)
+        }
+    }
+
+    /// The icon for a row that has no path of its own (synthetic rows, system
+    /// symbols), cached under a caller-supplied key.
+    static func image(key: String, resolve: () -> NSImage) -> NSImage {
+        if let cached = cache.object(forKey: key as NSString) {
+            return cached
+        }
+        let resolved = resolve()
+        cache.setObject(resolved, forKey: key as NSString)
+        return resolved
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/RowIconCache.swift
+++ b/apps/macos/LauncherApp/look-app/Support/RowIconCache.swift
@@ -3,33 +3,27 @@ import Foundation
 
 /// Cache for result-row icons, keyed by the path they were resolved from.
 ///
-/// `NSWorkspace.icon(forFile:)` returns a fresh `NSImage` on every call, and the
-/// row resolves its icon inside `body`. Without a cache, any redraw of the list
-/// (selecting a different row redraws all of them) hands SwiftUI a new image
-/// instance per visible row, which it treats as a changed image and redraws:
-/// every icon in the list visibly flickers on each keypress. Returning the same
-/// instance for the same path keeps them still.
+/// `NSWorkspace.icon(forFile:)` returns a fresh `NSImage` every call, and rows
+/// resolve their icon inside `body`. Uncached, any list redraw hands SwiftUI a
+/// new instance per visible row, which it redraws: every icon flickers on each
+/// keypress.
 nonisolated enum RowIconCache {
-    // NSCache is documented thread-safe; mark nonisolated(unsafe) to satisfy
-    // Swift 6 strict-concurrency without an actor wrapper, matching
-    // `HighlightedTextCache`.
+    // NSCache is documented thread-safe; nonisolated(unsafe) satisfies Swift 6
+    // strict-concurrency without an actor wrapper, as in `HighlightedTextCache`.
     nonisolated(unsafe) private static let cache: NSCache<NSString, NSImage> = {
         let c = NSCache<NSString, NSImage>()
-        // Comfortably more than a screenful of rows, so scrolling a long result
-        // list does not evict icons that are about to come back into view.
+        // Several screenfuls, so scrolling does not evict icons about to return.
         c.countLimit = 256
         return c
     }()
 
-    /// The icon for `path`, resolving and caching it on first use.
     static func icon(forFile path: String) -> NSImage {
         image(key: path) {
             NSWorkspace.shared.icon(forFile: path)
         }
     }
 
-    /// The icon for a row that has no path of its own (synthetic rows, system
-    /// symbols), cached under a caller-supplied key.
+    /// For rows with no path of their own (synthetic rows, system symbols).
     static func image(key: String, resolve: () -> NSImage) -> NSImage {
         if let cached = cache.object(forKey: key as NSString) {
             return cached

--- a/apps/macos/LauncherApp/look-app/Support/ThemeStore+Appearance.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ThemeStore+Appearance.swift
@@ -177,17 +177,11 @@ extension ThemeStore {
 
     /// The active rendering surface.
     ///
-    /// Keyed off the blur material first, not the preset alone. `savedThemeName`
-    /// stops recording `ui_theme` the moment any value diverges from the preset,
-    /// because the load path applies the theme *over* the individual keys and a
-    /// stale name would throw the user's tweaks away. `ui_blur_material` has no
-    /// such problem: it persists on its own. Reading it here means a customised
-    /// Liquid theme keeps its glass instead of silently reverting to the classic
-    /// geometry after a relaunch.
+    /// Keyed off the blur material first, not the preset alone: `savedThemeName`
+    /// drops `ui_theme` as soon as any value diverges from the preset, while
+    /// `ui_blur_material` persists on its own. So a customised Liquid theme
+    /// keeps its glass across a relaunch instead of reverting to classic.
     func themeSurface() -> ThemeSurface {
-        // Without the glass effect there is no liquid surface to have. A config
-        // carrying `ui_theme=liquid` from a newer machine renders fully classic
-        // rather than as classic blur wearing liquid geometry.
         guard LauncherBlurMaterial.liquidGlass.isSupported else {
             return .classic
         }

--- a/apps/macos/LauncherApp/look-app/Support/ThemeStore+Appearance.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ThemeStore+Appearance.swift
@@ -175,6 +175,33 @@ extension ThemeStore {
         activeAppearanceStyle()?.appearance ?? .dark
     }
 
+    /// The active rendering surface.
+    ///
+    /// Keyed off the blur material first, not the preset alone. `savedThemeName`
+    /// stops recording `ui_theme` the moment any value diverges from the preset,
+    /// because the load path applies the theme *over* the individual keys and a
+    /// stale name would throw the user's tweaks away. `ui_blur_material` has no
+    /// such problem: it persists on its own. Reading it here means a customised
+    /// Liquid theme keeps its glass instead of silently reverting to the classic
+    /// geometry after a relaunch.
+    func themeSurface() -> ThemeSurface {
+        // Without the glass effect there is no liquid surface to have. A config
+        // carrying `ui_theme=liquid` from a newer machine renders fully classic
+        // rather than as classic blur wearing liquid geometry.
+        guard LauncherBlurMaterial.liquidGlass.isSupported else {
+            return .classic
+        }
+        if settings.blurMaterial == .liquidGlass {
+            return .liquid
+        }
+        return activeAppearanceStyle()?.surface ?? .classic
+    }
+
+    /// Scales a surface's resting corner radius for the active theme.
+    func surfaceCornerRadius(_ base: CGFloat) -> CGFloat {
+        base * themeSurface().cornerRadiusScale
+    }
+
     func borderColor() -> Color {
         Color(
             red: settings.borderRed,

--- a/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
@@ -825,7 +825,8 @@ launch_at_login=true
 skip_dir_names=node_modules,target,build,dist,library,applications,old firefox data,deriveddata,pods,vendor,out,coverage,tmp,cache,venv
 
 # UI theme
-# Preset: catppuccin, tokyoNight, rosePine, gruvbox, dracula, kanagawa, kindle.
+# Preset: catppuccin, tokyoNight, rosePine, gruvbox, dracula, kanagawa, kindle,
+# liquid (liquid needs macOS 26; it falls back to the classic surface below that).
 # A preset overrides every ui_* value below. Leave it empty to use them as written.
 ui_theme=
 ui_tint_red=0.08

--- a/apps/macos/LauncherApp/look-app/Support/UI/Motion.swift
+++ b/apps/macos/LauncherApp/look-app/Support/UI/Motion.swift
@@ -89,20 +89,25 @@ enum Motion {
         }
     }
 
-    /// `symbolEffect(.bounce)` as a plain scale pop, for bitmap icons that are
-    /// `NSImage` rather than SF Symbols.
-    enum Pop {
-        static let peakScale: CGFloat = 1.16
-        static let riseSeconds: Double = 0.13
-        static let settleResponse: Double = 0.34
-        static let settleDamping: Double = 0.55
+    /// Horizontal slide-ins on open: the search placeholder from the right, the
+    /// running-apps strip from the left.
+    enum Slide {
+        static let placeholderOffsetX: CGFloat = 20
+        static let stripOffsetX: CGFloat = -18
+        static let startScale: CGFloat = 0.92
+        /// The spring's period: the main dial for how fast these read.
+        static let response: Double = 0.8
+        /// Loose enough to carry a little past 1 and settle back.
+        static let dampingFraction: Double = 0.76
+        /// Lands just behind the bar these sit in.
+        static let delaySeconds: Double = 0.09
+        static let staggerSeconds: Double = 0.04
+        static let maxStaggerSeconds: Double = 0.28
 
-        static var rise: Animation {
-            .easeOut(duration: riseSeconds)
-        }
-
-        static var settle: Animation {
-            .spring(response: settleResponse, dampingFraction: settleDamping)
+        static func arrive(index: Int) -> Animation {
+            let stagger = min(Double(max(0, index)) * staggerSeconds, maxStaggerSeconds)
+            return .spring(response: response, dampingFraction: dampingFraction)
+                .delay(delaySeconds + stagger)
         }
     }
 
@@ -129,13 +134,16 @@ enum Motion {
 private struct SpawnReveal: ViewModifier {
     let index: Int
     let token: UInt64
+    /// Off for surfaces holding an `NSViewRepresentable`: scaling the search
+    /// field softens its text for the length of the animation.
+    var scales: Bool = true
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var shown = false
 
     func body(content: Content) -> some View {
         content
             .opacity(shown ? 1 : 0)
-            .scaleEffect(shown ? 1 : Motion.Spawn.startScale)
+            .scaleEffect(shown || !scales ? 1 : Motion.Spawn.startScale)
             .offset(y: shown ? 0 : Motion.Spawn.startOffsetY)
             .onAppear { rearm() }
             .onChange(of: token) { _, _ in rearm() }
@@ -188,31 +196,39 @@ private struct RootReveal: ViewModifier {
     }
 }
 
-/// Pops a bitmap icon when `token` changes.
-private struct IconPop: ViewModifier {
+/// Slides a view in horizontally and settles it, on every launcher open.
+/// `index` places it in the stagger; a negative `startOffsetX` comes from the
+/// left, a positive one from the right.
+private struct SlideReveal: ViewModifier {
+    let index: Int
     let token: UInt64
+    let startOffsetX: CGFloat
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var popped = false
+    @State private var shown = false
 
     func body(content: Content) -> some View {
         content
-            .scaleEffect(popped ? Motion.Pop.peakScale : 1)
-            .onChange(of: token) { _, _ in fire() }
+            .opacity(shown ? 1 : 0)
+            .scaleEffect(shown ? 1 : Motion.Slide.startScale)
+            .offset(x: shown ? 0 : startOffsetX)
+            .onAppear { rearm() }
+            .onChange(of: token) { _, _ in rearm() }
     }
 
-    private func fire() {
-        guard !reduceMotion else { return }
-        withAnimation(Motion.Pop.rise) {
-            popped = true
+    private func rearm() {
+        if reduceMotion {
+            shown = true
+            return
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + Motion.Pop.riseSeconds) {
-            withAnimation(Motion.Pop.settle) {
-                popped = false
+        // Two transactions, same reason as `SpawnReveal`.
+        shown = false
+        DispatchQueue.main.async {
+            withAnimation(Motion.Slide.arrive(index: index)) {
+                shown = true
             }
         }
     }
 }
-
 /// Scales a surface down while it is held, so clicks read as physical.
 struct PressableSurfaceStyle: ButtonStyle {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -227,17 +243,21 @@ struct PressableSurfaceStyle: ButtonStyle {
 extension View {
     /// Reveals the view with the shared spawn cascade. `index` sets its place in the
     /// stagger; changing `token` replays the reveal (the launcher bumps it on show).
-    func spawnReveal(index: Int, token: UInt64) -> some View {
-        modifier(SpawnReveal(index: index, token: token))
+    func spawnReveal(index: Int, token: UInt64, scales: Bool = true) -> some View {
+        modifier(SpawnReveal(index: index, token: token, scales: scales))
     }
 
     /// Fades and scales the panel in on every launcher open.
     func rootReveal(token: UInt64) -> some View {
         modifier(RootReveal(token: token))
     }
+    /// Slides the search placeholder in from the right on every launcher open.
+    func placeholderReveal(token: UInt64) -> some View {
+        modifier(SlideReveal(index: 0, token: token, startOffsetX: Motion.Slide.placeholderOffsetX))
+    }
 
-    /// Bounces a bitmap icon when `token` changes.
-    func iconPop(token: UInt64) -> some View {
-        modifier(IconPop(token: token))
+    /// Slides a running-apps icon in from the left, staggered by `index`.
+    func stripReveal(index: Int, token: UInt64) -> some View {
+        modifier(SlideReveal(index: index, token: token, startOffsetX: Motion.Slide.stripOffsetX))
     }
 }

--- a/apps/macos/LauncherApp/look-app/Support/UI/Motion.swift
+++ b/apps/macos/LauncherApp/look-app/Support/UI/Motion.swift
@@ -6,12 +6,19 @@ enum Motion {
     /// The "materialize on open" reveal: tiles start slightly enlarged and
     /// transparent, then spring to rest, staggered so the grid settles in.
     enum Spawn {
-        static let startScale: CGFloat = 1.05
-        static let staggerSeconds: Double = 0.02
+        /// Tiles grow into place rather than shrinking into it: arriving reads as
+        /// coming toward the viewer, and the old 1.05 start was too near 1 to see.
+        static let startScale: CGFloat = 0.88
+        /// Each tile also rises the last few points into its slot, which is what
+        /// makes the grid look like it assembles rather than simply appearing.
+        static let startOffsetY: CGFloat = 14
+        static let staggerSeconds: Double = 0.035
         /// Ceiling on the cascade so a large grid never trails on too long.
-        static let maxStaggerSeconds: Double = 0.22
-        static let response: Double = 0.42
-        static let dampingFraction: Double = 0.82
+        static let maxStaggerSeconds: Double = 0.34
+        static let response: Double = 0.46
+        /// Under 1 by enough to overshoot slightly and settle back. That small
+        /// bounce is most of what reads as "alive" rather than "faded in".
+        static let dampingFraction: Double = 0.68
 
         static func animation(index: Int) -> Animation {
             let delay = min(Double(max(0, index)) * staggerSeconds, maxStaggerSeconds)
@@ -25,8 +32,36 @@ enum Motion {
         static let response: Double = 0.3
         static let dampingFraction: Double = 0.85
 
+        /// After the pill glides into place it zooms once and settles. The glide
+        /// alone is hard to follow when the travel is a single row, and this is
+        /// the only thing on screen that should move during keyboard nav.
+        ///
+        /// The icon and the pill need very different numbers: the icon is 22pt,
+        /// so a few percent is a change of one point and reads as nothing, while
+        /// the pill spans the whole row and the same percentage would look like
+        /// the layout breathing.
+        static let iconZoomScale: CGFloat = 1.24
+        static let pillZoomScale: CGFloat = 1.02
+        static let zoomInSeconds: Double = 0.11
+        static let zoomOutResponse: Double = 0.3
+        /// Loose enough to overshoot slightly coming back to rest.
+        static let zoomOutDamping: Double = 0.6
+
+        /// How far the selected row's text slides in from. Held while the row is
+        /// selected rather than sprung back, so the offset also reads as part of
+        /// the selection rather than only as a twitch on arrival.
+        static let titleShift: CGFloat = 4
+
         static var glide: Animation {
             .spring(response: response, dampingFraction: dampingFraction)
+        }
+
+        static var zoomIn: Animation {
+            .easeOut(duration: zoomInSeconds)
+        }
+
+        static var zoomOut: Animation {
+            .spring(response: zoomOutResponse, dampingFraction: zoomOutDamping)
         }
     }
 
@@ -44,16 +79,10 @@ enum Motion {
 
     /// Icon and value changes: a toggle flipping, a counter ticking.
     enum Value {
-        /// Fade applied to a divider that yields to the selection pill.
-        static let dividerFadeSeconds: Double = 0.18
         /// Digit roll for a readout that ticks (battery, temperature, timers).
         /// Kept under the one-second tick of the fastest caller (the pomo
         /// countdown) so a roll always settles before the next value lands.
         static let rollSeconds: Double = 0.28
-
-        static var dividerFade: Animation {
-            .easeOut(duration: dividerFadeSeconds)
-        }
 
         static var rollDigits: Animation {
             .easeInOut(duration: rollSeconds)
@@ -70,21 +99,28 @@ enum Motion {
         static let arriveScale: CGFloat = 0.965
         static let arriveResponse: Double = 0.34
         static let arriveDamping: Double = 0.86
-        /// Launchpad to results and back. Faster than the arrival, since it fires
-        /// on the first keystroke and must not feel like lag.
-        static let swapSeconds: Double = 0.2
 
         static var arrive: Animation {
             .spring(response: arriveResponse, dampingFraction: arriveDamping)
         }
+    }
 
-        static var swap: Animation {
-            .easeOut(duration: swapSeconds)
+    /// The bounce `symbolEffect(.bounce)` gives an SF Symbol, rebuilt as a plain
+    /// scale pop so bitmap icons (app icons are `NSImage`, not symbols) can join
+    /// the same moment.
+    enum Pop {
+        static let peakScale: CGFloat = 1.16
+        static let riseSeconds: Double = 0.13
+        static let settleResponse: Double = 0.34
+        /// Loose enough to overshoot on the way back, matching the symbol bounce.
+        static let settleDamping: Double = 0.55
+
+        static var rise: Animation {
+            .easeOut(duration: riseSeconds)
         }
 
-        /// Surfaces cross-dissolve with a touch of scale rather than cutting.
-        static var swapTransition: AnyTransition {
-            .opacity.combined(with: .scale(scale: 0.99))
+        static var settle: Animation {
+            .spring(response: settleResponse, dampingFraction: settleDamping)
         }
     }
 
@@ -118,6 +154,7 @@ private struct SpawnReveal: ViewModifier {
         content
             .opacity(shown ? 1 : 0)
             .scaleEffect(shown ? 1 : Motion.Spawn.startScale)
+            .offset(y: shown ? 0 : Motion.Spawn.startOffsetY)
             .onAppear { rearm() }
             .onChange(of: token) { _, _ in rearm() }
     }
@@ -172,6 +209,32 @@ private struct RootReveal: ViewModifier {
     }
 }
 
+/// Pops a non-symbol icon on every launcher open, so bitmap icons bounce
+/// alongside the SF Symbols that `symbolEffect(.bounce)` handles.
+private struct IconPop: ViewModifier {
+    let token: UInt64
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var popped = false
+
+    func body(content: Content) -> some View {
+        content
+            .scaleEffect(popped ? Motion.Pop.peakScale : 1)
+            .onChange(of: token) { _, _ in fire() }
+    }
+
+    private func fire() {
+        guard !reduceMotion else { return }
+        withAnimation(Motion.Pop.rise) {
+            popped = true
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + Motion.Pop.riseSeconds) {
+            withAnimation(Motion.Pop.settle) {
+                popped = false
+            }
+        }
+    }
+}
+
 /// Scales a surface down while it is held, so clicks read as physical. Under
 /// Reduce Motion the surface holds its resting size and only the hit behaviour
 /// remains.
@@ -196,5 +259,11 @@ extension View {
     /// counter that replays the tile cascade.
     func rootReveal(token: UInt64) -> some View {
         modifier(RootReveal(token: token))
+    }
+
+    /// Bounces a bitmap icon when `token` changes, matching what
+    /// `symbolEffect(.bounce)` does for SF Symbols.
+    func iconPop(token: UInt64) -> some View {
+        modifier(IconPop(token: token))
     }
 }

--- a/apps/macos/LauncherApp/look-app/Support/UI/Motion.swift
+++ b/apps/macos/LauncherApp/look-app/Support/UI/Motion.swift
@@ -30,6 +30,64 @@ enum Motion {
         }
     }
 
+    /// The press-down on an interactive surface (result rows, tiles), so a
+    /// click reads as physical rather than instant.
+    enum Press {
+        static let scale: CGFloat = 0.975
+        static let response: Double = 0.24
+        static let dampingFraction: Double = 0.9
+
+        static var animation: Animation {
+            .spring(response: response, dampingFraction: dampingFraction)
+        }
+    }
+
+    /// Icon and value changes: a toggle flipping, a counter ticking.
+    enum Value {
+        /// Fade applied to a divider that yields to the selection pill.
+        static let dividerFadeSeconds: Double = 0.18
+        /// Digit roll for a readout that ticks (battery, temperature, timers).
+        /// Kept under the one-second tick of the fastest caller (the pomo
+        /// countdown) so a roll always settles before the next value lands.
+        static let rollSeconds: Double = 0.28
+
+        static var dividerFade: Animation {
+            .easeOut(duration: dividerFadeSeconds)
+        }
+
+        static var rollDigits: Animation {
+            .easeInOut(duration: rollSeconds)
+        }
+    }
+
+    /// The whole panel arriving when the launcher opens, and the surfaces inside
+    /// it swapping as the query changes.
+    enum Surface {
+        /// The panel lands from slightly small and transparent. Deliberately a
+        /// content-layer effect: animating the window itself would mean touching
+        /// the `makeKeyAndOrderFront` path that the Cmd+Space cold-login bug
+        /// lives in, and this reads the same from the outside.
+        static let arriveScale: CGFloat = 0.965
+        static let arriveResponse: Double = 0.34
+        static let arriveDamping: Double = 0.86
+        /// Launchpad to results and back. Faster than the arrival, since it fires
+        /// on the first keystroke and must not feel like lag.
+        static let swapSeconds: Double = 0.2
+
+        static var arrive: Animation {
+            .spring(response: arriveResponse, dampingFraction: arriveDamping)
+        }
+
+        static var swap: Animation {
+            .easeOut(duration: swapSeconds)
+        }
+
+        /// Surfaces cross-dissolve with a touch of scale rather than cutting.
+        static var swapTransition: AnyTransition {
+            .opacity.combined(with: .scale(scale: 0.99))
+        }
+    }
+
     /// The gliding search-field caret (see `SmoothCaretTextField`).
     enum Caret {
         static let width: CGFloat = 2
@@ -81,10 +139,62 @@ private struct SpawnReveal: ViewModifier {
     }
 }
 
+/// Fades and scales the whole panel in each time the launcher is shown. The
+/// window is only ordered out and back in, so this keys off the same token the
+/// tile cascade uses rather than `onAppear`, and the panel arrives just ahead of
+/// the tiles settling into it.
+private struct RootReveal: ViewModifier {
+    let token: UInt64
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var shown = false
+
+    func body(content: Content) -> some View {
+        content
+            .opacity(shown ? 1 : 0)
+            .scaleEffect(shown ? 1 : Motion.Surface.arriveScale)
+            .onAppear { rearm() }
+            .onChange(of: token) { _, _ in rearm() }
+    }
+
+    private func rearm() {
+        if reduceMotion {
+            shown = true
+            return
+        }
+        // Two transactions, same reason as `SpawnReveal`: the hidden state has to
+        // land before the animated one or there is no "from" value to move off.
+        shown = false
+        DispatchQueue.main.async {
+            withAnimation(Motion.Surface.arrive) {
+                shown = true
+            }
+        }
+    }
+}
+
+/// Scales a surface down while it is held, so clicks read as physical. Under
+/// Reduce Motion the surface holds its resting size and only the hit behaviour
+/// remains.
+struct PressableSurfaceStyle: ButtonStyle {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed && !reduceMotion ? Motion.Press.scale : 1)
+            .animation(Motion.Press.animation, value: configuration.isPressed)
+    }
+}
+
 extension View {
     /// Reveals the view with the shared spawn cascade. `index` sets its place in the
     /// stagger; changing `token` replays the reveal (the launcher bumps it on show).
     func spawnReveal(index: Int, token: UInt64) -> some View {
         modifier(SpawnReveal(index: index, token: token))
+    }
+
+    /// Fades and scales the panel in on every launcher open. `token` is the same
+    /// counter that replays the tile cascade.
+    func rootReveal(token: UInt64) -> some View {
+        modifier(RootReveal(token: token))
     }
 }

--- a/apps/macos/LauncherApp/look-app/Support/UI/Motion.swift
+++ b/apps/macos/LauncherApp/look-app/Support/UI/Motion.swift
@@ -3,21 +3,16 @@ import SwiftUI
 /// Shared motion constants for the launcher, so every animated surface reads with
 /// the same physics and the feel is tuned in one place.
 enum Motion {
-    /// The "materialize on open" reveal: tiles start slightly enlarged and
-    /// transparent, then spring to rest, staggered so the grid settles in.
+    /// The "materialize on open" reveal: tiles grow and rise into place,
+    /// staggered so the grid assembles rather than appearing at once.
     enum Spawn {
-        /// Tiles grow into place rather than shrinking into it: arriving reads as
-        /// coming toward the viewer, and the old 1.05 start was too near 1 to see.
         static let startScale: CGFloat = 0.88
-        /// Each tile also rises the last few points into its slot, which is what
-        /// makes the grid look like it assembles rather than simply appearing.
         static let startOffsetY: CGFloat = 14
         static let staggerSeconds: Double = 0.035
         /// Ceiling on the cascade so a large grid never trails on too long.
         static let maxStaggerSeconds: Double = 0.34
         static let response: Double = 0.46
-        /// Under 1 by enough to overshoot slightly and settle back. That small
-        /// bounce is most of what reads as "alive" rather than "faded in".
+        /// Under 1 to overshoot slightly and settle back.
         static let dampingFraction: Double = 0.68
 
         static func animation(index: Int) -> Animation {
@@ -32,24 +27,16 @@ enum Motion {
         static let response: Double = 0.3
         static let dampingFraction: Double = 0.85
 
-        /// After the pill glides into place it zooms once and settles. The glide
-        /// alone is hard to follow when the travel is a single row, and this is
-        /// the only thing on screen that should move during keyboard nav.
-        ///
-        /// The icon and the pill need very different numbers: the icon is 22pt,
-        /// so a few percent is a change of one point and reads as nothing, while
-        /// the pill spans the whole row and the same percentage would look like
-        /// the layout breathing.
+        /// One-shot zoom as a row takes the selection. The icon needs a much
+        /// larger factor than the pill: at 22pt a few percent is one point,
+        /// while the same on a full-width pill looks like the layout breathing.
         static let iconZoomScale: CGFloat = 1.24
         static let pillZoomScale: CGFloat = 1.02
         static let zoomInSeconds: Double = 0.11
         static let zoomOutResponse: Double = 0.3
-        /// Loose enough to overshoot slightly coming back to rest.
         static let zoomOutDamping: Double = 0.6
 
-        /// How far the selected row's text slides in from. Held while the row is
-        /// selected rather than sprung back, so the offset also reads as part of
-        /// the selection rather than only as a twitch on arrival.
+        /// Horizontal offset held by the selected row's text while selected.
         static let titleShift: CGFloat = 4
 
         static var glide: Animation {
@@ -89,13 +76,10 @@ enum Motion {
         }
     }
 
-    /// The whole panel arriving when the launcher opens, and the surfaces inside
-    /// it swapping as the query changes.
+    /// The whole panel arriving when the launcher opens. A content-layer effect
+    /// on purpose: animating the window would mean touching the
+    /// `makeKeyAndOrderFront` path the Cmd+Space cold-login bug lives in.
     enum Surface {
-        /// The panel lands from slightly small and transparent. Deliberately a
-        /// content-layer effect: animating the window itself would mean touching
-        /// the `makeKeyAndOrderFront` path that the Cmd+Space cold-login bug
-        /// lives in, and this reads the same from the outside.
         static let arriveScale: CGFloat = 0.965
         static let arriveResponse: Double = 0.34
         static let arriveDamping: Double = 0.86
@@ -105,14 +89,12 @@ enum Motion {
         }
     }
 
-    /// The bounce `symbolEffect(.bounce)` gives an SF Symbol, rebuilt as a plain
-    /// scale pop so bitmap icons (app icons are `NSImage`, not symbols) can join
-    /// the same moment.
+    /// `symbolEffect(.bounce)` as a plain scale pop, for bitmap icons that are
+    /// `NSImage` rather than SF Symbols.
     enum Pop {
         static let peakScale: CGFloat = 1.16
         static let riseSeconds: Double = 0.13
         static let settleResponse: Double = 0.34
-        /// Loose enough to overshoot on the way back, matching the symbol bounce.
         static let settleDamping: Double = 0.55
 
         static var rise: Animation {
@@ -176,10 +158,8 @@ private struct SpawnReveal: ViewModifier {
     }
 }
 
-/// Fades and scales the whole panel in each time the launcher is shown. The
-/// window is only ordered out and back in, so this keys off the same token the
-/// tile cascade uses rather than `onAppear`, and the panel arrives just ahead of
-/// the tiles settling into it.
+/// Fades and scales the whole panel in on every show. Keys off the same token
+/// as `SpawnReveal`, since the window is only ordered out and back in.
 private struct RootReveal: ViewModifier {
     let token: UInt64
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -198,8 +178,7 @@ private struct RootReveal: ViewModifier {
             shown = true
             return
         }
-        // Two transactions, same reason as `SpawnReveal`: the hidden state has to
-        // land before the animated one or there is no "from" value to move off.
+        // Two transactions, same reason as `SpawnReveal`.
         shown = false
         DispatchQueue.main.async {
             withAnimation(Motion.Surface.arrive) {
@@ -209,8 +188,7 @@ private struct RootReveal: ViewModifier {
     }
 }
 
-/// Pops a non-symbol icon on every launcher open, so bitmap icons bounce
-/// alongside the SF Symbols that `symbolEffect(.bounce)` handles.
+/// Pops a bitmap icon when `token` changes.
 private struct IconPop: ViewModifier {
     let token: UInt64
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -235,9 +213,7 @@ private struct IconPop: ViewModifier {
     }
 }
 
-/// Scales a surface down while it is held, so clicks read as physical. Under
-/// Reduce Motion the surface holds its resting size and only the hit behaviour
-/// remains.
+/// Scales a surface down while it is held, so clicks read as physical.
 struct PressableSurfaceStyle: ButtonStyle {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -255,14 +231,12 @@ extension View {
         modifier(SpawnReveal(index: index, token: token))
     }
 
-    /// Fades and scales the panel in on every launcher open. `token` is the same
-    /// counter that replays the tile cascade.
+    /// Fades and scales the panel in on every launcher open.
     func rootReveal(token: UInt64) -> some View {
         modifier(RootReveal(token: token))
     }
 
-    /// Bounces a bitmap icon when `token` changes, matching what
-    /// `symbolEffect(.bounce)` does for SF Symbols.
+    /// Bounces a bitmap icon when `token` changes.
     func iconPop(token: UInt64) -> some View {
         modifier(IconPop(token: token))
     }

--- a/apps/macos/LauncherApp/look-app/Themes/BuiltinThemePreset.swift
+++ b/apps/macos/LauncherApp/look-app/Themes/BuiltinThemePreset.swift
@@ -13,10 +13,20 @@ enum BuiltinThemePreset: String, CaseIterable, Identifiable, Codable {
 
     var id: String { rawValue }
 
-    /// Offered in Settings on this machine: Liquid needs the macOS 26 glass
-    /// effect, so it is omitted where that does not exist.
-    static var selectable: [BuiltinThemePreset] {
-        allCases.filter { $0 != .liquid || LauncherBlurMaterial.liquidGlass.isSupported }
+    /// Liquid needs the macOS 26 glass effect.
+    var isSupported: Bool {
+        self != .liquid || LauncherBlurMaterial.liquidGlass.isSupported
+    }
+
+    /// Offered in Settings on this machine, plus `current` when that is a preset
+    /// this OS cannot render. See `LauncherBlurMaterial.options(including:)` for
+    /// why the unsupported value stays in the list rather than being rewritten.
+    static func options(including current: BuiltinThemePreset) -> [BuiltinThemePreset] {
+        var options = allCases.filter(\.isSupported)
+        if !options.contains(current) {
+            options.append(current)
+        }
+        return options
     }
 
     var title: String {
@@ -31,5 +41,10 @@ enum BuiltinThemePreset: String, CaseIterable, Identifiable, Codable {
         case .kindle: return "Kindle"
         case .liquid: return "Liquid"
         }
+    }
+
+    /// Title in Settings, flagging a preset this OS cannot render.
+    var pickerTitle: String {
+        isSupported ? title : "\(title) \(AppConstants.ThemeUI.unsupportedSuffix)"
     }
 }

--- a/apps/macos/LauncherApp/look-app/Themes/BuiltinThemePreset.swift
+++ b/apps/macos/LauncherApp/look-app/Themes/BuiltinThemePreset.swift
@@ -13,9 +13,8 @@ enum BuiltinThemePreset: String, CaseIterable, Identifiable, Codable {
 
     var id: String { rawValue }
 
-    /// Presets offered in Settings on this machine. Liquid renders through the
-    /// macOS 26 glass effect, so it is omitted where that does not exist rather
-    /// than shipping a preset that silently looks like something else.
+    /// Offered in Settings on this machine: Liquid needs the macOS 26 glass
+    /// effect, so it is omitted where that does not exist.
     static var selectable: [BuiltinThemePreset] {
         allCases.filter { $0 != .liquid || LauncherBlurMaterial.liquidGlass.isSupported }
     }

--- a/apps/macos/LauncherApp/look-app/Themes/BuiltinThemePreset.swift
+++ b/apps/macos/LauncherApp/look-app/Themes/BuiltinThemePreset.swift
@@ -9,8 +9,16 @@ enum BuiltinThemePreset: String, CaseIterable, Identifiable, Codable {
     case dracula
     case kanagawa
     case kindle
+    case liquid
 
     var id: String { rawValue }
+
+    /// Presets offered in Settings on this machine. Liquid renders through the
+    /// macOS 26 glass effect, so it is omitted where that does not exist rather
+    /// than shipping a preset that silently looks like something else.
+    static var selectable: [BuiltinThemePreset] {
+        allCases.filter { $0 != .liquid || LauncherBlurMaterial.liquidGlass.isSupported }
+    }
 
     var title: String {
         switch self {
@@ -22,6 +30,7 @@ enum BuiltinThemePreset: String, CaseIterable, Identifiable, Codable {
         case .dracula: return "Dracula"
         case .kanagawa: return "Kanagawa"
         case .kindle: return "Kindle"
+        case .liquid: return "Liquid"
         }
     }
 }

--- a/apps/macos/LauncherApp/look-app/Themes/BuiltinThemeStyle.swift
+++ b/apps/macos/LauncherApp/look-app/Themes/BuiltinThemeStyle.swift
@@ -22,16 +22,13 @@ enum ThemeAppearance {
 }
 
 /// How a preset renders its surfaces, as opposed to what colour they are. The
-/// second non-token axis a style carries, alongside `appearance`: both drive
-/// behaviour that cannot be derived from the palette.
+/// second non-token axis a style carries, alongside `appearance`.
 enum ThemeSurface {
-    /// Blur plus tint, the look every preset had before Liquid.
+    /// Blur plus tint.
     case classic
-    /// Liquid Glass, with the softer geometry glass reads best against.
     case liquid
 
-    /// Liquid rounds harder than the classic surface. Glass reads as a lens,
-    /// and a tight corner makes it look like a clipped rectangle instead.
+    /// Glass reads as a lens; a tight corner makes it a clipped rectangle.
     static let liquidRadiusScale: CGFloat = 1.5
 
     var cornerRadiusScale: CGFloat {
@@ -45,8 +42,8 @@ enum ThemeSurface {
 struct BuiltinThemeStyle {
     let themeName: String
     let appearance: ThemeAppearance
-    /// Rendering mode. Not written into `ThemeSettings`: like `appearance`, it
-    /// is read back off the resolved style rather than stored per-key.
+    /// Not written into `ThemeSettings`: like `appearance`, read back off the
+    /// resolved style rather than stored per-key.
     let surface: ThemeSurface
     let tintRed: Double
     let tintGreen: Double

--- a/apps/macos/LauncherApp/look-app/Themes/BuiltinThemeStyle.swift
+++ b/apps/macos/LauncherApp/look-app/Themes/BuiltinThemeStyle.swift
@@ -21,9 +21,33 @@ enum ThemeAppearance {
     }
 }
 
+/// How a preset renders its surfaces, as opposed to what colour they are. The
+/// second non-token axis a style carries, alongside `appearance`: both drive
+/// behaviour that cannot be derived from the palette.
+enum ThemeSurface {
+    /// Blur plus tint, the look every preset had before Liquid.
+    case classic
+    /// Liquid Glass, with the softer geometry glass reads best against.
+    case liquid
+
+    /// Liquid rounds harder than the classic surface. Glass reads as a lens,
+    /// and a tight corner makes it look like a clipped rectangle instead.
+    static let liquidRadiusScale: CGFloat = 1.5
+
+    var cornerRadiusScale: CGFloat {
+        switch self {
+        case .classic: return 1
+        case .liquid: return Self.liquidRadiusScale
+        }
+    }
+}
+
 struct BuiltinThemeStyle {
     let themeName: String
     let appearance: ThemeAppearance
+    /// Rendering mode. Not written into `ThemeSettings`: like `appearance`, it
+    /// is read back off the resolved style rather than stored per-key.
+    let surface: ThemeSurface
     let tintRed: Double
     let tintGreen: Double
     let tintBlue: Double
@@ -63,6 +87,7 @@ struct BuiltinThemeStyle {
 init(
         themeName: String = "",
         appearance: ThemeAppearance = .dark,
+        surface: ThemeSurface = .classic,
         tintRed: Double = 0.08,
         tintGreen: Double = 0.10,
         tintBlue: Double = 0.12,
@@ -96,6 +121,7 @@ init(
     ) {
         self.themeName = themeName
         self.appearance = appearance
+        self.surface = surface
         self.tintRed = tintRed
         self.tintGreen = tintGreen
         self.tintBlue = tintBlue

--- a/apps/macos/LauncherApp/look-app/Themes/LiquidTheme.swift
+++ b/apps/macos/LauncherApp/look-app/Themes/LiquidTheme.swift
@@ -41,11 +41,14 @@ enum LiquidTheme {
         controlFill: ThemeRGB(red: 0.66, green: 0.76, blue: 0.94),
         controlFillOpacity: 0.12,
         divider: ThemeRGB(red: 1.0, green: 1.0, blue: 1.0),
-        dividerOpacity: 0.12,
-        // The selection pill is the one place that earns real weight: it has to
-        // stay findable against a moving desktop showing through the glass.
-        selectionFill: ThemeRGB(red: 0.42, green: 0.62, blue: 1.0),
-        selectionFillOpacity: 0.34,
+        dividerOpacity: 0.18,
+        // The selection pill is the one place that earns real weight, and it has
+        // to earn more of it here than on a flat theme: it sits over refracting
+        // glass with the desktop moving behind it, so a light wash disappears.
+        // This is the only thing that moves during keyboard nav and it has to be
+        // unmistakable.
+        selectionFill: ThemeRGB(red: 0.40, green: 0.60, blue: 1.0),
+        selectionFillOpacity: 0.58,
         accent: ThemeRGB(red: 0.44, green: 0.72, blue: 1.0),
         onAccent: ThemeRGB(red: 0.04, green: 0.07, blue: 0.13),
         success: ThemeRGB(red: 0.40, green: 0.86, blue: 0.66),

--- a/apps/macos/LauncherApp/look-app/Themes/LiquidTheme.swift
+++ b/apps/macos/LauncherApp/look-app/Themes/LiquidTheme.swift
@@ -2,16 +2,10 @@ import Foundation
 
 /// Liquid: the glass surface as a theme of its own.
 ///
-/// The palette is built around the material rather than over it. Every fill is
-/// far more transparent than the classic presets use, because glass is a lens
-/// and an opaque panel sitting on it reads as a sticker rather than depth. The
-/// tint is deliberately light too: `LauncherBlurMaterial.liquidGlass` hands it
-/// to `NSGlassEffectView.tintColor`, where a heavy value would cancel the
-/// refraction it is supposed to colour.
-///
-/// Text stays near-white at full opacity. Glass runs lower contrast than
-/// `hudWindow`, and the results list is dense monospaced content, so the
-/// palette spends its contrast budget on type rather than on chrome.
+/// Fills are far more transparent than the classic presets use: glass is a lens,
+/// and an opaque panel on it reads as a sticker rather than depth. Text keeps
+/// full contrast, since glass is dimmer than `hudWindow` and the results list is
+/// dense monospaced content.
 enum LiquidTheme {
     static let style = BuiltinThemeStyle(
         themeName: "liquid",
@@ -28,8 +22,7 @@ enum LiquidTheme {
         fontGreen: 0.98,
         fontBlue: 1.0,
         fontOpacity: 1.0,
-        // A hairline, not a frame: glass already separates itself from the
-        // desktop by refracting it, so a strong border double-states the edge.
+        // A hairline: refraction already states the edge.
         borderRed: 1.0,
         borderGreen: 1.0,
         borderBlue: 1.0,
@@ -42,11 +35,8 @@ enum LiquidTheme {
         controlFillOpacity: 0.12,
         divider: ThemeRGB(red: 1.0, green: 1.0, blue: 1.0),
         dividerOpacity: 0.18,
-        // The selection pill is the one place that earns real weight, and it has
-        // to earn more of it here than on a flat theme: it sits over refracting
-        // glass with the desktop moving behind it, so a light wash disappears.
-        // This is the only thing that moves during keyboard nav and it has to be
-        // unmistakable.
+        // Heavier than a flat theme would need: it sits over refracting glass
+        // with the desktop moving behind it, where a light wash disappears.
         selectionFill: ThemeRGB(red: 0.40, green: 0.60, blue: 1.0),
         selectionFillOpacity: 0.58,
         accent: ThemeRGB(red: 0.44, green: 0.72, blue: 1.0),

--- a/apps/macos/LauncherApp/look-app/Themes/LiquidTheme.swift
+++ b/apps/macos/LauncherApp/look-app/Themes/LiquidTheme.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Liquid: the glass surface as a theme of its own.
+///
+/// The palette is built around the material rather than over it. Every fill is
+/// far more transparent than the classic presets use, because glass is a lens
+/// and an opaque panel sitting on it reads as a sticker rather than depth. The
+/// tint is deliberately light too: `LauncherBlurMaterial.liquidGlass` hands it
+/// to `NSGlassEffectView.tintColor`, where a heavy value would cancel the
+/// refraction it is supposed to colour.
+///
+/// Text stays near-white at full opacity. Glass runs lower contrast than
+/// `hudWindow`, and the results list is dense monospaced content, so the
+/// palette spends its contrast budget on type rather than on chrome.
+enum LiquidTheme {
+    static let style = BuiltinThemeStyle(
+        themeName: "liquid",
+        appearance: .dark,
+        surface: .liquid,
+        tintRed: 0.10,
+        tintGreen: 0.13,
+        tintBlue: 0.20,
+        tintOpacity: 0.35,
+        blurMaterial: .liquidGlass,
+        blurOpacity: 1.0,
+        fontName: nil,
+        fontRed: 0.98,
+        fontGreen: 0.98,
+        fontBlue: 1.0,
+        fontOpacity: 1.0,
+        // A hairline, not a frame: glass already separates itself from the
+        // desktop by refracting it, so a strong border double-states the edge.
+        borderRed: 1.0,
+        borderGreen: 1.0,
+        borderBlue: 1.0,
+        borderOpacity: 0.10,
+        textSecondary: ThemeRGB(red: 0.86, green: 0.89, blue: 0.95),
+        textMuted: ThemeRGB(red: 0.72, green: 0.77, blue: 0.87),
+        panelFill: ThemeRGB(red: 0.62, green: 0.72, blue: 0.92),
+        panelFillOpacity: 0.10,
+        controlFill: ThemeRGB(red: 0.66, green: 0.76, blue: 0.94),
+        controlFillOpacity: 0.12,
+        divider: ThemeRGB(red: 1.0, green: 1.0, blue: 1.0),
+        dividerOpacity: 0.12,
+        // The selection pill is the one place that earns real weight: it has to
+        // stay findable against a moving desktop showing through the glass.
+        selectionFill: ThemeRGB(red: 0.42, green: 0.62, blue: 1.0),
+        selectionFillOpacity: 0.34,
+        accent: ThemeRGB(red: 0.44, green: 0.72, blue: 1.0),
+        onAccent: ThemeRGB(red: 0.04, green: 0.07, blue: 0.13),
+        success: ThemeRGB(red: 0.40, green: 0.86, blue: 0.66),
+        warning: ThemeRGB(red: 1.0, green: 0.78, blue: 0.42),
+        danger: ThemeRGB(red: 1.0, green: 0.46, blue: 0.52)
+    )
+}

--- a/apps/macos/LauncherApp/look-app/Themes/ThemePresetRegistry.swift
+++ b/apps/macos/LauncherApp/look-app/Themes/ThemePresetRegistry.swift
@@ -19,6 +19,8 @@ extension BuiltinThemePreset {
             return KanagawaTheme.style
         case .kindle:
             return KindleTheme.style
+        case .liquid:
+            return LiquidTheme.style
         }
     }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
@@ -85,6 +85,7 @@ struct EmptyStateLaunchpadView: View {
             HStack(alignment: .top, spacing: Const.gap) {
                 slot(cell: cell)
                     .frame(width: width(columns: 2, cell: cell), height: height(rows: 2))
+                    .symbolEffect(.bounce, value: revealToken)
                     .spawnReveal(index: RevealIndex.slot, token: revealToken)
 
                 VStack(spacing: Const.gap) {
@@ -127,6 +128,10 @@ struct EmptyStateLaunchpadView: View {
             let h = height(rows: model.rowSpanCount)
             tileContent(model)
                 .frame(width: w, height: h)
+                // The same bounce the Bluetooth glyph does on toggle, fired for
+                // every symbol in the tile when the launcher opens. Applied to
+                // the container: symbol effects reach the symbol images inside.
+                .symbolEffect(.bounce, value: revealToken)
                 .spawnReveal(index: reveal, token: revealToken)
         }
     }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
@@ -454,7 +454,13 @@ private struct LaunchpadActionTile: View {
     /// tiles, and disappears with them when the border is turned off.
     @ViewBuilder
     private var border: some View {
-        let shape = RoundedRectangle(cornerRadius: Const.cornerRadius, style: .continuous)
+        // Must use the same scaled radius as `frostedTile`, or the outline is cut
+        // to a tighter corner than the fill behind it and reads as a stray line
+        // across each corner.
+        let shape = RoundedRectangle(
+            cornerRadius: themeStore.surfaceCornerRadius(Const.cornerRadius),
+            style: .continuous
+        )
         if confirming || micMuted {
             shape.strokeBorder(tint.opacity(launchpadAlertBorderOpacity), lineWidth: launchpadStateBorderWidth)
         } else if themeStore.borderLineWidth() > 0 {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
@@ -128,9 +128,7 @@ struct EmptyStateLaunchpadView: View {
             let h = height(rows: model.rowSpanCount)
             tileContent(model)
                 .frame(width: w, height: h)
-                // The same bounce the Bluetooth glyph does on toggle, fired for
-                // every symbol in the tile when the launcher opens. Applied to
-                // the container: symbol effects reach the symbol images inside.
+                // On the container: symbol effects reach the images inside.
                 .symbolEffect(.bounce, value: revealToken)
                 .spawnReveal(index: reveal, token: revealToken)
         }
@@ -228,8 +226,7 @@ private struct LaunchpadToggleTile: View {
                 Image(systemName: iconName)
                     .font(.system(size: 18, weight: .medium))
                     .foregroundColor(isOn ? themeStore.accentColor() : themeStore.mutedTextColor())
-                    // Theme and Keep Awake swap glyph on flip, so the icon
-                    // crossfades; the others keep one glyph and just react.
+                    // Theme and Keep Awake swap glyph on flip.
                     .contentTransition(.symbolEffect(.replace))
                     .symbolEffect(.bounce, value: isOn)
                 VStack(alignment: .leading, spacing: 1) {
@@ -311,8 +308,7 @@ private struct LaunchpadInfoTile: View {
             Image(systemName: iconName)
                 .font(.system(size: 18, weight: .medium))
                 .foregroundColor(themeStore.accentColor())
-                // The battery glyph gains and loses its bolt as charging starts
-                // and stops, and fills as the level changes.
+                // The glyph gains and loses its bolt as charging changes.
                 .contentTransition(.symbolEffect(.replace))
             VStack(alignment: .leading, spacing: 1) {
                 Text(label)
@@ -356,7 +352,6 @@ private struct LaunchpadWeatherTile: View {
             Image(systemName: weather?.symbolName ?? "cloud.sun.fill")
                 .font(.system(size: 20, weight: .medium))
                 .foregroundColor(themeStore.accentColor())
-                // The condition glyph changes as the forecast refreshes.
                 .contentTransition(.symbolEffect(.replace))
             Text(weather?.temperature ?? Const.weatherPlaceholderValue)
                 .font(themeStore.uiFont(size: Const.valueFontSize - 4, weight: .bold))
@@ -454,9 +449,7 @@ private struct LaunchpadActionTile: View {
     /// tiles, and disappears with them when the border is turned off.
     @ViewBuilder
     private var border: some View {
-        // Must use the same scaled radius as `frostedTile`, or the outline is cut
-        // to a tighter corner than the fill behind it and reads as a stray line
-        // across each corner.
+        // Same scaled radius as `frostedTile`, or the outline cuts the corners.
         let shape = RoundedRectangle(
             cornerRadius: themeStore.surfaceCornerRadius(Const.cornerRadius),
             style: .continuous
@@ -602,8 +595,7 @@ func frostedTile(themeStore: ThemeStore, tint: Color? = nil, tintOpacity: Double
 /// with it when the border is turned off.
 @ViewBuilder
 private func tileBorder(isOn: Bool, themeStore: ThemeStore) -> some View {
-    // Must track `frostedTile`'s radius exactly, or the outline and the fill
-    // disagree at the corners under Liquid.
+    // Must track `frostedTile`'s radius, or the two disagree at the corners.
     let shape = RoundedRectangle(
         cornerRadius: themeStore.surfaceCornerRadius(AppConstants.Launcher.Launchpad.cornerRadius),
         style: .continuous

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
@@ -223,6 +223,10 @@ private struct LaunchpadToggleTile: View {
                 Image(systemName: iconName)
                     .font(.system(size: 18, weight: .medium))
                     .foregroundColor(isOn ? themeStore.accentColor() : themeStore.mutedTextColor())
+                    // Theme and Keep Awake swap glyph on flip, so the icon
+                    // crossfades; the others keep one glyph and just react.
+                    .contentTransition(.symbolEffect(.replace))
+                    .symbolEffect(.bounce, value: isOn)
                 VStack(alignment: .leading, spacing: 1) {
                     mnemonicText(
                         model.title,
@@ -249,7 +253,7 @@ private struct LaunchpadToggleTile: View {
             )
             .overlay(tileBorder(isOn: isOn, themeStore: themeStore))
         }
-        .buttonStyle(.plain)
+        .buttonStyle(PressableSurfaceStyle())
     }
 
     private var stateLabel: String {
@@ -302,6 +306,9 @@ private struct LaunchpadInfoTile: View {
             Image(systemName: iconName)
                 .font(.system(size: 18, weight: .medium))
                 .foregroundColor(themeStore.accentColor())
+                // The battery glyph gains and loses its bolt as charging starts
+                // and stops, and fills as the level changes.
+                .contentTransition(.symbolEffect(.replace))
             VStack(alignment: .leading, spacing: 1) {
                 Text(label)
                     .font(themeStore.uiFont(size: Const.captionFontSize - 1, weight: .medium))
@@ -311,6 +318,8 @@ private struct LaunchpadInfoTile: View {
                     .foregroundColor(themeStore.fontColor())
                     .lineLimit(1)
                     .minimumScaleFactor(0.7)
+                    .contentTransition(.numericText())
+                    .animation(Motion.Value.rollDigits, value: value)
             }
             Spacer(minLength: 0)
         }
@@ -342,9 +351,13 @@ private struct LaunchpadWeatherTile: View {
             Image(systemName: weather?.symbolName ?? "cloud.sun.fill")
                 .font(.system(size: 20, weight: .medium))
                 .foregroundColor(themeStore.accentColor())
+                // The condition glyph changes as the forecast refreshes.
+                .contentTransition(.symbolEffect(.replace))
             Text(weather?.temperature ?? Const.weatherPlaceholderValue)
                 .font(themeStore.uiFont(size: Const.valueFontSize - 4, weight: .bold))
                 .foregroundColor(themeStore.fontColor())
+                .contentTransition(.numericText())
+                .animation(Motion.Value.rollDigits, value: weather?.temperature)
             Text(caption)
                 .font(themeStore.uiFont(size: Const.captionFontSize - 1, weight: .medium))
                 .foregroundColor(themeStore.mutedTextColor())
@@ -427,7 +440,7 @@ private struct LaunchpadActionTile: View {
             )
             .overlay(border)
         }
-        .buttonStyle(.plain)
+        .buttonStyle(PressableSurfaceStyle())
     }
 
     /// An armed confirm or a muted mic always draws its coloured state border, so
@@ -526,7 +539,7 @@ private struct LaunchpadMediaTile: View {
                 .background(themeStore.controlFillColor())
                 .clipShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
             }
-            .buttonStyle(.plain)
+            .buttonStyle(PressableSurfaceStyle())
             transportButton("forward.fill", action: onNext)
         }
     }
@@ -538,7 +551,7 @@ private struct LaunchpadMediaTile: View {
                 .foregroundColor(themeStore.secondaryTextColor())
                 .padding(6)
         }
-        .buttonStyle(.plain)
+        .buttonStyle(PressableSurfaceStyle())
     }
 }
 
@@ -561,9 +574,9 @@ private let launchpadAlertBorderOpacity = 0.3
 /// control-fill stack as `LauncherView.tileBackground(floats:)`. An optional tint
 /// (accent for on-state toggles, caution for a confirming/muted action) layers on top.
 func frostedTile(themeStore: ThemeStore, tint: Color? = nil, tintOpacity: Double = 0) -> some View {
-    let radius = AppConstants.Launcher.Launchpad.cornerRadius
+    let radius = themeStore.surfaceCornerRadius(AppConstants.Launcher.Launchpad.cornerRadius)
     return ZStack {
-        ThemedBackdrop(themeStore: themeStore)
+        ThemedBackdrop(themeStore: themeStore, cornerRadius: radius)
         themeStore.controlFillColor()
         if let tint {
             tint.opacity(tintOpacity)
@@ -578,7 +591,12 @@ func frostedTile(themeStore: ThemeStore, tint: Color? = nil, tintOpacity: Double
 /// with it when the border is turned off.
 @ViewBuilder
 private func tileBorder(isOn: Bool, themeStore: ThemeStore) -> some View {
-    let shape = RoundedRectangle(cornerRadius: AppConstants.Launcher.Launchpad.cornerRadius, style: .continuous)
+    // Must track `frostedTile`'s radius exactly, or the outline and the fill
+    // disagree at the corners under Liquid.
+    let shape = RoundedRectangle(
+        cornerRadius: themeStore.surfaceCornerRadius(AppConstants.Launcher.Launchpad.cornerRadius),
+        style: .continuous
+    )
     if isOn {
         shape.strokeBorder(themeStore.accentColor().opacity(launchpadOnBorderOpacity), lineWidth: launchpadStateBorderWidth)
     } else if themeStore.borderLineWidth() > 0 {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
@@ -8,6 +8,8 @@ struct LauncherRowView: View {
     let result: LauncherResult
     let isSelected: Bool
     let isPicked: Bool
+    /// Last row in the list, so the trailing divider is suppressed.
+    let isLast: Bool
     /// Shared namespace for the single selection pill that glides between rows
     /// (see `Motion.Selection`). Only the selected row is the geometry source.
     let selectionNamespace: Namespace.ID
@@ -16,6 +18,21 @@ struct LauncherRowView: View {
     private enum Layout {
         static let cornerRadius: CGFloat = 8
         static let borderWidth: CGFloat = 1
+        static let dividerHeight: CGFloat = 1
+        static let dividerInset: CGFloat = 6
+        static let dividerOpacity: Double = 0.8
+    }
+
+    private var pillCornerRadius: CGFloat {
+        themeStore.surfaceCornerRadius(Layout.cornerRadius)
+    }
+
+    /// The trailing hairline is suppressed under the selection pill (a rule
+    /// running through a filled pill reads as an artifact) and after the final
+    /// row (nothing follows it to separate). The row keeps the divider's height
+    /// either way and only fades it, so selection never reflows the list.
+    private var showsDivider: Bool {
+        !isLast && !isSelected
     }
 
     private var syntheticRow: SyntheticRow? {
@@ -110,52 +127,60 @@ struct LauncherRowView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            HStack(spacing: 10) {
-                if isPicked {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundStyle(themeStore.selectionFillColor())
-                        .frame(width: 14)
+            Button(action: onOpen) {
+                HStack(spacing: 10) {
+                    if isPicked {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(themeStore.selectionFillColor())
+                            .frame(width: 14)
+                    }
+                    Image(nsImage: rowIcon)
+                        .resizable()
+                        .frame(width: 22, height: 22)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(result.title)
+                            .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize), weight: .medium))
+                            .foregroundStyle(themeStore.fontColor())
+                        Text(metaLabel)
+                            .font(themeStore.uiFont(size: CGFloat(max(10, themeStore.settings.fontSize - 3)), weight: .regular))
+                            .foregroundStyle(themeStore.mutedTextColor())
+                            .lineLimit(1)
+                    }
+                    Spacer(minLength: 0)
                 }
-                Image(nsImage: rowIcon)
-                    .resizable()
-                    .frame(width: 22, height: 22)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(result.title)
-                        .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize), weight: .medium))
-                        .foregroundStyle(themeStore.fontColor())
-                    Text(metaLabel)
-                        .font(themeStore.uiFont(size: CGFloat(max(10, themeStore.settings.fontSize - 3)), weight: .regular))
-                        .foregroundStyle(themeStore.mutedTextColor())
-                        .lineLimit(1)
-                }
-                Spacer(minLength: 0)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .contentShape(Rectangle())
             }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 8)
+            .buttonStyle(PressableSurfaceStyle())
+            // The row used to be a bare tap gesture, which never took focus.
+            // A Button would accept it under Full Keyboard Access and pull the
+            // caret out of the search field, so keep the old focus behaviour.
+            .focusable(false)
+            // The pill stays outside the button so the press scale can't perturb
+            // the frame `matchedGeometryEffect` reports for the glide.
             .background {
                 // One pill shared across rows via matchedGeometryEffect. It
                 // glides when the selection change is wrapped in
                 // `Motion.Selection.glide` (keyboard nav) and snaps otherwise
                 // (click, results refresh).
                 if isSelected {
-                    RoundedRectangle(cornerRadius: Layout.cornerRadius, style: .continuous)
+                    RoundedRectangle(cornerRadius: pillCornerRadius, style: .continuous)
                         .fill(themeStore.selectionFillColor())
                         .overlay {
-                            RoundedRectangle(cornerRadius: Layout.cornerRadius, style: .continuous)
+                            RoundedRectangle(cornerRadius: pillCornerRadius, style: .continuous)
                                 .stroke(themeStore.dividerColor(), lineWidth: Layout.borderWidth)
                         }
                         .matchedGeometryEffect(id: Motion.Selection.geometryID, in: selectionNamespace)
                 }
             }
-            .contentShape(Rectangle())
-            .onTapGesture {
-                onOpen()
-            }
 
             Rectangle()
-                .fill(themeStore.dividerColor().opacity(0.8))
-                .frame(height: 1)
-                .padding(.horizontal, 6)
+                .fill(themeStore.dividerColor().opacity(Layout.dividerOpacity))
+                .frame(height: Layout.dividerHeight)
+                .padding(.horizontal, Layout.dividerInset)
+                .opacity(showsDivider ? 1 : 0)
+                .animation(Motion.Value.dividerFade, value: showsDivider)
         }
     }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
@@ -27,9 +27,7 @@ struct LauncherRowView: View {
         themeStore.surfaceCornerRadius(Layout.cornerRadius)
     }
 
-    /// Drives the one-shot zoom the pill and icon do as this row takes the
-    /// selection. Local to the row, so a row that is not gaining selection has
-    /// nothing to animate.
+    /// Drives the one-shot zoom as this row takes the selection.
     @State private var zoomed = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -45,10 +43,8 @@ struct LauncherRowView: View {
         }
     }
 
-    /// The trailing hairline is suppressed under the selection pill (a rule
-    /// running through a filled pill reads as an artifact) and after the final
-    /// row (nothing follows it to separate). The row keeps the divider's height
-    /// either way and only fades it, so selection never reflows the list.
+    /// Hidden under the selection pill and after the final row. The row keeps
+    /// the divider's height either way, so selection never reflows the list.
     private var showsDivider: Bool {
         !isLast && !isSelected
     }
@@ -57,9 +53,8 @@ struct LauncherRowView: View {
         SyntheticRow.classify(resultID: result.id)
     }
 
-    /// Resolved through `RowIconCache`: this runs inside `body`, so every redraw
-    /// of the list would otherwise mint a fresh `NSImage` for every visible row
-    /// and make all of them flicker. See the note on the cache.
+    /// Cached: this runs inside `body`, and a fresh `NSImage` per redraw makes
+    /// every icon in the list flicker. See `RowIconCache`.
     private var rowIcon: NSImage {
         switch syntheticRow {
         case .commandSuggestion:
@@ -177,10 +172,8 @@ struct LauncherRowView: View {
                             .foregroundStyle(themeStore.mutedTextColor())
                             .lineLimit(1)
                     }
-                    // Driven by `isSelected` rather than the one-shot state, so it
-                    // rides the glide transaction nav already wraps the selection
-                    // in and slides rather than snapping. Offset only, so the text
-                    // never reflows and neighbouring rows stay put.
+                    // Keyed on `isSelected` so it rides nav's glide transaction.
+                    // Offset, not padding: the text must not reflow.
                     .offset(x: isSelected ? Motion.Selection.titleShift : 0)
                     Spacer(minLength: 0)
                 }
@@ -205,15 +198,11 @@ struct LauncherRowView: View {
                         .scaleEffect(isSelected && zoomed ? Motion.Selection.pillZoomScale : 1)
                 }
             }
-            // Only the row that just became selected runs this, so exactly one
-            // row moves per keypress. No `.animation(_:value:)` anywhere in the
-            // row: applied per-row it fires on every neighbour as the selection
-            // passes, which is what made the whole list look like it flickered.
+            // Deliberately no `.animation(_:value:)` in this row: per-row it
+            // fires on every neighbour as the selection passes, flickering the
+            // whole list. Clearing on deselect covers LazyVStack recycling,
+            // where a view can arrive holding a previous row's `zoomed`.
             .onChange(of: isSelected) { _, selected in
-                // Rows are recycled by the LazyVStack, so a view can arrive
-                // carrying a stale `zoomed` from whichever row it was before.
-                // Clearing on deselect, and gating the scale on `isSelected`
-                // above, means an unselected row can never show a transform.
                 guard selected else {
                     zoomed = false
                     return

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
@@ -29,14 +29,21 @@ struct LauncherRowView: View {
 
     /// Drives the one-shot zoom as this row takes the selection.
     @State private var zoomed = false
+    /// Bumped on every zoom and on deselect, so a pending reset that belongs to
+    /// an earlier zoom cannot cut short a newer one. Reachable by arrowing away
+    /// and back inside `zoomInSeconds`.
+    @State private var zoomGeneration = 0
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private func zoom() {
         guard !reduceMotion else { return }
+        zoomGeneration &+= 1
+        let generation = zoomGeneration
         withAnimation(Motion.Selection.zoomIn) {
             zoomed = true
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + Motion.Selection.zoomInSeconds) {
+            guard zoomGeneration == generation else { return }
             withAnimation(Motion.Selection.zoomOut) {
                 zoomed = false
             }
@@ -204,6 +211,7 @@ struct LauncherRowView: View {
             // where a view can arrive holding a previous row's `zoomed`.
             .onChange(of: isSelected) { _, selected in
                 guard selected else {
+                    zoomGeneration &+= 1
                     zoomed = false
                     return
                 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
@@ -27,6 +27,24 @@ struct LauncherRowView: View {
         themeStore.surfaceCornerRadius(Layout.cornerRadius)
     }
 
+    /// Drives the one-shot zoom the pill and icon do as this row takes the
+    /// selection. Local to the row, so a row that is not gaining selection has
+    /// nothing to animate.
+    @State private var zoomed = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private func zoom() {
+        guard !reduceMotion else { return }
+        withAnimation(Motion.Selection.zoomIn) {
+            zoomed = true
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + Motion.Selection.zoomInSeconds) {
+            withAnimation(Motion.Selection.zoomOut) {
+                zoomed = false
+            }
+        }
+    }
+
     /// The trailing hairline is suppressed under the selection pill (a rule
     /// running through a filled pill reads as an artifact) and after the final
     /// row (nothing follows it to separate). The row keeps the divider's height
@@ -39,29 +57,41 @@ struct LauncherRowView: View {
         SyntheticRow.classify(resultID: result.id)
     }
 
+    /// Resolved through `RowIconCache`: this runs inside `body`, so every redraw
+    /// of the list would otherwise mint a fresh `NSImage` for every visible row
+    /// and make all of them flicker. See the note on the cache.
     private var rowIcon: NSImage {
         switch syntheticRow {
         case .commandSuggestion:
-            return NSImage(systemSymbolName: "terminal", accessibilityDescription: nil)
-                ?? NSWorkspace.shared.icon(for: .plainText)
+            return RowIconCache.image(key: "symbol:terminal") {
+                NSImage(systemSymbolName: "terminal", accessibilityDescription: nil)
+                    ?? NSWorkspace.shared.icon(for: .plainText)
+            }
         case .calc:
-            return LauncherCalcFeature.icon()
+            return RowIconCache.image(key: "feature:calc") { LauncherCalcFeature.icon() }
         case .webURL:
-            return NSImage(systemSymbolName: "globe", accessibilityDescription: nil)
-                ?? NSWorkspace.shared.icon(for: .plainText)
+            return RowIconCache.image(key: "symbol:globe") {
+                NSImage(systemSymbolName: "globe", accessibilityDescription: nil)
+                    ?? NSWorkspace.shared.icon(for: .plainText)
+            }
         case .prefixSuggestion, .webSuggestion:
-            return NSImage(systemSymbolName: "magnifyingglass", accessibilityDescription: nil)
-                ?? NSWorkspace.shared.icon(for: .plainText)
+            return RowIconCache.image(key: "symbol:magnifyingglass") {
+                NSImage(systemSymbolName: "magnifyingglass", accessibilityDescription: nil)
+                    ?? NSWorkspace.shared.icon(for: .plainText)
+            }
         case nil:
             break
         }
 
         if result.kind == .clipboard {
-            return NSImage(systemSymbolName: "doc.on.clipboard", accessibilityDescription: nil)
-                ?? NSImage(systemSymbolName: "doc.text", accessibilityDescription: nil)
-                ?? NSWorkspace.shared.icon(for: .plainText)
+            return RowIconCache.image(key: "symbol:doc.on.clipboard") {
+                NSImage(systemSymbolName: "doc.on.clipboard", accessibilityDescription: nil)
+                    ?? NSImage(systemSymbolName: "doc.text", accessibilityDescription: nil)
+                    ?? NSWorkspace.shared.icon(for: .plainText)
+            }
         }
 
+        // Not cached: a process icon is keyed to a live pid, and pids are reused.
         if result.kind == .process, let pid = result.processPID {
             return LauncherProcessFeature.icon(forPID: pid)
         }
@@ -69,12 +99,12 @@ struct LauncherRowView: View {
         if result.id.hasPrefix("setting:") {
             let settingsPath = "/System/Applications/System Settings.app"
             if FileManager.default.fileExists(atPath: settingsPath) {
-                return NSWorkspace.shared.icon(forFile: settingsPath)
+                return RowIconCache.icon(forFile: settingsPath)
             }
             let legacyPath = "/System/Applications/System Preferences.app"
-            return NSWorkspace.shared.icon(forFile: legacyPath)
+            return RowIconCache.icon(forFile: legacyPath)
         }
-        return NSWorkspace.shared.icon(forFile: result.path)
+        return RowIconCache.icon(forFile: result.path)
     }
 
     private var pathInfo: String {
@@ -137,6 +167,7 @@ struct LauncherRowView: View {
                     Image(nsImage: rowIcon)
                         .resizable()
                         .frame(width: 22, height: 22)
+                        .scaleEffect(isSelected && zoomed ? Motion.Selection.iconZoomScale : 1)
                     VStack(alignment: .leading, spacing: 2) {
                         Text(result.title)
                             .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize), weight: .medium))
@@ -146,19 +177,18 @@ struct LauncherRowView: View {
                             .foregroundStyle(themeStore.mutedTextColor())
                             .lineLimit(1)
                     }
+                    // Driven by `isSelected` rather than the one-shot state, so it
+                    // rides the glide transaction nav already wraps the selection
+                    // in and slides rather than snapping. Offset only, so the text
+                    // never reflows and neighbouring rows stay put.
+                    .offset(x: isSelected ? Motion.Selection.titleShift : 0)
                     Spacer(minLength: 0)
                 }
                 .padding(.horizontal, 10)
                 .padding(.vertical, 8)
-                .contentShape(Rectangle())
             }
-            .buttonStyle(PressableSurfaceStyle())
-            // The row used to be a bare tap gesture, which never took focus.
-            // A Button would accept it under Full Keyboard Access and pull the
-            // caret out of the search field, so keep the old focus behaviour.
+            .buttonStyle(.plain)
             .focusable(false)
-            // The pill stays outside the button so the press scale can't perturb
-            // the frame `matchedGeometryEffect` reports for the glide.
             .background {
                 // One pill shared across rows via matchedGeometryEffect. It
                 // glides when the selection change is wrapped in
@@ -172,7 +202,23 @@ struct LauncherRowView: View {
                                 .stroke(themeStore.dividerColor(), lineWidth: Layout.borderWidth)
                         }
                         .matchedGeometryEffect(id: Motion.Selection.geometryID, in: selectionNamespace)
+                        .scaleEffect(isSelected && zoomed ? Motion.Selection.pillZoomScale : 1)
                 }
+            }
+            // Only the row that just became selected runs this, so exactly one
+            // row moves per keypress. No `.animation(_:value:)` anywhere in the
+            // row: applied per-row it fires on every neighbour as the selection
+            // passes, which is what made the whole list look like it flickered.
+            .onChange(of: isSelected) { _, selected in
+                // Rows are recycled by the LazyVStack, so a view can arrive
+                // carrying a stale `zoomed` from whichever row it was before.
+                // Clearing on deselect, and gating the scale on `isSelected`
+                // above, means an unselected row can never show a transform.
+                guard selected else {
+                    zoomed = false
+                    return
+                }
+                zoom()
             }
 
             Rectangle()
@@ -180,7 +226,6 @@ struct LauncherRowView: View {
                 .frame(height: Layout.dividerHeight)
                 .padding(.horizontal, Layout.dividerInset)
                 .opacity(showsDivider ? 1 : 0)
-                .animation(Motion.Value.dividerFade, value: showsDivider)
         }
     }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
@@ -11,23 +11,51 @@ struct SearchInputBar: View {
     /// inside a shared top-row pane that already supplies one, so the search
     /// input and running-apps icons read as a single unified bar.
     var showsBackground: Bool = true
+    /// Changes each time the launcher opens, replaying the spawn cascade.
+    var revealToken: UInt64 = 0
     let onSubmit: () -> Void
     let onExitCommandMode: () -> Void
+
+    private enum Layout {
+        /// Matches where `NSTextField` starts drawing its own text, so the
+        /// placeholder does not shift sideways as soon as you type.
+        static let placeholderLeadingInset: CGFloat = 2
+    }
+
+    private var placeholderText: String {
+        if isCommandMode {
+            return activeCommand?.placeholder ?? AppConstants.Launcher.commandModePlaceholder
+        }
+        return AppConstants.Launcher.searchPlaceholder
+    }
 
     var body: some View {
         HStack(spacing: 8) {
             Image(systemName: isCommandMode ? "terminal" : "magnifyingglass")
                 .foregroundStyle(isCommandMode ? themeStore.accentColor() : themeStore.secondaryTextColor())
+                .contentTransition(.symbolEffect(.replace))
+                .symbolEffect(.bounce, value: revealToken)
             SmoothCaretTextField(
                 text: $text,
-                placeholder: isCommandMode
-                    ? (activeCommand?.placeholder ?? AppConstants.Launcher.commandModePlaceholder)
-                    : AppConstants.Launcher.searchPlaceholder,
+                // Empty: the placeholder is drawn as the overlay below instead,
+                // since an NSTextField's own placeholder cannot be animated.
+                placeholder: "",
                 isFocused: isQueryFocused,
                 themeStore: themeStore,
                 onSubmit: onSubmit
             )
                 .frame(maxWidth: .infinity)
+                .overlay(alignment: .leading) {
+                    if text.isEmpty {
+                        Text(placeholderText)
+                            .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize)))
+                            .foregroundStyle(themeStore.mutedTextColor())
+                            .lineLimit(1)
+                            .padding(.leading, Layout.placeholderLeadingInset)
+                            .allowsHitTesting(false)
+                            .placeholderReveal(token: revealToken)
+                    }
+                }
 
             if isCommandMode {
                 if let command = activeCommand {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
@@ -212,10 +212,16 @@ struct ResultsListView: View {
             }
             .onChange(of: selectedID) { _, newID in
                 guard let newID else { return }
-                // Same curve as the selection pill, so the pill can't trail the
-                // list when rows differ in height.
+                // No anchor, so this scrolls the minimum needed to bring the row
+                // into view and does nothing at all while the selection is
+                // already visible. `.center` re-centred on every keypress, which
+                // slid the whole list under a stationary pill and made the one
+                // thing that actually moved the hardest thing to follow.
+                //
+                // Same curve as the pill, so the two stay together on the scrolls
+                // that do happen.
                 withAnimation(Motion.Selection.glide) {
-                    proxy.scrollTo(newID, anchor: .center)
+                    proxy.scrollTo(newID)
                 }
             }
         }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
@@ -198,6 +198,7 @@ struct ResultsListView: View {
                             result: result,
                             isSelected: selectedID == result.id,
                             isPicked: pickedKeys.contains("\(result.kind.rawValue)|\(result.path)"),
+                            isLast: result.id == results.last?.id,
                             selectionNamespace: selectionNamespace,
                             onOpen: {
                                 onSelect(result.id)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
@@ -44,6 +44,9 @@ struct SearchInputBar: View {
                 themeStore: themeStore,
                 onSubmit: onSubmit
             )
+                // The field's own placeholder is empty, so it would otherwise
+                // reach VoiceOver unnamed.
+                .accessibilityLabel(placeholderText)
                 .frame(maxWidth: .infinity)
                 .overlay(alignment: .leading) {
                     if text.isEmpty {
@@ -53,6 +56,10 @@ struct SearchInputBar: View {
                             .lineLimit(1)
                             .padding(.leading, Layout.placeholderLeadingInset)
                             .allowsHitTesting(false)
+                            // Decorative: the field above carries the name.
+                            // `allowsHitTesting` does not remove it from the
+                            // accessibility tree.
+                            .accessibilityHidden(true)
                             .placeholderReveal(token: revealToken)
                     }
                 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -113,6 +113,8 @@ struct LauncherView: View {
     /// Resting corner for a tile that floats free of its neighbours, and for the
     /// seated variant that reads as part of one box. Both are scaled by the
     /// active theme surface (Liquid rounds harder) at each use.
+    /// First position in the spawn cascade, ahead of the launchpad grid.
+    static let searchBarRevealIndex = 0
     static let floatingTileCornerRadius: CGFloat = 12
     static let seatedTileCornerRadius: CGFloat = 10
     static let attachedPanelScrimOpacity = 0.16
@@ -951,6 +953,7 @@ struct LauncherView: View {
             activeCommand: activeCommand,
             themeStore: themeStore,
             showsBackground: showsBackground,
+            revealToken: appearanceRevealToken,
             onSubmit: handleSubmit,
             onExitCommandMode: exitCommandMode
         )
@@ -1447,6 +1450,9 @@ struct LauncherView: View {
             }
             .shadow(color: floats ? .black.opacity(0.25) : .clear,
                     radius: floats ? 7 : 0, x: 0, y: floats ? 3 : 0)
+            // Leads the cascade: the bar lands first, then the launchpad tiles.
+            // No scale, so the search field's text stays crisp (see spawnReveal).
+            .spawnReveal(index: Self.searchBarRevealIndex, token: appearanceRevealToken, scales: false)
     }
 
     /// Wraps a single-panel home state (translation, clipboard/recent empty) in a

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -699,11 +699,6 @@ struct LauncherView: View {
         // fixed-size panel regardless of the running-apps toggle.
         borderedPanel(windowCornerRadius: windowCornerRadius, contentSpacing: contentSpacing, contentPadding: contentPadding)
         .rootReveal(token: appearanceRevealToken)
-        // The launchpad and the results list used to hard-cut on the first
-        // keystroke, which is the most visible moment in the app. Keyed on that
-        // one value, so no other state change in the panel picks up a
-        // transaction (see the halo note in LauncherView+Background).
-        .animation(Motion.Surface.swap, value: hidesResultsForEmptyQuery)
         .ignoresSafeArea()
         .onAppear {
             refreshSearchResults()
@@ -979,7 +974,8 @@ struct LauncherView: View {
                             RunningAppsStripView(
                                 service: runningAppsService,
                                 themeStore: themeStore,
-                                onActivate: { key in _ = activateRunningApp(forKey: key) }
+                                onActivate: { key in _ = activateRunningApp(forKey: key) },
+                                revealToken: appearanceRevealToken
                             )
                             .frame(maxWidth: .infinity)
                         }
@@ -1033,12 +1029,10 @@ struct LauncherView: View {
                         themeStore: themeStore,
                         revealToken: appearanceRevealToken
                     )
-                    .transition(Motion.Surface.swapTransition)
                 }
                 Spacer(minLength: 0)
             } else {
                 resultsRow
-                    .transition(Motion.Surface.swapTransition)
             }
 
             if isCommandMode {
@@ -1215,6 +1209,14 @@ struct LauncherView: View {
                     processCPU: processCPU(for: selectedResult),
                     isMeasuringProcessCPU: isMeasuringCPU(for: selectedResult)
                 )
+                // Arrow-key nav assigns `selectedResultID` inside a global
+                // `withAnimation` so the pill can glide (see LauncherView+
+                // Selection). The preview swaps its whole contents on that same
+                // change and would inherit the transaction, animating icon and
+                // text on every keypress. Opted out for that value only, so the
+                // pill stays the one thing moving while the quick-action reveal
+                // inside this pane still animates on open.
+                .animation(nil, value: selectedResult.id)
             }
         }
     }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -110,6 +110,11 @@ struct LauncherView: View {
     static let panelCoordinateSpace = "launcherPanel"
 
     static let floatingTileScrimOpacity = 0.30
+    /// Resting corner for a tile that floats free of its neighbours, and for the
+    /// seated variant that reads as part of one box. Both are scaled by the
+    /// active theme surface (Liquid rounds harder) at each use.
+    static let floatingTileCornerRadius: CGFloat = 12
+    static let seatedTileCornerRadius: CGFloat = 10
     static let attachedPanelScrimOpacity = 0.16
 
     var runningAppsPlacement: RunningAppsPlacement {
@@ -693,6 +698,12 @@ struct LauncherView: View {
         // floating strip that grows the window. The launcher is always a single
         // fixed-size panel regardless of the running-apps toggle.
         borderedPanel(windowCornerRadius: windowCornerRadius, contentSpacing: contentSpacing, contentPadding: contentPadding)
+        .rootReveal(token: appearanceRevealToken)
+        // The launchpad and the results list used to hard-cut on the first
+        // keystroke, which is the most visible moment in the app. Keyed on that
+        // one value, so no other state change in the panel picks up a
+        // transaction (see the halo note in LauncherView+Background).
+        .animation(Motion.Surface.swap, value: hidesResultsForEmptyQuery)
         .ignoresSafeArea()
         .onAppear {
             refreshSearchResults()
@@ -1022,10 +1033,12 @@ struct LauncherView: View {
                         themeStore: themeStore,
                         revealToken: appearanceRevealToken
                     )
+                    .transition(Motion.Surface.swapTransition)
                 }
                 Spacer(minLength: 0)
             } else {
                 resultsRow
+                    .transition(Motion.Surface.swapTransition)
             }
 
             if isCommandMode {
@@ -1335,8 +1348,15 @@ struct LauncherView: View {
         if barFloatsFree {
             content()
                 .padding(padding)
-                .background { tileBackground(cornerRadius: 12, floats: true) }
-                .overlay { tileBorder(cornerRadius: 12) }
+                .background {
+                    tileBackground(
+                        cornerRadius: themeStore.surfaceCornerRadius(Self.floatingTileCornerRadius),
+                        floats: true
+                    )
+                }
+                .overlay {
+                    tileBorder(cornerRadius: themeStore.surfaceCornerRadius(Self.floatingTileCornerRadius))
+                }
                 // Lift each pane off the backdrop so the three parts read as
                 // separate floating tiles rather than sections of one box.
                 .shadow(color: .black.opacity(0.25), radius: 7, x: 0, y: 3)
@@ -1360,7 +1380,7 @@ struct LauncherView: View {
                     // covered by the tint.
                     themeStore.scrimColor(opacity: Self.floatingTileScrimOpacity)
                 } else {
-                    ThemedBackdrop(themeStore: themeStore)
+                    ThemedBackdrop(themeStore: themeStore, cornerRadius: cornerRadius)
                 }
                 themeStore.controlFillColor()
             }
@@ -1410,10 +1430,17 @@ struct LauncherView: View {
         // (e.g. typing the first character out of the empty-rest state at gap 0).
         let floats = barFloatsFree
         return content()
-            .background { tileBackground(cornerRadius: floats ? 12 : 10, floats: floats) }
+            .background {
+                tileBackground(
+                    cornerRadius: themeStore.surfaceCornerRadius(
+                        floats ? Self.floatingTileCornerRadius : Self.seatedTileCornerRadius
+                    ),
+                    floats: floats
+                )
+            }
             .overlay {
                 if floats {
-                    tileBorder(cornerRadius: 12)
+                    tileBorder(cornerRadius: themeStore.surfaceCornerRadius(Self.floatingTileCornerRadius))
                 }
             }
             .shadow(color: floats ? .black.opacity(0.25) : .clear,

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LaunchpadLSlotView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LaunchpadLSlotView.swift
@@ -283,6 +283,10 @@ private struct LaunchpadHeaderClock: View {
 /// readout in the top-right, and the slot's content pinned to the bottom. When
 /// `showsClock` is set, a compact time + date sits in the header so it stays
 /// visible even while the Todo or Pomo slot occupies the tile.
+/// The L slot's outline sits lighter than the theme divider it derives from, so
+/// the largest tile does not read as the most heavily framed.
+private let slotBorderOpacity = 0.4
+
 private struct LaunchpadSlotCard<Content: View>: View {
     var themeStore: ThemeStore
     let iconName: String
@@ -320,8 +324,13 @@ private struct LaunchpadSlotCard<Content: View>: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(frostedTile(themeStore: themeStore))
         .overlay(
-            RoundedRectangle(cornerRadius: Const.cornerRadius, style: .continuous)
-                .strokeBorder(themeStore.dividerColor().opacity(0.4), lineWidth: 1)
+            // Same scaled radius as the `frostedTile` behind it, so the outline
+            // follows the tile edge instead of cutting across its corners.
+            RoundedRectangle(
+                cornerRadius: themeStore.surfaceCornerRadius(Const.cornerRadius),
+                style: .continuous
+            )
+            .strokeBorder(themeStore.dividerColor().opacity(slotBorderOpacity), lineWidth: 1)
         )
     }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LaunchpadLSlotView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LaunchpadLSlotView.swift
@@ -324,8 +324,7 @@ private struct LaunchpadSlotCard<Content: View>: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(frostedTile(themeStore: themeStore))
         .overlay(
-            // Same scaled radius as the `frostedTile` behind it, so the outline
-            // follows the tile edge instead of cutting across its corners.
+            // Same scaled radius as `frostedTile`, or the outline cuts the corners.
             RoundedRectangle(
                 cornerRadius: themeStore.surfaceCornerRadius(Const.cornerRadius),
                 style: .continuous

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LaunchpadLSlotView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LaunchpadLSlotView.swift
@@ -122,6 +122,8 @@ private struct LaunchpadPomoTile: View {
                     .font(themeStore.uiFont(size: 30, weight: .bold))
                     .foregroundColor(themeStore.fontColor())
                     .monospacedDigit()
+                    .contentTransition(.numericText(countsDown: true))
+                    .animation(Motion.Value.rollDigits, value: state.secondsLeft)
                 Text(phaseLabel)
                     .font(themeStore.uiFont(size: Const.captionFontSize + 1))
                     .foregroundColor(themeStore.secondaryTextColor())

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/RunningAppsStripView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/RunningAppsStripView.swift
@@ -44,10 +44,8 @@ struct RunningAppsStripView: View {
                     hoveredIndex = hovering ? index : (hoveredIndex == index ? nil : hoveredIndex)
                 }
             )
-            // Right-aligned, so the cascade runs right to left.
-            .spawnReveal(index: total - 1 - index, token: revealToken)
-            // NSImage, so a scale pop rather than the symbol bounce.
-            .iconPop(token: revealToken)
+            // Slides in from the left, leftmost first.
+            .stripReveal(index: index, token: revealToken)
         }
     }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/RunningAppsStripView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/RunningAppsStripView.swift
@@ -44,11 +44,9 @@ struct RunningAppsStripView: View {
                     hoveredIndex = hovering ? index : (hoveredIndex == index ? nil : hoveredIndex)
                 }
             )
-            // Right-aligned strip, so the cascade runs right to left: the icons
-            // nearest the search caret settle first.
+            // Right-aligned, so the cascade runs right to left.
             .spawnReveal(index: total - 1 - index, token: revealToken)
-            // App icons are NSImage, so they get the scale pop rather than the
-            // symbol bounce the launchpad glyphs use.
+            // NSImage, so a scale pop rather than the symbol bounce.
             .iconPop(token: revealToken)
         }
     }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/RunningAppsStripView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/RunningAppsStripView.swift
@@ -7,6 +7,8 @@ struct RunningAppsStripView: View {
     @ObservedObject var service: RunningAppsService
     let themeStore: ThemeStore
     let onActivate: (Int) -> Void
+    /// Changes each time the launcher opens, replaying the spawn cascade.
+    var revealToken: UInt64 = 0
 
     @State private var hoveredIndex: Int?
 
@@ -42,6 +44,12 @@ struct RunningAppsStripView: View {
                     hoveredIndex = hovering ? index : (hoveredIndex == index ? nil : hoveredIndex)
                 }
             )
+            // Right-aligned strip, so the cascade runs right to left: the icons
+            // nearest the search caret settle first.
+            .spawnReveal(index: total - 1 - index, token: revealToken)
+            // App icons are NSImage, so they get the scale pop rather than the
+            // symbol bounce the launchpad glyphs use.
+            .iconPop(token: revealToken)
         }
     }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Appearance.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Appearance.swift
@@ -8,7 +8,7 @@ extension ThemeSettingsView {
                 HStack(spacing: 14) {
                     inlinePickerLabel("Theme")
                     Picker("Theme", selection: $settings.uiTheme) {
-                        ForEach(BuiltinThemePreset.allCases) { preset in
+                        ForEach(BuiltinThemePreset.selectable) { preset in
                             Text(preset.title).tag(preset)
                         }
                     }
@@ -59,7 +59,13 @@ extension ThemeSettingsView {
 
                 sectionHeader("Blur")
 
+                // Glass has no blur to thin: `ThemedBackdrop` ignores this on the
+                // Liquid surface, because dimming glass makes it ghostly rather
+                // than lighter. Shown disabled so the value the user set is still
+                // visible, and comes back when they switch material.
                 LabeledSlider(title: "Blur Opacity", value: $settings.blurOpacity, range: 0...1)
+                    .disabled(settings.blurMaterial == .liquidGlass)
+                    .opacity(settings.blurMaterial == .liquidGlass ? AppConstants.ThemeUI.disabledControlOpacity : 1)
                 LabeledSlider(title: "Settings Blur", value: $appUIState.settingsBlurMultiplier, range: 0.4...1)
 
                 HStack(spacing: 10) {
@@ -69,7 +75,7 @@ extension ThemeSettingsView {
                         .foregroundStyle(themeStore.secondaryTextColor())
 
                     Picker("Blur Style", selection: $settings.blurMaterial) {
-                        ForEach(LauncherBlurMaterial.allCases) { item in
+                        ForEach(LauncherBlurMaterial.selectable) { item in
                             Text(item.title).tag(item)
                         }
                     }

--- a/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Appearance.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Appearance.swift
@@ -59,10 +59,8 @@ extension ThemeSettingsView {
 
                 sectionHeader("Blur")
 
-                // Glass has no blur to thin: `ThemedBackdrop` ignores this on the
-                // Liquid surface, because dimming glass makes it ghostly rather
-                // than lighter. Shown disabled so the value the user set is still
-                // visible, and comes back when they switch material.
+                // Glass has no blur to thin, so `ThemedBackdrop` ignores this.
+                // Disabled rather than hidden, to keep the value visible.
                 LabeledSlider(title: "Blur Opacity", value: $settings.blurOpacity, range: 0...1)
                     .disabled(settings.blurMaterial == .liquidGlass)
                     .opacity(settings.blurMaterial == .liquidGlass ? AppConstants.ThemeUI.disabledControlOpacity : 1)

--- a/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Appearance.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Appearance.swift
@@ -8,8 +8,8 @@ extension ThemeSettingsView {
                 HStack(spacing: 14) {
                     inlinePickerLabel("Theme")
                     Picker("Theme", selection: $settings.uiTheme) {
-                        ForEach(BuiltinThemePreset.selectable) { preset in
-                            Text(preset.title).tag(preset)
+                        ForEach(BuiltinThemePreset.options(including: settings.uiTheme)) { preset in
+                            Text(preset.pickerTitle).tag(preset)
                         }
                     }
                     .pickerStyle(.menu)
@@ -62,8 +62,8 @@ extension ThemeSettingsView {
                 // Glass has no blur to thin, so `ThemedBackdrop` ignores this.
                 // Disabled rather than hidden, to keep the value visible.
                 LabeledSlider(title: "Blur Opacity", value: $settings.blurOpacity, range: 0...1)
-                    .disabled(settings.blurMaterial == .liquidGlass)
-                    .opacity(settings.blurMaterial == .liquidGlass ? AppConstants.ThemeUI.disabledControlOpacity : 1)
+                    .disabled(settings.blurMaterial.rendersGlass)
+                    .opacity(settings.blurMaterial.rendersGlass ? AppConstants.ThemeUI.disabledControlOpacity : 1)
                 LabeledSlider(title: "Settings Blur", value: $appUIState.settingsBlurMultiplier, range: 0.4...1)
 
                 HStack(spacing: 10) {
@@ -73,8 +73,8 @@ extension ThemeSettingsView {
                         .foregroundStyle(themeStore.secondaryTextColor())
 
                     Picker("Blur Style", selection: $settings.blurMaterial) {
-                        ForEach(LauncherBlurMaterial.selectable) { item in
-                            Text(item.title).tag(item)
+                        ForEach(LauncherBlurMaterial.options(including: settings.blurMaterial)) { item in
+                            Text(item.pickerTitle).tag(item)
                         }
                     }
                     .pickerStyle(.menu)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,6 +55,7 @@ flowchart LR
   - `EngineBridge`: search engine communication
   - `ClipboardHistoryStore`, `KeyboardSelectionMonitor`, `GlobalHotKeyManager`
 - `Themes/`: builtin theme presets (Catppuccin, Tokyo Night, Rose Pine, Gruvbox, Dracula, Kanagawa, Kindle, Liquid) and semantic color tokens
+- `Support/UI/`: shared UI primitives - `Motion` (all animation constants and the reveal modifiers), `ToggleSwitch`, `HoverTooltip`, `HoverBubble`
 - `bridge/ffi`: narrow C ABI surface for search, usage recording, config reload, translation, todo load/save, speed test, and error payloads.
 - `core/answers`: platform-agnostic, network-backed "web answer" lookups shared by every shell (macOS via `bridge/ffi`, Windows/Linux via Tauri commands). Instant answers (currency/weather/crypto), search suggestions, knowledge sources, and translation. Best-effort and panic-free: every entry point returns "no answer" on failure, with cheap network-free pattern-gating (`has_match`) so callers can fire speculatively while typing. No async runtime - HTTP is a blocking `curl` subprocess.
 - `core/indexing`: candidate model and indexing helpers used by engine/storage flows.
@@ -407,6 +408,40 @@ paper. The switch persists those values, so restore paths stay dumb and the
 sliders are the user's again from the next drag. Its font stack stays in CSS
 and applies while the Font field is left at `system-ui`; an explicit font still
 wins.
+
+### Motion
+
+Every animated surface reads its physics from `Support/UI/Motion.swift`, so the
+feel is tuned in one place: `Spawn` (the launchpad cascade), `Selection` (the
+gliding pill and the one-shot zoom), `Slide` (horizontal entrances), `Surface`
+(the panel arriving), `Press`, `Value` (digit rolls) and `Caret`.
+
+Entrances key off `appearanceRevealToken`, a counter `LauncherView` bumps on
+every show. The window is only ordered out and back in, so `onAppear` fires once
+per process and cannot drive them. The modifiers are `rootReveal` (whole panel),
+`spawnReveal` (launchpad tiles, quick actions, the search bar), `slideReveal`
+via `placeholderReveal` / `stripReveal`, plus `symbolEffect(.bounce, value:)` on
+SF Symbols.
+
+Three constraints that are easy to break:
+
+- **Scope animations tightly.** An `.animation(_:value:)` high in the tree
+  attaches to its whole subtree, so when it fires every result row animates at
+  once. Per-row it is just as bad: it fires on each neighbour as the selection
+  passes. Row-local one-shot state driven by `onChange(of: isSelected)` is what
+  keeps a single row moving.
+- **`ThemedBackdrop` opts out of ambient transactions.** Nav wraps its selection
+  assignment in a global `withAnimation`, and re-compositing an
+  `NSVisualEffectView` or `NSGlassEffectView` inside that transaction flickers
+  the whole window on every keypress.
+- **Do not resolve icons inside `body` uncached.** `NSWorkspace.icon(forFile:)`
+  returns a fresh `NSImage` per call, which SwiftUI redraws; every icon in the
+  list then flickers on each keypress. `Support/RowIconCache.swift` returns one
+  instance per path. Process icons stay uncached, since pids are reused.
+
+Panel arrival is a content-layer effect, not a window one: animating the window
+would mean touching the `makeKeyAndOrderFront` path that the Cmd+Space
+cold-login bug lives in. Reduce Motion is honoured by every modifier.
 
 ### Config File Integration
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -452,7 +452,7 @@ All settings are persisted to `.look.config`:
 
 **Appearance:**
 - `ui_tint_red`, `ui_tint_green`, `ui_tint_blue`, `ui_tint_opacity` - background tint (0-1)
-- `ui_blur_material` - blur style (hudWindow, sidebar, menu, underWindowBackground, liquidGlass). `liquidGlass` renders through `NSGlassEffectView` and needs macOS 26; below that it falls back to `hudWindow`, and neither it nor the Liquid theme is offered in Settings.
+- `ui_blur_material` - blur style (hudWindow, sidebar, menu, underWindowBackground, liquidGlass). `liquidGlass` renders through `NSGlassEffectView` and needs macOS 26; below that it falls back to `hudWindow`, and neither it nor the Liquid theme is offered as a new choice in Settings. A value already persisted stays selectable and is labelled as unsupported rather than being rewritten, since normalising it would destroy the setting for the same config on a newer machine.
 - `ui_blur_opacity` - blur opacity (0-1)
 - `ui_font_name`, `ui_font_size` - font settings
 - `ui_font_red`, `ui_font_green`, `ui_font_blue`, `ui_font_opacity` - text color (0-1)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,7 +54,7 @@ flowchart LR
   - `LauncherWindowCoordinator`: window/focus management
   - `EngineBridge`: search engine communication
   - `ClipboardHistoryStore`, `KeyboardSelectionMonitor`, `GlobalHotKeyManager`
-- `Themes/`: builtin theme presets (Catppuccin, Tokyo Night, Rose Pine, Gruvbox, Dracula, Kanagawa, Kindle) and semantic color tokens
+- `Themes/`: builtin theme presets (Catppuccin, Tokyo Night, Rose Pine, Gruvbox, Dracula, Kanagawa, Kindle, Liquid) and semantic color tokens
 - `bridge/ffi`: narrow C ABI surface for search, usage recording, config reload, translation, todo load/save, speed test, and error payloads.
 - `core/answers`: platform-agnostic, network-backed "web answer" lookups shared by every shell (macOS via `bridge/ffi`, Windows/Linux via Tauri commands). Instant answers (currency/weather/crypto), search suggestions, knowledge sources, and translation. Best-effort and panic-free: every entry point returns "no answer" on failure, with cheap network-free pattern-gating (`has_match`) so callers can fire speculatively while typing. No async runtime - HTTP is a blocking `curl` subprocess.
 - `core/indexing`: candidate model and indexing helpers used by engine/storage flows.
@@ -357,6 +357,7 @@ Available themes (selected via Settings > Appearance):
 | Dracula | Classic purple-accented dark |
 | Kanagawa | Japanese-inspired dark theme |
 | Kindle | Paper and ink, e-reader light theme (Charter serif) |
+| Liquid | Liquid Glass surface, translucent fills (macOS 26+) |
 | Custom | Auto-derived semantic colors from tint |
 
 Themes are defined in `Themes/` folder:
@@ -370,6 +371,27 @@ in Light or Dark mode, and it picks how the opaque command-mode surfaces and the
 pane scrims are mixed: dark themes darken, light themes lighten. A preset may
 also declare a `fontName`; presets that do not reset the font to the app default
 when applied.
+
+A preset also declares a `ThemeSurface` (`.classic` or `.liquid`), the second
+non-token axis alongside `ThemeAppearance`: it selects how surfaces are drawn
+rather than what colour they are, and scales every themed corner radius through
+`ThemeStore.surfaceCornerRadius(_:)`. Any new border or `clipShape` on a themed
+surface must go through that helper, or it desyncs from the fill behind it and
+draws a stray line across the corners.
+
+`ThemeStore.themeSurface()` resolves the axis from `blurMaterial` first and the
+preset second. That is deliberate: `savedThemeName()` stops recording `ui_theme`
+as soon as any value diverges from its preset (the load path applies the theme
+*over* the individual `ui_*` keys, so a stale name would discard the user's
+tweaks), while `ui_blur_material` persists on its own. Keying off the material
+means a customised Liquid theme keeps its glass across a relaunch.
+
+Liquid Glass itself is `Components/GlassEffectBackdrop.swift`, an
+`NSGlassEffectView` wrapper. Not SwiftUI's `glassEffect`, which refracts only
+what sits behind it inside its own view tree: the launcher window is
+transparent, so that renders as nearly nothing. The view also draws nothing
+without a `contentView`, and the theme tint is passed into its `tintColor`
+rather than layered over it, since a colour wash on top cancels the refraction.
 
 On linows the same presets live in `apps/linows/src/css/theme.css`, one
 `:root[data-theme="…"]` block per preset, with `js/screens/settings.js`
@@ -391,11 +413,11 @@ wins.
 All settings are persisted to `.look.config`:
 
 **UI Theme:**
-- `ui_theme` - theme name (catppuccin, tokyoNight, rosePine, gruvbox, dracula, kanagawa, kindle). Matched case-insensitively, and applied after the individual `ui_*` keys below, so a preset overrides them. Empty means Custom. Save Config writes a preset name only while the values still match that preset, so a theme you have tweaked is stored as its literal values.
+- `ui_theme` - theme name (catppuccin, tokyoNight, rosePine, gruvbox, dracula, kanagawa, kindle, liquid). Matched case-insensitively, and applied after the individual `ui_*` keys below, so a preset overrides them. Empty means Custom. Save Config writes a preset name only while the values still match that preset, so a theme you have tweaked is stored as its literal values.
 
 **Appearance:**
 - `ui_tint_red`, `ui_tint_green`, `ui_tint_blue`, `ui_tint_opacity` - background tint (0-1)
-- `ui_blur_material` - blur style (hudWindow, sidebar, menu, underWindowBackground)
+- `ui_blur_material` - blur style (hudWindow, sidebar, menu, underWindowBackground, liquidGlass). `liquidGlass` renders through `NSGlassEffectView` and needs macOS 26; below that it falls back to `hudWindow`, and neither it nor the Liquid theme is offered in Settings.
 - `ui_blur_opacity` - blur opacity (0-1)
 - `ui_font_name`, `ui_font_size` - font settings
 - `ui_font_red`, `ui_font_green`, `ui_font_blue`, `ui_font_opacity` - text color (0-1)

--- a/docs/features.md
+++ b/docs/features.md
@@ -85,7 +85,7 @@ This document tracks what `look` supports today and what is planned next.
 - in-app settings panel (`Cmd+Shift+,`)
 - local config file `~/.look.config`
 - runtime reload (`Cmd+Shift+;`)
-- 8 built-in theme presets (Catppuccin, Tokyo Night, Rose Pine, Gruvbox, Dracula, Kanagawa, Kindle, Custom)
+- 9 built-in theme presets (Catppuccin, Tokyo Night, Rose Pine, Gruvbox, Dracula, Kanagawa, Kindle, Liquid, Custom)
 - query alias presets in `~/.look.config` for app + System Settings intent expansion (`alias_note`, `alias_code`, `alias_term`, `alias_chat`, `alias_music`, `alias_brow`)
 - in-app config reset (`Settings > Advanced > Create Fresh Config`) with confirmation popup
 - semantic color system with auto-derived text colors in Custom mode

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -245,14 +245,15 @@ Liquid is the one preset that changes how surfaces are drawn rather than only
 what colour they are. It renders the window and every tile on macOS 26's Liquid
 Glass, rounds corners further, and uses far more transparent fills so the glass
 reads as a lens rather than a panel. It needs macOS 26 and is hidden from the
-picker on older releases. Two consequences worth knowing:
+picker on older releases. If a config written on macOS 26 is opened on an older one, the value is kept and shown as unsupported rather than silently changed. Two consequences worth knowing:
 
 - `Blur Opacity` is disabled while Liquid Glass is the blur style, because glass
   has no blur to thin. Your value is kept and returns when you switch back.
 - The glass follows `Blur Style`, not the theme name, so you can pick
   `Settings > Appearance > Blur Style > Liquid Glass` on any theme to get the
-  glass surface with that theme's palette. Equally, selecting Liquid and then
-  choosing a different blur style gives you its palette on the classic surface.
+  glass surface with that theme's palette. Going the other way, selecting Liquid
+  and then a different blur style keeps Liquid's palette *and* its rounder
+  corners, and swaps only the material for the classic blur.
 
 **Running Apps**: a switch that shows running-app icons in the right half of the search bar. When on, the search field shrinks to the left half and the running apps fill the right half (right-aligned, growing leftward as more apps open). Each icon has a corner number badge; pressing the modifier + the badge digit on the home screen activates that app - `Cmd+1`..`Cmd+9` on macOS, `Alt+1`..`Alt+9` on Linux and Windows. When off, the search bar spans the full width and the switcher shortcut is disabled. The launcher window stays the same size either way.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -229,6 +229,7 @@ Built-in theme presets are available:
 | Dracula     | Classic purple-accented dark      |
 | Kanagawa    | Japanese-inspired dark theme      |
 | Kindle      | Paper and ink e-reader look       |
+| Liquid      | Liquid Glass surface (macOS 26+)  |
 | Custom      | Your own colors derived from tint |
 
 Theme is saved as `ui_theme=<name>` in config, and a name written there overrides
@@ -239,6 +240,19 @@ one light preset: it also switches the frosted panels to a light material and th
 font to Charter, macOS' stand-in for Bookerly. Picking a preset overwrites your
 tint, text color, border and font; `Custom` keeps the current values and derives
 the rest from them.
+
+Liquid is the one preset that changes how surfaces are drawn rather than only
+what colour they are. It renders the window and every tile on macOS 26's Liquid
+Glass, rounds corners further, and uses far more transparent fills so the glass
+reads as a lens rather than a panel. It needs macOS 26 and is hidden from the
+picker on older releases. Two consequences worth knowing:
+
+- `Blur Opacity` is disabled while Liquid Glass is the blur style, because glass
+  has no blur to thin. Your value is kept and returns when you switch back.
+- The glass follows `Blur Style`, not the theme name, so you can pick
+  `Settings > Appearance > Blur Style > Liquid Glass` on any theme to get the
+  glass surface with that theme's palette. Equally, selecting Liquid and then
+  choosing a different blur style gives you its palette on the classic surface.
 
 **Running Apps**: a switch that shows running-app icons in the right half of the search bar. When on, the search field shrinks to the left half and the running apps fill the right half (right-aligned, growing leftward as more apps open). Each icon has a corner number badge; pressing the modifier + the badge digit on the home screen activates that app - `Cmd+1`..`Cmd+9` on macOS, `Alt+1`..`Alt+9` on Linux and Windows. When off, the search bar spans the full width and the switcher shortcut is disabled. The launcher window stays the same size either way.
 


### PR DESCRIPTION
## Summary

Liquid glass for MacOS
#360 

## Testing


- `apps/linows`
  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)


https://github.com/user-attachments/assets/f601aaa6-ee6e-4aa5-b02a-c887363175a8



## Checklist

- [x] I have read and agree to the CLA (CLA.md)
- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Liquid theme with translucent Liquid Glass styling on macOS 26 and later.
  * Older macOS versions automatically use a compatible fallback and clearly label unavailable options.
  * Improved theme-aware corner rounding, tinting, and appearance settings.

* **Enhancements**
  * Added smoother launcher, selection, search, tile, and panel animations.
  * Improved reduced-motion support and launchpad interactions.
  * Improved result scrolling, accessibility labeling, and icon loading performance.

* **Documentation**
  * Updated theme, configuration, architecture, and user-guide documentation for Liquid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->