### PR TITLE
fix: re-calc selection pill

### DIFF
--- a/apps/linows/src-tauri/src/commands.rs
+++ b/apps/linows/src-tauri/src/commands.rs
@@ -3,6 +3,7 @@ use crate::platform::linux::host_command;
 use crate::state::AppState;
 use look_engine::config::RuntimeConfig;
 use serde::Serialize;
+use std::num::NonZeroU64;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::{Emitter, State};
@@ -402,10 +403,12 @@ pub fn hide_armed(window: &tauri::WebviewWindow) {
 
 /// The frontend has painted the armed frame; the window can go now. Keyed on
 /// `arm` so a late confirmation can't hide a window a later dismiss just armed.
+/// `NonZeroU64` keeps the idle sentinel out of the compare: a payload of 0 is
+/// rejected while deserializing, never as a match against an idle `PENDING_HIDE`.
 #[tauri::command]
-pub fn confirm_hide(window: tauri::WebviewWindow, arm: u64) {
+pub fn confirm_hide(window: tauri::WebviewWindow, arm: NonZeroU64) {
     if PENDING_HIDE
-        .compare_exchange(arm, 0, Ordering::Relaxed, Ordering::Relaxed)
+        .compare_exchange(arm.get(), 0, Ordering::Relaxed, Ordering::Relaxed)
         .is_ok()
     {
         let _ = window.hide();

--- a/apps/linows/src-tauri/src/commands.rs
+++ b/apps/linows/src-tauri/src/commands.rs
@@ -401,14 +401,12 @@ pub fn hide_armed(window: &tauri::WebviewWindow) {
 }
 
 /// The frontend has painted the armed frame; the window can go now. Keyed on
-/// `arm` so a confirmation that arrives late, after a show or a later dismiss,
-/// can't hide a window whose current arm hasn't painted yet.
+/// `arm` so a late confirmation can't hide a window a later dismiss just armed.
 #[tauri::command]
 pub fn confirm_hide(window: tauri::WebviewWindow, arm: u64) {
-    if arm != 0
-        && PENDING_HIDE
-            .compare_exchange(arm, 0, Ordering::Relaxed, Ordering::Relaxed)
-            .is_ok()
+    if PENDING_HIDE
+        .compare_exchange(arm, 0, Ordering::Relaxed, Ordering::Relaxed)
+        .is_ok()
     {
         let _ = window.hide();
     }

--- a/apps/linows/src/css/components/results.css
+++ b/apps/linows/src/css/components/results.css
@@ -46,7 +46,7 @@
     opacity: 0;
     pointer-events: none;
     transition:
-        transform var(--motion-glide-ms) var(--motion-curve),
+        translate var(--motion-glide-ms) var(--motion-curve),
         height var(--motion-glide-ms) var(--motion-curve),
         opacity 120ms ease-out;
 }

--- a/apps/linows/src/css/motion.css
+++ b/apps/linows/src/css/motion.css
@@ -175,8 +175,9 @@
     }
 }
 
-/* The `scale` property, not a transform function: results.js drives position
- * through `transform`, and an animation there would eat the glide. */
+/* The `scale` property, not a transform function: an animation on `transform`
+ * would eat the glide. Position rides `translate` (results.js) so this can't
+ * multiply it. */
 @keyframes pill-gain {
     0% {
         scale: 1 1;

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -640,13 +640,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         motion.armReveal();
         // Rust holds the window up until this lands. Two frames: the first
         // callback runs before the armed frame is painted, the second after.
-        // The payload is the dismissal id, so a confirmation that misses its
-        // window is dropped instead of hiding a later one. A failed invoke
-        // falls back to Rust's timeout.
-        const arm = event?.payload ?? 0;
+        // The payload keys the dismissal. A failed invoke falls back to Rust's
+        // timeout.
         requestAnimationFrame(() =>
             requestAnimationFrame(() => {
-                confirmHide(arm).catch(() => {});
+                confirmHide(event.payload).catch(() => {});
             }),
         );
     });

--- a/apps/linows/src/js/components/results.js
+++ b/apps/linows/src/js/components/results.js
@@ -209,9 +209,10 @@ export function select(index, glide = false) {
 }
 
 // The pill is absolutely positioned in the list's content box, so its top:0 and
-// a row's offsetTop share an origin: translateY + height overlay it exactly. Its
+// a row's offsetTop share an origin: translate + height overlay it exactly. Its
 // left/right insets come from CSS (they match the row margin), so only the
-// vertical geometry is set here.
+// vertical geometry is set here. Position rides `translate`, not `transform`, or
+// the gain's `scale` multiplies it and kicks the pill by 2% of offsetTop.
 function placeSelectionPill(row, glide) {
     if (!selectionPill || selectionPill.parentNode !== container) {
         selectionPill = document.createElement('div');
@@ -219,7 +220,7 @@ function placeSelectionPill(row, glide) {
         container.prepend(selectionPill);
     }
     if (!glide) selectionPill.classList.add('is-instant');
-    selectionPill.style.transform = `translateY(${row.offsetTop}px)`;
+    selectionPill.style.translate = `0 ${row.offsetTop}px`;
     selectionPill.style.height = `${row.offsetHeight}px`;
     selectionPill.classList.add('is-visible');
     if (!glide) {


### PR DESCRIPTION
## Summary

- fix selection pill and result geo: y-axis aren't matched after a long move.  

## Testing

- `apps/linows`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] Manual verification completed (if UI/behavior changed)

## Checklist

- [x] I have read and agree to the CLA (CLA.md)
- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window-hide confirmation handling to prevent invalid confirmations and ensure windows hide reliably.

* **UI Improvements**
  * Refined result-selection animations for smoother movement and scaling.
  * Prevented selection positioning and scaling animations from interfering with each other.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->