### PR TITLE
chore: merge re-usable parts, add beta mark

### DIFF
--- a/apps/macos/LauncherApp/LauncherLogicTests/ShortcutCatalogTests.swift
+++ b/apps/macos/LauncherApp/LauncherLogicTests/ShortcutCatalogTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import LauncherLogic
+
+/// The catalog is the single source both the help screen and Settings render,
+/// so the drift these tests guard against used to be shipped: two hand-written
+/// tables that disagreed with each other and with the code.
+final class ShortcutCatalogTests: XCTestCase {
+    /// The bug this replaces: Settings listed `Cmd+1..6` naming /kill fourth,
+    /// after /speed had been inserted ahead of it, so every mapping from ⌘4 on
+    /// was off by one. Deriving from the catalog makes reordering enough.
+    func testCommandSwitchRowMatchesTheCommandCatalog() throws {
+        let commands = AppConstants.Launcher.commandCatalog
+        let row = try XCTUnwrap(entry("command.switchByIndex"))
+
+        XCTAssertEqual(row.keys, "Cmd+1..\(commands.count)")
+        for command in commands {
+            XCTAssertTrue(
+                row.action.contains("/\(command.id)"),
+                "the ⌘N row does not mention /\(command.id)")
+        }
+    }
+
+    /// `/speed` sits fourth, which is exactly the position the stale table got
+    /// wrong. Naming it explicitly keeps the regression legible.
+    func testSpeedIsListedFourth() {
+        let ids = AppConstants.Launcher.commandCatalog.map(\.id)
+        XCTAssertEqual(ids.count, 7)
+        XCTAssertEqual(ids[3], AppConstants.Launcher.Command.speed)
+    }
+
+    func testIDsAreUnique() {
+        let ids = ShortcutCatalog.allEntries.map(\.id)
+        XCTAssertEqual(Set(ids).count, ids.count, "duplicate shortcut id")
+    }
+
+    /// Ids are the handle a future user remapping binds to, so an entry without
+    /// one cannot be overridden and a blank key reads as a broken row.
+    func testEveryEntryIsRenderableAndAddressable() {
+        for entry in ShortcutCatalog.allEntries {
+            XCTAssertFalse(entry.id.isEmpty)
+            XCTAssertFalse(entry.keys.isEmpty, "\(entry.id) has no keys")
+            XCTAssertFalse(entry.action.isEmpty, "\(entry.id) has no description")
+        }
+    }
+
+    /// Settings renders every group; the help screen renders them by topic. If a
+    /// group belonged to no topic it would be visible in one surface only, which
+    /// is the failure mode the consolidation removed.
+    func testTopicsPartitionTheCatalog() {
+        let byTopic = ShortcutTopic.allCases.flatMap { ShortcutCatalog.groups(for: $0) }
+        XCTAssertEqual(byTopic.count, ShortcutCatalog.groups.count)
+        for topic in ShortcutTopic.allCases {
+            XCTAssertFalse(ShortcutCatalog.groups(for: topic).isEmpty, "\(topic.label) has no groups")
+        }
+    }
+
+    func testGroupTitlesAreUnique() {
+        let titles = ShortcutCatalog.groups.map(\.title)
+        XCTAssertEqual(Set(titles).count, titles.count)
+    }
+
+    /// Prefixes are derived, so the count follows the canonical list rather than
+    /// a copy of it.
+    func testPrefixesComeFromTheCanonicalList() {
+        let group = ShortcutCatalog.groups.first { $0.topic == .prefixes }
+        XCTAssertEqual(group?.entries.count, AppConstants.Launcher.PrefixSuggestion.all.count)
+    }
+
+    /// The AI keys existed only on the help screen before this; Settings had a
+    /// section for zoom but none for the assistant.
+    func testAIShortcutsAreInTheCatalog() {
+        let ai = ShortcutCatalog.groups(for: .ai).flatMap(\.entries)
+        XCTAssertFalse(ai.isEmpty)
+        XCTAssertTrue(ai.contains { $0.keys.contains("Option+Up") })
+    }
+
+    /// A typed prefix or a positional ⌘N has no chord to reassign, so a remap UI
+    /// must be able to tell them apart from real bindings.
+    func testUnassignableEntriesAreMarked() {
+        XCTAssertEqual(entry("command.switchByIndex")?.remappable, false)
+        XCTAssertEqual(entry("main.copy")?.remappable, true)
+        for entry in ShortcutCatalog.groups(for: .prefixes).flatMap(\.entries) {
+            XCTAssertFalse(entry.remappable, "\(entry.id) is typed text, not a chord")
+        }
+    }
+
+    private func entry(_ id: String) -> ShortcutEntry? {
+        ShortcutCatalog.allEntries.first { $0.id == id }
+    }
+}

--- a/apps/macos/LauncherApp/Package.swift
+++ b/apps/macos/LauncherApp/Package.swift
@@ -16,6 +16,7 @@ let package = Package(
             sources: [
                 "Support/Launcher/HintText.swift",
                 "Support/AppConstants.swift",
+                "Support/ShortcutCatalog.swift",
                 "Support/ConfigFileLines.swift",
                 "Support/Launcher/LauncherSearchLogic.swift",
                 "Support/Launcher/ProcessScoring.swift",

--- a/apps/macos/LauncherApp/look-app/Support/ShortcutCatalog.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ShortcutCatalog.swift
@@ -1,0 +1,180 @@
+import Foundation
+
+/// One documented shortcut.
+///
+/// `id` is the stable handle a future user remapping binds an override to: the
+/// displayed `keys` may change, the id must not. Entries carry one even though
+/// nothing overrides them yet, because adding remapping later must not have to
+/// invent identifiers for shortcuts people already learned.
+struct ShortcutEntry: Identifiable {
+    let id: String
+    let keys: String
+    let action: String
+    /// False when there is no chord to reassign - a typed prefix, a positional
+    /// `Cmd+N` derived from catalog order, or a pointer affordance. A remapping
+    /// UI offers only the remappable ones, so it never presents a row that
+    /// cannot be honoured.
+    var remappable: Bool = true
+
+    init(_ id: String, _ keys: String, _ action: String, remappable: Bool = true) {
+        self.id = id
+        self.keys = keys
+        self.action = action
+        self.remappable = remappable
+    }
+}
+
+/// The filter capsules on the help screen. Settings renders every topic in this
+/// order, so "all shortcuts" and "the Shortcuts tab" are the same list.
+enum ShortcutTopic: String, CaseIterable, Identifiable {
+    case main
+    case ai
+    case prefixes
+    case command
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .main: return "Main"
+        case .ai: return "AI"
+        case .prefixes: return "Prefixes"
+        case .command: return "Command"
+        }
+    }
+}
+
+/// One titled block. The title is the identity: two groups never share one.
+struct ShortcutGroup: Identifiable {
+    let title: String
+    let topic: ShortcutTopic
+    let entries: [ShortcutEntry]
+    var id: String { title }
+}
+
+/// The single source of truth for keyboard documentation.
+///
+/// Both surfaces read this: the in-window help screen (`Cmd+H`, filtered by
+/// topic) and Settings > Shortcuts (flat, every group). They used to be two
+/// hand-maintained tables, which drifted - six rows were duplicated verbatim,
+/// the AI keys existed only in help, and the `Cmd+N` command list in Settings
+/// had gone stale enough to name the wrong command.
+enum ShortcutCatalog {
+    static let groups: [ShortcutGroup] = [
+        ShortcutGroup(title: "Main", topic: .main, entries: [
+            ShortcutEntry("main.open", "Enter", "Open selected app/file/folder or copy selected clipboard item"),
+            ShortcutEntry("main.copy", "Cmd+C", "Copy selected file/folder to pasteboard"),
+            ShortcutEntry("main.pick", "Cmd+P", "Toggle pick on selected file/folder (multi-select copy)"),
+            ShortcutEntry("main.openPicked", "Shift+Enter", "Open all picked files/folders at once"),
+            ShortcutEntry("main.clearPicks", "Cmd+Shift+P", "Clear all picked items"),
+            ShortcutEntry("main.trash", "Cmd+D", "Trash selected file/folder (Trash pin: empty it) or remove the clipboard item"),
+            ShortcutEntry("main.moveTab", "Tab / Shift+Tab", "Move selection"),
+            ShortcutEntry("main.moveArrows", "Up / Down", "Move selection"),
+            ShortcutEntry("main.reveal", "Cmd+F", "Reveal selected app/file/folder in Finder"),
+            ShortcutEntry("main.webSearch", "Cmd+Enter", "Search current query on Google"),
+            ShortcutEntry("main.commandMode", "Cmd+/", "Enter command mode"),
+            ShortcutEntry("main.commandJump", ":cmd", "Jump to a command from home (e.g. :calc 2+2, :kill chrome)", remappable: false),
+            ShortcutEntry("main.hideApp", "Cmd+Shift+H", "Hide the selected app from Look"),
+            ShortcutEntry("main.help", "Cmd+H", "Toggle this help screen"),
+            ShortcutEntry("main.back", "Esc", "Back / close (context dependent)"),
+            ShortcutEntry("main.hideLauncher", "Shift+Esc", "Hide launcher"),
+        ]),
+
+        // The strip on the empty home screen. Keys are the tile mnemonics from
+        // the shared catalog (core/qactions), fired with Cmd.
+        ShortcutGroup(title: "Super actions", topic: .main, entries: [
+            ShortcutEntry("super.bluetoothWifi", "Cmd+B / Cmd+W", "Toggle Bluetooth / Wi-Fi"),
+            ShortcutEntry("super.themeAwake", "Cmd+T / Cmd+K", "Switch theme / toggle Keep Awake"),
+            ShortcutEntry("super.screensaverMic", "Cmd+S / Cmd+M", "Start screensaver / mute mic"),
+            ShortcutEntry("super.playPause", "Cmd+P", "Play/pause the current track"),
+            ShortcutEntry("super.power", "Cmd+R / Cmd+D", "Restart / Shut Down (press twice, Esc cancels)"),
+            ShortcutEntry("super.toggleStrip", "Settings > Appearance", "Show or hide the super actions strip", remappable: false),
+        ]),
+
+        ShortcutGroup(title: "Clipboard history", topic: .main, entries: [
+            ShortcutEntry("clipboard.copyBack", "Enter", "Copy selected history item back to clipboard"),
+            ShortcutEntry("clipboard.remove", "Cmd+D", "Remove selected clipboard item from Look history"),
+        ]),
+
+        ShortcutGroup(title: "View & panels", topic: .main, entries: [
+            ShortcutEntry("view.settings", "Cmd+Shift+,", "Open/close settings panel"),
+            ShortcutEntry("view.reloadConfig", "Cmd+Shift+;", "Reload .look.config"),
+            ShortcutEntry("view.zoom", "Cmd+- / Cmd+=", "Zoom UI scale out / in"),
+            ShortcutEntry("view.zoomReset", "Cmd+0", "Reset UI scale (opens the tenth session while the AI list is up)"),
+        ]),
+
+        // The `>` assistant: the sessions list, a live conversation, and the keys
+        // that only exist there (the running-apps strip is hidden in this mode,
+        // so Cmd+digit addresses conversations instead of apps).
+        ShortcutGroup(title: "AI mode (>)", topic: .ai, entries: [
+            ShortcutEntry("ai.enter", ">", "Enter AI mode (a dead-end Enter on the home screen goes here too)", remappable: false),
+            ShortcutEntry("ai.send", "Enter", "Send the message, or open the highlighted conversation"),
+            ShortcutEntry("ai.newline", "Shift+Enter", "New line in the message (the box grows to 6 lines)"),
+            ShortcutEntry("ai.history", "Option+Up / Option+Down", "Walk your recent prompts, like a shell history"),
+            ShortcutEntry("ai.selectText", "Shift+Up / Shift+Down", "Select text in the message you are composing"),
+            ShortcutEntry("ai.openSession", "Cmd+1..Cmd+9, Cmd+0", "Open the conversation carrying that chip (Cmd+0 is the tenth)"),
+            ShortcutEntry("ai.moveList", "Tab / Up / Down", "Move over the conversation list"),
+            ShortcutEntry("ai.deleteSession", "Cmd+D", "Delete the highlighted conversation"),
+            ShortcutEntry("ai.undo", "Cmd+Z", "Undo the last action, or restore a just-deleted conversation"),
+            ShortcutEntry("ai.stop", "Cmd+.", "Stop a streaming answer"),
+            ShortcutEntry("ai.mention", "@name", "Attach a file to the message (Enter picks the highlighted one)", remappable: false),
+            ShortcutEntry("ai.exactTime", "@ 5pm", "Set an exact time on an event or reminder", remappable: false),
+            ShortcutEntry("ai.chooseNumbered", "1, 2, 3 + Enter", "Answer a \u{201C}which one?\u{201D} list", remappable: false),
+            ShortcutEntry("ai.help", "Cmd+H", "Open this help without leaving the conversation"),
+            ShortcutEntry("ai.escape", "Esc", "Close the file popup, then leave the conversation"),
+            ShortcutEntry("ai.leave", "Shift+Esc", "Leave AI mode straight to the home screen"),
+        ]),
+
+        ShortcutGroup(title: "Query prefixes", topic: .prefixes, entries: prefixEntries),
+
+        ShortcutGroup(title: "Command mode", topic: .command, entries: [commandSwitchEntry] + [
+            ShortcutEntry("command.switchTab", "Tab / Shift+Tab", "Switch command"),
+            ShortcutEntry("command.byPort", "3000", "Find process by port or PID", remappable: false),
+            ShortcutEntry("command.killSelect", "Up / Down", "Select app in kill results"),
+            ShortcutEntry("command.killConfirm", "Y / N", "Confirm/cancel kill action"),
+            ShortcutEntry("command.back", "Esc", "Back to the app list"),
+        ]),
+
+        ShortcutGroup(title: "Pomodoro (/pomo)", topic: .command, entries: [
+            ShortcutEntry("pomo.startPause", "Space", "Start / pause the active session"),
+            ShortcutEntry("pomo.reset", "R", "Reset the timer back to idle"),
+            ShortcutEntry("pomo.music", "P", "Toggle music play / pause"),
+            ShortcutEntry("pomo.standby", "Mouse / key idle", "After 5s, panel fades to clock-only standby; any input restores", remappable: false),
+            ShortcutEntry("pomo.menuBar", "Menu bar item", "Click the timer icon in the menu bar to jump back into /pomo", remappable: false),
+        ]),
+
+        ShortcutGroup(title: "Todo & Speed panels", topic: .command, entries: [
+            ShortcutEntry("todo.togglePage", "Cmd+N", "Switch the Tasks / Stats page inside /todo"),
+            ShortcutEntry("todo.save", "Cmd+S", "Save changes inside /todo"),
+            ShortcutEntry("speed.rerun", "R", "Run the test again inside /speed"),
+            ShortcutEntry("speed.revealAddress", "E", "Show or hide the public address inside /speed"),
+        ]),
+    ]
+
+    /// Groups for one topic, in reading order.
+    static func groups(for topic: ShortcutTopic) -> [ShortcutGroup] {
+        groups.filter { $0.topic == topic }
+    }
+
+    static var allEntries: [ShortcutEntry] { groups.flatMap(\.entries) }
+
+    /// Derived from the canonical prefix list so the help screen, the Shortcuts
+    /// tab, and the `"` discovery menu cannot drift.
+    private static var prefixEntries: [ShortcutEntry] {
+        AppConstants.Launcher.PrefixSuggestion.all.map { entry in
+            ShortcutEntry("prefix.\(entry.prefix)", entry.displayWithArg, entry.description, remappable: false)
+        }
+    }
+
+    /// Derived from `commandCatalog`, whose ORDER is the mapping: ⌘N selects the
+    /// Nth entry. Writing this list by hand is what let Settings claim ⌘4 was
+    /// `/kill` after `/speed` was inserted ahead of it. Not remappable for the
+    /// same reason - the binding is positional, so reordering the catalog is the
+    /// only way to change it.
+    private static var commandSwitchEntry: ShortcutEntry {
+        let commands = AppConstants.Launcher.commandCatalog
+        let names = commands.map { "/\($0.id)" }.joined(separator: ", ")
+        let keys = commands.isEmpty ? "Cmd+1" : "Cmd+1..\(commands.count)"
+        return ShortcutEntry("command.switchByIndex", keys, "Switch directly to \(names)", remappable: false)
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/UI/ShortcutGroupView.swift
+++ b/apps/macos/LauncherApp/look-app/Support/UI/ShortcutGroupView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+/// One titled block of shortcuts, rendered identically wherever it appears: the
+/// in-window help screen (`Cmd+H`) and Settings > Shortcuts.
+///
+/// Both read the same `ShortcutCatalog`, so the content could not drift, but the
+/// two screens kept private copies of this view that differed in four constants
+/// - a key capsule that was a lighter fill on one screen than the other. Same
+/// data rendered two ways is the shallow end of the same problem, so there is
+/// one view.
+///
+/// The key capsule deliberately uses `liftColor` rather than `controlFillColor`:
+/// the help screen's topic capsules are `controlFillColor` and are *clickable*,
+/// and a static key badge should not look like a button sitting next to one.
+struct ShortcutGroupView: View {
+    @EnvironmentObject private var themeStore: ThemeStore
+
+    let title: String
+    let entries: [ShortcutEntry]
+
+    private enum Metrics {
+        static let rowSpacing: CGFloat = 8
+        static let keyToActionSpacing: CGFloat = 10
+        static let keyHorizontalPadding: CGFloat = 8
+        static let keyVerticalPadding: CGFloat = 3
+        static let keyFillOpacity = 0.14
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Metrics.rowSpacing) {
+            Text(title)
+                .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize), weight: .semibold))
+                .foregroundStyle(themeStore.secondaryTextColor())
+
+            ForEach(entries) { entry in
+                HStack(alignment: .firstTextBaseline, spacing: Metrics.keyToActionSpacing) {
+                    Text(entry.keys)
+                        .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular))
+                        .padding(.horizontal, Metrics.keyHorizontalPadding)
+                        .padding(.vertical, Metrics.keyVerticalPadding)
+                        .background(themeStore.liftColor(opacity: Metrics.keyFillOpacity), in: Capsule())
+                    Text(entry.action)
+                        .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular))
+                        .foregroundStyle(themeStore.secondaryTextColor())
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
@@ -24,6 +24,10 @@ struct SearchInputBar: View {
         static let placeholderLeadingInset: CGFloat = 2
     }
 
+    /// Command mode wins the bar's identity (see the icon below), so the badge
+    /// steps aside rather than sitting next to the `/command` capsule.
+    private var showsBetaBadge: Bool { isAIMode && !isCommandMode }
+
     private var placeholderText: String {
         if isCommandMode {
             return activeCommand?.placeholder ?? AppConstants.Launcher.commandModePlaceholder
@@ -73,6 +77,19 @@ struct SearchInputBar: View {
                             .placeholderReveal(token: revealToken)
                     }
                 }
+
+            if showsBetaBadge {
+                Text("BETA")
+                    .font(
+                        themeStore.uiFont(
+                            size: CGFloat(max(9, themeStore.settings.fontSize - 4)),
+                            weight: .semibold))
+                    .foregroundStyle(themeStore.accentColor().opacity(0.9))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(themeStore.liftColor(opacity: 0.14), in: Capsule())
+                    .accessibilityLabel("AI is in beta")
+            }
 
             if isCommandMode {
                 if let command = activeCommand {
@@ -514,54 +531,41 @@ struct RecentEmptyStateView: View {
 /// Which slice of the help the screen is showing. `all` keeps the original one
 /// scroll; the rest narrow it, so arriving from a mode lands on that mode's keys
 /// instead of a page the reader has to search.
+/// The help screen's capsules: every `ShortcutTopic`, plus an "All" that shows
+/// the whole catalog. Only the screen needs `all`, so it lives here rather than
+/// in the catalog Settings also reads.
 enum LauncherHelpTopic: CaseIterable, Identifiable {
     case all
-    case main
-    case ai
-    case prefixes
-    case command
+    case topic(ShortcutTopic)
 
-    var id: Self { self }
+    static var allCases: [LauncherHelpTopic] { [.all] + ShortcutTopic.allCases.map(Self.topic) }
+
+    var id: String {
+        switch self {
+        case .all: return "all"
+        case .topic(let topic): return topic.id
+        }
+    }
 
     var label: String {
         switch self {
         case .all: return "All"
-        case .main: return "Main"
-        case .ai: return "AI"
-        case .prefixes: return "Prefixes"
-        case .command: return "Command"
+        case .topic(let topic): return topic.label
         }
     }
 
-    /// The sections this topic shows, in reading order.
-    var sections: [LauncherHelpSection] {
+    var groups: [ShortcutGroup] {
         switch self {
-        case .all:
-            return LauncherHelpTopic.main.sections
-                + LauncherHelpTopic.ai.sections
-                + LauncherHelpTopic.prefixes.sections
-                + LauncherHelpTopic.command.sections
-        case .main:
-            return [
-                LauncherHelpSection(title: "Main", items: LauncherHelpContent.mainShortcuts),
-                LauncherHelpSection(title: "Super actions", items: LauncherHelpContent.superActions),
-            ]
-        case .ai:
-            return [LauncherHelpSection(title: "AI mode (>)", items: LauncherHelpContent.aiMode)]
-        case .prefixes:
-            return [LauncherHelpSection(title: "Query prefixes", items: LauncherHelpContent.queryModes)]
-        case .command:
-            return [LauncherHelpSection(title: "Command mode", items: LauncherHelpContent.commandMode)]
+        case .all: return ShortcutCatalog.groups
+        case .topic(let topic): return ShortcutCatalog.groups(for: topic)
         }
     }
+
+    static let ai = LauncherHelpTopic.topic(.ai)
 }
 
-/// One titled block of key/description pairs. The title is the identity: two
-/// sections never share one on the same screen.
-struct LauncherHelpSection: Identifiable {
-    let title: String
-    let items: [(String, String)]
-    var id: String { title }
+extension LauncherHelpTopic: Equatable {
+    static func == (lhs: Self, rhs: Self) -> Bool { lhs.id == rhs.id }
 }
 
 struct LauncherHelpScreenView: View {
@@ -612,8 +616,8 @@ struct LauncherHelpScreenView: View {
                     .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize), weight: .regular))
                     .foregroundStyle(themeStore.secondaryTextColor())
 
-                ForEach(topic.sections) { section in
-                    ShortcutHelpSection(title: section.title, items: section.items)
+                ForEach(topic.groups) { group in
+                    ShortcutGroupView(title: group.title, entries: group.entries)
                 }
             }
             .padding(12)
@@ -655,97 +659,4 @@ private enum LauncherHelpContent {
     static let title = "Help"
     static let closeHint = "Cmd+H to close"
     static let subtitle = "Quick guide for app list, clipboard search, and command flow."
-
-    static let mainShortcuts: [(String, String)] = [
-        ("Enter", "Open selected app/file/folder or copy selected clipboard item"),
-        ("Cmd+C", "Copy selected file/folder to pasteboard"),
-        ("Cmd+P", "Toggle pick on selected file/folder (multi-select copy)"),
-        ("Shift+Enter", "Open all picked files/folders at once"),
-        ("Cmd+Shift+P", "Clear all picked items"),
-        ("Cmd+D", "Trash selected file/folder (Trash pin: empty it) or remove the clipboard item"),
-        ("Tab / Shift+Tab", "Move selection"),
-        ("Up / Down", "Move selection"),
-        ("Cmd+F", "Reveal selected app/file/folder in Finder"),
-        ("Cmd+Enter", "Search current query on Google"),
-        ("Cmd+/", "Enter command mode"),
-        ("Cmd+Shift+,", "Open/close settings panel"),
-        ("Cmd+Shift+;", "Reload .look.config"),
-        ("Cmd+Shift+H", "Hide the selected app from Look"),
-        ("Cmd+H", "Toggle this help screen"),
-        ("Esc", "Close help / back / hide launcher"),
-    ]
-
-    // The `>` assistant: the sessions list, a live conversation, and the keys
-    // that only exist there (the running-apps strip is hidden in this mode, so
-    // Cmd+digit addresses conversations instead of apps).
-    static let aiMode: [(String, String)] = [
-        (">", "Enter AI mode (a dead-end Enter on the home screen goes here too)"),
-        ("Enter", "Send the message, or open the highlighted conversation"),
-        ("Shift+Enter", "New line in the message (the box grows to 6 lines)"),
-        ("Option+Up / Option+Down", "Walk your recent prompts, like a shell history"),
-        ("Shift+Up / Shift+Down", "Select text in the message you are composing"),
-        ("Cmd+1..Cmd+9, Cmd+0", "Open the conversation carrying that chip (Cmd+0 is the tenth)"),
-        ("Tab / Up / Down", "Move over the conversation list"),
-        ("Cmd+D", "Delete the highlighted conversation"),
-        ("Cmd+Z", "Undo the last action, or restore a just-deleted conversation"),
-        ("Cmd+.", "Stop a streaming answer"),
-        ("@name", "Attach a file to the message (Enter picks the highlighted one)"),
-        ("@ 5pm", "Set an exact time on an event or reminder"),
-        ("1, 2, 3 + Enter", "Answer a \u{201C}which one?\u{201D} list"),
-        ("Cmd+H", "Open this help without leaving the conversation"),
-        ("Esc", "Close the file popup, then leave the conversation"),
-        ("Shift+Esc", "Leave AI mode straight to the home screen"),
-    ]
-
-    // The strip on the empty home screen. Keys are the tile mnemonics from the
-    // shared catalog (core/qactions), fired with Cmd.
-    static let superActions: [(String, String)] = [
-        ("Cmd+B / Cmd+W", "Toggle Bluetooth / Wi-Fi"),
-        ("Cmd+T / Cmd+K", "Switch theme / toggle Keep Awake"),
-        ("Cmd+S / Cmd+M", "Start screensaver / mute mic"),
-        ("Cmd+P", "Play/pause the current track"),
-        ("Cmd+R / Cmd+D", "Restart / Shut Down (press twice, Esc cancels)"),
-        ("Settings > Appearance", "Show or hide the super actions strip"),
-    ]
-
-    // Derived from the canonical prefix list so the help screen and the `"`
-    // discovery menu stay in sync.
-    static let queryModes: [(String, String)] =
-        AppConstants.Launcher.PrefixSuggestion.all.map { ($0.displayWithArg, $0.description) }
-
-    static let commandMode: [(String, String)] = [
-        ("Tab / Shift+Tab", "Switch command"),
-        ("Cmd+1 / Cmd+2 / Cmd+3 / Cmd+4", "Switch command"),
-        ("3000", "Find process by port or PID"),
-        ("Up / Down", "Select app in kill results"),
-        ("Y / N", "Confirm/cancel kill action"),
-    ]
-}
-
-private struct ShortcutHelpSection: View {
-    @EnvironmentObject private var themeStore: ThemeStore
-    let title: String
-    let items: [(String, String)]
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(title)
-                .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize), weight: .semibold))
-                .foregroundStyle(themeStore.secondaryTextColor())
-
-            ForEach(Array(items.enumerated()), id: \.offset) { _, item in
-                HStack(alignment: .firstTextBaseline, spacing: 8) {
-                    Text(item.0)
-                        .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular))
-                        .padding(.horizontal, 7)
-                        .padding(.vertical, 3)
-                        .background(themeStore.controlFillColor(), in: Capsule())
-                    Text(item.1)
-                        .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular))
-                        .foregroundStyle(themeStore.mutedTextColor())
-                    Spacer(minLength: 0)
-                }
-            }
-        }
-    }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Shortcuts.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Shortcuts.swift
@@ -1,138 +1,20 @@
 import SwiftUI
 
 extension ThemeSettingsView {
+    /// Every group in `ShortcutCatalog`, flat. The help screen (`Cmd+H`) shows
+    /// the same catalog filtered by topic, so the two can no longer disagree.
     var shortcutsTab: some View {
         ScrollView(.vertical, showsIndicators: false) {
             VStack(alignment: .leading, spacing: 14) {
-                ForEach(ShortcutDocs.sections) { section in
-                    ShortcutSection(title: section.title, items: section.items)
+                ForEach(ShortcutCatalog.groups) { group in
+                    ShortcutGroupView(title: group.title, entries: group.entries)
                 }
-
-                Text("This panel is intended as living documentation. We can add command and workflow docs here as features grow.")
-                    .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
-                    .foregroundStyle(themeStore.secondaryTextColor())
 
                 Text(HintText.Settings.shortcutsTips)
                     .font(themeStore.uiFont(size: CGFloat(settings.fontSize - 1), weight: .regular))
                     .foregroundStyle(themeStore.secondaryTextColor())
             }
             .padding(.top, 4)
-        }
-    }
-}
-
-struct ShortcutItem: Identifiable {
-    let id = UUID()
-    let keys: String
-    let action: String
-}
-
-struct ShortcutSectionData: Identifiable {
-    let id = UUID()
-    let title: String
-    let items: [ShortcutItem]
-}
-
-enum ShortcutDocs {
-    static let sections: [ShortcutSectionData] = [
-        ShortcutSectionData(
-            title: "Core launcher",
-            items: [
-                ShortcutItem(keys: "Tab", action: "Select next result"),
-                ShortcutItem(keys: "Shift+Tab", action: "Select previous result"),
-                ShortcutItem(keys: "Up / Down", action: "Move selection"),
-                ShortcutItem(keys: "Cmd+C", action: "Copy selected file/folder to pasteboard"),
-                ShortcutItem(keys: "Cmd+F", action: "Reveal selected app/file/folder in Finder"),
-                ShortcutItem(keys: "Cmd+Enter", action: "Search query on Google"),
-                ShortcutItem(keys: "Cmd+/", action: "Enter command mode"),
-                ShortcutItem(keys: ":cmd", action: "Jump to a command from home (e.g. :calc 2+2, :kill chrome, :sys, :pomo)"),
-                ShortcutItem(keys: "Cmd+1..6", action: "Switch directly to /calc, /pomo, /todo, /kill, /shell, /sys"),
-                ShortcutItem(keys: "Cmd+Shift+,", action: "Open/close settings panel"),
-                ShortcutItem(keys: "Cmd+Shift+;", action: "Reload .look.config"),
-                ShortcutItem(keys: "Cmd+Shift+H", action: "Hide the selected app from Look"),
-                ShortcutItem(keys: "Cmd+H", action: "Toggle in-window keyboard help screen"),
-                ShortcutItem(keys: "Esc", action: "Back to app list (in command mode)"),
-                ShortcutItem(keys: "Shift+Esc", action: "Hide launcher"),
-            ]
-        ),
-        ShortcutSectionData(
-            title: "Search prefixes",
-            // Derived from the canonical prefix list (AppConstants) so this panel,
-            // the in-window help screen, and the `"` discovery menu can't drift.
-            // Type `"` alone to browse these prefixes interactively.
-            items: AppConstants.Launcher.PrefixSuggestion.all.map {
-                ShortcutItem(keys: $0.prefix, action: $0.description)
-            }
-        ),
-        ShortcutSectionData(
-            title: "Clipboard history",
-            items: [
-                ShortcutItem(keys: "Enter", action: "Copy selected history item back to clipboard"),
-                ShortcutItem(keys: "Cmd+D", action: "Remove selected clipboard item from look history"),
-            ]
-        ),
-        ShortcutSectionData(
-            title: "Pomodoro (/pomo)",
-            items: [
-                ShortcutItem(keys: "Space", action: "Start / pause the active session"),
-                ShortcutItem(keys: "R", action: "Reset the timer back to idle"),
-                ShortcutItem(keys: "P", action: "Toggle music play / pause"),
-                ShortcutItem(keys: "Mouse / key idle", action: "After 5s, panel fades to clock-only standby; any input restores"),
-                ShortcutItem(keys: "Menu bar item", action: "Click the timer icon in the menu bar to jump back into /pomo"),
-            ]
-        ),
-        ShortcutSectionData(
-            title: "Panels",
-            items: [
-                ShortcutItem(keys: "Cmd+Shift+,", action: "Open/close theme and docs panel"),
-                ShortcutItem(keys: "Cmd+Shift+;", action: "Reload .look.config"),
-                ShortcutItem(keys: "Save Config", action: "Write current UI settings to .look.config"),
-            ]
-        ),
-        ShortcutSectionData(
-            title: "Zoom",
-            items: [
-                ShortcutItem(keys: "Cmd+-", action: "Zoom out UI scale"),
-                ShortcutItem(keys: "Cmd+=", action: "Zoom in UI scale"),
-                ShortcutItem(keys: "Cmd+0", action: "Reset UI scale (opens the tenth session while the AI list is up)"),
-            ]
-        ),
-        ShortcutSectionData(
-            title: "Theme controls",
-            items: [
-                ShortcutItem(keys: "Appearance tab", action: "Tint, blur material, blur opacity"),
-                ShortcutItem(keys: "Advanced tab", action: "Background, indexing, privacy, logging controls"),
-                ShortcutItem(keys: "Shortcuts tab", action: "In-app keyboard documentation"),
-            ]
-        ),
-    ]
-}
-
-struct ShortcutSection: View {
-    @EnvironmentObject private var themeStore: ThemeStore
-
-    let title: String
-    let items: [ShortcutItem]
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(title)
-                .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize), weight: .medium))
-                .foregroundStyle(themeStore.secondaryTextColor())
-
-            ForEach(items) { item in
-                HStack(alignment: .firstTextBaseline, spacing: 10) {
-                    Text(item.keys)
-                        .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular))
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 3)
-                        .background(themeStore.liftColor(opacity: 0.14), in: Capsule())
-                    Text(item.action)
-                        .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular))
-                        .foregroundStyle(themeStore.secondaryTextColor())
-                    Spacer(minLength: 0)
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- Merge catalog in help and setting/shortcuts -> one
- add a beta mark for ai mode



## Testing

- `apps/linows`
  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Manual verification completed (if UI/behavior changed)


## Checklist

- [x] I have read and agree to the CLA (CLA.md)
- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a centralized shortcut catalog covering navigation, command mode, AI mode, clipboard history, views, Pomodoro, Todo, and other panels.
  * Updated Help and Settings to display organized, consistent shortcut groups.
  * Added topic-based shortcut browsing, including dedicated AI shortcuts.
  * Shortcut keys now appear in aligned, easy-to-scan badges and rows.

* **Bug Fixes**
  * Improved shortcut documentation consistency and ensured shortcut entries remain uniquely identifiable and addressable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->