### PR TITLE
fix look-icon on gnome

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -79,8 +79,11 @@ jobs:
             core
             apps/linows/src-tauri
 
+      # 2.6 is the floor: earlier bundlers emit a .desktop file without
+      # StartupWMClass, so GNOME can't match the window (app_id "lookapp") to
+      # the entry it installs as Look.desktop, and falls back to a blank icon.
       - name: Install cargo-tauri
-        run: cargo install tauri-cli --version "^2" --locked
+        run: cargo install tauri-cli --version "^2.6" --locked
 
       - name: Build Tauri app
         working-directory: apps/linows

--- a/apps/linows/assets/lookapp.desktop
+++ b/apps/linows/assets/lookapp.desktop
@@ -1,9 +1,0 @@
-[Desktop Entry]
-Name=Look
-Comment=Keyboard-first desktop launcher
-Exec=lookapp
-Icon=lookapp
-Type=Application
-Categories=Utility;
-StartupWMClass=Look
-Terminal=false

--- a/apps/linows/nix/package.nix
+++ b/apps/linows/nix/package.nix
@@ -101,25 +101,27 @@ rustPlatform.buildRustPackage {
   '';
 
   postInstall = ''
-    # Desktop file
+    # Desktop file. StartupWMClass is the app_id GTK derives from argv[0], and
+    # the icon name matches the .deb's (both keyed off the binary name), so the
+    # shell resolves the window to this entry on either packaging.
     mkdir -p $out/share/applications
     cat > $out/share/applications/lookapp.desktop <<'EOF'
 [Desktop Entry]
 Name=Look
 Comment=Keyboard-first desktop launcher
 Exec=lookapp
-Icon=look
+Icon=lookapp
 Type=Application
 Categories=Utility;
-StartupWMClass=Look
+StartupWMClass=lookapp
 EOF
 
     # Icons
-    for size in 32 128 256; do
+    for size in 32 64 128; do
       icon="$src/apps/linows/src-tauri/icons/''${size}x''${size}.png"
       if [ -f "$icon" ]; then
         mkdir -p $out/share/icons/hicolor/''${size}x''${size}/apps
-        cp "$icon" $out/share/icons/hicolor/''${size}x''${size}/apps/look.png
+        cp "$icon" $out/share/icons/hicolor/''${size}x''${size}/apps/lookapp.png
       fi
     done
   '';

--- a/apps/linows/src-tauri/src/platform/linux/autostart.rs
+++ b/apps/linows/src-tauri/src/platform/linux/autostart.rs
@@ -58,16 +58,18 @@ const EXEC_RESERVED: &[char] = &[
 /// Serialize a path as an `Exec` argument. Escaping is two-layered: the Exec
 /// grammar backslash-escapes `"`, backtick, `$` and `\` inside quotes, then the
 /// key file's string type escapes each backslash again - so a literal backslash
-/// ends up as four, and control characters as `\n`-style sequences.
+/// ends up as four, and control characters as `\n`-style sequences. `%` doubles
+/// regardless of quoting, else `100%foo` reads as the `%f` field code.
 fn exec_arg(path: &Path) -> String {
     let raw = path.to_string_lossy();
     if !raw.contains(EXEC_RESERVED) {
-        return raw.into_owned();
+        return raw.replace('%', "%%");
     }
     let mut out = String::with_capacity(raw.len() + 2);
     out.push('"');
     for c in raw.chars() {
         match c {
+            '%' => out.push_str("%%"),
             '\\' => out.push_str(r"\\\\"),
             '"' | '`' | '$' => {
                 out.push_str(r"\\");
@@ -157,6 +159,18 @@ mod tests {
         assert_eq!(
             exec_arg(Path::new("/opt/a\"b/lookapp")),
             r#""/opt/a\\"b/lookapp""#
+        );
+    }
+
+    #[test]
+    fn doubles_percent_in_either_form() {
+        assert_eq!(
+            exec_arg(Path::new("/opt/100%foo/lookapp")),
+            "/opt/100%%foo/lookapp"
+        );
+        assert_eq!(
+            exec_arg(Path::new("/opt/100%foo bar/lookapp")),
+            "\"/opt/100%%foo bar/lookapp\""
         );
     }
 

--- a/apps/linows/src-tauri/src/platform/linux/autostart.rs
+++ b/apps/linows/src-tauri/src/platform/linux/autostart.rs
@@ -1,6 +1,6 @@
 //! Linux autostart via XDG `.desktop` file in `$XDG_CONFIG_HOME/autostart/`.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 fn autostart_dir() -> PathBuf {
     let config = std::env::var("XDG_CONFIG_HOME").unwrap_or_else(|_| {
@@ -14,6 +14,37 @@ fn desktop_entry_path() -> PathBuf {
     autostart_dir().join("look.desktop")
 }
 
+/// Base name behind a Nix wrapper file name (`.lookapp-wrapped` -> `lookapp`).
+/// Nested wrappers append underscores (`.lookapp-wrapped_`).
+fn wrapper_base_name(file_name: &str) -> Option<&str> {
+    let (base, suffix) = file_name.strip_prefix('.')?.split_once("-wrapped")?;
+    if base.is_empty() || suffix.chars().any(|c| c != '_') {
+        return None;
+    }
+    Some(base)
+}
+
+/// Nix wraps GUI binaries: `bin/lookapp` sets up the environment and execs
+/// `bin/.lookapp-wrapped`, which is what `current_exe()` reports. Starting the
+/// inner binary skips that environment and leaves argv[0] as `.lookapp-wrapped`,
+/// which GTK hands to the compositor as the app_id - GNOME then matches no
+/// desktop entry and draws a placeholder icon instead of ours.
+fn unwrap_launcher(exe: &Path) -> Option<PathBuf> {
+    let base = wrapper_base_name(exe.file_name()?.to_str()?)?;
+    let wrapper = exe.with_file_name(base);
+    wrapper.exists().then_some(wrapper)
+}
+
+/// Prefer a `PATH` entry resolving to the same binary: profile paths survive
+/// updates, while a pinned `/nix/store` path dies with its generation.
+fn path_alias(exe: &Path) -> Option<PathBuf> {
+    let name = exe.file_name()?;
+    let target = exe.canonicalize().ok()?;
+    std::env::split_paths(&std::env::var_os("PATH")?)
+        .map(|dir| dir.join(name))
+        .find(|candidate| candidate.canonicalize().is_ok_and(|c| c == target))
+}
+
 fn current_exe_path() -> String {
     // Under an AppImage, current_exe() resolves to the temporary FUSE mount
     // (/tmp/.mount_Look_*/usr/bin/lookapp), gone by next login. The runtime
@@ -21,9 +52,14 @@ fn current_exe_path() -> String {
     if let Ok(appimage) = std::env::var("APPIMAGE") {
         return appimage;
     }
-    std::env::current_exe()
-        .map(|p| p.to_string_lossy().to_string())
-        .unwrap_or_else(|_| "lookapp".to_string())
+    let Ok(exe) = std::env::current_exe() else {
+        return "lookapp".to_string();
+    };
+    let exe = unwrap_launcher(&exe).unwrap_or(exe);
+    path_alias(&exe)
+        .unwrap_or(exe)
+        .to_string_lossy()
+        .into_owned()
 }
 
 pub(crate) fn set(enabled: bool) -> Result<(), String> {
@@ -38,7 +74,7 @@ pub(crate) fn set(enabled: bool) -> Result<(), String> {
              Type=Application\n\
              Name=Look\n\
              Exec={exe}\n\
-             Icon=look\n\
+             Icon=lookapp\n\
              Comment=Desktop launcher\n\
              X-GNOME-Autostart-enabled=true\n\
              StartupNotify=false\n"
@@ -53,4 +89,19 @@ pub(crate) fn set(enabled: bool) -> Result<(), String> {
 
 pub(crate) fn get() -> bool {
     desktop_entry_path().exists()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::wrapper_base_name;
+
+    #[test]
+    fn strips_nix_wrapper_names() {
+        assert_eq!(wrapper_base_name(".lookapp-wrapped"), Some("lookapp"));
+        assert_eq!(wrapper_base_name(".lookapp-wrapped_"), Some("lookapp"));
+        assert_eq!(wrapper_base_name("lookapp"), None);
+        assert_eq!(wrapper_base_name(".lookapp"), None);
+        assert_eq!(wrapper_base_name(".-wrapped"), None);
+        assert_eq!(wrapper_base_name(".lookapp-wrapped.bak"), None);
+    }
 }

--- a/apps/linows/src-tauri/src/platform/linux/autostart.rs
+++ b/apps/linows/src-tauri/src/platform/linux/autostart.rs
@@ -37,29 +37,65 @@ fn unwrap_launcher(exe: &Path) -> Option<PathBuf> {
 
 /// Prefer a `PATH` entry resolving to the same binary: profile paths survive
 /// updates, while a pinned `/nix/store` path dies with its generation.
+/// Relative entries (`.`, or the empty entry `PATH=/usr/bin:`) are skipped:
+/// `Exec` takes an absolute path or a bare name resolved against `PATH`.
 fn path_alias(exe: &Path) -> Option<PathBuf> {
     let name = exe.file_name()?;
     let target = exe.canonicalize().ok()?;
     std::env::split_paths(&std::env::var_os("PATH")?)
+        .filter(|dir| dir.is_absolute())
         .map(|dir| dir.join(name))
         .find(|candidate| candidate.canonicalize().is_ok_and(|c| c == target))
 }
 
-fn current_exe_path() -> String {
+/// Characters that force quoting of an `Exec` argument, per the Desktop Entry
+/// spec. Space is the one that shows up in practice (`~/My Apps/Look.AppImage`).
+const EXEC_RESERVED: &[char] = &[
+    ' ', '\t', '\n', '\r', '"', '\'', '\\', '>', '<', '~', '|', '&', ';', '$', '*', '?', '#', '(',
+    ')', '`',
+];
+
+/// Serialize a path as an `Exec` argument. Escaping is two-layered: the Exec
+/// grammar backslash-escapes `"`, backtick, `$` and `\` inside quotes, then the
+/// key file's string type escapes each backslash again - so a literal backslash
+/// ends up as four, and control characters as `\n`-style sequences.
+fn exec_arg(path: &Path) -> String {
+    let raw = path.to_string_lossy();
+    if !raw.contains(EXEC_RESERVED) {
+        return raw.into_owned();
+    }
+    let mut out = String::with_capacity(raw.len() + 2);
+    out.push('"');
+    for c in raw.chars() {
+        match c {
+            '\\' => out.push_str(r"\\\\"),
+            '"' | '`' | '$' => {
+                out.push_str(r"\\");
+                out.push(c);
+            }
+            '\n' => out.push_str(r"\n"),
+            '\r' => out.push_str(r"\r"),
+            '\t' => out.push_str(r"\t"),
+            _ => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+fn current_exe_path() -> PathBuf {
     // Under an AppImage, current_exe() resolves to the temporary FUSE mount
     // (/tmp/.mount_Look_*/usr/bin/lookapp), gone by next login. The runtime
     // exposes the .AppImage path itself in $APPIMAGE - use that instead.
-    if let Ok(appimage) = std::env::var("APPIMAGE") {
-        return appimage;
+    if let Some(appimage) = std::env::var_os("APPIMAGE") {
+        let appimage = PathBuf::from(appimage);
+        return std::path::absolute(&appimage).unwrap_or(appimage);
     }
     let Ok(exe) = std::env::current_exe() else {
-        return "lookapp".to_string();
+        return PathBuf::from("lookapp");
     };
     let exe = unwrap_launcher(&exe).unwrap_or(exe);
-    path_alias(&exe)
-        .unwrap_or(exe)
-        .to_string_lossy()
-        .into_owned()
+    path_alias(&exe).unwrap_or(exe)
 }
 
 pub(crate) fn set(enabled: bool) -> Result<(), String> {
@@ -68,7 +104,7 @@ pub(crate) fn set(enabled: bool) -> Result<(), String> {
         let dir = autostart_dir();
         std::fs::create_dir_all(&dir)
             .map_err(|e| format!("Failed to create autostart dir: {e}"))?;
-        let exe = current_exe_path();
+        let exe = exec_arg(&current_exe_path());
         let contents = format!(
             "[Desktop Entry]\n\
              Type=Application\n\
@@ -93,7 +129,36 @@ pub(crate) fn get() -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::wrapper_base_name;
+    use super::{exec_arg, wrapper_base_name};
+    use std::path::Path;
+
+    #[test]
+    fn leaves_plain_paths_unquoted() {
+        assert_eq!(
+            exec_arg(Path::new("/home/u/.nix-profile/bin/lookapp")),
+            "/home/u/.nix-profile/bin/lookapp"
+        );
+    }
+
+    #[test]
+    fn quotes_paths_with_reserved_chars() {
+        assert_eq!(
+            exec_arg(Path::new("/home/u/My Apps/Look.AppImage")),
+            "\"/home/u/My Apps/Look.AppImage\""
+        );
+        assert_eq!(
+            exec_arg(Path::new("/opt/a$b/lookapp")),
+            r#""/opt/a\\$b/lookapp""#
+        );
+        assert_eq!(
+            exec_arg(Path::new(r"/opt/a\b/lookapp")),
+            r#""/opt/a\\\\b/lookapp""#
+        );
+        assert_eq!(
+            exec_arg(Path::new("/opt/a\"b/lookapp")),
+            r#""/opt/a\\"b/lookapp""#
+        );
+    }
 
     #[test]
     fn strips_nix_wrapper_names() {


### PR DESCRIPTION
## Summary

- On gnome, look-icon is inconsistent, sometimes, lookapp doesn't show the icon, fallback to default icon.  

## Testing

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

## Checklist

- [x] I have read and agree to the CLA (CLA.md)
- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux autostart reliability, including support for Nix-installed applications and correctly escaped executable paths.
  * Fixed Linux desktop integration by aligning application names, icons, and startup behavior.
* **Improvements**
  * Updated Linux packages to use consistent application naming and icon assets.
  * Standardized release tooling to a compatible version for improved desktop-entry support.
* **Testing**
  * Added coverage for Linux executable detection and path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->