### PR TITLE
hot fix grant permission on macos

### DIFF
--- a/apps/macos/LauncherApp/look-app/Support/Actions/ActionController+Links.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Actions/ActionController+Links.swift
@@ -21,7 +21,7 @@ extension ActionController {
             // retrying on that loops.
             guard !didAsk else { return Self.noCalendarAccess }
             Task {
-                await EventKitService.shared.requestCalendarAccess()
+                await PermissionPrompt.run { await EventKitService.shared.requestCalendarAccess() }
                 setFeedback(presentJoinChoices(named: name, didAsk: true))
             }
             return ""
@@ -68,7 +68,7 @@ extension ActionController {
             // Once only: see the calendar branch.
             guard !didAsk else { return Self.noContactsAccess }
             Task {
-                await ContactsService.shared.requestAccess()
+                await PermissionPrompt.run { await ContactsService.shared.requestAccess() }
                 setFeedback(presentCallChoices(named: name, modality: modality, didAsk: true))
             }
             return ""

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/PermissionPrompt.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/PermissionPrompt.swift
@@ -1,0 +1,18 @@
+import AppKit
+
+/// Runs a TCC request with the launcher pinned open.
+///
+/// The system dialog takes focus, which fires `didResignActive` and hides the
+/// window. The app is then in the background, where macOS will not present the
+/// next prompt, so a sequence of requests dies after the first one.
+@MainActor
+enum PermissionPrompt {
+    private(set) static var isPresenting = false
+
+    static func run(_ request: () async -> Void) async {
+        isPresenting = true
+        NSApplication.shared.activate(ignoringOtherApps: true)
+        await request()
+        isPresenting = false
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -929,7 +929,9 @@ struct LauncherView: View {
         .onReceive(
             NotificationCenter.default.publisher(for: NSApplication.didResignActiveNotification)
         ) { _ in
-            if launcherWindow()?.isVisible == true {
+            // Not while a TCC dialog is up: it steals focus, and hiding here
+            // backgrounds the app so the next prompt never appears.
+            if !PermissionPrompt.isPresenting, launcherWindow()?.isVisible == true {
                 Logger(subsystem: "noah-code.Look", category: "window-resize")
                     .debug("didResignActiveNotification -> hideLauncherWindow(restorePreviousApp: false)")
                 hideLauncherWindow(restorePreviousApp: false)

--- a/apps/macos/LauncherApp/look-app/Views/Settings/PermissionsRow.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Settings/PermissionsRow.swift
@@ -157,10 +157,12 @@ struct PermissionsRow: View {
     }
 
     private func request(_ capability: PermissionItem.Capability) async {
-        switch capability {
-        case .calendar: await EventKitService.shared.requestCalendarAccess()
-        case .reminders: await EventKitService.shared.requestReminderAccess()
-        case .contacts: await ContactsService.shared.requestAccess()
+        await PermissionPrompt.run {
+            switch capability {
+            case .calendar: await EventKitService.shared.requestCalendarAccess()
+            case .reminders: await EventKitService.shared.requestReminderAccess()
+            case .contacts: await ContactsService.shared.requestAccess()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- grant permission has a bug: click grall-all -> only reminder granted.


## Test

- `apps/linows`
  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)


## Checklist

- [ ] I have read and agree to the CLA (CLA.md)
- [ ] PR title is clear and scoped
- [ ] Docs updated for user-visible changes
- [ ] No secrets or private files included
- [ ] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the handling of Calendar and Contacts permission prompts.
  * Prevented the launcher window from hiding while a permission request is active.
  * Preserved existing retry and feedback behavior for permission requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->