### PR TITLE
fix: permission grant popup

### DIFF
--- a/.github/workflows/reusable-release-macos.yml
+++ b/.github/workflows/reusable-release-macos.yml
@@ -174,9 +174,18 @@ jobs:
             --entitlements "$ENTITLEMENTS_PATH" \
             --sign "$APPLE_DEVELOPER_ID_APPLICATION" "$APP_PATH"
           codesign --verify --deep --strict --verbose=2 "$APP_PATH"
-          # Confirm the entitlement actually made it into the signature.
-          codesign -d --entitlements - --xml "$APP_PATH" | grep -q "com.apple.security.automation.apple-events" \
-            || { echo "apple-events entitlement missing after signing" >&2; exit 1; }
+          # Confirm the entitlements actually made it into the signature. Under
+          # Hardened Runtime a missing one is silent: tccd denies the service
+          # without ever prompting, so the app can never ask for it.
+          SIGNED_ENTITLEMENTS="$(codesign -d --entitlements - --xml "$APP_PATH")"
+          for entitlement in \
+            com.apple.security.automation.apple-events \
+            com.apple.security.personal-information.calendars \
+            com.apple.security.personal-information.addressbook
+          do
+            grep -q "$entitlement" <<<"$SIGNED_ENTITLEMENTS" \
+              || { echo "$entitlement missing after signing" >&2; exit 1; }
+          done
 
           rm -f "$ZIP_PATH"
           ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" "$ZIP_PATH"

--- a/.github/workflows/reusable-release-macos.yml
+++ b/.github/workflows/reusable-release-macos.yml
@@ -177,15 +177,29 @@ jobs:
           # Confirm the entitlements actually made it into the signature. Under
           # Hardened Runtime a missing one is silent: tccd denies the service
           # without ever prompting, so the app can never ask for it.
+          # Read as a plist rather than grepped as text: a key signed as
+          # <false/> is present but disabled, which text matching would pass.
           SIGNED_ENTITLEMENTS="$(codesign -d --entitlements - --xml "$APP_PATH")"
-          for entitlement in \
-            com.apple.security.automation.apple-events \
-            com.apple.security.personal-information.calendars \
-            com.apple.security.personal-information.addressbook
-          do
-            grep -q "$entitlement" <<<"$SIGNED_ENTITLEMENTS" \
-              || { echo "$entitlement missing after signing" >&2; exit 1; }
-          done
+          SIGNED_ENTITLEMENTS="$SIGNED_ENTITLEMENTS" python3 <<'PY'
+          import os
+          import plistlib
+          import sys
+
+          REQUIRED = (
+              "com.apple.security.automation.apple-events",
+              "com.apple.security.personal-information.calendars",
+              "com.apple.security.personal-information.addressbook",
+          )
+
+          try:
+              signed = plistlib.loads(os.environ["SIGNED_ENTITLEMENTS"].encode())
+          except plistlib.InvalidFileException as error:
+              sys.exit(f"Could not parse signed entitlements: {error}")
+
+          disabled = [key for key in REQUIRED if signed.get(key) is not True]
+          if disabled:
+              sys.exit("missing or disabled after signing: " + ", ".join(disabled))
+          PY
 
           rm -f "$ZIP_PATH"
           ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" "$ZIP_PATH"

--- a/apps/macos/LauncherApp/look-app/Look.entitlements
+++ b/apps/macos/LauncherApp/look-app/Look.entitlements
@@ -8,5 +8,12 @@
 	     the Automation consent prompt, so Look can't empty the Trash. -->
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
+	<!-- Same rule for EventKit and Contacts: without these, tccd logs "requires
+	     entitlement ... but it is missing" and denies without ever prompting,
+	     so the permission can never be granted from inside the app. -->
+	<key>com.apple.security.personal-information.calendars</key>
+	<true/>
+	<key>com.apple.security.personal-information.addressbook</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

- same with #382 


## Testing

  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Manual verification completed (if UI/behavior changed)


## Checklist

- [x] I have read and agree to the CLA (CLA.md)
- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS permission handling for Calendar and Contacts access.
  * Release validation now confirms Apple Events, Calendar, and Contacts permissions are correctly enabled before publishing.
  * Added clearer explanations for permission prompts and what happens when access is denied.
  * Prevented releases when required permissions are missing, disabled, or invalid, helping ensure consistent app behavior after installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->