### PR TITLE
fix: ai answer affects to web answer

### DIFF
--- a/bridge/ffi/src/search_api.rs
+++ b/bridge/ffi/src/search_api.rs
@@ -136,6 +136,7 @@ pub(crate) fn look_search_files_json_impl(
 /// the web answer for what is usually a question ("how to download bitcoin").
 fn is_weak_empty_recall(filter: &look_engine::FileFilter, results: &[LaunchResult]) -> bool {
     results.is_empty()
+        && !filter.terms.trim().is_empty()
         && filter.categories.is_empty()
         && filter.locations.is_empty()
         && filter.start.is_none()
@@ -356,5 +357,12 @@ mod tests {
         };
         assert!(!is_weak_empty_recall(&typed, &[]));
         assert!(!is_weak_empty_recall(&dated, &[]));
+    }
+
+    #[test]
+    fn a_bare_files_request_is_not_weak() {
+        // "show me my files": every word is glue, so an empty index is the only
+        // way it comes back empty. That still asked for files.
+        assert!(!is_weak_empty_recall(&FileFilter::default(), &[]));
     }
 }

--- a/bridge/ffi/src/search_api.rs
+++ b/bridge/ffi/src/search_api.rs
@@ -103,8 +103,8 @@ pub(crate) fn look_search_json_impl(query: *const c_char, limit: u32) -> *mut c_
 
 /// Natural-language file recall: parse the query (core/ai), run it against
 /// Look's own index (fast, no Spotlight), and return the same JSON shape as
-/// `look_search_json`. Null when the query is not a file-recall query, so the
-/// shell falls back to normal search.
+/// `look_search_json`. Null when the query is not a file-recall query or when
+/// a terms-only parse matched nothing, so the shell falls back to normal search.
 pub(crate) fn look_search_files_json_impl(
     query: *const c_char,
     now_epoch: i64,
@@ -123,8 +123,23 @@ pub(crate) fn look_search_files_json_impl(
         locations: fq.locations,
     };
     let outcome = with_engine(|engine| engine.search_files(&filter, max as usize));
+    if is_weak_empty_recall(&filter, &outcome.results) {
+        return std::ptr::null_mut();
+    }
     let relaxed = relaxed_code(outcome.relaxation);
     store_json_allocation(serialize_full_payload(&query, outcome.results, relaxed))
+}
+
+/// A parse with terms and nothing else was triggered by a bare "file" or
+/// "download" word, so the terms are just words lifted from a sentence. With
+/// zero matches there is nothing to show, and claiming the panel would cancel
+/// the web answer for what is usually a question ("how to download bitcoin").
+fn is_weak_empty_recall(filter: &look_engine::FileFilter, results: &[LaunchResult]) -> bool {
+    results.is_empty()
+        && filter.categories.is_empty()
+        && filter.locations.is_empty()
+        && filter.start.is_none()
+        && filter.end.is_none()
 }
 
 fn relaxed_code(relaxation: Option<look_engine::FileSearchRelaxation>) -> Option<&'static str> {
@@ -301,4 +316,45 @@ fn search_error_json_compact(err: SearchError) -> String {
         }
     })
     .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_weak_empty_recall;
+    use look_engine::{FileFilter, LaunchResult};
+    use look_indexing::{Candidate, CandidateKind};
+
+    fn result() -> LaunchResult {
+        LaunchResult::from((
+            &Candidate::new("file:a", CandidateKind::File, "a.pdf", "/tmp/a.pdf"),
+            1,
+        ))
+    }
+
+    #[test]
+    fn terms_only_recall_with_no_match_falls_back_to_normal_search() {
+        let filter = FileFilter {
+            terms: "bitcoin price".into(),
+            ..Default::default()
+        };
+        assert!(is_weak_empty_recall(&filter, &[]));
+        assert!(!is_weak_empty_recall(&filter, &[result()]));
+    }
+
+    #[test]
+    fn typed_or_dated_recall_keeps_its_empty_panel() {
+        let typed = FileFilter {
+            terms: "invoice".into(),
+            categories: vec!["pdf".into()],
+            ..Default::default()
+        };
+        let dated = FileFilter {
+            terms: "invoice".into(),
+            start: Some(0),
+            end: Some(1),
+            ..Default::default()
+        };
+        assert!(!is_weak_empty_recall(&typed, &[]));
+        assert!(!is_weak_empty_recall(&dated, &[]));
+    }
 }

--- a/core/engine/src/lib.rs
+++ b/core/engine/src/lib.rs
@@ -130,12 +130,21 @@ impl QueryEngine {
     /// only after that: an unrecognized glue word the parser didn't strip
     /// ("files added to ...") lands in terms and would otherwise filter
     /// everything out. Type and location filters are never relaxed.
+    ///
+    /// Terms are kept when they are the ONLY filter: dropping them leaves a
+    /// query with no constraint at all, which matches the entire index. That
+    /// is not a near miss, it is every file the user owns, and it lets a
+    /// misread query ("bitcoin price") claim the panel with unrelated rows.
     fn relaxations(filter: &FileFilter) -> Vec<(FileFilter, FileSearchRelaxation)> {
         let widened_window = match (filter.start, filter.end) {
             (Some(start), Some(end)) if end > start => Some((start - (end - start), end)),
             _ => None,
         };
         let has_terms = !filter.terms.trim().is_empty();
+        let has_other_filter = !filter.categories.is_empty()
+            || !filter.locations.is_empty()
+            || filter.start.is_some()
+            || filter.end.is_some();
 
         let build = |terms: &str, window: Option<(i64, i64)>| FileFilter {
             terms: terms.into(),
@@ -152,7 +161,7 @@ impl QueryEngine {
                 FileSearchRelaxation::WidenedWindow,
             ));
         }
-        if has_terms {
+        if has_terms && has_other_filter {
             steps.push((build("", None), FileSearchRelaxation::DroppedTerms));
             if let Some(window) = widened_window {
                 steps.push((
@@ -483,6 +492,25 @@ mod tests {
         assert_eq!(outcome.results.len(), 1);
         assert_eq!(outcome.results[0].title, "notes.md");
         assert_eq!(outcome.relaxation, Some(FileSearchRelaxation::DroppedTerms));
+    }
+
+    #[test]
+    fn terms_only_recall_never_degrades_to_the_whole_index() {
+        // "bitcoin price" reaches file recall as terms with nothing else.
+        // Dropping them would leave no filter at all and return every file,
+        // which reads as an answer and hides the real one.
+        let now = 1_754_000_000;
+        let engine = QueryEngine::new(vec![
+            file_candidate("file:a", "clip.mp4", "/Users/u/Documents/clip.mp4", now),
+            file_candidate("file:b", "notes.md", "/Users/u/Desktop/notes.md", now),
+        ]);
+        let filter = FileFilter {
+            terms: "bitcoin price".into(),
+            ..Default::default()
+        };
+        let outcome = engine.search_files(&filter, 10);
+        assert!(outcome.results.is_empty());
+        assert_eq!(outcome.relaxation, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- weather, currency, ... are affected by ai answer process if the internet connection isn't good enough to return result quickly.
- Add filter guards to prevent the issue


## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`
  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Manual verification completed (if UI/behavior changed)

## Checklist

- [x] I have read and agree to the CLA (CLA.md)
- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file search behavior for terms-only queries.
  * Unmatched terms-only searches no longer return the entire file index.
  * Searches with type, location, or date filters correctly show no results when nothing matches.
  * Empty terms-only searches now fall back to standard search behavior when appropriate.

* **Tests**
  * Added coverage for terms-only searches with and without additional filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->