### PR TITLE
feat: user defined source

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -78,7 +78,7 @@ make app-run
 
 - builds a local Debug app bundle with Xcode
 - stops any running `Look` process (including a Homebrew-installed instance)
-- launches with `LOOK_CONFIG_PATH=$HOME/.look.dev.config`
+- launches with `LOOK_CONFIG_PATH=$HOME/.look/config.dev`
 - shows a red `TEST APP` badge so the dev run is visually distinct
 
 `make app-run` behavior (Windows):
@@ -93,7 +93,7 @@ Install a side-by-side test build (`Look Dev`) without replacing the normal inst
 make app-run-dev
 ```
 
-`make app-run-dev` (macOS) builds a local Debug bundle, installs `/Applications/Look Dev.app` with bundle id `noah-code.Look.Dev`, leaves the Homebrew `/Applications/Look.app` untouched, then launches `Look Dev` with `LOOK_CONFIG_PATH=$HOME/.look.dev.config`. On Windows there is no separate dev install; use `make app-run` (hot reload) or `make app-run-release`.
+`make app-run-dev` (macOS) builds a local Debug bundle, installs `/Applications/Look Dev.app` with bundle id `noah-code.Look.Dev`, leaves the Homebrew `/Applications/Look.app` untouched, then launches `Look Dev` with `LOOK_CONFIG_PATH=$HOME/.look/config.dev`. On Windows there is no separate dev install; use `make app-run` (hot reload) or `make app-run-release`.
 
 Override the macOS dev config path:
 

--- a/apps/linows/BUILDING.md
+++ b/apps/linows/BUILDING.md
@@ -144,18 +144,23 @@ derived from the preset at startup, so the module only writes `ui_theme`, plus
 the opacity values for `kindle` and `liquid` because those two own them. Use
 `custom` to drive every `ui_*` value from `settings` instead.
 
-`settings` keys map directly to `~/.look.config` keys and override values
+`settings` keys map directly to `~/.look/config` keys and override values
 derived from `theme`. Lists are written as comma-separated values, except
 `ignored_patterns_*` and `alias_*`, which Look parses as pipe-separated.
 `aliases` is the same thing with the prefix filled in, so declaring
 `aliases.note` and `settings.alias_note` together is an error.
 
-Activation merges the managed keys into `~/.look.config` rather than replacing
+Activation merges the managed keys into `~/.look/config` rather than replacing
 it: keys you set in Nix win, anything you changed in-app is kept, and keys you
 remove from the Nix config are cleaned up on the next rebuild. The file stays
 writable so the app can keep saving to it, but Nix wins again on every
 activation, so treat Nix as the source of truth for the keys it manages. The
-first activation copies the pre-Nix file to `~/.look.config.hm-backup`.
+first activation copies the pre-Nix file to `<config>.hm-backup`.
+
+Upgrading from a Look that kept its config at `~/.look.config`: activation
+merges into that file until Look has copied it into `~/.look/`, which it does on
+its next launch and which carries the managed keys across. Nothing needs doing
+by hand, and the old file is left where it is.
 
 ### Windows
 
@@ -190,7 +195,7 @@ scripts\windows\with-vcvars.bat cargo fmt --manifest-path apps\linows\src-tauri\
 scripts\windows\with-vcvars.bat cargo clippy --manifest-path apps\linows\src-tauri\Cargo.toml -- -D warnings
 ```
 
-**Dev paths:** in dev mode, Look writes to `%LOCALAPPDATA%\look\look.dev.db` and `%USERPROFILE%\.look.dev.config`. Production builds use `%LOCALAPPDATA%\look\` for both.
+**Dev paths:** in dev mode, Look writes to `%LOCALAPPDATA%\look\look.dev.db` and `%USERPROFILE%\.look\config.dev`. Production builds use `%LOCALAPPDATA%\look\` for both.
 
 **Hot reload caveats:**
 

--- a/apps/linows/BUILDING.md
+++ b/apps/linows/BUILDING.md
@@ -158,9 +158,9 @@ activation, so treat Nix as the source of truth for the keys it manages. The
 first activation copies the pre-Nix file to `<config>.hm-backup`.
 
 Upgrading from a Look that kept its config at `~/.look.config`: activation
-merges into that file until Look has copied it into `~/.look/`, which it does on
-its next launch and which carries the managed keys across. Nothing needs doing
-by hand, and the old file is left where it is.
+merges into whichever file Look reads, the old one until Look copies it into
+`~/.look/` on its next launch, which carries the managed keys across. Nothing
+needs doing by hand, and the old file is left where it is.
 
 ### Windows
 

--- a/apps/linows/nix/home-manager.nix
+++ b/apps/linows/nix/home-manager.nix
@@ -101,12 +101,16 @@ let
 
   stateFile = "${config.xdg.stateHome}/lookapp/home-manager-keys";
 
-  # Look merges its own writes into ~/.look.config line by line and keeps keys
+  # Look merges its own writes into its config file line by line and keeps keys
   # it does not know about (set_config in src-tauri/src/config.rs), so replacing
   # the whole file on activation would throw away everything the user changed
   # in-app. Merge the same way instead: managed keys win, everything else is
   # left alone, and keys dropped from the Nix config since the last generation
   # are removed so the file cannot go stale.
+  #
+  # Target whichever file Look reads (core/engine/src/config_path.rs): the
+  # legacy ~/.look.config until Look copies it into ~/.look/ on its next launch,
+  # which carries these keys across. Writing to it after that applies nothing.
   mergeScript = pkgs.writeShellScript "lookapp-merge-config" ''
     set -eu
     export PATH=${lib.makeBinPath [ pkgs.coreutils ]}
@@ -115,6 +119,14 @@ let
     managed_keys=$2
     prev_keys_file=$3
     target=$4
+    legacy=$5
+
+    if [ ! -e "$target" ] && [ -e "$legacy" ]; then
+      case "$(head -n 1 "$legacy")" in
+        '# Moved to '*) ;;
+        *) target=$legacy ;;
+      esac
+    fi
 
     keys=" "
     while IFS= read -r key; do
@@ -139,6 +151,7 @@ let
       if [ "$keys" = " " ]; then
         exit 0
       fi
+      mkdir -p "$(dirname "$target")"
       {
         printf '# look configuration\n'
         printf '# Keys below are managed by Home Manager. Edit your Nix config, not this file.\n\n'
@@ -234,7 +247,7 @@ in
       defaultText = lib.literalExpression "inputs.look.packages.\${pkgs.stdenv.hostPlatform.system}.default";
       description = ''
         The Look package to install. `null` installs nothing and manages only
-        `~/.look.config`, for when Look is already installed system-wide.
+        `~/.look/config`, for when Look is already installed system-wide.
       '';
     };
 
@@ -269,7 +282,7 @@ in
         }
       '';
       description = ''
-        Settings written to ~/.look.config. Attribute names map directly to
+        Settings written to ~/.look/config. Attribute names map directly to
         Look config keys, for example `ui_theme` becomes `ui_theme=...`.
         Lists are serialized as comma-separated values, except for
         `ignored_patterns_*` and `alias_*` keys, which Look parses as
@@ -303,11 +316,11 @@ in
 
     home.packages = lib.optional (cfg.package != null) cfg.package;
 
-    # Look writes ~/.look.config itself on every settings change, so a home.file
+    # Look writes its config itself on every settings change, so a home.file
     # symlink into the read-only store makes those writes fail and the frontend
     # only logs the error. Merge into a mutable file instead.
     home.activation.lookappConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-      run ${mergeScript} ${managedFile} ${managedKeysFile} ${lib.escapeShellArg stateFile} "$HOME/.look.config"
+      run ${mergeScript} ${managedFile} ${managedKeysFile} ${lib.escapeShellArg stateFile} "$HOME/.look/config" "$HOME/.look.config"
       run install -Dm0644 ${managedKeysFile} ${lib.escapeShellArg stateFile}
     '';
   };

--- a/apps/linows/nix/home-manager.nix
+++ b/apps/linows/nix/home-manager.nix
@@ -108,9 +108,8 @@ let
   # left alone, and keys dropped from the Nix config since the last generation
   # are removed so the file cannot go stale.
   #
-  # Target whichever file Look reads (core/engine/src/config_path.rs): the
-  # legacy ~/.look.config until Look copies it into ~/.look/ on its next launch,
-  # which carries these keys across. Writing to it after that applies nothing.
+  # Target whichever file Look reads (core/engine/src/config_path.rs): both are
+  # kept and ~/.look/config wins, so this follows the same order.
   mergeScript = pkgs.writeShellScript "lookapp-merge-config" ''
     set -eu
     export PATH=${lib.makeBinPath [ pkgs.coreutils ]}
@@ -122,10 +121,7 @@ let
     legacy=$5
 
     if [ ! -e "$target" ] && [ -e "$legacy" ]; then
-      case "$(head -n 1 "$legacy")" in
-        '# Moved to '*) ;;
-        *) target=$legacy ;;
-      esac
+      target=$legacy
     fi
 
     keys=" "

--- a/apps/linows/src-tauri/Cargo.lock
+++ b/apps/linows/src-tauri/Cargo.lock
@@ -2474,6 +2474,7 @@ dependencies = [
  "look-indexing",
  "look-matching",
  "look-ranking",
+ "look-sources",
  "look-storage",
  "objc2",
  "objc2-foundation",
@@ -2525,6 +2526,15 @@ name = "look-ranking"
 version = "0.1.0"
 dependencies = [
  "look-indexing",
+]
+
+[[package]]
+name = "look-sources"
+version = "0.1.0"
+dependencies = [
+ "globset",
+ "serde",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]

--- a/apps/linows/src-tauri/src/config.rs
+++ b/apps/linows/src-tauri/src/config.rs
@@ -154,7 +154,6 @@ fn default_config_contents() -> String {
 }
 
 pub const ENV_CONFIG_PATH: &str = "LOOK_CONFIG_PATH";
-const CONFIG_FILE: &str = ".look.config";
 
 const CLIPBOARD_HISTORY_LIMIT_KEY: &str = "clipboard_history_limit";
 pub const CLIPBOARD_HISTORY_LIMIT_DEFAULT: usize = 10;
@@ -220,6 +219,12 @@ fn parse_clipboard_history_limit(contents: &str) -> usize {
     CLIPBOARD_HISTORY_LIMIT_DEFAULT
 }
 
+/// The config file to read and write, migrating a legacy `~/.look.config` into
+/// `~/.look/` the first time.
+///
+/// Delegates to the shared resolver rather than re-deriving the path: the app
+/// writes this file as well as reading it, so a second implementation that
+/// disagreed would read one file and save to another.
 pub fn config_file_path() -> std::path::PathBuf {
     if let Ok(custom) = std::env::var(ENV_CONFIG_PATH) {
         let trimmed = custom.trim();
@@ -230,7 +235,7 @@ pub fn config_file_path() -> std::path::PathBuf {
     let home = std::env::var("HOME")
         .or_else(|_| std::env::var("USERPROFILE"))
         .unwrap_or_else(|_| ".".to_string());
-    std::path::PathBuf::from(home).join(CONFIG_FILE)
+    look_engine::config_path::resolve_home(std::path::Path::new(&home)).path
 }
 
 #[cfg(test)]

--- a/apps/linows/src-tauri/src/config.rs
+++ b/apps/linows/src-tauri/src/config.rs
@@ -153,7 +153,8 @@ fn default_config_contents() -> String {
     out
 }
 
-pub const ENV_CONFIG_PATH: &str = "LOOK_CONFIG_PATH";
+/// Re-exported, not repeated: a second name is a second file.
+pub use look_engine::config_path::ENV_CONFIG_PATH;
 
 const CLIPBOARD_HISTORY_LIMIT_KEY: &str = "clipboard_history_limit";
 pub const CLIPBOARD_HISTORY_LIMIT_DEFAULT: usize = 10;
@@ -222,20 +223,13 @@ fn parse_clipboard_history_limit(contents: &str) -> usize {
 /// The config file to read and write, migrating a legacy `~/.look.config` into
 /// `~/.look/` the first time.
 ///
-/// Delegates to the shared resolver rather than re-deriving the path: the app
-/// writes this file as well as reading it, so a second implementation that
-/// disagreed would read one file and save to another.
+/// Delegates to the shared resolver, home directory included: the app writes
+/// this file as well as reading it, so a second answer would read one file and
+/// save to another.
 pub fn config_file_path() -> std::path::PathBuf {
-    if let Ok(custom) = std::env::var(ENV_CONFIG_PATH) {
-        let trimmed = custom.trim();
-        if !trimmed.is_empty() {
-            return std::path::PathBuf::from(trimmed);
-        }
-    }
-    let home = std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .unwrap_or_else(|_| ".".to_string());
-    look_engine::config_path::resolve_home(std::path::Path::new(&home)).path
+    look_engine::config_path::current()
+        .unwrap_or_else(|| look_engine::config_path::resolve_home(std::path::Path::new(".")))
+        .path
 }
 
 #[cfg(test)]

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -291,25 +291,20 @@ fn is_wayland() -> bool {
 /// SAFETY: Must be called at startup before any threads are spawned.
 #[cfg(debug_assertions)]
 fn setup_dev_env() {
-    // Resolve home/data dirs per platform. On Linux cmd shells set HOME; on
-    // Windows cmd/PowerShell set USERPROFILE instead - falling back to "."
-    // would land dev artifacts inside the repo.
-    let home = std::env::var("HOME")
-        .ok()
-        .or_else(|| std::env::var("USERPROFILE").ok())
-        .filter(|s| !s.trim().is_empty())
-        .unwrap_or_else(|| ".".to_string());
+    // The engine's answer, not a second one: Windows can have $HOME and
+    // $USERPROFILE pointing at different directories.
+    let home = look_engine::config_path::home().unwrap_or_else(|| ".".to_string());
 
     if std::env::var(config::ENV_CONFIG_PATH)
         .unwrap_or_default()
         .trim()
         .is_empty()
     {
+        // `~/.look/config.dev`, never migrated: a dev file is written by hand.
+        let dev =
+            look_engine::config_path::resolve_home_variant(std::path::Path::new(&home), true).path;
         unsafe {
-            std::env::set_var(
-                config::ENV_CONFIG_PATH,
-                std::path::PathBuf::from(&home).join(".look.dev.config"),
-            );
+            std::env::set_var(config::ENV_CONFIG_PATH, dev);
         }
     }
     if std::env::var(state::ENV_DB_PATH)

--- a/apps/linows/src-tauri/src/platform/windows/icons.rs
+++ b/apps/linows/src-tauri/src/platform/windows/icons.rs
@@ -112,7 +112,7 @@ unsafe fn hbitmap_to_png(hbitmap: HBITMAP) -> Option<Vec<u8>> {
     }
 
     // GetDIBits returns BGRA; PNG wants RGBA.
-    for chunk in pixels.chunks_exact_mut(4) {
+    for chunk in pixels.as_chunks_mut::<4>().0 {
         chunk.swap(0, 2);
     }
 

--- a/apps/linows/src-tauri/src/state.rs
+++ b/apps/linows/src-tauri/src/state.rs
@@ -371,6 +371,7 @@ impl AppState {
                         apps: apps_dirty,
                         files: files_dirty,
                         settings: false,
+                        sources: false,
                     };
                     last_dirty_at = None;
                     apps_dirty = false;

--- a/apps/macos/LauncherApp/look-app/Models/LauncherResult.swift
+++ b/apps/macos/LauncherApp/look-app/Models/LauncherResult.swift
@@ -8,6 +8,9 @@ enum LauncherResultKind: String, Codable {
     /// A running process row from the `ps"` finder. Carries `processPID` /
     /// `processPorts`; detail (cmdline, memory, …) loads per-selection.
     case process
+    /// A row from a user-declared block that has no filesystem target: Enter
+    /// performs its steps rather than opening anything.
+    case action
 
     /// Filesystem targets - the only kinds `Cmd+D`/`Cmd+P`/pick-to-pasteboard
     /// operate on.

--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -318,6 +318,14 @@ enum AppConstants {
             static let cannotRevealBanner = "Cannot reveal this target in Finder"
         }
 
+        /// Rows from a user-declared block in `~/.look/sources`.
+        enum SourceBlock {
+            static let idPrefix = "src:"
+            /// Recorded like an open, so a routine run every morning ranks like
+            /// one. The engine's usage table only needs the verb to be stable.
+            static let usageAction = "execute"
+        }
+
         enum QuickFolder {
             static let idPrefix = "quickfolder:"
             static let pinnedSubtitle = "Pinned home folder"

--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -318,6 +318,21 @@ enum AppConstants {
             static let cannotRevealBanner = "Cannot reveal this target in Finder"
         }
 
+        /// The Cmd+K action menu: everything you can do to the selected row,
+        /// in one place, instead of scattered across Cmd+F / Cmd+C / Cmd+P.
+        enum ActionMenu {
+            static let openHint = "⌘K actions"
+            static let runHint = "↵"
+            static let maxHeight: CGFloat = 240
+            /// Over the launchpad the menu has no panel to fill, so it takes a
+            /// readable column instead of the whole window width.
+            static let launchpadWidth: CGFloat = 320
+            static let cornerRadius: CGFloat = 10
+            static let rowVerticalPadding: CGFloat = 7
+            static let rowHorizontalPadding: CGFloat = 10
+            static let shadowRadius: CGFloat = 14
+        }
+
         /// Rows from a user-declared block in `~/.look/sources`.
         enum SourceBlock {
             static let idPrefix = "src:"
@@ -393,6 +408,8 @@ enum AppConstants {
             static let f: UInt16 = 3
             static let h: UInt16 = 4
             static let c: UInt16 = 8
+            static let j: UInt16 = 38
+            static let k: UInt16 = 40
             static let p: UInt16 = 35
             static let returnKey: UInt16 = 36
             static let tab: UInt16 = 48

--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -324,9 +324,6 @@ enum AppConstants {
             static let openHint = "⌘K actions"
             static let runHint = "↵"
             static let maxHeight: CGFloat = 240
-            /// Over the launchpad the menu has no panel to fill, so it takes a
-            /// readable column instead of the whole window width.
-            static let launchpadWidth: CGFloat = 320
             static let cornerRadius: CGFloat = 10
             static let rowVerticalPadding: CGFloat = 7
             static let rowHorizontalPadding: CGFloat = 10

--- a/apps/macos/LauncherApp/look-app/Support/AppUIState.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppUIState.swift
@@ -36,6 +36,9 @@ final class AppUIState: ObservableObject {
 extension Notification.Name {
     static let lookReloadConfigRequested = Notification.Name("look.reloadConfigRequested")
     static let lookRefocusInputRequested = Notification.Name("look.refocusInputRequested")
+    /// A row's `then` targets finished loading off the main actor, so the panel
+    /// that showed none can build its action list now.
+    static let lookSourceTargetsLoaded = Notification.Name("look.sourceTargetsLoaded")
     static let lookFocusSettingsInputRequested = Notification.Name("look.focusSettingsInputRequested")
     static let lookToggleWindowRequested = Notification.Name("look.toggleWindowRequested")
     static let lookActivateLauncherRequested = Notification.Name("look.activateLauncherRequested")

--- a/apps/macos/LauncherApp/look-app/Support/ConfigPathResolver.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ConfigPathResolver.swift
@@ -32,7 +32,7 @@ enum ConfigPathResolver {
             // The core could not answer (no HOME). Fall back to the legacy path
             // rather than losing the user's settings.
             return (home as NSString).appendingPathComponent(
-                isDevBuild ? ".look.dev.config" : ".look.config")
+                isDevBuild ? ".look/config.dev" : ".look.config")
         }
         defer { look_free_config_cstring(ptr) }
         return String(cString: ptr)

--- a/apps/macos/LauncherApp/look-app/Support/ConfigPathResolver.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ConfigPathResolver.swift
@@ -1,9 +1,24 @@
 import Darwin
 import Foundation
 
+@_silgen_name("look_config_path")
+nonisolated
+private func look_config_path(_ dev: Bool) -> UnsafeMutablePointer<CChar>?
+
+@_silgen_name("look_free_cstring")
+nonisolated
+private func look_free_config_cstring(_ ptr: UnsafeMutablePointer<CChar>?)
+
 enum ConfigPathResolver {
     private static let productionBundleIdentifier = "noah-code.Look"
 
+    /// Where this build reads and writes its settings.
+    ///
+    /// The app decides only WHICH build it is; the core decides where that
+    /// build's file lives, including the one-time move of a legacy
+    /// `~/.look.config` into `~/.look/`. Two implementations of "where is the
+    /// config" could disagree, and the app would then read one file and save to
+    /// another, which looks exactly like settings not persisting.
     static func resolvedPath() -> String {
         let env = ProcessInfo.processInfo.environment
         if let custom = env["LOOK_CONFIG_PATH"]?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -13,19 +28,29 @@ enum ConfigPathResolver {
         }
 
         let home = env["HOME"] ?? NSHomeDirectory()
+        guard let ptr = look_config_path(isDevBuild) else {
+            // The core could not answer (no HOME). Fall back to the legacy path
+            // rather than losing the user's settings.
+            return (home as NSString).appendingPathComponent(
+                isDevBuild ? ".look.dev.config" : ".look.config")
+        }
+        defer { look_free_config_cstring(ptr) }
+        return String(cString: ptr)
+    }
 
+    /// A dev build keeps its own settings, so running it never edits the
+    /// installed copy's config.
+    private static var isDevBuild: Bool {
         if let bundleIdentifier = Bundle.main.bundleIdentifier,
             bundleIdentifier.caseInsensitiveCompare(productionBundleIdentifier) != .orderedSame
         {
-            return (home as NSString).appendingPathComponent(".look.dev.config")
+            return true
         }
-
-        let bundlePath = Bundle.main.bundleURL.resolvingSymlinksInPath().path.lowercased()
-        if bundlePath.contains("/look dev.app") {
-            return (home as NSString).appendingPathComponent(".look.dev.config")
-        }
-
-        return (home as NSString).appendingPathComponent(".look.config")
+        return Bundle.main.bundleURL
+            .resolvingSymlinksInPath()
+            .path
+            .lowercased()
+            .contains("/look dev.app")
     }
 
     static func applyDefaultConfigEnvironmentIfNeeded() {

--- a/apps/macos/LauncherApp/look-app/Support/ConfigPathResolver.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ConfigPathResolver.swift
@@ -24,6 +24,11 @@ enum ConfigPathResolver {
         if let custom = env["LOOK_CONFIG_PATH"]?.trimmingCharacters(in: .whitespacesAndNewlines),
             !custom.isEmpty
         {
+            // Ensured like every answer the core gives: an override into a
+            // folder that does not exist yet is a path nothing can write.
+            try? FileManager.default.createDirectory(
+                atPath: (custom as NSString).deletingLastPathComponent,
+                withIntermediateDirectories: true)
             return custom
         }
 

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
@@ -224,6 +224,14 @@ private func look_todo_save_json(_ json: UnsafePointer<CChar>?) -> Bool
 nonisolated
 private func look_lunar_date_json(_ year: Int64, _ month: Int64, _ day: Int64, _ tz: Double) -> UnsafeMutablePointer<CChar>?
 
+@_silgen_name("look_source_block_json")
+nonisolated
+private func look_source_block_json(_ candidateID: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
+
+@_silgen_name("look_perform_block_json")
+nonisolated
+private func look_perform_block_json(_ candidateID: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
+
 @_silgen_name("look_netspeed_run_json")
 nonisolated
 private func look_netspeed_run_json() -> UnsafeMutablePointer<CChar>?
@@ -985,6 +993,30 @@ final class EngineBridge: @unchecked Sendable {
         url.withCString { look_record_url_hit($0) }
     }
 
+    /// The user-declared block a row belongs to, with the exact steps Enter will
+    /// perform. Reads the sources directory, so call it off the main thread.
+    nonisolated func sourceBlock(candidateID: String) -> SourceBlock? {
+        let ptr = candidateID.withCString { look_source_block_json($0) }
+        guard let ptr else { return nil }
+        defer { look_free_cstring(ptr) }
+        guard let data = String(cString: ptr).data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(SourceBlock.self, from: data)
+    }
+
+    /// Performs every step of that block, detached, through the user's login
+    /// shell. Spawns processes - call off the main thread.
+    nonisolated func performBlock(candidateID: String) -> PerformBlockOutcome {
+        let ptr = candidateID.withCString { look_perform_block_json($0) }
+        guard let ptr else { return PerformBlockOutcome(performed: 0, errors: []) }
+        defer { look_free_cstring(ptr) }
+        guard let data = String(cString: ptr).data(using: .utf8),
+              let outcome = try? JSONDecoder().decode(PerformBlockOutcome.self, from: data)
+        else {
+            return PerformBlockOutcome(performed: 0, errors: [])
+        }
+        return outcome
+    }
+
     /// Up to `limit` previously-opened URLs matching `query`, most-recent first.
     /// Opens the shared look.db - call off the main thread.
     nonisolated func recentURLs(query: String, limit: Int) -> [URLHistoryEntry] {
@@ -1171,6 +1203,23 @@ nonisolated struct URLMatch: Decodable {
 
     let url: String
     let tier: Tier
+}
+
+/// A user-declared block and the steps performing it will run, so the panel can
+/// show exactly what Enter is about to do.
+nonisolated struct SourceBlock: Decodable {
+    let id: String
+    let name: String
+    let steps: [String]
+    /// The `.toml` (or script) that declared it, for showing and revealing.
+    let file: String?
+}
+
+/// How performing a block went. `errors` is empty when every step was spawned;
+/// a step's own exit code is its business, since nothing waits for it.
+nonisolated struct PerformBlockOutcome: Decodable {
+    let performed: Int
+    let errors: [String]
 }
 
 /// Wire shape of a `url_history` row (see url-history spec), decoded with

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
@@ -224,6 +224,10 @@ private func look_todo_save_json(_ json: UnsafePointer<CChar>?) -> Bool
 nonisolated
 private func look_lunar_date_json(_ year: Int64, _ month: Int64, _ day: Int64, _ tz: Double) -> UnsafeMutablePointer<CChar>?
 
+@_silgen_name("look_source_blocks_json")
+nonisolated
+private func look_source_blocks_json() -> UnsafeMutablePointer<CChar>?
+
 @_silgen_name("look_source_block_json")
 nonisolated
 private func look_source_block_json(_ candidateID: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
@@ -1003,6 +1007,15 @@ final class EngineBridge: @unchecked Sendable {
         return try? JSONDecoder().decode(SourceBlock.self, from: data)
     }
 
+    /// Every declared block, for the row-icon cache. Reads the sources
+    /// directory, so call it off the main thread.
+    nonisolated func sourceBlocks() -> [SourceBlockSummary] {
+        guard let ptr = look_source_blocks_json() else { return [] }
+        defer { look_free_cstring(ptr) }
+        guard let data = String(cString: ptr).data(using: .utf8) else { return [] }
+        return (try? JSONDecoder().decode([SourceBlockSummary].self, from: data)) ?? []
+    }
+
     /// Performs every step of that block, detached, through the user's login
     /// shell. Spawns processes - call off the main thread.
     nonisolated func performBlock(candidateID: String) -> PerformBlockOutcome {
@@ -1213,6 +1226,14 @@ nonisolated struct SourceBlock: Decodable {
     let steps: [String]
     /// The `.toml` (or script) that declared it, for showing and revealing.
     let file: String?
+}
+
+/// A declared block as the row layer needs it: what to call it and what icon it
+/// asked for. Cached per launcher open so rendering a row never touches disk.
+nonisolated struct SourceBlockSummary: Decodable {
+    let id: String
+    let name: String
+    let icon: String?
 }
 
 /// How performing a block went. `errors` is empty when every step was spawned;

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
@@ -242,7 +242,7 @@ private func look_source_block_json(_ candidateID: UnsafePointer<CChar>?, _ rowI
 
 @_silgen_name("look_perform_block_json")
 nonisolated
-private func look_perform_block_json(_ blockID: UnsafePointer<CChar>?, _ rowID: UnsafePointer<CChar>?, _ rowTitle: UnsafePointer<CChar>?, _ rowPath: UnsafePointer<CChar>?, _ query: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
+private func look_perform_block_json(_ blockID: UnsafePointer<CChar>?, _ rowID: UnsafePointer<CChar>?, _ rowTitle: UnsafePointer<CChar>?, _ rowPath: UnsafePointer<CChar>?, _ query: UnsafePointer<CChar>?, _ asTarget: Bool) -> UnsafeMutablePointer<CChar>?
 
 @_silgen_name("look_netspeed_run_json")
 nonisolated
@@ -1071,19 +1071,23 @@ final class EngineBridge: @unchecked Sendable {
 
     /// Performs every step of that block, detached, through the user's login
     /// shell. Spawns processes - call off the main thread.
+    /// `asTarget` is the caller's intent, and only the caller knows it: Enter on
+    /// a row runs that block's `open`, while a `then` target that produces rows
+    /// is a level to descend into rather than something to run.
     nonisolated func performBlock(
         blockID: String,
         rowID: String = "",
         rowTitle: String = "",
         rowPath: String = "",
-        query: String = ""
+        query: String = "",
+        asTarget: Bool = false
     ) -> PerformBlockOutcome {
         let ptr = blockID.withCString { block in
             rowID.withCString { id in
                 rowTitle.withCString { title in
                     rowPath.withCString { path in
                         query.withCString { query in
-                            look_perform_block_json(block, id, title, path, query)
+                            look_perform_block_json(block, id, title, path, query, asTarget)
                         }
                     }
                 }
@@ -1093,13 +1097,19 @@ final class EngineBridge: @unchecked Sendable {
         // means something else entirely (a block that produces rows), and the
         // caller keys on that, so the two must not share a value.
         guard let ptr else {
-            return PerformBlockOutcome(performed: 0, errors: ["the core did not answer"])
+            return PerformBlockOutcome(
+                performed: 0, errors: ["the core did not answer"], producesRows: false)
         }
         defer { look_free_cstring(ptr) }
+        // The core sends snake_case, so `produces_rows` only reaches
+        // `producesRows` with the conversion strategy set.
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
         guard let data = String(cString: ptr).data(using: .utf8),
-              let outcome = try? JSONDecoder().decode(PerformBlockOutcome.self, from: data)
+              let outcome = try? decoder.decode(PerformBlockOutcome.self, from: data)
         else {
-            return PerformBlockOutcome(performed: 0, errors: ["the core's answer could not be read"])
+            return PerformBlockOutcome(
+                performed: 0, errors: ["the core's answer could not be read"], producesRows: false)
         }
         return outcome
     }
@@ -1340,6 +1350,9 @@ nonisolated struct SourcePreview: Decodable {
 nonisolated struct PerformBlockOutcome: Decodable {
     let performed: Int
     let errors: [String]
+    /// The target lists rows to pick from rather than steps to run. An explicit
+    /// flag, because "nothing performed" is also what a failure looks like.
+    let producesRows: Bool
 }
 
 /// Wire shape of a `url_history` row (see url-history spec), decoded with

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
@@ -1089,12 +1089,17 @@ final class EngineBridge: @unchecked Sendable {
                 }
             }
         }
-        guard let ptr else { return PerformBlockOutcome(performed: 0, errors: []) }
+        // A failure carries a reason. An empty `errors` with nothing performed
+        // means something else entirely (a block that produces rows), and the
+        // caller keys on that, so the two must not share a value.
+        guard let ptr else {
+            return PerformBlockOutcome(performed: 0, errors: ["the core did not answer"])
+        }
         defer { look_free_cstring(ptr) }
         guard let data = String(cString: ptr).data(using: .utf8),
               let outcome = try? JSONDecoder().decode(PerformBlockOutcome.self, from: data)
         else {
-            return PerformBlockOutcome(performed: 0, errors: [])
+            return PerformBlockOutcome(performed: 0, errors: ["the core's answer could not be read"])
         }
         return outcome
     }

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
@@ -224,13 +224,21 @@ private func look_todo_save_json(_ json: UnsafePointer<CChar>?) -> Bool
 nonisolated
 private func look_lunar_date_json(_ year: Int64, _ month: Int64, _ day: Int64, _ tz: Double) -> UnsafeMutablePointer<CChar>?
 
+@_silgen_name("look_refresh_run_blocks_json")
+nonisolated
+private func look_refresh_run_blocks_json() -> UnsafeMutablePointer<CChar>?
+
+@_silgen_name("look_source_preview_json")
+nonisolated
+private func look_source_preview_json(_ candidateID: UnsafePointer<CChar>?, _ rowID: UnsafePointer<CChar>?, _ rowTitle: UnsafePointer<CChar>?, _ rowPath: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
+
 @_silgen_name("look_source_blocks_json")
 nonisolated
 private func look_source_blocks_json() -> UnsafeMutablePointer<CChar>?
 
 @_silgen_name("look_source_block_json")
 nonisolated
-private func look_source_block_json(_ candidateID: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
+private func look_source_block_json(_ candidateID: UnsafePointer<CChar>?, _ rowID: UnsafePointer<CChar>?, _ rowTitle: UnsafePointer<CChar>?, _ rowPath: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
 
 @_silgen_name("look_perform_block_json")
 nonisolated
@@ -999,12 +1007,57 @@ final class EngineBridge: @unchecked Sendable {
 
     /// The user-declared block a row belongs to, with the exact steps Enter will
     /// perform. Reads the sources directory, so call it off the main thread.
-    nonisolated func sourceBlock(candidateID: String) -> SourceBlock? {
-        let ptr = candidateID.withCString { look_source_block_json($0) }
+    nonisolated func sourceBlock(
+        candidateID: String, rowID: String = "", rowTitle: String = "", rowPath: String = ""
+    ) -> SourceBlock? {
+        let ptr = candidateID.withCString { candidate in
+            rowID.withCString { id in
+                rowTitle.withCString { title in
+                    rowPath.withCString { path in
+                        look_source_block_json(candidate, id, title, path)
+                    }
+                }
+            }
+        }
         guard let ptr else { return nil }
         defer { look_free_cstring(ptr) }
         guard let data = String(cString: ptr).data(using: .utf8) else { return nil }
         return try? JSONDecoder().decode(SourceBlock.self, from: data)
+    }
+
+    /// Re-runs every `run` block and stores its rows for the next index pass.
+    /// Spawns the user's commands and waits for them - call off the main thread.
+    nonisolated func refreshRunBlocks() -> RunBlockRefreshOutcome {
+        guard let ptr = look_refresh_run_blocks_json() else {
+            return RunBlockRefreshOutcome(refreshed: 0, errors: [])
+        }
+        defer { look_free_cstring(ptr) }
+        guard let data = String(cString: ptr).data(using: .utf8),
+              let outcome = try? JSONDecoder().decode(RunBlockRefreshOutcome.self, from: data)
+        else {
+            return RunBlockRefreshOutcome(refreshed: 0, errors: [])
+        }
+        return outcome
+    }
+
+    /// A block's declared `preview`, run against the selected row. Nil when the
+    /// block declares none. Runs a command - call off the main thread.
+    nonisolated func sourcePreview(
+        candidateID: String, rowID: String, rowTitle: String, rowPath: String
+    ) -> SourcePreview? {
+        let ptr = candidateID.withCString { candidate in
+            rowID.withCString { id in
+                rowTitle.withCString { title in
+                    rowPath.withCString { path in
+                        look_source_preview_json(candidate, id, title, path)
+                    }
+                }
+            }
+        }
+        guard let ptr else { return nil }
+        defer { look_free_cstring(ptr) }
+        guard let data = String(cString: ptr).data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(SourcePreview.self, from: data)
     }
 
     /// Every declared block, for the row-icon cache. Reads the sources
@@ -1253,6 +1306,8 @@ nonisolated struct SourceBlockTarget: Decodable, Identifiable {
     let name: String
     let icon: String?
     let performs: Bool
+    /// Already expanded against the row, so it names what will actually happen.
+    let confirm: String?
 }
 
 /// A declared block as the row layer needs it: what to call it and what icon it
@@ -1261,6 +1316,18 @@ nonisolated struct SourceBlockSummary: Decodable {
     let id: String
     let name: String
     let icon: String?
+}
+
+/// How a `run`-block refresh went. A block that failed kept the rows it had.
+nonisolated struct RunBlockRefreshOutcome: Decodable {
+    let refreshed: Int
+    let errors: [String]
+}
+
+/// A block's `preview` output, or why it could not run.
+nonisolated struct SourcePreview: Decodable {
+    let text: String
+    let error: String?
 }
 
 /// How performing a block went. `errors` is empty when every step was spawned;

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
@@ -234,7 +234,7 @@ private func look_source_block_json(_ candidateID: UnsafePointer<CChar>?) -> Uns
 
 @_silgen_name("look_perform_block_json")
 nonisolated
-private func look_perform_block_json(_ candidateID: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
+private func look_perform_block_json(_ blockID: UnsafePointer<CChar>?, _ rowID: UnsafePointer<CChar>?, _ rowTitle: UnsafePointer<CChar>?, _ rowPath: UnsafePointer<CChar>?, _ query: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
 
 @_silgen_name("look_netspeed_run_json")
 nonisolated
@@ -1018,8 +1018,24 @@ final class EngineBridge: @unchecked Sendable {
 
     /// Performs every step of that block, detached, through the user's login
     /// shell. Spawns processes - call off the main thread.
-    nonisolated func performBlock(candidateID: String) -> PerformBlockOutcome {
-        let ptr = candidateID.withCString { look_perform_block_json($0) }
+    nonisolated func performBlock(
+        blockID: String,
+        rowID: String = "",
+        rowTitle: String = "",
+        rowPath: String = "",
+        query: String = ""
+    ) -> PerformBlockOutcome {
+        let ptr = blockID.withCString { block in
+            rowID.withCString { id in
+                rowTitle.withCString { title in
+                    rowPath.withCString { path in
+                        query.withCString { query in
+                            look_perform_block_json(block, id, title, path, query)
+                        }
+                    }
+                }
+            }
+        }
         guard let ptr else { return PerformBlockOutcome(performed: 0, errors: []) }
         defer { look_free_cstring(ptr) }
         guard let data = String(cString: ptr).data(using: .utf8),
@@ -1226,6 +1242,17 @@ nonisolated struct SourceBlock: Decodable {
     let steps: [String]
     /// The `.toml` (or script) that declared it, for showing and revealing.
     let file: String?
+    /// Where a row of this block can go next.
+    let then: [SourceBlockTarget]
+}
+
+/// One `then` target. `performs` says what the target's own producer decided:
+/// steps to run now, or rows to descend into.
+nonisolated struct SourceBlockTarget: Decodable, Identifiable {
+    let id: String
+    let name: String
+    let icon: String?
+    let performs: Bool
 }
 
 /// A declared block as the row layer needs it: what to call it and what icon it

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
@@ -139,7 +139,13 @@ final class KeyboardSelectionMonitor {
 
             // Cmd+K opens it. Cmd+J opens it too and starts on the first row,
             // so either half of the pair gets you in.
+            //
+            // Never on the launchpad: its tiles ARE the actions, each with its
+            // own mnemonic, and ⌘K is already Keep Awake there. Opening a menu
+            // of the same tiles would both duplicate what is on screen and
+            // shadow the key the user meant.
             if flags == [.command],
+                !isLaunchpadActive(),
                 event.keyCode == KeyCode.k || event.keyCode == KeyCode.j
                     || event.charactersIgnoringModifiers?.lowercased() == "k"
                     || event.charactersIgnoringModifiers?.lowercased() == "j"

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
@@ -35,6 +35,13 @@ final class KeyboardSelectionMonitor {
         /// is a line break there, not "open all picked").
         inAIMode: @escaping @MainActor () -> Bool = { false },
         onWebSearch: @escaping @MainActor () -> Void,
+        /// The Cmd+K action menu. While it is open it owns the arrows, Enter,
+        /// and Escape, so those never reach the results list underneath.
+        inActionMenu: @escaping @MainActor () -> Bool = { false },
+        onToggleActionMenu: @escaping @MainActor () -> Void = {},
+        onActionMenuMove: @escaping @MainActor (Int) -> Void = { _ in },
+        onActionMenuRun: @escaping @MainActor () -> Void = {},
+        onActionMenuClose: @escaping @MainActor () -> Void = {},
         onRevealInFinder: @escaping @MainActor () -> Void,
         onCopySelection: @escaping @MainActor () -> Bool,
         onTogglePick: @escaping @MainActor () -> Void,
@@ -100,6 +107,44 @@ final class KeyboardSelectionMonitor {
                     onCancelHideApp?()
                     return nil
                 }
+                return nil
+            }
+
+            // Open: the menu owns navigation. Cmd+J / Cmd+K step through it
+            // (vim-style), arrows do the same, Escape closes. Anything else
+            // falls through, so typing still reaches the query field.
+            if inActionMenu() {
+                let character = event.charactersIgnoringModifiers?.lowercased()
+                if event.keyCode == KeyCode.escape {
+                    onActionMenuClose()
+                    return nil
+                }
+                if event.keyCode == KeyCode.returnKey || event.keyCode == KeyCode.keypadEnter {
+                    onActionMenuRun()
+                    return nil
+                }
+                if event.keyCode == KeyCode.arrowDown
+                    || (flags == [.command] && (event.keyCode == KeyCode.j || character == "j"))
+                {
+                    onActionMenuMove(1)
+                    return nil
+                }
+                if event.keyCode == KeyCode.arrowUp
+                    || (flags == [.command] && (event.keyCode == KeyCode.k || character == "k"))
+                {
+                    onActionMenuMove(-1)
+                    return nil
+                }
+            }
+
+            // Cmd+K opens it. Cmd+J opens it too and starts on the first row,
+            // so either half of the pair gets you in.
+            if flags == [.command],
+                event.keyCode == KeyCode.k || event.keyCode == KeyCode.j
+                    || event.charactersIgnoringModifiers?.lowercased() == "k"
+                    || event.charactersIgnoringModifiers?.lowercased() == "j"
+            {
+                onToggleActionMenu()
                 return nil
             }
 

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/LauncherSearchLogic.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/LauncherSearchLogic.swift
@@ -92,9 +92,10 @@ enum LauncherSearchLogic {
             return "\(result.kind.rawValue):\(normalizedTitle)"
         case .file, .folder:
             return "\(result.kind.rawValue):\(normalizedPath)"
-        case .clipboard, .process:
-            // Clipboard entries and process rows are already unique by id
-            // (entry UUID / pid), so key on it rather than title/path.
+        case .clipboard, .process, .action:
+            // Clipboard entries, process rows, and declared blocks are already
+            // unique by id (entry UUID / pid / block id), so key on it rather
+            // than title/path.
             return result.id
         }
     }

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/SourceBlockIcons.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/SourceBlockIcons.swift
@@ -1,0 +1,160 @@
+import AppKit
+
+/// What each declared block asked to be drawn as, keyed by block id.
+///
+/// Rows render synchronously and there are many of them, so this is read on
+/// first use and kept for the process rather than fetched per row. The files
+/// involved are a handful of small TOMLs, and `invalidate()` drops the cache
+/// when they change.
+@MainActor
+enum SourceBlockCatalog {
+    private static var iconsByBlockID: [String: String]?
+
+    static func invalidate() {
+        iconsByBlockID = nil
+    }
+
+    /// The declared icon for the block a candidate id belongs to.
+    static func icon(forCandidateID candidateID: String) -> String? {
+        guard let blockID = blockID(fromCandidateID: candidateID) else { return nil }
+        if iconsByBlockID == nil {
+            iconsByBlockID = Dictionary(
+                EngineBridge.shared.sourceBlocks().compactMap { summary in
+                    summary.icon.map { (summary.id, $0) }
+                },
+                uniquingKeysWith: { first, _ in first }
+            )
+        }
+        return iconsByBlockID?[blockID]
+    }
+
+    /// `src:<block>:<row>` -> `<block>`.
+    private static func blockID(fromCandidateID candidateID: String) -> String? {
+        let prefix = AppConstants.Launcher.SourceBlock.idPrefix
+        guard candidateID.hasPrefix(prefix) else { return nil }
+        let rest = candidateID.dropFirst(prefix.count)
+        guard let separator = rest.firstIndex(of: ":") else { return nil }
+        return String(rest[rest.startIndex..<separator])
+    }
+}
+
+/// Icons for rows and panels that come from a user-declared block.
+///
+/// Two sources, in order of trust: what the block declared (`icon = …`), then
+/// what its steps obviously do. Guessing is deliberately narrow, since a wrong
+/// icon is worse than a generic one.
+enum SourceBlockIcons {
+    /// Row-icon size. Larger than the list needs, so the same cached image can
+    /// serve the panel without looking soft.
+    private static let renderedSize = NSSize(width: 64, height: 64)
+
+    /// `open -a Slack`, `open -a "Google Chrome" https://…`. Anything else (a
+    /// CLI like `code`, a shell pipeline) resolves to nothing rather than a
+    /// guess.
+    static func appName(inStep step: String) -> String? {
+        let trimmed = step.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix("open ") else { return nil }
+
+        var rest = Substring(trimmed.dropFirst("open ".count))
+        while let flagRange = rest.range(of: "-a ") {
+            rest = rest[flagRange.upperBound...]
+            return firstArgument(in: rest)
+        }
+        return nil
+    }
+
+    /// The declared `icon`, resolved as an image path, an SF Symbol name, or
+    /// text to draw (an emoji). Nil when the block declared nothing.
+    static func declaredIcon(_ declared: String?) -> NSImage? {
+        guard let declared, !declared.trimmingCharacters(in: .whitespaces).isEmpty else {
+            return nil
+        }
+        return RowIconCache.image(key: "blockicon:\(declared)") {
+            if FileManager.default.fileExists(atPath: declared),
+               let image = NSImage(contentsOfFile: declared) {
+                return image
+            }
+            if let symbol = NSImage(systemSymbolName: declared, accessibilityDescription: nil) {
+                return symbol
+            }
+            return rendered(text: declared)
+        }
+    }
+
+    /// The app icons a bundle's steps will bring up, deduplicated and in step
+    /// order. Steps that name no app contribute nothing, so the strip never
+    /// implies more than the block does.
+    static func appIcons(forSteps steps: [String], limit: Int) -> [NSImage] {
+        var seen = Set<String>()
+        var icons: [NSImage] = []
+        for step in steps {
+            guard icons.count < limit,
+                  let name = appName(inStep: step),
+                  seen.insert(name.lowercased()).inserted,
+                  let path = bundlePath(forAppNamed: name)
+            else { continue }
+            icons.append(RowIconCache.icon(forFile: path))
+        }
+        return icons
+    }
+
+    /// Where `open -a Name` would find the bundle. The same roots `open` itself
+    /// searches, plus a bundle-id lookup for a step that names one.
+    private static func bundlePath(forAppNamed name: String) -> String? {
+        let roots = [
+            "/Applications",
+            "/System/Applications",
+            "/System/Applications/Utilities",
+            "/Applications/Utilities",
+            NSHomeDirectory() + "/Applications",
+        ]
+        let bundleName = name.hasSuffix(".app") ? name : name + ".app"
+        for root in roots {
+            let candidate = root + "/" + bundleName
+            if FileManager.default.fileExists(atPath: candidate) {
+                return candidate
+            }
+        }
+        return NSWorkspace.shared
+            .urlForApplication(withBundleIdentifier: name)?
+            .path
+    }
+
+    /// The first argument after `-a`, honouring quotes so a two-word app name
+    /// survives.
+    private static func firstArgument(in text: Substring) -> String? {
+        let trimmed = text.drop(while: { $0 == " " })
+        guard let first = trimmed.first else { return nil }
+
+        if first == "\"" || first == "'" {
+            let body = trimmed.dropFirst()
+            guard let end = body.firstIndex(of: first) else { return nil }
+            let name = String(body[body.startIndex..<end])
+            return name.isEmpty ? nil : name
+        }
+
+        let name = String(trimmed.prefix(while: { $0 != " " }))
+        return name.isEmpty ? nil : name
+    }
+
+    /// Draws text (an emoji) into an image, so a declared glyph can sit in the
+    /// same image slot as an app icon.
+    private static func rendered(text: String) -> NSImage {
+        let image = NSImage(size: renderedSize)
+        image.lockFocus()
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: renderedSize.height * 0.72)
+        ]
+        let string = text as NSString
+        let bounds = string.size(withAttributes: attributes)
+        string.draw(
+            at: NSPoint(
+                x: (renderedSize.width - bounds.width) / 2,
+                y: (renderedSize.height - bounds.height) / 2
+            ),
+            withAttributes: attributes
+        )
+        image.unlockFocus()
+        return image
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/SourceBlockIcons.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/SourceBlockIcons.swift
@@ -9,25 +9,30 @@ import AppKit
 @MainActor
 enum SourceBlockCatalog {
     private static var iconsByBlockID: [String: String]?
-    private static var targetsByBlockID: [String: [SourceBlockTarget]] = [:]
+    private static var targetsByCandidateID: [String: [SourceBlockTarget]] = [:]
 
     static func invalidate() {
         iconsByBlockID = nil
-        targetsByBlockID = [:]
+        targetsByCandidateID = [:]
     }
 
-    /// The `then` targets of the block a candidate id belongs to.
+    /// The `then` targets for one row.
     ///
-    /// Memoised per block: this is read while building the panel on every
-    /// selection change, and arrow-keying down a list of projects should not
-    /// re-read the sources directory once per row. `invalidate()` on config
-    /// reload is what picks up an edited `then`.
-    static func targets(forCandidateID candidateID: String) -> [SourceBlockTarget] {
-        guard let blockID = blockID(fromCandidateID: candidateID) else { return [] }
-        if let cached = targetsByBlockID[blockID] { return cached }
+    /// Keyed on the candidate rather than the block, because a target's confirm
+    /// question is expanded against the row ("Delete main?"). Memoised because
+    /// this is read while building the panel on every selection change, and
+    /// arrow-keying down a list should not re-read the sources directory once
+    /// per row. `invalidate()` on config reload picks up an edited `then`.
+    static func targets(for result: LauncherResult) -> [SourceBlockTarget] {
+        if let cached = targetsByCandidateID[result.id] { return cached }
 
-        let targets = EngineBridge.shared.sourceBlock(candidateID: candidateID)?.then ?? []
-        targetsByBlockID[blockID] = targets
+        let targets = EngineBridge.shared.sourceBlock(
+            candidateID: result.id,
+            rowID: result.id,
+            rowTitle: result.title,
+            rowPath: result.path
+        )?.then ?? []
+        targetsByCandidateID[result.id] = targets
         return targets
     }
 

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/SourceBlockIcons.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/SourceBlockIcons.swift
@@ -10,10 +10,13 @@ import AppKit
 enum SourceBlockCatalog {
     private static var iconsByBlockID: [String: String]?
     private static var targetsByCandidateID: [String: [SourceBlockTarget]] = [:]
+    private static var targetsInFlight: Set<String> = []
 
     static func invalidate() {
         iconsByBlockID = nil
         targetsByCandidateID = [:]
+        targetsInFlight = []
+        prefill()
     }
 
     /// The `then` targets for one row.
@@ -24,30 +27,69 @@ enum SourceBlockCatalog {
     /// arrow-keying down a list should not re-read the sources directory once
     /// per row. `invalidate()` on config reload picks up an edited `then`.
     static func targets(for result: LauncherResult) -> [SourceBlockTarget] {
-        if let cached = targetsByCandidateID[result.id] { return cached }
+        if let cached = targetsByCandidateID[cacheKey(for: result)] { return cached }
+        loadTargets(for: result)
+        return []
+    }
 
-        let targets = EngineBridge.shared.sourceBlock(
-            candidateID: result.id,
-            rowID: result.id,
-            rowTitle: result.title,
-            rowPath: result.path
-        )?.then ?? []
-        targetsByCandidateID[result.id] = targets
-        return targets
+    /// Reads one row's targets off the main actor and caches them. The panel
+    /// re-reads on the next selection change, so an empty first answer costs a
+    /// moment rather than an action.
+    private static func loadTargets(for result: LauncherResult) {
+        let key = cacheKey(for: result)
+        guard !targetsInFlight.contains(key) else { return }
+        targetsInFlight.insert(key)
+
+        Task {
+            let targets = await Task.detached(priority: .userInitiated) {
+                EngineBridge.shared.sourceBlock(
+                    candidateID: result.id,
+                    rowID: result.id,
+                    rowTitle: result.title,
+                    rowPath: result.path
+                )?.then ?? []
+            }.value
+            await MainActor.run {
+                targetsByCandidateID[key] = targets
+                targetsInFlight.remove(key)
+                NotificationCenter.default.post(name: .lookSourceTargetsLoaded, object: nil)
+            }
+        }
+    }
+
+    /// A target's `confirm` text is expanded against the row, so two rows that
+    /// share an id but differ in title or path must not share a cache entry.
+    private static func cacheKey(for result: LauncherResult) -> String {
+        "\(result.id)\u{1}\(result.title)\u{1}\(result.path)"
     }
 
     /// The declared icon for the block a candidate id belongs to.
+    ///
+    /// Never reads from disk: rows render synchronously and there are many of
+    /// them, so a cache miss returns nil and the row falls back to the generic
+    /// glyph until `prefill()` lands. A momentarily generic icon is a far
+    /// smaller cost than a directory walk on the main actor mid-render.
     static func icon(forCandidateID candidateID: String) -> String? {
         guard let blockID = blockID(fromCandidateID: candidateID) else { return nil }
-        if iconsByBlockID == nil {
-            iconsByBlockID = Dictionary(
-                EngineBridge.shared.sourceBlocks().compactMap { summary in
-                    summary.icon.map { (summary.id, $0) }
-                },
-                uniquingKeysWith: { first, _ in first }
-            )
-        }
         return iconsByBlockID?[blockID]
+    }
+
+    /// Loads the block catalog off the main actor. Called on launcher open and
+    /// after a config reload, so the caches are warm before anything renders.
+    static func prefill() {
+        Task {
+            let summaries = await Task.detached(priority: .userInitiated) {
+                EngineBridge.shared.sourceBlocks()
+            }.value
+            await MainActor.run {
+                iconsByBlockID = Dictionary(
+                    summaries.compactMap { summary in
+                        summary.icon.map { (summary.id, $0) }
+                    },
+                    uniquingKeysWith: { first, _ in first }
+                )
+            }
+        }
     }
 
     /// `src:<block>:<row>` -> `<block>`.

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/SourceBlockIcons.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/SourceBlockIcons.swift
@@ -9,9 +9,26 @@ import AppKit
 @MainActor
 enum SourceBlockCatalog {
     private static var iconsByBlockID: [String: String]?
+    private static var targetsByBlockID: [String: [SourceBlockTarget]] = [:]
 
     static func invalidate() {
         iconsByBlockID = nil
+        targetsByBlockID = [:]
+    }
+
+    /// The `then` targets of the block a candidate id belongs to.
+    ///
+    /// Memoised per block: this is read while building the panel on every
+    /// selection change, and arrow-keying down a list of projects should not
+    /// re-read the sources directory once per row. `invalidate()` on config
+    /// reload is what picks up an edited `then`.
+    static func targets(forCandidateID candidateID: String) -> [SourceBlockTarget] {
+        guard let blockID = blockID(fromCandidateID: candidateID) else { return [] }
+        if let cached = targetsByBlockID[blockID] { return cached }
+
+        let targets = EngineBridge.shared.sourceBlock(candidateID: candidateID)?.then ?? []
+        targetsByBlockID[blockID] = targets
+        return targets
     }
 
     /// The declared icon for the block a candidate id belongs to.
@@ -29,7 +46,7 @@ enum SourceBlockCatalog {
     }
 
     /// `src:<block>:<row>` -> `<block>`.
-    private static func blockID(fromCandidateID candidateID: String) -> String? {
+    static func blockID(fromCandidateID candidateID: String) -> String? {
         let prefix = AppConstants.Launcher.SourceBlock.idPrefix
         guard candidateID.hasPrefix(prefix) else { return nil }
         let rest = candidateID.dropFirst(prefix.count)

--- a/apps/macos/LauncherApp/look-app/Support/QuickActions/QuickActionModels.swift
+++ b/apps/macos/LauncherApp/look-app/Support/QuickActions/QuickActionModels.swift
@@ -27,6 +27,14 @@ struct QuickActionDescriptor: Decodable, Equatable, Identifiable {
     let onLabel: String?
     let offLabel: String?
     let info: [QuickActionInfoField]
+    /// A question to ask before running, already expanded against the row.
+    ///
+    /// Carried ON the descriptor rather than looked up when the key is pressed:
+    /// a lookup can miss (a cleared cache, a load still in flight) and a missing
+    /// question reads as "no confirmation needed", which would run a destructive
+    /// action silently. The descriptor is what gets activated, so the guard
+    /// travels with it.
+    var confirm: String? = nil
 
     var id: String { actionId }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ActionMenuView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ActionMenuView.swift
@@ -11,7 +11,9 @@ struct ActionMenuView: View {
     let states: [String: ActionState]
     let focusedIndex: Int
     let themeStore: ThemeStore
-    let onRun: (QuickActionDescriptor) -> Void
+    /// Activate one row. The menu never runs anything itself: confirmation and
+    /// closing live with the coordinator that owns the pending question.
+    let onActivate: (QuickActionDescriptor) -> Void
 
     private typealias Layout = AppConstants.Launcher.ActionMenu
 
@@ -78,7 +80,7 @@ struct ActionMenuView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(rowBackground(isFocused: isFocused))
         .contentShape(Rectangle())
-        .onTapGesture { onRun(descriptor) }
+        .onTapGesture { onActivate(descriptor) }
     }
 
     private func rowBackground(isFocused: Bool) -> some View {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ActionMenuView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ActionMenuView.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+
+/// Everything you can do to the selected row, in one popup.
+///
+/// It floats under the preview's header rather than sitting in the layout, so a
+/// row with actions costs the preview no space until the user asks for them
+/// with Cmd+K. Information (a file preview, a folder listing, Bluetooth's paired
+/// devices) stays in the panel; only the verbs live here.
+struct ActionMenuView: View {
+    let descriptors: [QuickActionDescriptor]
+    let states: [String: ActionState]
+    let focusedIndex: Int
+    let themeStore: ThemeStore
+    let onRun: (QuickActionDescriptor) -> Void
+
+    private typealias Layout = AppConstants.Launcher.ActionMenu
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView(.vertical, showsIndicators: false) {
+                LazyVStack(alignment: .leading, spacing: 2) {
+                    ForEach(Array(descriptors.enumerated()), id: \.element.id) { pair in
+                        row(pair.element, isFocused: pair.offset == focusedIndex)
+                            .id(pair.offset)
+                    }
+                }
+            }
+            .frame(height: menuHeight)
+            .onChange(of: focusedIndex) { _, index in
+                withAnimation(Motion.Selection.glide) { proxy.scrollTo(index) }
+            }
+        }
+        .padding(4)
+        .background(menuBackground)
+        .overlay(menuBorder)
+    }
+
+    /// Tall enough for its rows, never taller than the cap.
+    private var menuHeight: CGFloat {
+        let rows = CGFloat(descriptors.count)
+        let rowHeight = CGFloat(themeStore.settings.fontSize - 1) + Layout.rowVerticalPadding * 2 + 6
+        return min(rows * rowHeight + max(0, rows - 1) * 2, Layout.maxHeight)
+    }
+
+    private var menuBackground: some View {
+        RoundedRectangle(cornerRadius: Layout.cornerRadius, style: .continuous)
+            .fill(.ultraThinMaterial)
+            .background(
+                RoundedRectangle(cornerRadius: Layout.cornerRadius, style: .continuous)
+                    .fill(themeStore.panelFillColor())
+            )
+            .shadow(color: .black.opacity(0.45), radius: Layout.shadowRadius, x: 0, y: 8)
+    }
+
+    private var menuBorder: some View {
+        RoundedRectangle(cornerRadius: Layout.cornerRadius, style: .continuous)
+            .strokeBorder(themeStore.dividerColor(), lineWidth: 1)
+    }
+
+    private func row(_ descriptor: QuickActionDescriptor, isFocused: Bool) -> some View {
+        let titleSize = CGFloat(themeStore.settings.fontSize - 1)
+        let hintSize = CGFloat(themeStore.settings.fontSize - 2)
+
+        return HStack(spacing: 8) {
+            Text(title(for: descriptor))
+                .font(themeStore.uiFont(size: titleSize, weight: .medium))
+                .foregroundStyle(themeStore.fontColor())
+                .lineLimit(1)
+            Spacer(minLength: 8)
+            if isFocused {
+                Text(Layout.runHint)
+                    .font(themeStore.uiFont(size: hintSize, weight: .semibold))
+                    .foregroundStyle(themeStore.secondaryTextColor())
+            }
+        }
+        .padding(.horizontal, Layout.rowHorizontalPadding)
+        .padding(.vertical, Layout.rowVerticalPadding)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(rowBackground(isFocused: isFocused))
+        .contentShape(Rectangle())
+        .onTapGesture { onRun(descriptor) }
+    }
+
+    private func rowBackground(isFocused: Bool) -> some View {
+        RoundedRectangle(cornerRadius: 6, style: .continuous)
+            .fill(isFocused ? themeStore.selectionFillColor() : Color.clear)
+    }
+
+    /// A toggle names the change it would make, not the setting: in a list of
+    /// verbs "Turn on Bluetooth" reads as something to do, where a bare
+    /// "Bluetooth" reads as a place to go.
+    private func title(for descriptor: QuickActionDescriptor) -> String {
+        guard descriptor.control == .toggle else { return descriptor.title }
+        switch states[descriptor.actionId] {
+        case .on:
+            return descriptor.offLabel ?? descriptor.title
+        case .off:
+            return descriptor.onLabel ?? descriptor.title
+        default:
+            return descriptor.title
+        }
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
@@ -81,6 +81,15 @@ struct LauncherRowView: View {
             }
         }
 
+        // A declared block has no file to take an icon from, and must not look
+        // like one: Enter performs steps rather than opening anything.
+        if result.kind == .action {
+            return RowIconCache.image(key: "symbol:bolt") {
+                NSImage(systemSymbolName: "bolt.fill", accessibilityDescription: nil)
+                    ?? NSWorkspace.shared.icon(for: .plainText)
+            }
+        }
+
         // Not cached: a process icon is keyed to a live pid, and pids are reused.
         if result.kind == .process, let pid = result.processPID {
             return LauncherProcessFeature.icon(forPID: pid)
@@ -125,6 +134,8 @@ struct LauncherRowView: View {
             return "Clipboard"
         case .process:
             return "Process"
+        case .action:
+            return "Action"
         }
     }
 
@@ -141,6 +152,13 @@ struct LauncherRowView: View {
         }
         if result.kind == .app {
             return kindLabel
+        }
+        if result.kind == .action {
+            // "Action • 3 steps": there is no path, and the step count says this
+            // will do several things before the user commits to it.
+            return [kindLabel, result.subtitle]
+                .compactMap { $0 }
+                .joined(separator: "  •  ")
         }
         return "\(kindLabel)  •  \(pathInfo)"
     }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
@@ -32,6 +32,11 @@ struct LauncherRowView: View {
         SyntheticRow.classify(resultID: result.id)
     }
 
+    /// A row a user-declared block produced (`specs/user-sources.md`).
+    private var isSourceRow: Bool {
+        result.id.hasPrefix(AppConstants.Launcher.SourceBlock.idPrefix)
+    }
+
     /// Cached: this runs inside `body`, and a fresh `NSImage` per redraw makes
     /// every icon in the list flicker. See `RowIconCache`.
     private var rowIcon: NSImage {
@@ -165,6 +170,12 @@ struct LauncherRowView: View {
             return [kindLabel, result.subtitle]
                 .compactMap { $0 }
                 .joined(separator: "  •  ")
+        }
+        // A row a user's block produced says WHICH block, not "Folder". The kind
+        // is already on the icon, and where the row came from is the thing the
+        // list cannot otherwise tell you.
+        if isSourceRow, let block = result.subtitle {
+            return "\(block)  •  \(pathInfo)"
         }
         return "\(kindLabel)  •  \(pathInfo)"
     }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
@@ -82,8 +82,14 @@ struct LauncherRowView: View {
         }
 
         // A declared block has no file to take an icon from, and must not look
-        // like one: Enter performs steps rather than opening anything.
+        // like one: Enter performs steps rather than opening anything. What the
+        // block declared wins; the bolt is the fallback.
         if result.kind == .action {
+            if let declared = SourceBlockIcons.declaredIcon(
+                SourceBlockCatalog.icon(forCandidateID: result.id)
+            ) {
+                return declared
+            }
             return RowIconCache.image(key: "symbol:bolt") {
                 NSImage(systemSymbolName: "bolt.fill", accessibilityDescription: nil)
                     ?? NSWorkspace.shared.icon(for: .plainText)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
@@ -383,26 +383,44 @@ struct HintBar: View {
     var todo: TodoQuickView? = nil
     let themeStore: ThemeStore
 
+    private enum Layout {
+        /// How far the hint may shrink before it truncates instead. Enough to
+        /// absorb a long hint or a large font setting, not so much that the bar
+        /// becomes unreadable.
+        static let minimumScale: CGFloat = 0.75
+    }
+
     private var hintFont: Font {
         themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular)
     }
 
     var body: some View {
+        // One line, always. The hint is a reminder, not content: a second line
+        // would reflow the whole bar as the selection changes, and a longer
+        // font or another hint must shrink the text rather than move the layout.
         HStack(spacing: 0) {
             Text(hint)
                 .font(hintFont)
                 .foregroundStyle(themeStore.secondaryTextColor())
+                .lineLimit(1)
+                .minimumScaleFactor(Layout.minimumScale)
+                .truncationMode(.tail)
+                .layoutPriority(1)
 
             if let todo {
                 Text("  •  ")
                     .font(hintFont)
                     .foregroundStyle(themeStore.secondaryTextColor())
+                    .lineLimit(1)
+                    .fixedSize()
                 Button(action: todo.onTap) {
                     HStack(spacing: 5) {
                         Image(systemName: "checklist")
                             .font(.system(size: CGFloat(themeStore.settings.fontSize - 3)))
                         Text("Todo \(todo.done)/\(todo.total)")
                             .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .semibold))
+                            .lineLimit(1)
+                            .fixedSize()
                     }
                     .foregroundStyle(themeStore.accentColor())
                     .contentShape(Rectangle())

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+ActionMenu.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+ActionMenu.swift
@@ -30,6 +30,32 @@ extension LauncherView {
             }
     }
 
+    /// Ids of the two rows the menu shows in place of the action list while a
+    /// destructive target waits for an answer.
+    enum Confirm {
+        static let yes = "srcconfirm:yes"
+        static let no = "srcconfirm:no"
+        static let cancelTitle = "Cancel"
+    }
+
+    /// What the menu lists right now: the pending question when one is waiting,
+    /// otherwise the row's actions.
+    ///
+    /// The confirmation reuses the menu rather than opening a modal, so the
+    /// keys the user already has (move, Enter, Escape) keep working and Escape
+    /// means the safe thing.
+    var actionMenuRows: [QuickActionDescriptor] {
+        guard let pending = pendingActionConfirm else { return actionMenuDescriptors }
+        return [
+            QuickActionDescriptor(
+                actionId: Confirm.yes, title: pending.question, control: .button,
+                onLabel: nil, offLabel: nil, info: []),
+            QuickActionDescriptor(
+                actionId: Confirm.no, title: Confirm.cancelTitle, control: .button,
+                onLabel: nil, offLabel: nil, info: []),
+        ]
+    }
+
     /// Cmd+K. Opening with nothing to offer would show an empty box, so a row
     /// with no actions says so instead.
     func toggleActionMenu() {
@@ -46,6 +72,7 @@ extension LauncherView {
     }
 
     func closeActionMenu() {
+        pendingActionConfirm = nil
         guard isActionMenuOpen else { return }
         withAnimation(Motion.Selection.glide) { isActionMenuOpen = false }
         actionMenuIndex = 0
@@ -53,23 +80,52 @@ extension LauncherView {
 
     /// Wraps at both ends, so holding one direction cycles rather than dead-ends.
     func moveActionMenuFocus(by offset: Int) {
-        let count = actionMenuDescriptors.count
+        let count = actionMenuRows.count
         guard count > 0 else { return }
         actionMenuIndex = ((actionMenuIndex + offset) % count + count) % count
     }
 
     func runFocusedAction() {
-        let descriptors = actionMenuDescriptors
-        guard descriptors.indices.contains(actionMenuIndex) else { return }
-        let descriptor = descriptors[actionMenuIndex]
+        let rows = actionMenuRows
+        guard rows.indices.contains(actionMenuIndex) else { return }
+        let descriptor = rows[actionMenuIndex]
+
+        // Answering a pending question.
+        if let pending = pendingActionConfirm {
+            pendingActionConfirm = nil
+            closeActionMenu()
+            guard descriptor.actionId == Confirm.yes else { return }
+            performSourceBlockTarget(blockID: pending.blockID, title: pending.title)
+            return
+        }
+
+        // Asking one. The menu stays open and swaps to the question, so the
+        // answer happens where the user's eyes already are.
+        if let blockID = SourceBlockAction.blockID(fromActionID: descriptor.actionId),
+           let question = confirmQuestion(forBlockID: blockID) {
+            pendingActionConfirm = (blockID: blockID, title: descriptor.title, question: question)
+            // Start on Cancel: a destructive action should cost one more press
+            // than an accidental double-Enter.
+            actionMenuIndex = 1
+            return
+        }
+
         closeActionMenu()
         runQuickAction(descriptor, intent: descriptor.control == .toggle ? .toggle : .run)
+    }
+
+    /// The question a `then` target declared, already expanded against the row.
+    private func confirmQuestion(forBlockID blockID: String) -> String? {
+        guard let result = actionableSelectedResult() else { return nil }
+        return SourceBlockCatalog.targets(for: result)
+            .first(where: { $0.id == blockID })?
+            .confirm
     }
 
     /// Keeps the focused row inside the list when the offered actions change
     /// under it (a launchpad tile resolving, a block reloading).
     func clampActionMenuFocus() {
-        let count = actionMenuDescriptors.count
+        let count = actionMenuRows.count
         guard count > 0 else {
             closeActionMenu()
             return

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+ActionMenu.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+ActionMenu.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+extension LauncherView {
+    /// Actions offered right now: for a selected row, its compiled controls plus
+    /// any `then` targets its block declared. With an empty query there is no
+    /// row, but the launchpad is on screen and its tiles are actions too, so the
+    /// menu offers those instead of refusing.
+    var actionMenuDescriptors: [QuickActionDescriptor] {
+        if selectedResultID != nil, !quickActionDescriptors.isEmpty {
+            return quickActionDescriptors
+        }
+        return isLaunchpadActive ? launchpadActionDescriptors : quickActionDescriptors
+    }
+
+    /// The launchpad's own controls, as menu rows. Display-only tiles (weather,
+    /// battery, now playing, the L slot) are things to read, not to do, so they
+    /// stay out of a list of verbs.
+    private var launchpadActionDescriptors: [QuickActionDescriptor] {
+        launchpadTiles
+            .filter { $0.role == .toggle || $0.role == .action }
+            .map { tile in
+                QuickActionDescriptor(
+                    actionId: tile.actionId,
+                    title: tile.title,
+                    control: tile.role == .toggle ? .toggle : .button,
+                    onLabel: tile.onLabel,
+                    offLabel: tile.offLabel,
+                    info: []
+                )
+            }
+    }
+
+    /// Cmd+K. Opening with nothing to offer would show an empty box, so a row
+    /// with no actions says so instead.
+    func toggleActionMenu() {
+        if isActionMenuOpen {
+            closeActionMenu()
+            return
+        }
+        guard !actionMenuDescriptors.isEmpty else {
+            showBanner("Nothing to do here", style: .info, duration: 1.2)
+            return
+        }
+        actionMenuIndex = 0
+        withAnimation(Motion.Selection.glide) { isActionMenuOpen = true }
+    }
+
+    func closeActionMenu() {
+        guard isActionMenuOpen else { return }
+        withAnimation(Motion.Selection.glide) { isActionMenuOpen = false }
+        actionMenuIndex = 0
+    }
+
+    /// Wraps at both ends, so holding one direction cycles rather than dead-ends.
+    func moveActionMenuFocus(by offset: Int) {
+        let count = actionMenuDescriptors.count
+        guard count > 0 else { return }
+        actionMenuIndex = ((actionMenuIndex + offset) % count + count) % count
+    }
+
+    func runFocusedAction() {
+        let descriptors = actionMenuDescriptors
+        guard descriptors.indices.contains(actionMenuIndex) else { return }
+        let descriptor = descriptors[actionMenuIndex]
+        closeActionMenu()
+        runQuickAction(descriptor, intent: descriptor.control == .toggle ? .toggle : .run)
+    }
+
+    /// Keeps the focused row inside the list when the offered actions change
+    /// under it (a launchpad tile resolving, a block reloading).
+    func clampActionMenuFocus() {
+        let count = actionMenuDescriptors.count
+        guard count > 0 else {
+            closeActionMenu()
+            return
+        }
+        actionMenuIndex = min(actionMenuIndex, count - 1)
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+ActionMenu.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+ActionMenu.swift
@@ -88,8 +88,15 @@ extension LauncherView {
     func runFocusedAction() {
         let rows = actionMenuRows
         guard rows.indices.contains(actionMenuIndex) else { return }
-        let descriptor = rows[actionMenuIndex]
+        activateActionMenuRow(rows[actionMenuIndex])
+    }
 
+    /// Activating one row of the menu, by key or by click.
+    ///
+    /// The single entry point on purpose: a click that bypassed this would skip
+    /// the confirmation, so a `confirm` target would ask when reached with Enter
+    /// and delete silently when reached with the mouse.
+    func activateActionMenuRow(_ descriptor: QuickActionDescriptor) {
         // Answering a pending question.
         if let pending = pendingActionConfirm {
             pendingActionConfirm = nil

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+ActionMenu.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+ActionMenu.swift
@@ -109,7 +109,7 @@ extension LauncherView {
         // Asking one. The menu stays open and swaps to the question, so the
         // answer happens where the user's eyes already are.
         if let blockID = SourceBlockAction.blockID(fromActionID: descriptor.actionId),
-           let question = confirmQuestion(forBlockID: blockID) {
+           let question = descriptor.confirm {
             pendingActionConfirm = (blockID: blockID, title: descriptor.title, question: question)
             // Start on Cancel: a destructive action should cost one more press
             // than an accidental double-Enter.
@@ -119,14 +119,6 @@ extension LauncherView {
 
         closeActionMenu()
         runQuickAction(descriptor, intent: descriptor.control == .toggle ? .toggle : .run)
-    }
-
-    /// The question a `then` target declared, already expanded against the row.
-    private func confirmQuestion(forBlockID blockID: String) -> String? {
-        guard let result = actionableSelectedResult() else { return nil }
-        return SourceBlockCatalog.targets(for: result)
-            .first(where: { $0.id == blockID })?
-            .confirm
     }
 
     /// Keeps the focused row inside the list when the offered actions change

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+ActionMenu.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+ActionMenu.swift
@@ -1,33 +1,15 @@
 import SwiftUI
 
 extension LauncherView {
-    /// Actions offered right now: for a selected row, its compiled controls plus
-    /// any `then` targets its block declared. With an empty query there is no
-    /// row, but the launchpad is on screen and its tiles are actions too, so the
-    /// menu offers those instead of refusing.
+    /// Actions offered for the selected row: its compiled controls plus any
+    /// `then` targets its block declared.
+    ///
+    /// The launchpad deliberately has none. Its tiles are already the actions,
+    /// each with its own mnemonic (⌘B, ⌘W, ⌘T...), so a menu there would list
+    /// what is on screen and cover it - and ⌘K is Keep Awake, so opening one
+    /// would shadow the key the user meant.
     var actionMenuDescriptors: [QuickActionDescriptor] {
-        if selectedResultID != nil, !quickActionDescriptors.isEmpty {
-            return quickActionDescriptors
-        }
-        return isLaunchpadActive ? launchpadActionDescriptors : quickActionDescriptors
-    }
-
-    /// The launchpad's own controls, as menu rows. Display-only tiles (weather,
-    /// battery, now playing, the L slot) are things to read, not to do, so they
-    /// stay out of a list of verbs.
-    private var launchpadActionDescriptors: [QuickActionDescriptor] {
-        launchpadTiles
-            .filter { $0.role == .toggle || $0.role == .action }
-            .map { tile in
-                QuickActionDescriptor(
-                    actionId: tile.actionId,
-                    title: tile.title,
-                    control: tile.role == .toggle ? .toggle : .button,
-                    onLabel: tile.onLabel,
-                    offLabel: tile.offLabel,
-                    info: []
-                )
-            }
+        quickActionDescriptors
     }
 
     /// Ids of the two rows the menu shows in place of the action list while a

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+QuickActions.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+QuickActions.swift
@@ -71,6 +71,7 @@ extension LauncherView {
         quickActionTask?.cancel()
 
         guard let result = selectedResultForActions else {
+            closeActionMenu()
             if !quickActionDescriptors.isEmpty { quickActionDescriptors = [] }
             if !quickActionStates.isEmpty { quickActionStates = [:] }
             if !quickActionInfo.isEmpty { quickActionInfo = [:] }
@@ -79,10 +80,9 @@ extension LauncherView {
         }
 
         var descriptors = bridge.quickActions(forResultID: result.id, kind: result.kind.rawValue)
-        // A block's `then` targets are actions on this row, so they belong in
-        // the same panel and on the same Cmd+J/K + Enter as the compiled ones.
-        // They are declared at parse time rather than build time; that is the
-        // only difference.
+        // A block's `then` targets are actions on this row, so they join the
+        // same Cmd+K menu as the compiled controls. They are declared at parse
+        // time rather than build time; that is the only difference.
         descriptors.append(contentsOf: sourceBlockTargets(for: result))
         quickActionDescriptors = descriptors
 
@@ -98,6 +98,10 @@ extension LauncherView {
             quickActionStates = [:]
             quickActionInfo = [:]
             quickActionsLoadedResultID = result.id
+            // The menu lists the SELECTED row's verbs, so it must not survive a
+            // move to another row and offer the previous one's. Re-reading the
+            // same result (a window show, a re-render) leaves it alone.
+            closeActionMenu()
         }
 
         guard !descriptors.isEmpty else { return }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+QuickActions.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+QuickActions.swift
@@ -78,7 +78,12 @@ extension LauncherView {
             return
         }
 
-        let descriptors = bridge.quickActions(forResultID: result.id, kind: result.kind.rawValue)
+        var descriptors = bridge.quickActions(forResultID: result.id, kind: result.kind.rawValue)
+        // A block's `then` targets are actions on this row, so they belong in
+        // the same panel and on the same Cmd+J/K + Enter as the compiled ones.
+        // They are declared at parse time rather than build time; that is the
+        // only difference.
+        descriptors.append(contentsOf: sourceBlockTargets(for: result))
         quickActionDescriptors = descriptors
 
         // Only a *different* result invalidates what the panel is showing. Re-reading
@@ -101,6 +106,12 @@ extension LauncherView {
         quickActionTask = Task {
             for descriptor in descriptors {
                 guard !Task.isCancelled else { return }
+                // A declared target has no adapter and nothing to read: it is a
+                // button that runs a command. Asking the registry for its state
+                // would resolve to "not supported on this Mac".
+                if SourceBlockAction.blockID(fromActionID: descriptor.actionId) != nil {
+                    continue
+                }
                 let (state, info) = await readQuickAction(descriptor)
                 guard !Task.isCancelled else { return }
                 await MainActor.run {
@@ -123,6 +134,10 @@ extension LauncherView {
     /// Runs a specific action's intent (from a click or a key), shows the
     /// outcome, and reloads its state + info. Shared by the toggle and Cmd+O.
     func runQuickAction(_ descriptor: QuickActionDescriptor, intent: ActionIntent) {
+        if let blockID = SourceBlockAction.blockID(fromActionID: descriptor.actionId) {
+            performSourceBlockTarget(blockID: blockID, title: descriptor.title)
+            return
+        }
         guard let adapter = ActionAdapterRegistry.adapter(for: descriptor.actionId) else {
             showBanner("\(descriptor.title) is not available", style: .info, duration: Banner.unavailable)
             return

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
@@ -191,11 +191,18 @@ extension LauncherView {
         recordOpen(selected, action: AppConstants.Launcher.SourceBlock.usageAction)
         hideLauncherWindow(restorePreviousApp: false)
 
-        let candidateID = selected.id
+        guard let blockID = SourceBlockCatalog.blockID(fromCandidateID: selected.id) else { return }
         let name = selected.title
+        let row = (id: selected.id, title: selected.title, path: selected.path, query: query)
         Task {
             let outcome = await Task.detached(priority: .userInitiated) {
-                EngineBridge.shared.performBlock(candidateID: candidateID)
+                EngineBridge.shared.performBlock(
+                    blockID: blockID,
+                    rowID: row.id,
+                    rowTitle: row.title,
+                    rowPath: row.path,
+                    query: row.query
+                )
             }.value
             await MainActor.run {
                 guard let failure = outcome.errors.first else { return }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
@@ -188,10 +188,16 @@ extension LauncherView {
     /// Performs a declared block's steps. Usage is recorded on intent, like an
     /// open, so a routine you run every morning ranks like one.
     private func performSourceBlock(_ selected: LauncherResult) {
+        // Resolve BEFORE recording usage or hiding: an unparseable id would
+        // otherwise rank the row up, close the window, and do nothing, with no
+        // way for the user to tell that it failed.
+        guard let blockID = SourceBlockCatalog.blockID(fromCandidateID: selected.id) else {
+            showBanner("Couldn't tell which block this row belongs to", style: .error, duration: 2.0)
+            return
+        }
         recordOpen(selected, action: AppConstants.Launcher.SourceBlock.usageAction)
         hideLauncherWindow(restorePreviousApp: false)
 
-        guard let blockID = SourceBlockCatalog.blockID(fromCandidateID: selected.id) else { return }
         let name = selected.title
         let row = (id: selected.id, title: selected.title, path: selected.path, query: query)
         Task {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
@@ -78,6 +78,11 @@ extension LauncherView {
                 recordOpen(selected, action: "open_folder")
             }
             hideLauncherWindow(restorePreviousApp: false)
+        case .action:
+            // A declared block: there is nothing to open, so Enter performs its
+            // steps. The window goes away first, since the steps usually launch
+            // something that wants the focus.
+            performSourceBlock(selected)
         case .clipboard:
             // Labeled entries (e.g. calculator results) paste their value, not
             // the label shown in the list.
@@ -162,6 +167,45 @@ extension LauncherView {
         DeleteTargetLogic.isURLScheme(target)
     }
 
+    /// Reveals the `.toml` (or script) a block was declared in. Reading the
+    /// sources directory touches disk, so it happens off the main thread.
+    private func revealDeclaringFile(for selected: LauncherResult) {
+        let candidateID = selected.id
+        Task {
+            let block = await Task.detached(priority: .userInitiated) {
+                EngineBridge.shared.sourceBlock(candidateID: candidateID)
+            }.value
+            await MainActor.run {
+                guard let file = block?.file, FileManager.default.fileExists(atPath: file) else {
+                    showBanner("Couldn't find the file that declares this", style: .info, duration: 1.6)
+                    return
+                }
+                NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: file)])
+            }
+        }
+    }
+
+    /// Performs a declared block's steps. Usage is recorded on intent, like an
+    /// open, so a routine you run every morning ranks like one.
+    private func performSourceBlock(_ selected: LauncherResult) {
+        recordOpen(selected, action: AppConstants.Launcher.SourceBlock.usageAction)
+        hideLauncherWindow(restorePreviousApp: false)
+
+        let candidateID = selected.id
+        let name = selected.title
+        Task {
+            let outcome = await Task.detached(priority: .userInitiated) {
+                EngineBridge.shared.performBlock(candidateID: candidateID)
+            }.value
+            await MainActor.run {
+                guard let failure = outcome.errors.first else { return }
+                // Steps are detached, so this only fires when one could not be
+                // started at all. A step's own exit code is its business.
+                showBanner("\(name): \(failure)", style: .error, duration: 4.0)
+            }
+        }
+    }
+
     private func recordOpen(_ selected: LauncherResult, action: String) {
         if let error = bridge.recordUsage(candidateID: selected.id, action: action) {
             showBanner(error.userFacingMessage, style: .info, duration: 1.4)
@@ -232,6 +276,10 @@ extension LauncherView {
             )
         case .process:
             showBanner("Processes can't be revealed in Finder", style: .info, duration: 1.2)
+        case .action:
+            // No file of its own, but the declaration that created it is a real
+            // file and is the thing the user wants to get to from here.
+            revealDeclaringFile(for: selected)
         }
     }
 

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Search.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Search.swift
@@ -345,11 +345,17 @@ extension LauncherView {
         successDuration: Double = 2.0
     ) -> Bool {
         let result = themeStore.reloadFromConfig()
+        // `run` blocks produce their rows by executing a command, so they must
+        // run BEFORE the reindex that reads what they produced.
+        let runBlocks = bridge.refreshRunBlocks()
         let backendReloaded = bridge.reloadConfig()
         clipboardStore.reloadFromConfig()
-        // Declared block icons are cached for the process, so a reload is the
-        // point where an edited `icon = …` should start showing.
+        // Declared block icons and `then` targets are cached for the process, so
+        // a reload is the point where an edited file should start showing.
         SourceBlockCatalog.invalidate()
+        for failure in runBlocks.errors {
+            showBanner(failure, style: .error, duration: 3.0)
+        }
 
         // Sync settings blur multiplier to AppUIState
         if let blurMultiplier = result.settingsBlurMultiplier {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Search.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Search.swift
@@ -347,6 +347,9 @@ extension LauncherView {
         let result = themeStore.reloadFromConfig()
         let backendReloaded = bridge.reloadConfig()
         clipboardStore.reloadFromConfig()
+        // Declared block icons are cached for the process, so a reload is the
+        // point where an edited `icon = …` should start showing.
+        SourceBlockCatalog.invalidate()
 
         // Sync settings blur multiplier to AppUIState
         if let blurMultiplier = result.settingsBlurMultiplier {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Search.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Search.swift
@@ -105,6 +105,34 @@ extension LauncherView {
         }
     }
 
+    /// Re-runs every `run` block, then reindexes so the rows it produced are
+    /// picked up.
+    ///
+    /// Off the main actor and after the config reload, not inline with it: each
+    /// block spawns a command and waits for it, so doing this on the main actor
+    /// freezes the window for the sum of their timeouts. The reindex is
+    /// triggered from the completion, which keeps the ordering that matters -
+    /// the blocks must run before the pass that reads their rows.
+    private func refreshRunBlocksInBackground() {
+        Task {
+            let outcome = await Task.detached(priority: .utility) {
+                let outcome = EngineBridge.shared.refreshRunBlocks()
+                // Only worth a second index pass when a block actually produced
+                // rows; the reload above already covered everything else.
+                if outcome.refreshed > 0 {
+                    _ = EngineBridge.shared.requestIndexRefresh()
+                }
+                return outcome
+            }.value
+
+            await MainActor.run {
+                for failure in outcome.errors {
+                    showBanner(failure, style: .error, duration: 3.0)
+                }
+            }
+        }
+    }
+
     /// Publishes results on the main actor only if this request is still the
     /// latest and the query hasn't changed out from under it.
     @MainActor
@@ -345,17 +373,12 @@ extension LauncherView {
         successDuration: Double = 2.0
     ) -> Bool {
         let result = themeStore.reloadFromConfig()
-        // `run` blocks produce their rows by executing a command, so they must
-        // run BEFORE the reindex that reads what they produced.
-        let runBlocks = bridge.refreshRunBlocks()
         let backendReloaded = bridge.reloadConfig()
         clipboardStore.reloadFromConfig()
         // Declared block icons and `then` targets are cached for the process, so
         // a reload is the point where an edited file should start showing.
         SourceBlockCatalog.invalidate()
-        for failure in runBlocks.errors {
-            showBanner(failure, style: .error, duration: 3.0)
-        }
+        refreshRunBlocksInBackground()
 
         // Sync settings blur multiplier to AppUIState
         if let blurMultiplier = result.settingsBlurMultiplier {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
@@ -222,6 +222,11 @@ extension LauncherView {
             onWebSearch: {
                 performWebSearchFromQuery()
             },
+            inActionMenu: { isActionMenuOpen },
+            onToggleActionMenu: { toggleActionMenu() },
+            onActionMenuMove: { moveActionMenuFocus(by: $0) },
+            onActionMenuRun: { runFocusedAction() },
+            onActionMenuClose: { closeActionMenu() },
             onRevealInFinder: {
                 revealSelectedInFinder()
             },

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+SourceBlocks.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+SourceBlocks.swift
@@ -28,7 +28,7 @@ extension LauncherView {
     func sourceBlockTargets(for result: LauncherResult) -> [QuickActionDescriptor] {
         guard result.id.hasPrefix(AppConstants.Launcher.SourceBlock.idPrefix) else { return [] }
 
-        return SourceBlockCatalog.targets(forCandidateID: result.id).map { target in
+        return SourceBlockCatalog.targets(for: result).map { target in
             QuickActionDescriptor(
                 actionId: SourceBlockAction.actionID(forBlockID: target.id),
                 title: target.performs ? target.name : "\(target.name)…",

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+SourceBlocks.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+SourceBlocks.swift
@@ -35,7 +35,8 @@ extension LauncherView {
                 control: .button,
                 onLabel: nil,
                 offLabel: nil,
-                info: []
+                info: [],
+                confirm: target.confirm
             )
         }
     }
@@ -53,7 +54,8 @@ extension LauncherView {
                     rowID: row.id,
                     rowTitle: row.title,
                     rowPath: row.path,
-                    query: row.query
+                    query: row.query,
+                    asTarget: true
                 )
             }.value
 
@@ -62,10 +64,10 @@ extension LauncherView {
                     showBanner("\(title): \(failure)", style: .error, duration: 4.0)
                     return
                 }
-                if outcome.performed == 0 {
-                    // A target that produces rows rather than performing steps.
-                    // Descending into it needs the level stack, which does not
-                    // exist yet, so say so rather than appearing to do nothing.
+                if outcome.producesRows {
+                    // Descending needs the level stack, which does not exist
+                    // yet. Said plainly rather than inferred from a zero count,
+                    // which is also what a failure looks like.
                     showBanner("\(title) produces rows; drill-down is not built yet", style: .info, duration: 2.4)
                     return
                 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+SourceBlocks.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+SourceBlocks.swift
@@ -1,0 +1,76 @@
+import AppKit
+import SwiftUI
+
+/// A `then` target rendered as a quick action.
+///
+/// Compiled controls key on a build-time `action_id`; these key on the block
+/// they run. The prefix is what tells the two apart at dispatch, so a declared
+/// target can never collide with a control id.
+enum SourceBlockAction {
+    private static let actionIDPrefix = "srcblock:"
+
+    static func actionID(forBlockID blockID: String) -> String {
+        actionIDPrefix + blockID
+    }
+
+    static func blockID(fromActionID actionID: String) -> String? {
+        guard actionID.hasPrefix(actionIDPrefix) else { return nil }
+        return String(actionID.dropFirst(actionIDPrefix.count))
+    }
+}
+
+extension LauncherView {
+    /// The `then` targets of the block behind `result`, as panel descriptors.
+    ///
+    /// Read synchronously, from a per-block memo: the panel is built during a
+    /// selection change, and an async load that appends later would make the
+    /// action list grow under the user's cursor.
+    func sourceBlockTargets(for result: LauncherResult) -> [QuickActionDescriptor] {
+        guard result.id.hasPrefix(AppConstants.Launcher.SourceBlock.idPrefix) else { return [] }
+
+        return SourceBlockCatalog.targets(forCandidateID: result.id).map { target in
+            QuickActionDescriptor(
+                actionId: SourceBlockAction.actionID(forBlockID: target.id),
+                title: target.performs ? target.name : "\(target.name)…",
+                control: .button,
+                onLabel: nil,
+                offLabel: nil,
+                info: []
+            )
+        }
+    }
+
+    /// Runs a `then` target against the selected row, which is what its
+    /// placeholders expand to.
+    func performSourceBlockTarget(blockID: String, title: String) {
+        guard let selected = actionableSelectedResult() else { return }
+
+        let row = (id: selected.id, title: selected.title, path: selected.path, query: query)
+        Task {
+            let outcome = await Task.detached(priority: .userInitiated) {
+                EngineBridge.shared.performBlock(
+                    blockID: blockID,
+                    rowID: row.id,
+                    rowTitle: row.title,
+                    rowPath: row.path,
+                    query: row.query
+                )
+            }.value
+
+            await MainActor.run {
+                if let failure = outcome.errors.first {
+                    showBanner("\(title): \(failure)", style: .error, duration: 4.0)
+                    return
+                }
+                if outcome.performed == 0 {
+                    // A target that produces rows rather than performing steps.
+                    // Descending into it needs the level stack, which does not
+                    // exist yet, so say so rather than appearing to do nothing.
+                    showBanner("\(title) produces rows; drill-down is not built yet", style: .info, duration: 2.4)
+                    return
+                }
+                hideLauncherWindow(restorePreviousApp: false)
+            }
+        }
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -257,7 +257,7 @@ struct LauncherView: View {
         }
 
         if let configPath = env["LOOK_CONFIG_PATH"]?.trimmingCharacters(in: .whitespacesAndNewlines),
-            configPath.lowercased().contains(".look.dev.config")
+            configPath.lowercased().hasSuffix("config.dev")
         {
             return true
         }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -601,7 +601,6 @@ struct LauncherView: View {
                 "Cmd+/ command mode",
                 "Cmd+Shift+, close settings",
                 "Cmd+Shift+; apply config",
-                AppConstants.Launcher.ActionMenu.openHint,
             ]
         }
 
@@ -673,7 +672,12 @@ struct LauncherView: View {
         // The home screen replaces the "Cmd+/ command mode" hint with a
         // clickable today done/total quick view (see todoQuickView), so it
         // is intentionally omitted here.
-        return [enterHint, AppConstants.Launcher.ActionMenu.openHint, "Cmd+H help"]
+        var hints = [enterHint]
+        if !isLaunchpadActive {
+            hints.append(AppConstants.Launcher.ActionMenu.openHint)
+        }
+        hints.append("Cmd+H help")
+        return hints
     }
 
     /// What Enter does to the selected row. A declared block performs steps or
@@ -1309,22 +1313,6 @@ struct LauncherView: View {
                         themeStore: themeStore,
                         revealToken: appearanceRevealToken
                     )
-                    // The preview panel is not on screen here, so the empty
-                    // state renders the Cmd+K menu itself: the launchpad's
-                    // controls are actions like any other row's.
-                    .overlay(alignment: .top) {
-                        if isActionMenuOpen {
-                            ActionMenuView(
-                                descriptors: actionMenuRows,
-                                states: quickActionStates,
-                                focusedIndex: actionMenuIndex,
-                                themeStore: themeStore,
-                                onActivate: { activateActionMenuRow($0) }
-                            )
-                            .frame(maxWidth: AppConstants.Launcher.ActionMenu.launchpadWidth)
-                            .padding(.top, 8)
-                        }
-                    }
                 }
                 Spacer(minLength: 0)
             } else {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -834,6 +834,9 @@ struct LauncherView: View {
             refreshSearchResults()
             configureLaunchpadIfNeeded()
             refreshLaunchpadState()
+            // Warms the block catalog off the main actor, so a row that has one
+            // renders its declared icon rather than the generic bolt.
+            SourceBlockCatalog.prefill()
             startKeyboardNavigationIfNeeded()
             focusActiveInput()
             refreshClipboardMonitoringMode()
@@ -985,6 +988,9 @@ struct LauncherView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .lookReloadConfigRequested)) { _ in
             reloadConfig()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .lookSourceTargetsLoaded)) { _ in
+            refreshQuickActions()
         }
         .onReceive(NotificationCenter.default.publisher(for: .lookRefocusInputRequested)) { _ in
             DispatchQueue.main.async {
@@ -1313,7 +1319,7 @@ struct LauncherView: View {
                                 states: quickActionStates,
                                 focusedIndex: actionMenuIndex,
                                 themeStore: themeStore,
-                                onRun: { runQuickAction($0, intent: $0.control == .toggle ? .toggle : .run) }
+                                onActivate: { activateActionMenuRow($0) }
                             )
                             .frame(maxWidth: AppConstants.Launcher.ActionMenu.launchpadWidth)
                             .padding(.top, 8)
@@ -2066,7 +2072,8 @@ struct LauncherView: View {
                     isMeasuringProcessCPU: isMeasuringCPU(for: selectedResult),
                     isActionMenuOpen: isActionMenuOpen,
                     actionMenuIndex: actionMenuIndex,
-                    actionMenuDescriptors: actionMenuRows
+                    actionMenuDescriptors: actionMenuRows,
+                    onActivateActionMenuRow: { activateActionMenuRow($0) }
                 )
                 // Arrow-key nav assigns `selectedResultID` inside a global
                 // `withAnimation` so the pill can glide (see LauncherView+

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -93,6 +93,10 @@ struct LauncherView: View {
     @State var recentURLTask: Task<Void, Never>?
     // Quick Actions for the selected result (see docs/writing-controls.md).
     @State var quickActionDescriptors: [QuickActionDescriptor] = []
+    // The Cmd+K action menu. Closed by default, so a row's verbs cost the
+    // preview no space until asked for.
+    @State var isActionMenuOpen = false
+    @State var actionMenuIndex = 0
     @State var quickActionStates: [String: ActionState] = [:]
     // The result `quickActionStates`/`quickActionInfo` were read for. Lets a refresh
     // of the SAME result keep showing what it already resolved, instead of blanking
@@ -540,6 +544,19 @@ struct LauncherView: View {
         )
     }
 
+    /// Query shapes that render their OWN panel instead of backend results:
+    /// clipboard history, the `"` prefix menu, the `:` command menu,
+    /// translation, the process finder.
+    ///
+    /// One list because every consumer needs the same answer - skip the search,
+    /// skip the AI card, skip the home hint bar. Each call site used to spell
+    /// the disjunction out by hand, and they had already drifted apart. A new
+    /// mode belongs HERE, not in each caller.
+    var usesOwnResultPanel: Bool {
+        isClipboardQuery || isPrefixSuggestionQuery || isCommandSuggestionQuery
+            || isTranslationQuery || isProcessQuery
+    }
+
     var isTranslationQuery: Bool {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         return extractTranslationQuery(from: trimmed) != nil
@@ -582,6 +599,7 @@ struct LauncherView: View {
                 "Cmd+/ command mode",
                 "Cmd+Shift+, close settings",
                 "Cmd+Shift+; apply config",
+                AppConstants.Launcher.ActionMenu.openHint,
             ]
         }
 
@@ -661,10 +679,7 @@ struct LauncherView: View {
     /// view is shown in place of the command-mode hint.
     var isHomeHintScreen: Bool {
         guard isLauncherIdle else { return false }
-        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        if extractTranslationQuery(from: trimmed) != nil { return false }
-        if isPrefixSuggestionQuery || isCommandSuggestionQuery || isClipboardQuery || isProcessQuery { return false }
-        return true
+        return !usesOwnResultPanel
     }
 
     /// Today's done/total quick view for the home hint bar, or nil when
@@ -1085,7 +1100,7 @@ struct LauncherView: View {
                 if showsHelpScreen {
                     showsHelpScreen = false
                 }
-                if isClipboardQuery || isPrefixSuggestionQuery || isCommandSuggestionQuery || isTranslationQuery || isProcessQuery {
+                if usesOwnResultPanel {
                     // These render their own panels (clip history / prefix menu /
                     // command menu / translation / process finder), not backend
                     // results. Skip the search + AI answer entirely - otherwise a
@@ -1276,6 +1291,22 @@ struct LauncherView: View {
                         themeStore: themeStore,
                         revealToken: appearanceRevealToken
                     )
+                    // The preview panel is not on screen here, so the empty
+                    // state renders the Cmd+K menu itself: the launchpad's
+                    // controls are actions like any other row's.
+                    .overlay(alignment: .top) {
+                        if isActionMenuOpen {
+                            ActionMenuView(
+                                descriptors: actionMenuDescriptors,
+                                states: quickActionStates,
+                                focusedIndex: actionMenuIndex,
+                                themeStore: themeStore,
+                                onRun: { runQuickAction($0, intent: $0.control == .toggle ? .toggle : .run) }
+                            )
+                            .frame(maxWidth: AppConstants.Launcher.ActionMenu.launchpadWidth)
+                            .padding(.top, 8)
+                        }
+                    }
                 }
                 Spacer(minLength: 0)
             } else {
@@ -2020,7 +2051,10 @@ struct LauncherView: View {
                         : nil,
                     processDetail: processDetail(for: selectedResult),
                     processCPU: processCPU(for: selectedResult),
-                    isMeasuringProcessCPU: isMeasuringCPU(for: selectedResult)
+                    isMeasuringProcessCPU: isMeasuringCPU(for: selectedResult),
+                    isActionMenuOpen: isActionMenuOpen,
+                    actionMenuIndex: actionMenuIndex,
+                    actionMenuDescriptors: actionMenuDescriptors
                 )
                 // Arrow-key nav assigns `selectedResultID` inside a global
                 // `withAnimation` so the pill can glide (see LauncherView+

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -673,7 +673,17 @@ struct LauncherView: View {
         // The home screen replaces the "Cmd+/ command mode" hint with a
         // clickable today done/total quick view (see todoQuickView), so it
         // is intentionally omitted here.
-        return ["Enter open", "Cmd+H help"]
+        return [enterHint, AppConstants.Launcher.ActionMenu.openHint, "Cmd+H help"]
+    }
+
+    /// What Enter does to the selected row. A declared block performs steps or
+    /// runs its own command, so claiming "open" there is simply wrong.
+    private var enterHint: String {
+        guard let id = selectedResultID,
+              let selected = displayedResults.first(where: { $0.id == id }),
+              selected.kind == .action
+        else { return "Enter open" }
+        return "Enter run"
     }
 
     /// True when the launcher is on its default/home screen (the state

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -97,6 +97,8 @@ struct LauncherView: View {
     // preview no space until asked for.
     @State var isActionMenuOpen = false
     @State var actionMenuIndex = 0
+    /// A destructive `then` target waiting for a yes/no answer in the menu.
+    @State var pendingActionConfirm: (blockID: String, title: String, question: String)?
     @State var quickActionStates: [String: ActionState] = [:]
     // The result `quickActionStates`/`quickActionInfo` were read for. Lets a refresh
     // of the SAME result keep showing what it already resolved, instead of blanking
@@ -1297,7 +1299,7 @@ struct LauncherView: View {
                     .overlay(alignment: .top) {
                         if isActionMenuOpen {
                             ActionMenuView(
-                                descriptors: actionMenuDescriptors,
+                                descriptors: actionMenuRows,
                                 states: quickActionStates,
                                 focusedIndex: actionMenuIndex,
                                 themeStore: themeStore,
@@ -2054,7 +2056,7 @@ struct LauncherView: View {
                     isMeasuringProcessCPU: isMeasuringCPU(for: selectedResult),
                     isActionMenuOpen: isActionMenuOpen,
                     actionMenuIndex: actionMenuIndex,
-                    actionMenuDescriptors: actionMenuDescriptors
+                    actionMenuDescriptors: actionMenuRows
                 )
                 // Arrow-key nav assigns `selectedResultID` inside a global
                 // `withAnimation` so the pill can glide (see LauncherView+

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/QuickActionsSection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/QuickActionsSection.swift
@@ -24,6 +24,10 @@ struct QuickActionsSection: View {
     var onRun: (QuickActionDescriptor, ActionIntent) -> Void = { _, _ in }
     /// A list item (e.g. a device row) was clicked to connect/disconnect.
     var onActivateItem: (QuickActionDescriptor, QuickActionListItem) -> Void = { _, _ in }
+    /// Information belongs in the panel and verbs belong in the Cmd+K menu, so
+    /// the panel renders this with the control row suppressed: Bluetooth's
+    /// paired devices stay visible without its switch taking the space.
+    var controlHidden: Bool = false
 
     private enum Layout {
         static let rowSpacing: CGFloat = 6
@@ -40,7 +44,8 @@ struct QuickActionsSection: View {
                     isBusy: busyActionIds.contains(descriptor.actionId),
                     themeStore: themeStore,
                     onRun: { intent in onRun(descriptor, intent) },
-                    onActivateItem: { item in onActivateItem(descriptor, item) }
+                    onActivateItem: { item in onActivateItem(descriptor, item) },
+                    controlHidden: controlHidden
                 )
                 .spawnReveal(index: index, token: revealToken)
             }
@@ -59,6 +64,10 @@ private struct QuickActionControl: View {
     let themeStore: ThemeStore
     let onRun: (ActionIntent) -> Void
     let onActivateItem: (QuickActionListItem) -> Void
+    /// Information belongs in the panel and verbs belong in the Cmd+K menu, so
+    /// the panel renders this with the control row suppressed: Bluetooth's
+    /// paired devices stay visible without its switch taking the space.
+    var controlHidden: Bool = false
 
     private enum Layout {
         static let sectionSpacing: CGFloat = 4
@@ -79,7 +88,9 @@ private struct QuickActionControl: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
-            controlRow
+            if !controlHidden {
+                controlRow
+            }
             infoFields
         }
     }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
@@ -469,6 +469,20 @@ struct ResultPreviewView: View {
                 Spacer()
             }
 
+            let appIcons = SourceBlockIcons.appIcons(forSteps: blockSteps, limit: 8)
+            if !appIcons.isEmpty {
+                // What the steps will actually bring up. Only steps that name an
+                // app contribute, so the strip never implies more than the block
+                // does.
+                HStack(spacing: 6) {
+                    ForEach(Array(appIcons.enumerated()), id: \.offset) { _, icon in
+                        Image(nsImage: icon)
+                            .resizable()
+                            .frame(width: 24, height: 24)
+                    }
+                }
+            }
+
             Text("Enter runs")
                 .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .medium))
                 .foregroundStyle(themeStore.secondaryTextColor())

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
@@ -23,6 +23,13 @@ struct ResultPreviewView: View {
     var processDetail: ProcessDetail? = nil
     var processCPU: Double? = nil
     var isMeasuringProcessCPU: Bool = false
+    /// The Cmd+K action menu, floated under the header rather than laid out, so
+    /// a row's verbs cost the preview nothing until they are asked for.
+    var isActionMenuOpen: Bool = false
+    var actionMenuIndex: Int = 0
+    /// What the menu lists. Not always `quickActions`: with an empty query the
+    /// launchpad's own controls take its place.
+    var actionMenuDescriptors: [QuickActionDescriptor] = []
 
     @State private var folderListing: FolderListing?
     @State private var trashItemCount: Int?
@@ -30,6 +37,26 @@ struct ResultPreviewView: View {
     /// with the file that declared it.
     @State private var blockSteps: [String] = []
     @State private var blockFile: String?
+
+    /// The Cmd+K popup, pinned to the top of the content area so it opens flush
+    /// under the header and floats over whatever the preview is showing.
+    private var actionMenu: some View {
+        ActionMenuView(
+            descriptors: actionMenuDescriptors,
+            states: quickActionStates,
+            focusedIndex: actionMenuIndex,
+            themeStore: themeStore,
+            onRun: { onRunQuickAction($0, $0.control == .toggle ? .toggle : .run) }
+        )
+        .transition(.opacity.combined(with: .move(edge: .top)))
+        .zIndex(1)
+    }
+
+    /// Actions with live details worth reading (Bluetooth's paired devices).
+    /// Their verbs live in the Cmd+K menu; only what they know stays here.
+    private var infoOnlyQuickActions: [QuickActionDescriptor] {
+        quickActions.filter { !$0.info.isEmpty }
+    }
 
     /// A System Settings pane result (its "path" is a URL scheme, not a file).
     private var isSetting: Bool {
@@ -366,17 +393,22 @@ struct ResultPreviewView: View {
                     Spacer()
                 }
 
-                if !quickActions.isEmpty {
+                ZStack(alignment: .topLeading) {
+                    VStack(alignment: .leading, spacing: 12) {
+                // Info only: an action's live details (Bluetooth's paired
+                // devices) are what the panel is for. Its verbs are in Cmd+K.
+                if !infoOnlyQuickActions.isEmpty {
                     QuickActionsSection(
-                        descriptors: quickActions,
+                        descriptors: infoOnlyQuickActions,
                         states: quickActionStates,
                         info: quickActionInfo,
                         pendingItems: pendingQuickActionItems,
                         busyActionIds: busyQuickActionIds,
                         themeStore: themeStore,
                         revealToken: quickActionsRevealToken,
-                        onRun: onRunQuickAction,
-                        onActivateItem: onActivateQuickActionItem
+                        onRun: { _, _ in },
+                        onActivateItem: onActivateQuickActionItem,
+                        controlHidden: true
                     )
                 }
 
@@ -418,6 +450,12 @@ struct ResultPreviewView: View {
 
                 if result.kind != .file && result.kind != .folder {
                     Spacer()
+                }
+                    }
+
+                    if isActionMenuOpen {
+                        actionMenu
+                    }
                 }
             }
             .padding(12)
@@ -494,22 +532,6 @@ struct ResultPreviewView: View {
                     code: blockSteps.joined(separator: "\n"),
                     language: "sh",
                     themeStore: themeStore
-                )
-            }
-
-            if !quickActions.isEmpty {
-                // A bundle can have `then` targets too, and they belong on the
-                // same Cmd+J/K + Enter as everywhere else.
-                QuickActionsSection(
-                    descriptors: quickActions,
-                    states: quickActionStates,
-                    info: quickActionInfo,
-                    pendingItems: pendingQuickActionItems,
-                    busyActionIds: busyQuickActionIds,
-                    themeStore: themeStore,
-                    revealToken: quickActionsRevealToken,
-                    onRun: onRunQuickAction,
-                    onActivateItem: onActivateQuickActionItem
                 )
             }
 

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
@@ -37,6 +37,19 @@ struct ResultPreviewView: View {
     /// with the file that declared it.
     @State private var blockSteps: [String] = []
     @State private var blockFile: String?
+    /// Output of the block's declared `preview`, for rows that have one.
+    @State private var blockPreview: SourcePreview?
+
+    /// The menu for a preview that has no content area to pin it into. Padded
+    /// clear of the header so it still reads as attached to the row above it.
+    @ViewBuilder
+    private var floatingActionMenu: some View {
+        if isActionMenuOpen {
+            actionMenu
+                .padding(.horizontal, 16)
+                .padding(.top, 84)
+        }
+    }
 
     /// The Cmd+K popup, pinned to the top of the content area so it opens flush
     /// under the header and floats over whatever the preview is showing.
@@ -341,7 +354,7 @@ struct ResultPreviewView: View {
 
     var body: some View {
         if result.kind == .action {
-            actionPreview
+            actionPreview.overlay(alignment: .top) { floatingActionMenu }
         } else if result.kind == .process {
             processPreview
         } else if result.kind == .clipboard {
@@ -521,18 +534,27 @@ struct ResultPreviewView: View {
                 }
             }
 
-            Text("Enter runs")
-                .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .medium))
-                .foregroundStyle(themeStore.secondaryTextColor())
+            if !blockSteps.isEmpty {
+                Text("Enter runs")
+                    .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .medium))
+                    .foregroundStyle(themeStore.secondaryTextColor())
+            }
 
             // The steps ARE shell, so they get the same block an AI answer's
             // code gets: highlighted, selectable, and copyable in one press.
             ScrollView {
-                AICodeBlockView(
-                    code: blockSteps.joined(separator: "\n"),
-                    language: "sh",
-                    themeStore: themeStore
-                )
+                VStack(alignment: .leading, spacing: 10) {
+                    if !blockSteps.isEmpty {
+                        AICodeBlockView(
+                            code: blockSteps.joined(separator: "\n"),
+                            language: "sh",
+                            themeStore: themeStore
+                        )
+                    }
+                    if let preview = blockPreview {
+                        blockPreviewBody(preview)
+                    }
+                }
             }
 
             Spacer(minLength: 0)
@@ -555,6 +577,39 @@ struct ResultPreviewView: View {
             if Task.isCancelled { return }
             blockSteps = block?.steps ?? []
             blockFile = block?.file
+
+            // The declared `preview` runs a command, so it is read separately
+            // and only after the cheap details are on screen.
+            blockPreview = nil
+            let row = (id: result.id, title: result.title, path: result.path)
+            let preview = await Task.detached(priority: .userInitiated) {
+                EngineBridge.shared.sourcePreview(
+                    candidateID: candidateID,
+                    rowID: row.id,
+                    rowTitle: row.title,
+                    rowPath: row.path
+                )
+            }.value
+            if Task.isCancelled { return }
+            blockPreview = preview
+        }
+    }
+
+    /// A block's `preview` output, or the reason it could not run. A failure is
+    /// shown rather than swallowed: a preview that silently does nothing reads
+    /// as the feature being broken.
+    @ViewBuilder
+    private func blockPreviewBody(_ preview: SourcePreview) -> some View {
+        if let error = preview.error {
+            Text(error)
+                .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular))
+                .foregroundStyle(themeStore.mutedTextColor())
+        } else if !preview.text.isEmpty {
+            Text(preview.text)
+                .font(.system(size: CGFloat(themeStore.settings.fontSize - 2), design: .monospaced))
+                .foregroundStyle(themeStore.secondaryTextColor())
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
@@ -497,6 +497,22 @@ struct ResultPreviewView: View {
                 )
             }
 
+            if !quickActions.isEmpty {
+                // A bundle can have `then` targets too, and they belong on the
+                // same Cmd+J/K + Enter as everywhere else.
+                QuickActionsSection(
+                    descriptors: quickActions,
+                    states: quickActionStates,
+                    info: quickActionInfo,
+                    pendingItems: pendingQuickActionItems,
+                    busyActionIds: busyQuickActionIds,
+                    themeStore: themeStore,
+                    revealToken: quickActionsRevealToken,
+                    onRun: onRunQuickAction,
+                    onActivateItem: onActivateQuickActionItem
+                )
+            }
+
             Spacer(minLength: 0)
 
             if let file = blockFile {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
@@ -30,6 +30,9 @@ struct ResultPreviewView: View {
     /// What the menu lists. Not always `quickActions`: with an empty query the
     /// launchpad's own controls take its place.
     var actionMenuDescriptors: [QuickActionDescriptor] = []
+    /// Activating a row of the Cmd+K menu, which is not the same as running it:
+    /// a target with a `confirm` asks first.
+    var onActivateActionMenuRow: (QuickActionDescriptor) -> Void = { _ in }
 
     @State private var folderListing: FolderListing?
     @State private var trashItemCount: Int?
@@ -59,7 +62,7 @@ struct ResultPreviewView: View {
             states: quickActionStates,
             focusedIndex: actionMenuIndex,
             themeStore: themeStore,
-            onRun: { onRunQuickAction($0, $0.control == .toggle ? .toggle : .run) }
+            onActivate: onActivateActionMenuRow
         )
         .transition(.opacity.combined(with: .move(edge: .top)))
         .zIndex(1)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
@@ -26,6 +26,10 @@ struct ResultPreviewView: View {
 
     @State private var folderListing: FolderListing?
     @State private var trashItemCount: Int?
+    /// Steps of the declared block behind an `.action` row, read on selection,
+    /// with the file that declared it.
+    @State private var blockSteps: [String] = []
+    @State private var blockFile: String?
 
     /// A System Settings pane result (its "path" is a URL scheme, not a file).
     private var isSetting: Bool {
@@ -309,7 +313,9 @@ struct ResultPreviewView: View {
     }
 
     var body: some View {
-        if result.kind == .process {
+        if result.kind == .action {
+            actionPreview
+        } else if result.kind == .process {
             processPreview
         } else if result.kind == .clipboard {
             clipboardPreview
@@ -438,6 +444,65 @@ struct ResultPreviewView: View {
                 if Task.isCancelled { return }
                 folderListing = listing
             }
+        }
+    }
+
+    /// A declared block has no file to describe, so the panel answers the only
+    /// question that matters before Enter: exactly what is about to run.
+    private var actionPreview: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 12) {
+                Image(systemName: "bolt.fill")
+                    .font(.system(size: 26))
+                    .foregroundStyle(themeStore.accentColor())
+                    .frame(width: 48, height: 48)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(result.title)
+                        .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize + 2), weight: .semibold))
+                        .foregroundStyle(themeStore.fontColor())
+                        .lineLimit(2)
+                    Text(result.subtitle ?? "")
+                        .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular))
+                        .foregroundStyle(themeStore.secondaryTextColor())
+                }
+                Spacer()
+            }
+
+            Text("Enter runs")
+                .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .medium))
+                .foregroundStyle(themeStore.secondaryTextColor())
+
+            // The steps ARE shell, so they get the same block an AI answer's
+            // code gets: highlighted, selectable, and copyable in one press.
+            ScrollView {
+                AICodeBlockView(
+                    code: blockSteps.joined(separator: "\n"),
+                    language: "sh",
+                    themeStore: themeStore
+                )
+            }
+
+            Spacer(minLength: 0)
+
+            if let file = blockFile {
+                Divider().overlay(themeStore.secondaryTextColor().opacity(0.2))
+                InfoRow(label: "Declared in", value: (file as NSString).abbreviatingWithTildeInPath)
+                hintRow(key: "⌘F", text: "Reveal that file")
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .task(id: result.id) {
+            let candidateID = result.id
+            let block = await Task.detached(priority: .userInitiated) {
+                EngineBridge.shared.sourceBlock(candidateID: candidateID)
+            }.value
+            // The detached read outlives a cancelled task, so a late answer must
+            // not populate the panel of a row the user has already left.
+            if Task.isCancelled { return }
+            blockSteps = block?.steps ?? []
+            blockFile = block?.file
         }
     }
 

--- a/bridge/ffi/Cargo.lock
+++ b/bridge/ffi/Cargo.lock
@@ -126,6 +126,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,6 +269,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "inotify"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,6 +394,7 @@ dependencies = [
  "look-indexing",
  "look-matching",
  "look-ranking",
+ "look-sources",
  "look-storage",
  "objc2",
  "objc2-foundation",
@@ -450,6 +467,15 @@ name = "look-ranking"
 version = "0.1.0"
 dependencies = [
  "look-indexing",
+]
+
+[[package]]
+name = "look-sources"
+version = "0.1.0"
+dependencies = [
+ "globset",
+ "serde",
+ "toml",
 ]
 
 [[package]]
@@ -710,6 +736,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,6 +830,45 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "unicode-ident"
@@ -1079,6 +1153,18 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "zmij"

--- a/bridge/ffi/Cargo.lock
+++ b/bridge/ffi/Cargo.lock
@@ -419,6 +419,7 @@ dependencies = [
  "look-netspeed",
  "look-qactions",
  "look-ranking",
+ "look-sources",
  "look-storage",
  "look-todo",
  "notify",

--- a/bridge/ffi/Cargo.toml
+++ b/bridge/ffi/Cargo.toml
@@ -16,6 +16,7 @@ look-answers = { path = "../../core/answers" }
 look-calc = { path = "../../core/calc" }
 look-engine = { path = "../../core/engine" }
 look-indexing = { path = "../../core/indexing" }
+look-sources = { path = "../../core/sources" }
 look-lunar = { path = "../../core/lunar" }
 look-matching = { path = "../../core/matching" }
 look-netspeed = { path = "../../core/netspeed" }

--- a/bridge/ffi/src/lib.rs
+++ b/bridge/ffi/src/lib.rs
@@ -335,9 +335,12 @@ pub extern "C" fn look_perform_block_json(
     row_title: *const c_char,
     row_path: *const c_char,
     query: *const c_char,
+    as_target: bool,
 ) -> *mut c_char {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        sources_api::look_perform_block_json_impl(block_id, row_id, row_title, row_path, query)
+        sources_api::look_perform_block_json_impl(
+            block_id, row_id, row_title, row_path, query, as_target,
+        )
     }))
     .unwrap_or(std::ptr::null_mut())
 }

--- a/bridge/ffi/src/lib.rs
+++ b/bridge/ffi/src/lib.rs
@@ -269,9 +269,14 @@ pub extern "C" fn look_instant_answer_json(query: *const c_char) -> *mut c_char 
 /// so the panel can show what Enter will perform. `null` when the row is not a
 /// block row.
 #[unsafe(no_mangle)]
-pub extern "C" fn look_source_block_json(candidate_id: *const c_char) -> *mut c_char {
+pub extern "C" fn look_source_block_json(
+    candidate_id: *const c_char,
+    row_id: *const c_char,
+    row_title: *const c_char,
+    row_path: *const c_char,
+) -> *mut c_char {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        sources_api::look_source_block_json_impl(candidate_id)
+        sources_api::look_source_block_json_impl(candidate_id, row_id, row_title, row_path)
     }))
     .unwrap_or(std::ptr::null_mut())
 }
@@ -282,6 +287,31 @@ pub extern "C" fn look_source_blocks_json() -> *mut c_char {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(
         sources_api::look_source_blocks_json_impl,
     ))
+    .unwrap_or(std::ptr::null_mut())
+}
+
+/// Re-runs every enabled `run` block and stores its rows for the next index
+/// pass. Blocks while commands run - call off the main thread.
+#[unsafe(no_mangle)]
+pub extern "C" fn look_refresh_run_blocks_json() -> *mut c_char {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(
+        sources_api::look_refresh_run_blocks_json_impl,
+    ))
+    .unwrap_or(std::ptr::null_mut())
+}
+
+/// A block's declared `preview`, run against the selected row. `null` when the
+/// block declares none.
+#[unsafe(no_mangle)]
+pub extern "C" fn look_source_preview_json(
+    candidate_id: *const c_char,
+    row_id: *const c_char,
+    row_title: *const c_char,
+    row_path: *const c_char,
+) -> *mut c_char {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        sources_api::look_source_preview_json_impl(candidate_id, row_id, row_title, row_path)
+    }))
     .unwrap_or(std::ptr::null_mut())
 }
 

--- a/bridge/ffi/src/lib.rs
+++ b/bridge/ffi/src/lib.rs
@@ -290,6 +290,17 @@ pub extern "C" fn look_source_blocks_json() -> *mut c_char {
     .unwrap_or(std::ptr::null_mut())
 }
 
+/// The config file to read and write. Pass `dev` for a development build, which
+/// keeps its own pair so it never edits the installed copy's settings. Plain
+/// path string, not JSON.
+#[unsafe(no_mangle)]
+pub extern "C" fn look_config_path(dev: bool) -> *mut c_char {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        sources_api::look_config_path_impl(dev)
+    }))
+    .unwrap_or(std::ptr::null_mut())
+}
+
 /// Re-runs every enabled `run` block and stores its rows for the next index
 /// pass. Blocks while commands run - call off the main thread.
 #[unsafe(no_mangle)]

--- a/bridge/ffi/src/lib.rs
+++ b/bridge/ffi/src/lib.rs
@@ -13,6 +13,7 @@ mod qactions_api;
 mod runtime_config;
 mod search_api;
 mod seed_api;
+mod sources_api;
 mod state;
 mod todo_api;
 mod translate_api;
@@ -260,6 +261,27 @@ pub extern "C" fn look_translate_json(
 pub extern "C" fn look_instant_answer_json(query: *const c_char) -> *mut c_char {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         answers_api::look_instant_answer_json_impl(query)
+    }))
+    .unwrap_or(std::ptr::null_mut())
+}
+
+/// `{id, name, steps}` for the user-declared block a candidate id belongs to,
+/// so the panel can show what Enter will perform. `null` when the row is not a
+/// block row.
+#[unsafe(no_mangle)]
+pub extern "C" fn look_source_block_json(candidate_id: *const c_char) -> *mut c_char {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        sources_api::look_source_block_json_impl(candidate_id)
+    }))
+    .unwrap_or(std::ptr::null_mut())
+}
+
+/// Performs every step of that block, detached, through the user's login shell.
+/// Returns `{performed, errors}`.
+#[unsafe(no_mangle)]
+pub extern "C" fn look_perform_block_json(candidate_id: *const c_char) -> *mut c_char {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        sources_api::look_perform_block_json_impl(candidate_id)
     }))
     .unwrap_or(std::ptr::null_mut())
 }

--- a/bridge/ffi/src/lib.rs
+++ b/bridge/ffi/src/lib.rs
@@ -276,6 +276,15 @@ pub extern "C" fn look_source_block_json(candidate_id: *const c_char) -> *mut c_
     .unwrap_or(std::ptr::null_mut())
 }
 
+/// Every declared block as `{id, name, icon}`, for the shell's row-icon cache.
+#[unsafe(no_mangle)]
+pub extern "C" fn look_source_blocks_json() -> *mut c_char {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(
+        sources_api::look_source_blocks_json_impl,
+    ))
+    .unwrap_or(std::ptr::null_mut())
+}
+
 /// Performs every step of that block, detached, through the user's login shell.
 /// Returns `{performed, errors}`.
 #[unsafe(no_mangle)]

--- a/bridge/ffi/src/lib.rs
+++ b/bridge/ffi/src/lib.rs
@@ -288,9 +288,15 @@ pub extern "C" fn look_source_blocks_json() -> *mut c_char {
 /// Performs every step of that block, detached, through the user's login shell.
 /// Returns `{performed, errors}`.
 #[unsafe(no_mangle)]
-pub extern "C" fn look_perform_block_json(candidate_id: *const c_char) -> *mut c_char {
+pub extern "C" fn look_perform_block_json(
+    block_id: *const c_char,
+    row_id: *const c_char,
+    row_title: *const c_char,
+    row_path: *const c_char,
+    query: *const c_char,
+) -> *mut c_char {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        sources_api::look_perform_block_json_impl(candidate_id)
+        sources_api::look_perform_block_json_impl(block_id, row_id, row_title, row_path, query)
     }))
     .unwrap_or(std::ptr::null_mut())
 }

--- a/bridge/ffi/src/runtime_config.rs
+++ b/bridge/ffi/src/runtime_config.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::env;
-use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 
 #[derive(Clone, Copy, Debug)]
@@ -66,7 +65,9 @@ fn runtime_config() -> &'static Mutex<RuntimeConfig> {
 
 fn load_runtime_config() -> RuntimeConfig {
     let mut from_file: HashMap<String, String> = HashMap::new();
-    if let Ok(contents) = std::fs::read_to_string(default_config_path()) {
+    if let Some(path) = look_engine::config_path::current().map(|resolved| resolved.path)
+        && let Ok(contents) = std::fs::read_to_string(path)
+    {
         for raw_line in contents.lines() {
             let line = raw_line.split('#').next().unwrap_or("").trim();
             if line.is_empty() {
@@ -93,40 +94,6 @@ fn load_runtime_config() -> RuntimeConfig {
     RuntimeConfig { log_level }
 }
 
-fn default_config_path() -> PathBuf {
-    if let Ok(custom) = env::var("LOOK_CONFIG_PATH")
-        && !custom.trim().is_empty()
-    {
-        return PathBuf::from(custom);
-    }
-
-    #[cfg(target_os = "windows")]
-    if let Some(path) = windows_default_config_path() {
-        return path;
-    }
-
-    legacy_default_config_path()
-}
-
-fn legacy_default_config_path() -> PathBuf {
-    let home = env::var("HOME").unwrap_or_else(|_| ".".to_string());
-    PathBuf::from(home).join(".look.config")
-}
-
-#[cfg(target_os = "windows")]
-fn windows_default_config_path() -> Option<PathBuf> {
-    if let Ok(user_profile) = env::var("USERPROFILE")
-        && !user_profile.trim().is_empty()
-    {
-        return Some(PathBuf::from(user_profile).join(".look.config"));
-    }
-
-    env::var("APPDATA")
-        .ok()
-        .filter(|value| !value.trim().is_empty())
-        .map(|base| PathBuf::from(base).join("look").join("config"))
-}
-
 fn parse_log_level(value: &str) -> Option<LogLevel> {
     match value.trim().to_ascii_lowercase().as_str() {
         "debug" => Some(LogLevel::Debug),
@@ -138,7 +105,7 @@ fn parse_log_level(value: &str) -> Option<LogLevel> {
 
 #[cfg(test)]
 mod tests {
-    use super::{LogLevel, legacy_default_config_path, parse_log_level};
+    use super::{LogLevel, parse_log_level};
 
     #[test]
     fn parse_log_level_accepts_known_values() {
@@ -146,20 +113,5 @@ mod tests {
         assert_eq!(parse_log_level("INFO"), Some(LogLevel::Info));
         assert_eq!(parse_log_level("error"), Some(LogLevel::Error));
         assert_eq!(parse_log_level("trace"), None);
-    }
-
-    #[test]
-    fn legacy_config_path_points_to_dot_config() {
-        let path = legacy_default_config_path();
-        assert!(path.to_string_lossy().ends_with(".look.config"));
-    }
-
-    #[cfg(target_os = "windows")]
-    #[test]
-    fn windows_config_path_shape_is_stable_when_present() {
-        if let Some(path) = super::windows_default_config_path() {
-            let path_str = path.to_string_lossy().to_ascii_lowercase();
-            assert!(path_str.contains("look") || path_str.ends_with(".look.config"));
-        }
     }
 }

--- a/bridge/ffi/src/sources_api.rs
+++ b/bridge/ffi/src/sources_api.rs
@@ -27,6 +27,15 @@ struct BlockDetail {
     file: Option<String>,
 }
 
+/// One row of the block index the shell caches: enough to render a row without
+/// re-reading the directory for every one of them.
+#[derive(Serialize)]
+struct BlockSummary {
+    id: String,
+    name: String,
+    icon: Option<String>,
+}
+
 #[derive(Serialize)]
 struct PerformOutcome {
     performed: usize,
@@ -53,6 +62,25 @@ pub(crate) fn look_source_block_json_impl(candidate_id: *const c_char) -> *mut c
             })
             .and_then(|detail| serde_json::to_string(&detail).ok()),
     )
+}
+
+/// Every declared block as `{id, name, icon}`. The shell caches this once per
+/// launcher open so a row can show its declared icon without a disk read each
+/// time it renders.
+pub(crate) fn look_source_blocks_json_impl() -> *mut c_char {
+    let Some(home) = home_dir() else {
+        return json_cstring_or_null(Some("[]".to_string()));
+    };
+    let summaries: Vec<BlockSummary> = load_dir(&sources_dir(&home))
+        .blocks
+        .into_iter()
+        .map(|block| BlockSummary {
+            id: block.id,
+            name: block.name,
+            icon: block.icon,
+        })
+        .collect();
+    json_cstring_or_null(serde_json::to_string(&summaries).ok())
 }
 
 /// Performs every step of the block a candidate id belongs to. Returns

--- a/bridge/ffi/src/sources_api.rs
+++ b/bridge/ffi/src/sources_api.rs
@@ -55,6 +55,10 @@ struct BlockSummary {
 struct PerformOutcome {
     performed: usize,
     errors: Vec<String>,
+    /// The target makes rows to pick from rather than steps to run, so the
+    /// caller should descend into it. An explicit signal, because "nothing was
+    /// performed" is also what a failure looks like.
+    produces_rows: bool,
 }
 
 /// `{id, name, steps, file, then}` for the block a candidate id belongs to, or
@@ -128,15 +132,21 @@ pub(crate) fn look_source_blocks_json_impl() -> *mut c_char {
     json_cstring_or_null(serde_json::to_string(&summaries).ok())
 }
 
-/// Performs `block_id`'s steps against the selected row, which is what its
-/// placeholders expand to. Returns `{performed, errors}`; an empty `errors`
-/// means every step was spawned.
+/// Performs `block_id` against the selected row, which is what its placeholders
+/// expand to. Returns `{performed, errors, produces_rows}`.
+///
+/// `as_target` is the caller's intent, and only the caller knows it. Enter on a
+/// row means "do what this block's `open` says", so a row-producing block runs
+/// its verb. A `then` target means "go to this block", so a row-producing one is
+/// a level to descend into and running its `open` would act on the WRONG row -
+/// the one currently selected, not one of the rows the target would list.
 pub(crate) fn look_perform_block_json_impl(
     block_id: *const c_char,
     row_id: *const c_char,
     row_title: *const c_char,
     row_path: *const c_char,
     query: *const c_char,
+    as_target: bool,
 ) -> *mut c_char {
     let block_id = cstr_to_string(block_id);
     let row = row_context(row_id, row_title, row_path, &cstr_to_string(query));
@@ -145,10 +155,11 @@ pub(crate) fn look_perform_block_json_impl(
         return outcome(0, vec!["that block no longer exists".into()]);
     };
 
-    // A bundle IS its steps. Any other producer makes rows, so what Enter does
-    // to one of them is the block's `open` verb.
+    // A bundle IS its steps. Any other producer makes rows: reached as a target
+    // that means descend, reached by Enter it means run the block's `open`.
     let steps: Vec<String> = match &block.producer {
         Producer::Bundle { steps } => steps.clone(),
+        _ if as_target => return produces_rows(),
         _ => match block.verbs.open.as_deref() {
             Some(command) => vec![command.to_string()],
             None => {
@@ -295,7 +306,25 @@ fn steps_of(block: &Block) -> Vec<String> {
 }
 
 fn outcome(performed: usize, errors: Vec<String>) -> *mut c_char {
-    json_cstring_or_null(serde_json::to_string(&PerformOutcome { performed, errors }).ok())
+    json_cstring_or_null(
+        serde_json::to_string(&PerformOutcome {
+            performed,
+            errors,
+            produces_rows: false,
+        })
+        .ok(),
+    )
+}
+
+fn produces_rows() -> *mut c_char {
+    json_cstring_or_null(
+        serde_json::to_string(&PerformOutcome {
+            performed: 0,
+            errors: Vec::new(),
+            produces_rows: true,
+        })
+        .ok(),
+    )
 }
 
 fn find_block(block_id: &str) -> Option<Block> {

--- a/bridge/ffi/src/sources_api.rs
+++ b/bridge/ffi/src/sources_api.rs
@@ -1,0 +1,117 @@
+//! C-ABI wrappers over `look_sources`, so the Swift shell can read a
+//! user-declared block and perform it.
+//!
+//! A row carries only its candidate id, so both entry points start by resolving
+//! `src:<block>:<row>` back to the block that declared it. Reading the
+//! directory again on demand (rather than caching it here) means a file the user
+//! just edited takes effect without a reindex.
+
+use std::path::PathBuf;
+
+use look_indexing::CandidateIdKind;
+use look_sources::{Block, Producer, load_dir, sources_dir};
+use serde::Serialize;
+use std::os::raw::c_char;
+
+use crate::state::{cstr_to_string, json_cstring_or_null};
+
+/// What the panel shows for a block row: its name and the exact steps Enter
+/// will perform, so the user reads what will happen before it happens.
+#[derive(Serialize)]
+struct BlockDetail {
+    id: String,
+    name: String,
+    steps: Vec<String>,
+    /// The file this block was declared in, so the panel can show it and
+    /// reveal-in-Finder has something to point at.
+    file: Option<String>,
+}
+
+#[derive(Serialize)]
+struct PerformOutcome {
+    performed: usize,
+    errors: Vec<String>,
+}
+
+/// `{id, name, steps}` for the block a candidate id belongs to, or the JSON
+/// literal `null` when it is not a block row or no longer exists.
+pub(crate) fn look_source_block_json_impl(candidate_id: *const c_char) -> *mut c_char {
+    let candidate_id = cstr_to_string(candidate_id);
+    json_cstring_or_null(
+        find_block(&candidate_id)
+            .map(|block| {
+                let steps = match &block.producer {
+                    Producer::Bundle { steps } => steps.clone(),
+                    _ => Vec::new(),
+                };
+                BlockDetail {
+                    id: block.id.clone(),
+                    name: block.name.clone(),
+                    steps,
+                    file: block.source_file.clone(),
+                }
+            })
+            .and_then(|detail| serde_json::to_string(&detail).ok()),
+    )
+}
+
+/// Performs every step of the block a candidate id belongs to. Returns
+/// `{performed, errors}`; an empty `errors` means every step was spawned.
+pub(crate) fn look_perform_block_json_impl(candidate_id: *const c_char) -> *mut c_char {
+    let candidate_id = cstr_to_string(candidate_id);
+    let Some(block) = find_block(&candidate_id) else {
+        return json_cstring_or_null(
+            serde_json::to_string(&PerformOutcome {
+                performed: 0,
+                errors: vec!["that block no longer exists".into()],
+            })
+            .ok(),
+        );
+    };
+
+    let Producer::Bundle { steps } = &block.producer else {
+        return json_cstring_or_null(
+            serde_json::to_string(&PerformOutcome {
+                performed: 0,
+                errors: vec![format!("[{}] has no steps to perform", block.id)],
+            })
+            .ok(),
+        );
+    };
+
+    let outcomes = look_sources::perform(steps, None);
+    let errors: Vec<String> = outcomes
+        .iter()
+        .filter_map(|outcome| {
+            outcome
+                .error
+                .as_ref()
+                .map(|error| format!("{}: {error}", outcome.step))
+        })
+        .collect();
+
+    json_cstring_or_null(
+        serde_json::to_string(&PerformOutcome {
+            performed: outcomes.len() - errors.len(),
+            errors,
+        })
+        .ok(),
+    )
+}
+
+fn find_block(candidate_id: &str) -> Option<Block> {
+    let block_id = CandidateIdKind::source_id_of(candidate_id)?;
+    let home = home_dir()?;
+    load_dir(&sources_dir(&home))
+        .blocks
+        .into_iter()
+        .find(|block| block.id == block_id)
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .map(PathBuf::from)
+}

--- a/bridge/ffi/src/sources_api.rs
+++ b/bridge/ffi/src/sources_api.rs
@@ -1,22 +1,32 @@
 //! C-ABI wrappers over `look_sources`, so the Swift shell can read a
-//! user-declared block and perform it.
+//! user-declared block, list what a row can go on to, and perform it.
 //!
-//! A row carries only its candidate id, so both entry points start by resolving
-//! `src:<block>:<row>` back to the block that declared it. Reading the
+//! A row carries only its candidate id, so every entry point starts by
+//! resolving `src:<block>:<row>` back to the block that declared it. Reading the
 //! directory again on demand (rather than caching it here) means a file the user
 //! just edited takes effect without a reindex.
 
 use std::path::PathBuf;
 
 use look_indexing::CandidateIdKind;
-use look_sources::{Block, Producer, load_dir, sources_dir};
+use look_sources::{Block, Producer, RowContext, load_dir, sources_dir};
 use serde::Serialize;
 use std::os::raw::c_char;
 
 use crate::state::{cstr_to_string, json_cstring_or_null};
 
-/// What the panel shows for a block row: its name and the exact steps Enter
-/// will perform, so the user reads what will happen before it happens.
+/// Somewhere a row can go from here. `performs` is what the target's own
+/// producer decides: steps to run, or rows to descend into.
+#[derive(Serialize)]
+struct ThenTarget {
+    id: String,
+    name: String,
+    icon: Option<String>,
+    performs: bool,
+}
+
+/// What the panel shows for a block row: its name, the exact steps Enter will
+/// perform, and where a row can go next.
 #[derive(Serialize)]
 struct BlockDetail {
     id: String,
@@ -25,6 +35,7 @@ struct BlockDetail {
     /// The file this block was declared in, so the panel can show it and
     /// reveal-in-Finder has something to point at.
     file: Option<String>,
+    then: Vec<ThenTarget>,
 }
 
 /// One row of the block index the shell caches: enough to render a row without
@@ -42,25 +53,43 @@ struct PerformOutcome {
     errors: Vec<String>,
 }
 
-/// `{id, name, steps}` for the block a candidate id belongs to, or the JSON
-/// literal `null` when it is not a block row or no longer exists.
+/// `{id, name, steps, file, then}` for the block a candidate id belongs to, or
+/// the JSON literal `null` when it is not a block row or no longer exists.
 pub(crate) fn look_source_block_json_impl(candidate_id: *const c_char) -> *mut c_char {
     let candidate_id = cstr_to_string(candidate_id);
+    let Some(block_id) = CandidateIdKind::source_id_of(&candidate_id) else {
+        return json_cstring_or_null(None);
+    };
+    let Some(home) = home_dir() else {
+        return json_cstring_or_null(None);
+    };
+
+    let blocks = load_dir(&sources_dir(&home)).blocks;
+    let Some(block) = blocks.iter().find(|block| block.id == block_id) else {
+        return json_cstring_or_null(None);
+    };
+
+    let then = block
+        .then
+        .iter()
+        .filter_map(|target| blocks.iter().find(|block| &block.id == target))
+        .map(|target| ThenTarget {
+            id: target.id.clone(),
+            name: target.name.clone(),
+            icon: target.icon.clone(),
+            performs: target.is_bundle(),
+        })
+        .collect();
+
     json_cstring_or_null(
-        find_block(&candidate_id)
-            .map(|block| {
-                let steps = match &block.producer {
-                    Producer::Bundle { steps } => steps.clone(),
-                    _ => Vec::new(),
-                };
-                BlockDetail {
-                    id: block.id.clone(),
-                    name: block.name.clone(),
-                    steps,
-                    file: block.source_file.clone(),
-                }
-            })
-            .and_then(|detail| serde_json::to_string(&detail).ok()),
+        serde_json::to_string(&BlockDetail {
+            id: block.id.clone(),
+            name: block.name.clone(),
+            steps: steps_of(block),
+            file: block.source_file.clone(),
+            then,
+        })
+        .ok(),
     )
 }
 
@@ -83,52 +112,55 @@ pub(crate) fn look_source_blocks_json_impl() -> *mut c_char {
     json_cstring_or_null(serde_json::to_string(&summaries).ok())
 }
 
-/// Performs every step of the block a candidate id belongs to. Returns
-/// `{performed, errors}`; an empty `errors` means every step was spawned.
-pub(crate) fn look_perform_block_json_impl(candidate_id: *const c_char) -> *mut c_char {
-    let candidate_id = cstr_to_string(candidate_id);
-    let Some(block) = find_block(&candidate_id) else {
-        return json_cstring_or_null(
-            serde_json::to_string(&PerformOutcome {
-                performed: 0,
-                errors: vec!["that block no longer exists".into()],
-            })
-            .ok(),
-        );
+/// Performs `block_id`'s steps against the selected row, which is what its
+/// placeholders expand to. Returns `{performed, errors}`; an empty `errors`
+/// means every step was spawned.
+pub(crate) fn look_perform_block_json_impl(
+    block_id: *const c_char,
+    row_id: *const c_char,
+    row_title: *const c_char,
+    row_path: *const c_char,
+    query: *const c_char,
+) -> *mut c_char {
+    let block_id = cstr_to_string(block_id);
+    let row = RowContext {
+        id: cstr_to_string(row_id),
+        title: cstr_to_string(row_title),
+        path: cstr_to_string(row_path),
+        query: cstr_to_string(query),
     };
 
+    let Some(block) = find_block(&block_id) else {
+        return outcome(0, vec!["that block no longer exists".into()]);
+    };
     let Producer::Bundle { steps } = &block.producer else {
-        return json_cstring_or_null(
-            serde_json::to_string(&PerformOutcome {
-                performed: 0,
-                errors: vec![format!("[{}] has no steps to perform", block.id)],
-            })
-            .ok(),
-        );
+        return outcome(0, vec![format!("[{}] has no steps to perform", block.id)]);
     };
 
-    let outcomes = look_sources::perform(steps, None);
+    let outcomes = look_sources::perform(steps, Some(&row));
     let errors: Vec<String> = outcomes
         .iter()
-        .filter_map(|outcome| {
-            outcome
-                .error
+        .filter_map(|step| {
+            step.error
                 .as_ref()
-                .map(|error| format!("{}: {error}", outcome.step))
+                .map(|error| format!("{}: {error}", step.step))
         })
         .collect();
-
-    json_cstring_or_null(
-        serde_json::to_string(&PerformOutcome {
-            performed: outcomes.len() - errors.len(),
-            errors,
-        })
-        .ok(),
-    )
+    outcome(outcomes.len() - errors.len(), errors)
 }
 
-fn find_block(candidate_id: &str) -> Option<Block> {
-    let block_id = CandidateIdKind::source_id_of(candidate_id)?;
+fn steps_of(block: &Block) -> Vec<String> {
+    match &block.producer {
+        Producer::Bundle { steps } => steps.clone(),
+        _ => Vec::new(),
+    }
+}
+
+fn outcome(performed: usize, errors: Vec<String>) -> *mut c_char {
+    json_cstring_or_null(serde_json::to_string(&PerformOutcome { performed, errors }).ok())
+}
+
+fn find_block(block_id: &str) -> Option<Block> {
     let home = home_dir()?;
     load_dir(&sources_dir(&home))
         .blocks

--- a/bridge/ffi/src/sources_api.rs
+++ b/bridge/ffi/src/sources_api.rs
@@ -12,6 +12,7 @@ use look_indexing::CandidateIdKind;
 use look_sources::{Block, Producer, RowContext, load_dir, sources_dir};
 use serde::Serialize;
 use std::os::raw::c_char;
+use std::time::Duration;
 
 use crate::state::{cstr_to_string, json_cstring_or_null};
 
@@ -23,6 +24,9 @@ struct ThenTarget {
     name: String,
     icon: Option<String>,
     performs: bool,
+    /// The question to ask before running it, already expanded against the row,
+    /// or null when it needs no confirmation.
+    confirm: Option<String>,
 }
 
 /// What the panel shows for a block row: its name, the exact steps Enter will
@@ -55,8 +59,14 @@ struct PerformOutcome {
 
 /// `{id, name, steps, file, then}` for the block a candidate id belongs to, or
 /// the JSON literal `null` when it is not a block row or no longer exists.
-pub(crate) fn look_source_block_json_impl(candidate_id: *const c_char) -> *mut c_char {
+pub(crate) fn look_source_block_json_impl(
+    candidate_id: *const c_char,
+    row_id: *const c_char,
+    row_title: *const c_char,
+    row_path: *const c_char,
+) -> *mut c_char {
     let candidate_id = cstr_to_string(candidate_id);
+    let row = row_context(row_id, row_title, row_path, "");
     let Some(block_id) = CandidateIdKind::source_id_of(&candidate_id) else {
         return json_cstring_or_null(None);
     };
@@ -78,6 +88,12 @@ pub(crate) fn look_source_block_json_impl(candidate_id: *const c_char) -> *mut c
             name: target.name.clone(),
             icon: target.icon.clone(),
             performs: target.is_bundle(),
+            // Expanded here so the question names the row the user is looking
+            // at ("Delete main?"), not the template.
+            confirm: target
+                .confirm
+                .as_deref()
+                .map(|question| look_sources::expand(question, &row)),
         })
         .collect();
 
@@ -123,21 +139,28 @@ pub(crate) fn look_perform_block_json_impl(
     query: *const c_char,
 ) -> *mut c_char {
     let block_id = cstr_to_string(block_id);
-    let row = RowContext {
-        id: cstr_to_string(row_id),
-        title: cstr_to_string(row_title),
-        path: cstr_to_string(row_path),
-        query: cstr_to_string(query),
-    };
+    let row = row_context(row_id, row_title, row_path, &cstr_to_string(query));
 
     let Some(block) = find_block(&block_id) else {
         return outcome(0, vec!["that block no longer exists".into()]);
     };
-    let Producer::Bundle { steps } = &block.producer else {
-        return outcome(0, vec![format!("[{}] has no steps to perform", block.id)]);
+
+    // A bundle IS its steps. Any other producer makes rows, so what Enter does
+    // to one of them is the block's `open` verb.
+    let steps: Vec<String> = match &block.producer {
+        Producer::Bundle { steps } => steps.clone(),
+        _ => match block.verbs.open.as_deref() {
+            Some(command) => vec![command.to_string()],
+            None => {
+                return outcome(
+                    0,
+                    vec![format!("[{}] declares no `open` for its rows", block.id)],
+                );
+            }
+        },
     };
 
-    let outcomes = look_sources::perform(steps, Some(&row));
+    let outcomes = look_sources::perform(&steps, Some(&row));
     let errors: Vec<String> = outcomes
         .iter()
         .filter_map(|step| {
@@ -149,10 +172,124 @@ pub(crate) fn look_perform_block_json_impl(
     outcome(outcomes.len() - errors.len(), errors)
 }
 
+/// Fallback limits for a captured command, when the block names none. A source
+/// refresh happens while the user waits, so the ceiling is low on purpose.
+const DEFAULT_CAPTURE_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_CAPTURE_BYTES: usize = 256 * 1024;
+
+/// Re-runs every enabled `run` block and stores its rows, so the next index pass
+/// picks them up. Returns `{refreshed, errors}`.
+///
+/// A block that fails keeps the rows it had: losing them would also drop the
+/// usage history keyed to their ids, which is a worse outcome than stale rows.
+pub(crate) fn look_refresh_run_blocks_json_impl() -> *mut c_char {
+    let Some(home) = home_dir() else {
+        return json_cstring_or_null(Some("{\"refreshed\":0,\"errors\":[]}".into()));
+    };
+
+    let mut refreshed = 0usize;
+    let mut errors: Vec<String> = Vec::new();
+    for block in load_dir(&sources_dir(&home)).blocks {
+        let Producer::Run {
+            command,
+            cwd,
+            timeout,
+            ..
+        } = &block.producer
+        else {
+            continue;
+        };
+        if !block.enabled {
+            look_engine::index::clear_run_rows(&block.id);
+            continue;
+        }
+
+        let outcome = look_sources::capture(
+            command,
+            cwd.as_deref(),
+            timeout.unwrap_or(DEFAULT_CAPTURE_TIMEOUT),
+            MAX_CAPTURE_BYTES,
+        )
+        .and_then(|output| look_engine::index::store_run_rows(&block.id, &output));
+
+        match outcome {
+            Ok(rows) => refreshed += rows,
+            Err(message) => errors.push(format!("[{}] {message}", block.id)),
+        }
+    }
+
+    json_cstring_or_null(
+        serde_json::to_string(&serde_json::json!({
+            "refreshed": refreshed,
+            "errors": errors,
+        }))
+        .ok(),
+    )
+}
+
+/// Runs a block's declared `preview` against the selected row and returns its
+/// output as `{rows, error}`-shaped text, or `null` when it declares none.
+pub(crate) fn look_source_preview_json_impl(
+    candidate_id: *const c_char,
+    row_id: *const c_char,
+    row_title: *const c_char,
+    row_path: *const c_char,
+) -> *mut c_char {
+    let candidate_id = cstr_to_string(candidate_id);
+    let Some(block_id) = CandidateIdKind::source_id_of(&candidate_id) else {
+        return json_cstring_or_null(None);
+    };
+    let Some(block) = find_block(block_id) else {
+        return json_cstring_or_null(None);
+    };
+    let Some(preview) = block.preview.as_deref() else {
+        return json_cstring_or_null(None);
+    };
+
+    let row = row_context(row_id, row_title, row_path, "");
+    let command = look_sources::expand(preview, &row);
+    let text = look_sources::capture(
+        &command,
+        Some(&row.path),
+        DEFAULT_CAPTURE_TIMEOUT,
+        MAX_CAPTURE_BYTES,
+    );
+
+    json_cstring_or_null(
+        serde_json::to_string(&match text {
+            Ok(text) => serde_json::json!({ "text": text, "error": serde_json::Value::Null }),
+            Err(message) => serde_json::json!({ "text": "", "error": message }),
+        })
+        .ok(),
+    )
+}
+
+/// What Enter will run: a bundle's steps, or the `open` verb that acts on a
+/// row the block produced. Either way the panel shows the real commands.
+/// The selected row as a user's command sees it.
+///
+/// `{id}` is the row's OWN id, never the namespaced candidate id: a script
+/// asking for a branch expects `main`, and handing it `src:branches:main` makes
+/// git read the whole thing as `rev:path`.
+fn row_context(
+    row_id: *const c_char,
+    row_title: *const c_char,
+    row_path: *const c_char,
+    query: &str,
+) -> RowContext {
+    let candidate_id = cstr_to_string(row_id);
+    RowContext {
+        id: CandidateIdKind::source_row_id_of(&candidate_id).to_string(),
+        title: cstr_to_string(row_title),
+        path: cstr_to_string(row_path),
+        query: query.to_string(),
+    }
+}
+
 fn steps_of(block: &Block) -> Vec<String> {
     match &block.producer {
         Producer::Bundle { steps } => steps.clone(),
-        _ => Vec::new(),
+        _ => block.verbs.open.iter().cloned().collect(),
     }
 }
 

--- a/bridge/ffi/src/sources_api.rs
+++ b/bridge/ffi/src/sources_api.rs
@@ -199,6 +199,7 @@ pub(crate) fn look_refresh_run_blocks_json_impl() -> *mut c_char {
         else {
             continue;
         };
+
         if !block.enabled {
             look_engine::index::clear_run_rows(&block.id);
             continue;

--- a/bridge/ffi/src/sources_api.rs
+++ b/bridge/ffi/src/sources_api.rs
@@ -306,6 +306,19 @@ fn find_block(block_id: &str) -> Option<Block> {
         .find(|block| block.id == block_id)
 }
 
+/// The config file this build reads and writes, migrating a legacy
+/// `~/.look.config` into `~/.look/` the first time.
+///
+/// The shell asks Rust rather than deciding for itself, so the two can never
+/// resolve differently and end up reading one file while saving to another.
+pub(crate) fn look_config_path_impl(dev: bool) -> *mut c_char {
+    let Some(home) = home_dir() else {
+        return json_cstring_or_null(None);
+    };
+    let resolved = look_engine::config_path::resolve_home_variant(&home, dev);
+    json_cstring_or_null(Some(resolved.path.to_string_lossy().into_owned()))
+}
+
 fn home_dir() -> Option<PathBuf> {
     std::env::var("HOME")
         .or_else(|_| std::env::var("USERPROFILE"))

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -126,6 +126,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +260,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +345,7 @@ dependencies = [
  "look-indexing",
  "look-matching",
  "look-ranking",
+ "look-sources",
  "look-storage",
  "objc2",
  "objc2-foundation",
@@ -380,6 +397,15 @@ name = "look-ranking"
 version = "0.1.0"
 dependencies = [
  "look-indexing",
+]
+
+[[package]]
+name = "look-sources"
+version = "0.1.0"
+dependencies = [
+ "globset",
+ "serde",
+ "toml",
 ]
 
 [[package]]
@@ -602,6 +628,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,6 +722,45 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "unicode-ident"
@@ -891,6 +965,18 @@ checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "zmij"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "matching",
   "netspeed",
   "ranking",
+  "sources",
   "storage",
   "todo",
 ]

--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -10,6 +10,7 @@ version = "0.1.0"
 look-indexing = { path = "../indexing" }
 look-matching = { path = "../matching" }
 look-ranking = { path = "../ranking" }
+look-sources = { path = "../sources" }
 look-storage = { path = "../storage" }
 ignore = "0.4"
 regex = "1"

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -608,7 +608,7 @@ fn default_file_scan_roots() -> Vec<String> {
 }
 
 #[cfg(target_os = "windows")]
-fn user_home_dir() -> Option<String> {
+pub(crate) fn user_home_dir() -> Option<String> {
     env::var("USERPROFILE")
         .ok()
         .filter(|value| !value.trim().is_empty())
@@ -620,7 +620,7 @@ fn user_home_dir() -> Option<String> {
 }
 
 #[cfg(not(target_os = "windows"))]
-fn user_home_dir() -> Option<String> {
+pub(crate) fn user_home_dir() -> Option<String> {
     env::var("HOME")
         .ok()
         .filter(|value| !value.trim().is_empty())

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -33,6 +33,12 @@ pub const SCORE_REGEX_SUBTITLE_ONLY: i64 = 1000;
 pub const BIAS_APP: i64 = 220;
 pub const BIAS_FOLDER: i64 = 0;
 pub const BIAS_FILE: i64 = -20;
+/// A user declared this row by hand and named it, so a match on that name is
+/// deliberate in a way a file path match is not. Sits with apps, not below them.
+pub const BIAS_ACTION: i64 = 200;
+/// On an empty query the launchpad already covers routines, so bundles sit
+/// between apps and folders rather than leading the browse list.
+pub const BROWSE_BOOST_ACTION: i64 = 300;
 
 pub const BIAS_SETTINGS_MATCH: i64 = 420;
 pub const BIAS_APP_ON_SETTINGS_QUERY: i64 = 120;

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -337,7 +337,7 @@ impl RuntimeConfig {
 /// Where the config lives, migrating a legacy `~/.look.config` into `~/.look/`
 /// the first time. One resolver for every caller: see `crate::config_path`.
 fn config_path() -> Option<PathBuf> {
-    user_home_dir().map(|home| crate::config_path::resolve(Path::new(&home)).path)
+    crate::config_path::current().map(|resolved| resolved.path)
 }
 
 fn ensure_default_config_file(path: &Path) {

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -334,15 +334,10 @@ impl RuntimeConfig {
     }
 }
 
+/// Where the config lives, migrating a legacy `~/.look.config` into `~/.look/`
+/// the first time. One resolver for every caller: see `crate::config_path`.
 fn config_path() -> Option<PathBuf> {
-    if let Ok(custom) = env::var("LOOK_CONFIG_PATH") {
-        let trimmed = custom.trim();
-        if !trimmed.is_empty() {
-            return Some(PathBuf::from(trimmed));
-        }
-    }
-
-    user_home_dir().map(|home| PathBuf::from(home).join(".look.config"))
+    user_home_dir().map(|home| crate::config_path::resolve(Path::new(&home)).path)
 }
 
 fn ensure_default_config_file(path: &Path) {

--- a/core/engine/src/config_path.rs
+++ b/core/engine/src/config_path.rs
@@ -34,19 +34,49 @@ pub struct ResolvedConfig {
     pub migrated: bool,
 }
 
+/// The home Look resolves its paths against, for callers needing one for
+/// something other than the config. Same answer as `current`.
+pub fn home() -> Option<String> {
+    crate::config::user_home_dir()
+}
+
+/// The config file for the user running this process, home directory and all.
+///
+/// Deriving the home is where implementations drift apart: `$HOME` and
+/// `$USERPROFILE` can name different directories on Windows, so callers
+/// ordering them differently resolve different files. `None` means no home and
+/// no override.
+pub fn current() -> Option<ResolvedConfig> {
+    if let Some(path) = overridden() {
+        return Some(ResolvedConfig {
+            path,
+            migrated: false,
+        });
+    }
+    crate::config::user_home_dir().map(|home| resolve_home(Path::new(&home)))
+}
+
 /// The config file to read and write. `$LOOK_CONFIG_PATH` overrides everything;
 /// otherwise this is `resolve_home`.
 pub fn resolve(home: &Path) -> ResolvedConfig {
-    if let Ok(custom) = std::env::var(ENV_CONFIG_PATH) {
-        let trimmed = custom.trim();
-        if !trimmed.is_empty() {
-            return ResolvedConfig {
-                path: PathBuf::from(trimmed),
-                migrated: false,
-            };
-        }
+    match overridden() {
+        Some(path) => ResolvedConfig {
+            path,
+            migrated: false,
+        },
+        None => resolve_home(home),
     }
-    resolve_home(home)
+}
+
+/// `$LOOK_CONFIG_PATH`, when it names anything. Set but empty would resolve to
+/// wherever the app was launched from.
+fn overridden() -> Option<PathBuf> {
+    let custom = std::env::var(ENV_CONFIG_PATH).ok()?;
+    let trimmed = custom.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(trimmed))
 }
 
 /// Resolution against a home directory, ignoring the environment. Split out so

--- a/core/engine/src/config_path.rs
+++ b/core/engine/src/config_path.rs
@@ -65,7 +65,7 @@ pub fn resolve_home(home: &Path) -> ResolvedConfig {
 pub fn resolve_home_variant(home: &Path, dev: bool) -> ResolvedConfig {
     if dev {
         return ResolvedConfig {
-            path: home.join(CONFIG_DIR).join(DEV_CONFIG_NAME),
+            path: ensured(home.join(CONFIG_DIR).join(DEV_CONFIG_NAME)),
             migrated: false,
         };
     }
@@ -80,8 +80,12 @@ pub fn resolve_home_variant(home: &Path, dev: bool) -> ResolvedConfig {
 
     let legacy = home.join(LEGACY_CONFIG_NAME);
     if !legacy.exists() {
+        // A fresh install: nothing to migrate, and `~/.look/` may not exist
+        // yet. Every caller here goes on to WRITE this path, so the directory
+        // has to be there or the default config is silently never created and
+        // settings never persist.
         return ResolvedConfig {
-            path: current,
+            path: ensured(current),
             migrated: false,
         };
     }
@@ -108,6 +112,15 @@ pub fn resolve_home_variant(home: &Path, dev: bool) -> ResolvedConfig {
             migrated: false,
         },
     }
+}
+
+/// Makes sure the returned path is writable by creating its parent. Failure is
+/// left to the caller's own write, which reports it in context.
+fn ensured(path: PathBuf) -> PathBuf {
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    path
 }
 
 /// Copies the legacy file across and marks it, leaving the original in place so
@@ -162,11 +175,23 @@ mod tests {
     }
 
     #[test]
-    fn a_new_install_gets_the_folder_path() {
+    fn a_new_install_gets_a_folder_path_it_can_actually_write() {
+        // Every caller writes the resolved path. Without the directory the
+        // default config is never created, and the user's settings silently
+        // fail to persist on every launch.
         let home = TempHome::new("fresh");
         let resolved = resolve_home(&home.0);
         assert_eq!(resolved.path, home.current());
         assert!(!resolved.migrated);
+        assert!(resolved.path.parent().is_some_and(Path::exists));
+        fs::write(&resolved.path, "ui_theme=x\n").expect("the path must be writable");
+    }
+
+    #[test]
+    fn a_dev_path_is_writable_too() {
+        let home = TempHome::new("devwrite");
+        let resolved = resolve_home_variant(&home.0, true);
+        fs::write(&resolved.path, "ui_theme=x\n").expect("the path must be writable");
     }
 
     #[test]

--- a/core/engine/src/config_path.rs
+++ b/core/engine/src/config_path.rs
@@ -1,0 +1,253 @@
+//! Where the config file lives, and the one-time move into `~/.look/`.
+//!
+//! Look reads AND writes this file (the app upserts the `ui_*` keys), so every
+//! caller must agree on the answer. Three implementations resolve it today (this
+//! one, the macOS `ThemeStore`, and the linows config module), and if they ever
+//! disagree the app reads one file and saves to another, which looks like
+//! settings silently not persisting. That is the failure mode this module
+//! exists to prevent: resolve once, hand back the path, read and write there.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Overrides everything, for tests and for people who keep dotfiles elsewhere.
+pub const ENV_CONFIG_PATH: &str = "LOOK_CONFIG_PATH";
+
+/// The home-relative locations, newest first. A dev build keeps its own pair so
+/// running Look Dev never edits the settings of the installed copy.
+const CONFIG_DIR: &str = ".look";
+const CONFIG_NAME: &str = "config";
+const DEV_CONFIG_NAME: &str = "config.dev";
+const LEGACY_CONFIG_NAME: &str = ".look.config";
+
+/// Prepended to the legacy file once its contents have been copied across, so
+/// someone who edits it out of habit is told why nothing happened. Doubles as
+/// the "already moved" flag: a deliberate delete of the new file must not be
+/// silently undone by copying the old one back.
+const MOVED_NOTICE_PREFIX: &str = "# Moved to ~/.look/";
+
+/// What resolution found, so a caller can report it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedConfig {
+    pub path: PathBuf,
+    /// True when the legacy file was copied into `~/.look/` by this call.
+    pub migrated: bool,
+}
+
+/// The config file to read and write. `$LOOK_CONFIG_PATH` overrides everything;
+/// otherwise this is `resolve_home`.
+pub fn resolve(home: &Path) -> ResolvedConfig {
+    if let Ok(custom) = std::env::var(ENV_CONFIG_PATH) {
+        let trimmed = custom.trim();
+        if !trimmed.is_empty() {
+            return ResolvedConfig {
+                path: PathBuf::from(trimmed),
+                migrated: false,
+            };
+        }
+    }
+    resolve_home(home)
+}
+
+/// Resolution against a home directory, ignoring the environment. Split out so
+/// the move can be tested without an ambient `$LOOK_CONFIG_PATH` deciding the
+/// answer for every case.
+pub fn resolve_home(home: &Path) -> ResolvedConfig {
+    resolve_home_variant(home, false)
+}
+
+/// `dev` selects the file a development build uses, so running it never edits
+/// the installed copy's settings.
+///
+/// The dev file is never migrated: it belongs to whoever is working on Look and
+/// is created by hand, so a released build has nothing to move and no business
+/// touching it.
+pub fn resolve_home_variant(home: &Path, dev: bool) -> ResolvedConfig {
+    if dev {
+        return ResolvedConfig {
+            path: home.join(CONFIG_DIR).join(DEV_CONFIG_NAME),
+            migrated: false,
+        };
+    }
+
+    let current = home.join(CONFIG_DIR).join(CONFIG_NAME);
+    if current.exists() {
+        return ResolvedConfig {
+            path: current,
+            migrated: false,
+        };
+    }
+
+    let legacy = home.join(LEGACY_CONFIG_NAME);
+    if !legacy.exists() {
+        return ResolvedConfig {
+            path: current,
+            migrated: false,
+        };
+    }
+
+    // A symlinked config is someone's dotfile repo. Copying would turn it into
+    // a plain file and their repo edits would stop applying, so it is read
+    // where it lies and never moved.
+    if fs::symlink_metadata(&legacy).is_ok_and(|meta| meta.file_type().is_symlink()) {
+        return ResolvedConfig {
+            path: legacy,
+            migrated: false,
+        };
+    }
+
+    match migrate(&legacy, &current, CONFIG_NAME) {
+        Ok(()) => ResolvedConfig {
+            path: current,
+            migrated: true,
+        },
+        // A failed copy must not lose the user's settings: keep reading the
+        // file that definitely has them.
+        Err(_) => ResolvedConfig {
+            path: legacy,
+            migrated: false,
+        },
+    }
+}
+
+/// Copies the legacy file across and marks it, leaving the original in place so
+/// nothing is destroyed and a downgrade still finds its settings.
+fn migrate(legacy: &Path, current: &Path, name: &str) -> std::io::Result<()> {
+    let contents = fs::read_to_string(legacy)?;
+    if contents.starts_with(MOVED_NOTICE_PREFIX) {
+        // Already moved once, and the new file has since been deleted. Honour
+        // that rather than copying the stale contents back.
+        return Err(std::io::Error::other("already migrated"));
+    }
+
+    if let Some(parent) = current.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(current, &contents)?;
+    let notice = format!("{MOVED_NOTICE_PREFIX}{name} - Look no longer reads this file.");
+    fs::write(legacy, format!("{notice}\n\n{contents}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TempHome(PathBuf);
+
+    impl TempHome {
+        fn new(label: &str) -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "look-config-path-{label}-{}-{:?}",
+                std::process::id(),
+                std::thread::current().id()
+            ));
+            let _ = fs::remove_dir_all(&path);
+            fs::create_dir_all(&path).expect("temp home");
+            Self(path)
+        }
+
+        fn legacy(&self) -> PathBuf {
+            self.0.join(LEGACY_CONFIG_NAME)
+        }
+
+        fn current(&self) -> PathBuf {
+            self.0.join(CONFIG_DIR).join(CONFIG_NAME)
+        }
+    }
+
+    impl Drop for TempHome {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn a_new_install_gets_the_folder_path() {
+        let home = TempHome::new("fresh");
+        let resolved = resolve_home(&home.0);
+        assert_eq!(resolved.path, home.current());
+        assert!(!resolved.migrated);
+    }
+
+    #[test]
+    fn an_existing_user_is_moved_once_and_keeps_their_settings() {
+        let home = TempHome::new("migrate");
+        fs::write(home.legacy(), "ui_theme=dracula\n").expect("legacy");
+
+        let resolved = resolve_home(&home.0);
+        assert_eq!(resolved.path, home.current());
+        assert!(resolved.migrated);
+        assert_eq!(
+            fs::read_to_string(home.current()).unwrap(),
+            "ui_theme=dracula\n"
+        );
+
+        // The original survives, so a downgrade still finds its settings, and
+        // it says why editing it no longer does anything.
+        let legacy = fs::read_to_string(home.legacy()).unwrap();
+        assert!(legacy.starts_with(MOVED_NOTICE_PREFIX));
+        assert!(legacy.contains("ui_theme=dracula"));
+    }
+
+    #[test]
+    fn the_folder_file_wins_once_it_exists() {
+        let home = TempHome::new("prefer");
+        fs::create_dir_all(home.current().parent().unwrap()).unwrap();
+        fs::write(home.current(), "ui_theme=new\n").unwrap();
+        fs::write(home.legacy(), "ui_theme=old\n").unwrap();
+
+        let resolved = resolve_home(&home.0);
+        assert_eq!(resolved.path, home.current());
+        assert!(!resolved.migrated);
+        // The legacy file is left exactly as it was: nothing to migrate.
+        assert_eq!(fs::read_to_string(home.legacy()).unwrap(), "ui_theme=old\n");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_config_is_read_where_it_lies() {
+        // Copying would turn a dotfile-repo symlink into a plain file and
+        // silently stop the user's repo edits from applying.
+        let home = TempHome::new("symlink");
+        let real = home.0.join("dotfiles-look.config");
+        fs::write(&real, "ui_theme=linked\n").unwrap();
+        std::os::unix::fs::symlink(&real, home.legacy()).unwrap();
+
+        let resolved = resolve_home(&home.0);
+        assert_eq!(resolved.path, home.legacy());
+        assert!(!resolved.migrated);
+        assert!(!home.current().exists(), "nothing was copied");
+    }
+
+    #[test]
+    fn a_dev_build_has_its_own_file_and_never_migrates() {
+        // The dev file is a developer's own copy, placed by hand. A released
+        // build has nothing to move and must not touch the installed settings.
+        let home = TempHome::new("dev");
+        fs::write(home.legacy(), "ui_theme=installed\n").unwrap();
+
+        let resolved = resolve_home_variant(&home.0, true);
+        assert_eq!(resolved.path, home.0.join(CONFIG_DIR).join(DEV_CONFIG_NAME));
+        assert!(!resolved.migrated);
+        assert_eq!(
+            fs::read_to_string(home.legacy()).unwrap(),
+            "ui_theme=installed\n",
+            "the installed config is left alone"
+        );
+    }
+
+    #[test]
+    fn a_deleted_new_file_is_not_silently_recreated_from_the_old_one() {
+        let home = TempHome::new("deleted");
+        fs::write(home.legacy(), "ui_theme=dracula\n").unwrap();
+
+        assert!(resolve_home(&home.0).migrated);
+        fs::remove_file(home.current()).unwrap();
+
+        // The marker says the move already happened, so the stale contents do
+        // not come back.
+        let again = resolve_home(&home.0);
+        assert_eq!(again.path, home.legacy());
+        assert!(!again.migrated);
+    }
+}

--- a/core/engine/src/config_path.rs
+++ b/core/engine/src/config_path.rs
@@ -8,6 +8,7 @@
 //! exists to prevent: resolve once, hand back the path, read and write there.
 
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 /// Overrides everything, for tests and for people who keep dotfiles elsewhere.
@@ -69,14 +70,15 @@ pub fn resolve(home: &Path) -> ResolvedConfig {
 }
 
 /// `$LOOK_CONFIG_PATH`, when it names anything. Set but empty would resolve to
-/// wherever the app was launched from.
+/// wherever the app was launched from. Ensured like every other answer: an
+/// override into a folder that does not exist yet is a path Look cannot write.
 fn overridden() -> Option<PathBuf> {
     let custom = std::env::var(ENV_CONFIG_PATH).ok()?;
     let trimmed = custom.trim();
     if trimmed.is_empty() {
         return None;
     }
-    Some(PathBuf::from(trimmed))
+    Some(ensured(PathBuf::from(trimmed)))
 }
 
 /// Resolution against a home directory, ignoring the environment. Split out so
@@ -135,13 +137,27 @@ pub fn resolve_home_variant(home: &Path, dev: bool) -> ResolvedConfig {
             path: current,
             migrated: true,
         },
-        // A failed copy must not lose the user's settings: keep reading the
-        // file that definitely has them.
-        Err(_) => ResolvedConfig {
+        // Another process copied it while this one was resolving. Its file is
+        // the one to read, the same as if it had been there all along.
+        Err(NotMigrated::AlreadyThere) => ResolvedConfig {
+            path: current,
+            migrated: false,
+        },
+        // Moved once already, or the copy failed. Both files are kept and the
+        // folder one wins, so with none there the old file is what there is.
+        Err(NotMigrated::KeepLegacy) => ResolvedConfig {
             path: legacy,
             migrated: false,
         },
     }
+}
+
+/// Why a legacy file was not copied across.
+enum NotMigrated {
+    /// A concurrent resolve got there first.
+    AlreadyThere,
+    /// Moved once before, or the copy itself failed.
+    KeepLegacy,
 }
 
 /// Makes sure the returned path is writable by creating its parent. Failure is
@@ -155,20 +171,30 @@ fn ensured(path: PathBuf) -> PathBuf {
 
 /// Copies the legacy file across and marks it, leaving the original in place so
 /// nothing is destroyed and a downgrade still finds its settings.
-fn migrate(legacy: &Path, current: &Path, name: &str) -> std::io::Result<()> {
-    let contents = fs::read_to_string(legacy)?;
+fn migrate(legacy: &Path, current: &Path, name: &str) -> Result<(), NotMigrated> {
+    let contents = fs::read_to_string(legacy).map_err(|_| NotMigrated::KeepLegacy)?;
     if contents.starts_with(MOVED_NOTICE_PREFIX) {
-        // Already moved once, and the new file has since been deleted. Honour
-        // that rather than copying the stale contents back.
-        return Err(std::io::Error::other("already migrated"));
+        return Err(NotMigrated::KeepLegacy);
     }
 
     if let Some(parent) = current.parent() {
-        fs::create_dir_all(parent)?;
+        fs::create_dir_all(parent).map_err(|_| NotMigrated::KeepLegacy)?;
     }
-    fs::write(current, &contents)?;
+    // Create-new rather than write: two Look processes can resolve at the same
+    // moment, and the loser must not land a half-read copy on top of the
+    // winner's whole one.
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(current)
+        .map_err(|err| match err.kind() {
+            std::io::ErrorKind::AlreadyExists => NotMigrated::AlreadyThere,
+            _ => NotMigrated::KeepLegacy,
+        })?;
+    file.write_all(contents.as_bytes())
+        .map_err(|_| NotMigrated::KeepLegacy)?;
     let notice = format!("{MOVED_NOTICE_PREFIX}{name} - Look no longer reads this file.");
-    fs::write(legacy, format!("{notice}\n\n{contents}"))
+    fs::write(legacy, format!("{notice}\n\n{contents}")).map_err(|_| NotMigrated::KeepLegacy)
 }
 
 #[cfg(test)]
@@ -292,6 +318,25 @@ mod tests {
     }
 
     #[test]
+    fn a_second_process_mid_move_does_not_overwrite_the_first_ones_copy() {
+        // Both resolve before either writes: the loser reads a legacy file the
+        // winner is busy rewriting, so its copy must not be the one that lands.
+        let home = TempHome::new("racing");
+        fs::write(home.legacy(), "ui_theme=dracula\n").unwrap();
+        fs::create_dir_all(home.current().parent().unwrap()).unwrap();
+        fs::write(home.current(), "ui_theme=whole\n").unwrap();
+
+        assert!(matches!(
+            migrate(&home.legacy(), &home.current(), CONFIG_NAME),
+            Err(NotMigrated::AlreadyThere)
+        ));
+        assert_eq!(
+            fs::read_to_string(home.current()).unwrap(),
+            "ui_theme=whole\n"
+        );
+    }
+
+    #[test]
     fn a_deleted_new_file_is_not_silently_recreated_from_the_old_one() {
         let home = TempHome::new("deleted");
         fs::write(home.legacy(), "ui_theme=dracula\n").unwrap();
@@ -299,10 +344,11 @@ mod tests {
         assert!(resolve_home(&home.0).migrated);
         fs::remove_file(home.current()).unwrap();
 
-        // The marker says the move already happened, so the stale contents do
-        // not come back.
+        // Both files are kept and the folder one wins. With it gone, the old
+        // file is read where it lies rather than copied across again.
         let again = resolve_home(&home.0);
         assert_eq!(again.path, home.legacy());
         assert!(!again.migrated);
+        assert!(!home.current().exists(), "nothing was copied back");
     }
 }

--- a/core/engine/src/index/mod.rs
+++ b/core/engine/src/index/mod.rs
@@ -3,6 +3,7 @@ use crate::config::RuntimeConfig;
 mod apps;
 mod files;
 mod settings;
+mod sources;
 
 use look_indexing::{Candidate, CandidateIdKind};
 use std::collections::HashSet;
@@ -50,6 +51,9 @@ pub fn discover_candidates_stream_scoped(
         }
         if scope.settings {
             settings::discover_system_settings_entries(config.localized_app_names, tx.clone());
+        }
+        if scope.sources {
+            sources::discover_user_sources(tx.clone());
         }
         drop(tx);
 

--- a/core/engine/src/index/mod.rs
+++ b/core/engine/src/index/mod.rs
@@ -2,8 +2,12 @@ use crate::BootstrapScope;
 use crate::config::RuntimeConfig;
 mod apps;
 mod files;
+mod run_cache;
 mod settings;
 mod sources;
+
+pub use run_cache::{clear as clear_run_rows, write as store_run_rows};
+pub use sources::declared_blocks;
 
 use look_indexing::{Candidate, CandidateIdKind};
 use std::collections::HashSet;

--- a/core/engine/src/index/run_cache.rs
+++ b/core/engine/src/index/run_cache.rs
@@ -1,0 +1,93 @@
+//! Rows a `run` block last produced.
+//!
+//! Running a user's command is the shell's job: it owns a process seam, and
+//! spawning arbitrary commands on the indexing thread would let one slow script
+//! stall the whole walk. So the shell runs the block, hands the rows here, and
+//! the next index pass reads them back.
+//!
+//! The cache is what makes a failed refresh harmless. A command that errors,
+//! times out, or returns nothing leaves the last good rows in place, because
+//! losing them would also delete the usage history keyed to their ids.
+
+use std::fs;
+use std::path::PathBuf;
+
+use look_sources::{SourceRow, parse_lines};
+
+/// Where a block's rows are kept between refreshes.
+const CACHE_DIR_NAME: &str = ".look/cache/rows";
+
+/// Same ceiling the collectors use, applied again on read: a cache file edited
+/// or corrupted outside Look must not be able to flood the index.
+const MAX_CACHED_ROWS: usize = look_sources::MAX_ROWS_PER_SOURCE;
+
+fn cache_path(block_id: &str) -> Option<PathBuf> {
+    // A block id is a TOML table header, so it can contain path separators. Any
+    // id that could escape the cache directory is refused rather than sanitized,
+    // since a silently renamed file would lose the rows it was meant to keep.
+    if block_id.is_empty() || block_id.contains(['/', '\\']) || block_id.contains("..") {
+        return None;
+    }
+    let home = crate::config::user_home_dir()?;
+    Some(PathBuf::from(home).join(CACHE_DIR_NAME).join(block_id))
+}
+
+/// The rows `block_id` last produced, or empty when it has never run.
+pub(super) fn read(block_id: &str) -> Vec<SourceRow> {
+    let Some(path) = cache_path(block_id) else {
+        return Vec::new();
+    };
+    let Ok(contents) = fs::read(&path) else {
+        return Vec::new();
+    };
+    let (rows, _) = parse_lines(&String::from_utf8_lossy(&contents), MAX_CACHED_ROWS);
+    rows
+}
+
+/// Replaces `block_id`'s rows with `output` (a command's raw stdout).
+///
+/// Empty output is refused: a command that returns nothing is far more often
+/// broken (network down, tool missing, wrong directory) than genuinely empty,
+/// and keeping the last good rows costs nothing while clearing them loses the
+/// user's ranking.
+pub fn write(block_id: &str, output: &str) -> Result<usize, String> {
+    let (rows, _) = parse_lines(output, MAX_CACHED_ROWS);
+    if rows.is_empty() {
+        return Err("produced no rows; keeping the previous ones".into());
+    }
+    let Some(path) = cache_path(block_id) else {
+        return Err(format!("[{block_id}] is not a usable cache name"));
+    };
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|err| err.to_string())?;
+    }
+    fs::write(&path, output).map_err(|err| err.to_string())?;
+    Ok(rows.len())
+}
+
+/// Drops a block's rows, for a block the user deleted or disabled.
+pub fn clear(block_id: &str) {
+    if let Some(path) = cache_path(block_id) {
+        let _ = fs::remove_file(path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_id_that_could_escape_the_cache_directory_is_refused() {
+        assert!(cache_path("../../etc/passwd").is_none());
+        assert!(cache_path("a/b").is_none());
+        assert!(cache_path("").is_none());
+    }
+
+    #[test]
+    fn empty_output_keeps_the_previous_rows() {
+        // A command returning nothing is usually broken, not empty, and the ids
+        // it produced carry the user's usage history.
+        assert!(write("probe", "").is_err());
+        assert!(write("probe", "   \n\n").is_err());
+    }
+}

--- a/core/engine/src/index/sources.rs
+++ b/core/engine/src/index/sources.rs
@@ -6,10 +6,9 @@
 //! refresh prunes its own rows and nothing else.
 //!
 //! A `dir` block's rows are real files and folders, so they keep the file kinds
-//! and everything those give (preview, reveal, open). A `do` bundle has no
-//! filesystem target at all: it is one `Action` row whose steps are performed.
-//! `file` and `run` blocks need a process or a reader the shell owns, so they
-//! are loaded here but not yet indexed.
+//! and everything those give (preview, reveal, open). A `do` bundle and the rows
+//! of a `file` or `run` block have no filesystem target, so they are `Action`
+//! rows: performed, never opened.
 
 use std::fs;
 use std::path::Path;
@@ -17,11 +16,23 @@ use std::sync::mpsc::SyncSender;
 use std::time::UNIX_EPOCH;
 
 use look_indexing::{Candidate, CandidateIdKind, CandidateKind};
-use look_sources::{Block, Producer, collect, load_dir, sources_dir};
+use look_sources::{Block, Producer, SourceRow, collect, load_dir, sources_dir};
+
+use crate::index::run_cache;
 
 /// Shown as the subtitle of a bundle row, so a row with no path still says what
 /// it is rather than borrowing a file's look.
 const BUNDLE_STEP_LABEL: &str = "step";
+
+/// Every declared block, for callers that need the declarations rather than the
+/// rows (scoring bias, search aliases). Problems are reported by the indexing
+/// pass, so this stays quiet.
+pub fn declared_blocks() -> Vec<Block> {
+    let Some(home) = crate::config::user_home_dir() else {
+        return Vec::new();
+    };
+    load_dir(&sources_dir(Path::new(&home))).blocks
+}
 
 pub(super) fn discover_user_sources(tx: SyncSender<Candidate>) {
     let Some(home) = crate::config::user_home_dir() else {
@@ -50,8 +61,11 @@ pub(super) fn discover_user_sources(tx: SyncSender<Candidate>) {
                 let _ = tx.send(bundle_candidate(block, steps.len()));
             }
             Producer::Dir { .. } => emit_dir(block, home, &tx),
-            // Rows from a file or a command still need the shell's reader.
-            Producer::File { .. } | Producer::Run { .. } => {}
+            Producer::File { .. } => emit_rows(block, home, &tx),
+            // A `run` block needs a process, and spawning one per index pass
+            // would put arbitrary user commands on the indexing thread. The
+            // shell runs it and hands the rows back (see `run_cache`).
+            Producer::Run { .. } => emit_cached_rows(block, &tx),
         }
     }
 }
@@ -95,6 +109,60 @@ fn emit_dir(block: &Block, home: &Path, tx: &SyncSender<Candidate>) {
             return;
         }
     }
+}
+
+/// Rows a `file` block read, or a `run` block's cached output: text, not
+/// filesystem entries, so each becomes an `Action` row whose id is what the
+/// block's verbs and `then` targets receive.
+fn emit_rows(block: &Block, home: &Path, tx: &SyncSender<Candidate>) {
+    let collected = match collect(block, home) {
+        Ok(collected) => collected,
+        Err(err) => {
+            eprintln!("look sources: [{}] produced no rows: {err}", block.id);
+            return;
+        }
+    };
+    if collected.truncated {
+        eprintln!(
+            "look sources: [{}] hit the row cap; some rows are not indexed",
+            block.id
+        );
+    }
+    send_rows(block, &collected.rows, tx);
+}
+
+/// A `run` block's rows come from the last refresh the shell performed. No cache
+/// means the block has not been run yet, which is silent: a first launcher open
+/// should not look like a broken source.
+fn emit_cached_rows(block: &Block, tx: &SyncSender<Candidate>) {
+    let rows = run_cache::read(&block.id);
+    send_rows(block, &rows, tx);
+}
+
+fn send_rows(block: &Block, rows: &[SourceRow], tx: &SyncSender<Candidate>) {
+    for row in rows {
+        if tx.send(row_candidate(block, row)).is_err() {
+            return;
+        }
+    }
+}
+
+fn row_candidate(block: &Block, row: &SourceRow) -> Candidate {
+    let id = format!(
+        "{}{}",
+        CandidateIdKind::source_row_prefix(&block.id),
+        row.id
+    );
+    let mut candidate = Candidate::new(
+        &id,
+        CandidateKind::Action,
+        &row.title,
+        row.path.as_deref().unwrap_or_default(),
+    );
+    // The group when the row named one, else the block: either way the row says
+    // where it came from, and typing that word lists the block.
+    candidate.subtitle = Some(row.group.as_deref().unwrap_or(block.name.as_str()).into());
+    candidate
 }
 
 fn dir_candidate(block: &Block, row_id: &str, title: &str, path: &str) -> Candidate {

--- a/core/engine/src/index/sources.rs
+++ b/core/engine/src/index/sources.rs
@@ -1,0 +1,164 @@
+//! Candidates from user-declared sources.
+//!
+//! A source's rows are ordinary candidates, which is the whole point: they rank
+//! against apps and files on one scale, carry usage history, and render with the
+//! rows the launcher already has. Only the id namespace differs (`src:`), so a
+//! source refresh prunes its own rows and nothing else.
+//!
+//! Folder sources are answered here. List and command sources are loaded but not
+//! indexed yet: their rows have no filesystem target, so they need a candidate
+//! kind of their own before a shell can render or open one.
+
+use std::fs;
+use std::path::Path;
+use std::sync::mpsc::SyncSender;
+use std::time::UNIX_EPOCH;
+
+use look_indexing::{Candidate, CandidateIdKind, CandidateKind};
+use look_sources::{SourceDef, SourceSpec, collect, load_dir, sources_dir};
+
+pub(super) fn discover_user_sources(tx: SyncSender<Candidate>) {
+    let Some(home) = crate::config::user_home_dir() else {
+        return;
+    };
+    let home = Path::new(&home);
+    let loaded = load_dir(&sources_dir(home));
+
+    for problem in &loaded.problems {
+        eprintln!(
+            "look sources: {} skipped: {}",
+            problem.file.display(),
+            problem.message
+        );
+    }
+
+    for def in &loaded.sources {
+        if !def.enabled || !matches!(def.spec, SourceSpec::Folder { .. }) {
+            continue;
+        }
+        emit_source(def, home, &tx);
+    }
+}
+
+fn emit_source(def: &SourceDef, home: &Path, tx: &SyncSender<Candidate>) {
+    let collected = match collect(def, home) {
+        Ok(collected) => collected,
+        Err(err) => {
+            eprintln!("look sources: {} produced no rows: {err}", def.id);
+            return;
+        }
+    };
+    if collected.truncated {
+        eprintln!(
+            "look sources: {} hit the row cap; some rows are not indexed",
+            def.id
+        );
+    }
+
+    for row in collected.rows {
+        let Some(path) = row.path.as_deref() else {
+            continue;
+        };
+        if tx
+            .send(candidate_for(def, &row.id, &row.title, path))
+            .is_err()
+        {
+            return;
+        }
+    }
+}
+
+fn candidate_for(def: &SourceDef, row_id: &str, title: &str, path: &str) -> Candidate {
+    let metadata = fs::metadata(path).ok();
+    let kind = match metadata.as_ref() {
+        Some(meta) if meta.is_dir() => CandidateKind::Folder,
+        _ => CandidateKind::File,
+    };
+
+    let id = format!("{}{row_id}", CandidateIdKind::source_row_prefix(&def.id));
+    let mut candidate = Candidate::new(&id, kind, title, path);
+    // The source's name, not the generic kind word the file walker uses, so the
+    // row says where it came from.
+    candidate.subtitle = Some(def.name.as_str().into());
+    candidate.fs_modified_at_unix_s = metadata
+        .and_then(|meta| meta.modified().ok())
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .map(|since| since.as_secs() as i64);
+    candidate
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use look_sources::parse;
+    use std::sync::mpsc::sync_channel;
+
+    struct TempDir(std::path::PathBuf);
+
+    impl TempDir {
+        fn new(label: &str) -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "look-index-sources-{label}-{}-{:?}",
+                std::process::id(),
+                std::thread::current().id()
+            ));
+            let _ = fs::remove_dir_all(&path);
+            fs::create_dir_all(&path).expect("temp dir");
+            Self(path)
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn folder_rows_become_candidates_in_the_source_namespace() {
+        let tmp = TempDir::new("emit");
+        fs::create_dir_all(tmp.0.join("look")).expect("project dir");
+        fs::write(tmp.0.join("notes.md"), "x").expect("file");
+
+        let def = parse(
+            "projects",
+            &format!(
+                "root = {:?}\nname = \"Projects\"\n",
+                tmp.0.to_str().unwrap()
+            ),
+            None,
+        )
+        .expect("valid source");
+
+        let (tx, rx) = sync_channel(16);
+        emit_source(&def, Path::new("/nonexistent"), &tx);
+        drop(tx);
+        let emitted: Vec<Candidate> = rx.into_iter().collect();
+
+        assert_eq!(emitted.len(), 2);
+        let project = emitted
+            .iter()
+            .find(|candidate| candidate.title.as_ref() == "look")
+            .expect("the project row");
+        assert!(project.id.starts_with("src:projects:"));
+        assert_eq!(CandidateIdKind::source_id_of(&project.id), Some("projects"));
+        assert_eq!(project.kind, CandidateKind::Folder);
+        assert_eq!(project.subtitle.as_deref(), Some("Projects"));
+
+        let note = emitted
+            .iter()
+            .find(|candidate| candidate.title.as_ref() == "notes.md")
+            .expect("the file row");
+        assert_eq!(note.kind, CandidateKind::File);
+        assert!(note.fs_modified_at_unix_s.is_some());
+    }
+
+    #[test]
+    fn a_source_that_cannot_be_read_emits_nothing_rather_than_failing_the_walk() {
+        let def = parse("gone", "root = \"/definitely/not/here\"\n", None).expect("valid source");
+        let (tx, rx) = sync_channel(4);
+        emit_source(&def, Path::new("/nonexistent"), &tx);
+        drop(tx);
+        assert_eq!(rx.into_iter().count(), 0);
+    }
+}

--- a/core/engine/src/index/sources.rs
+++ b/core/engine/src/index/sources.rs
@@ -1,13 +1,15 @@
-//! Candidates from user-declared sources.
+//! Candidates from user-declared blocks.
 //!
-//! A source's rows are ordinary candidates, which is the whole point: they rank
+//! Their rows are ordinary candidates, which is the whole point: they rank
 //! against apps and files on one scale, carry usage history, and render with the
 //! rows the launcher already has. Only the id namespace differs (`src:`), so a
-//! source refresh prunes its own rows and nothing else.
+//! refresh prunes its own rows and nothing else.
 //!
-//! Folder sources are answered here. List and command sources are loaded but not
-//! indexed yet: their rows have no filesystem target, so they need a candidate
-//! kind of their own before a shell can render or open one.
+//! A `dir` block's rows are real files and folders, so they keep the file kinds
+//! and everything those give (preview, reveal, open). A `do` bundle has no
+//! filesystem target at all: it is one `Action` row whose steps are performed.
+//! `file` and `run` blocks need a process or a reader the shell owns, so they
+//! are loaded here but not yet indexed.
 
 use std::fs;
 use std::path::Path;
@@ -15,7 +17,11 @@ use std::sync::mpsc::SyncSender;
 use std::time::UNIX_EPOCH;
 
 use look_indexing::{Candidate, CandidateIdKind, CandidateKind};
-use look_sources::{SourceDef, SourceSpec, collect, load_dir, sources_dir};
+use look_sources::{Block, Producer, collect, load_dir, sources_dir};
+
+/// Shown as the subtitle of a bundle row, so a row with no path still says what
+/// it is rather than borrowing a file's look.
+const BUNDLE_STEP_LABEL: &str = "step";
 
 pub(super) fn discover_user_sources(tx: SyncSender<Candidate>) {
     let Some(home) = crate::config::user_home_dir() else {
@@ -32,27 +38,47 @@ pub(super) fn discover_user_sources(tx: SyncSender<Candidate>) {
         );
     }
 
-    for def in &loaded.sources {
-        if !def.enabled || !matches!(def.spec, SourceSpec::Folder { .. }) {
+    for block in &loaded.blocks {
+        if !block.enabled {
             continue;
         }
-        emit_source(def, home, &tx);
+        match &block.producer {
+            Producer::Bundle { steps } => {
+                let _ = tx.send(bundle_candidate(block, steps.len()));
+            }
+            Producer::Dir { .. } => emit_dir(block, home, &tx),
+            // Rows from a file or a command still need the shell's reader.
+            Producer::File { .. } | Producer::Run { .. } => {}
+        }
     }
 }
 
-fn emit_source(def: &SourceDef, home: &Path, tx: &SyncSender<Candidate>) {
-    let collected = match collect(def, home) {
+/// A bundle is one row, and Enter performs its steps. The step count is the
+/// honest subtitle: it says this will do several things before you press it.
+fn bundle_candidate(block: &Block, steps: usize) -> Candidate {
+    let id = format!("{}{}", CandidateIdKind::source_row_prefix(&block.id), "");
+    let mut candidate = Candidate::new(&id, CandidateKind::Action, &block.name, "");
+    let plural = if steps == 1 { "" } else { "s" };
+    candidate.subtitle = Some(format!("{steps} {BUNDLE_STEP_LABEL}{plural}").into());
+    candidate
+}
+
+fn emit_dir(block: &Block, home: &Path, tx: &SyncSender<Candidate>) {
+    let collected = match collect(block, home) {
         Ok(collected) => collected,
         Err(err) => {
-            eprintln!("look sources: {} produced no rows: {err}", def.id);
+            eprintln!("look sources: [{}] produced no rows: {err}", block.id);
             return;
         }
     };
     if collected.truncated {
         eprintln!(
-            "look sources: {} hit the row cap; some rows are not indexed",
-            def.id
+            "look sources: [{}] hit the row cap; some rows are not indexed",
+            block.id
         );
+    }
+    for root in &collected.unreadable {
+        eprintln!("look sources: [{}] could not read {root}", block.id);
     }
 
     for row in collected.rows {
@@ -60,7 +86,7 @@ fn emit_source(def: &SourceDef, home: &Path, tx: &SyncSender<Candidate>) {
             continue;
         };
         if tx
-            .send(candidate_for(def, &row.id, &row.title, path))
+            .send(dir_candidate(block, &row.id, &row.title, path))
             .is_err()
         {
             return;
@@ -68,18 +94,18 @@ fn emit_source(def: &SourceDef, home: &Path, tx: &SyncSender<Candidate>) {
     }
 }
 
-fn candidate_for(def: &SourceDef, row_id: &str, title: &str, path: &str) -> Candidate {
+fn dir_candidate(block: &Block, row_id: &str, title: &str, path: &str) -> Candidate {
     let metadata = fs::metadata(path).ok();
     let kind = match metadata.as_ref() {
         Some(meta) if meta.is_dir() => CandidateKind::Folder,
         _ => CandidateKind::File,
     };
 
-    let id = format!("{}{row_id}", CandidateIdKind::source_row_prefix(&def.id));
+    let id = format!("{}{row_id}", CandidateIdKind::source_row_prefix(&block.id));
     let mut candidate = Candidate::new(&id, kind, title, path);
-    // The source's name, not the generic kind word the file walker uses, so the
-    // row says where it came from.
-    candidate.subtitle = Some(def.name.as_str().into());
+    // The block's name, not the generic kind word the file walker uses, so the
+    // row says where it came from and typing that name lists the whole block.
+    candidate.subtitle = Some(block.name.as_str().into());
     candidate.fs_modified_at_unix_s = metadata
         .and_then(|meta| meta.modified().ok())
         .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
@@ -90,7 +116,7 @@ fn candidate_for(def: &SourceDef, row_id: &str, title: &str, path: &str) -> Cand
 #[cfg(test)]
 mod tests {
     use super::*;
-    use look_sources::parse;
+    use look_sources::parse_file;
     use std::sync::mpsc::sync_channel;
 
     struct TempDir(std::path::PathBuf);
@@ -114,24 +140,48 @@ mod tests {
         }
     }
 
+    fn block_of(contents: &str) -> Block {
+        let parsed = parse_file(contents).expect("valid file");
+        assert!(parsed.problems.is_empty(), "{:?}", parsed.problems);
+        parsed.blocks.into_iter().next().expect("one block")
+    }
+
     #[test]
-    fn folder_rows_become_candidates_in_the_source_namespace() {
+    fn a_bundle_is_one_action_row_with_no_path() {
+        let block = block_of(
+            "[work]\nname = \"Work setup\"\ndo = [\"open -a Slack\", \"open -a Ghostty\"]\n",
+        );
+        let candidate = bundle_candidate(&block, 2);
+
+        assert_eq!(candidate.kind, CandidateKind::Action);
+        assert_eq!(candidate.title.as_ref(), "Work setup");
+        assert_eq!(candidate.path.as_ref(), "");
+        assert_eq!(candidate.subtitle.as_deref(), Some("2 steps"));
+        assert_eq!(CandidateIdKind::source_id_of(&candidate.id), Some("work"));
+    }
+
+    #[test]
+    fn one_step_reads_as_one_step() {
+        let block = block_of("[w]\ndo = [\"open -a Slack\"]\n");
+        assert_eq!(
+            bundle_candidate(&block, 1).subtitle.as_deref(),
+            Some("1 step")
+        );
+    }
+
+    #[test]
+    fn dir_rows_stay_files_and_folders_so_preview_and_open_keep_working() {
         let tmp = TempDir::new("emit");
         fs::create_dir_all(tmp.0.join("look")).expect("project dir");
         fs::write(tmp.0.join("notes.md"), "x").expect("file");
 
-        let def = parse(
-            "projects",
-            &format!(
-                "root = {:?}\nname = \"Projects\"\n",
-                tmp.0.to_str().unwrap()
-            ),
-            None,
-        )
-        .expect("valid source");
+        let block = block_of(&format!(
+            "[projects]\nname = \"Projects\"\ndir = {:?}\n",
+            tmp.0.to_str().unwrap()
+        ));
 
         let (tx, rx) = sync_channel(16);
-        emit_source(&def, Path::new("/nonexistent"), &tx);
+        emit_dir(&block, Path::new("/nonexistent"), &tx);
         drop(tx);
         let emitted: Vec<Candidate> = rx.into_iter().collect();
 
@@ -140,10 +190,9 @@ mod tests {
             .iter()
             .find(|candidate| candidate.title.as_ref() == "look")
             .expect("the project row");
-        assert!(project.id.starts_with("src:projects:"));
-        assert_eq!(CandidateIdKind::source_id_of(&project.id), Some("projects"));
         assert_eq!(project.kind, CandidateKind::Folder);
         assert_eq!(project.subtitle.as_deref(), Some("Projects"));
+        assert_eq!(CandidateIdKind::source_id_of(&project.id), Some("projects"));
 
         let note = emitted
             .iter()
@@ -154,10 +203,10 @@ mod tests {
     }
 
     #[test]
-    fn a_source_that_cannot_be_read_emits_nothing_rather_than_failing_the_walk() {
-        let def = parse("gone", "root = \"/definitely/not/here\"\n", None).expect("valid source");
+    fn a_block_that_cannot_be_read_emits_nothing_rather_than_failing_the_walk() {
+        let block = block_of("[gone]\ndir = \"/definitely/not/here\"\n");
         let (tx, rx) = sync_channel(4);
-        emit_source(&def, Path::new("/nonexistent"), &tx);
+        emit_dir(&block, Path::new("/nonexistent"), &tx);
         drop(tx);
         assert_eq!(rx.into_iter().count(), 0);
     }

--- a/core/engine/src/index/sources.rs
+++ b/core/engine/src/index/sources.rs
@@ -39,7 +39,10 @@ pub(super) fn discover_user_sources(tx: SyncSender<Candidate>) {
     }
 
     for block in &loaded.blocks {
-        if !block.enabled {
+        // A block whose producer refers to a row (`make -C {path} deploy`) is
+        // only reachable through another block's `then`. Indexing it as a
+        // top-level row would offer to run it against nothing.
+        if !block.enabled || block.needs_row() {
             continue;
         }
         match &block.producer {

--- a/core/engine/src/lib.rs
+++ b/core/engine/src/lib.rs
@@ -111,7 +111,8 @@ impl QueryEngine {
                 }
             }
         }
-        let results = indices
+        let results = self
+            .drop_source_shadowed(indices)
             .into_iter()
             .map(|(idx, score)| {
                 LaunchResult::from((&self.candidates[idx as usize].candidate, score))
@@ -338,6 +339,7 @@ pub struct BootstrapScope {
     pub apps: bool,
     pub files: bool,
     pub settings: bool,
+    pub sources: bool,
 }
 
 impl BootstrapScope {
@@ -345,24 +347,33 @@ impl BootstrapScope {
         apps: true,
         files: true,
         settings: true,
+        sources: true,
     };
     pub const APPS_ONLY: Self = Self {
         apps: true,
         files: false,
         settings: false,
+        sources: false,
     };
     pub const FILES_ONLY: Self = Self {
         apps: false,
         files: true,
         settings: false,
+        sources: false,
+    };
+    pub const SOURCES_ONLY: Self = Self {
+        apps: false,
+        files: false,
+        settings: false,
+        sources: true,
     };
 
     pub fn is_all(&self) -> bool {
-        self.apps && self.files && self.settings
+        self.apps && self.files && self.settings && self.sources
     }
 
     pub fn is_empty(&self) -> bool {
-        !(self.apps || self.files || self.settings)
+        !(self.apps || self.files || self.settings || self.sources)
     }
 
     pub(crate) fn id_prefixes(&self) -> Vec<&'static str> {
@@ -377,6 +388,9 @@ impl BootstrapScope {
         }
         if self.settings {
             out.push(CandidateIdKind::PREFIX_SETTING);
+        }
+        if self.sources {
+            out.push(CandidateIdKind::PREFIX_SOURCE);
         }
         out
     }
@@ -580,7 +594,7 @@ mod tests {
         let s = BootstrapScope::ALL;
         assert!(s.is_all());
         assert!(!s.is_empty());
-        assert!(s.apps && s.files && s.settings);
+        assert!(s.apps && s.files && s.settings && s.sources);
     }
 
     #[test]
@@ -604,7 +618,7 @@ mod tests {
     }
 
     #[test]
-    fn bootstrap_scope_all_yields_all_four_prefixes() {
+    fn bootstrap_scope_all_yields_every_prefix() {
         let prefixes = BootstrapScope::ALL.id_prefixes();
         assert_eq!(
             prefixes,
@@ -613,7 +627,23 @@ mod tests {
                 CandidateIdKind::PREFIX_FILE,
                 CandidateIdKind::PREFIX_FOLDER,
                 CandidateIdKind::PREFIX_SETTING,
+                CandidateIdKind::PREFIX_SOURCE,
             ]
+        );
+    }
+
+    #[test]
+    fn bootstrap_scope_sources_only_sweeps_only_source_rows() {
+        // A source refresh must never prune an app, a file, or a setting, and a
+        // file refresh must never prune a source's rows.
+        assert_eq!(
+            BootstrapScope::SOURCES_ONLY.id_prefixes(),
+            vec![CandidateIdKind::PREFIX_SOURCE]
+        );
+        assert!(
+            !BootstrapScope::FILES_ONLY
+                .id_prefixes()
+                .contains(&CandidateIdKind::PREFIX_SOURCE)
         );
     }
 
@@ -623,6 +653,7 @@ mod tests {
             apps: false,
             files: false,
             settings: false,
+            sources: false,
         };
         assert!(s.is_empty());
         assert!(!s.is_all());

--- a/core/engine/src/lib.rs
+++ b/core/engine/src/lib.rs
@@ -67,6 +67,11 @@ struct IndexedCandidate {
 pub struct QueryEngine {
     candidates: Vec<IndexedCandidate>,
     search_aliases: HashMap<String, Vec<String>>,
+    /// Per-block score offset from a declared `bias`, keyed by block id. Kept
+    /// beside the candidates rather than on them: the bias belongs to the
+    /// declaration, so editing it must take effect without reindexing every row
+    /// the block produced.
+    source_biases: HashMap<String, i64>,
 }
 
 impl QueryEngine {
@@ -78,10 +83,44 @@ impl QueryEngine {
     pub fn new_with_config(candidates: Vec<Candidate>, config: &RuntimeConfig) -> Self {
         // Build an in-memory search index up front (hot path reads only).
         let candidates = candidates.into_iter().map(IndexedCandidate::new).collect();
+        let declared = index::declared_blocks();
+        let mut search_aliases = config.search_aliases.clone();
+        // A block's `aliases` are extra words that should find its rows. Its
+        // rows carry the block name as their subtitle, so pointing the alias at
+        // that name reuses the existing alias matcher unchanged.
+        for block in &declared {
+            for alias in &block.aliases {
+                let key = normalize_for_search(alias);
+                if key.is_empty() {
+                    continue;
+                }
+                search_aliases
+                    .entry(key)
+                    .or_default()
+                    .push(normalize_for_search(&block.name));
+            }
+        }
+
         Self {
             candidates,
-            search_aliases: config.search_aliases.clone(),
+            search_aliases,
+            source_biases: declared
+                .into_iter()
+                .filter(|block| block.bias != 0)
+                .map(|block| (block.id, block.bias))
+                .collect(),
         }
+    }
+
+    /// The declared bias for the block that produced `candidate`, or 0.
+    pub(crate) fn source_bias(&self, candidate: &Candidate) -> i64 {
+        if self.source_biases.is_empty() {
+            return 0;
+        }
+        CandidateIdKind::source_id_of(&candidate.id)
+            .and_then(|id| self.source_biases.get(id))
+            .copied()
+            .unwrap_or(0)
     }
 
     pub fn search(&self, query: &str, limit: usize) -> Vec<LaunchResult> {

--- a/core/engine/src/lib.rs
+++ b/core/engine/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod action;
 pub mod config;
+pub mod config_path;
 pub mod index;
 mod normalize;
 mod platform;

--- a/core/engine/src/result.rs
+++ b/core/engine/src/result.rs
@@ -16,11 +16,27 @@ pub struct LaunchResult {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum LaunchResultAction {
-    Open { path: String },
-    OpenFolder { path: String },
-    Reveal { path: String },
-    WebSearch { query: String },
-    Translate { text: String, target_lang: String },
+    Open {
+        path: String,
+    },
+    OpenFolder {
+        path: String,
+    },
+    Reveal {
+        path: String,
+    },
+    WebSearch {
+        query: String,
+    },
+    Translate {
+        text: String,
+        target_lang: String,
+    },
+    /// A user-declared block, identified by its candidate id. There is nothing
+    /// to open: the shell looks the block up and performs its steps.
+    PerformBlock {
+        candidate_id: String,
+    },
 }
 
 impl From<(&Candidate, i64)> for LaunchResult {
@@ -34,6 +50,9 @@ impl From<(&Candidate, i64)> for LaunchResult {
             },
             CandidateKind::Folder => LaunchResultAction::OpenFolder {
                 path: candidate.path.to_string(),
+            },
+            CandidateKind::Action => LaunchResultAction::PerformBlock {
+                candidate_id: candidate.id.to_string(),
             },
         };
 

--- a/core/engine/src/scoring.rs
+++ b/core/engine/src/scoring.rs
@@ -101,6 +101,7 @@ pub(crate) fn kind_bias(candidate: &Candidate) -> i64 {
         CandidateKind::App => BIAS_APP,
         CandidateKind::Folder => BIAS_FOLDER,
         CandidateKind::File => BIAS_FILE,
+        CandidateKind::Action => BIAS_ACTION,
     }
 }
 
@@ -119,7 +120,9 @@ pub(crate) fn query_kind_penalty_with_settings_flag(
                     BIAS_APP_ON_SETTINGS_QUERY
                 }
             }
-            CandidateKind::Folder | CandidateKind::File => BIAS_NON_APP_ON_SETTINGS_QUERY,
+            CandidateKind::Folder | CandidateKind::File | CandidateKind::Action => {
+                BIAS_NON_APP_ON_SETTINGS_QUERY
+            }
         }
     } else if is_system_settings_candidate(candidate) {
         SETTINGS_ON_NON_SETTINGS_QUERY_PENALTY
@@ -158,7 +161,8 @@ pub(crate) fn is_system_settings_candidate(candidate: &Candidate) -> bool {
 
 pub(crate) fn path_depth_penalty(candidate: &Candidate) -> i64 {
     match candidate.kind {
-        CandidateKind::App => 0,
+        // Neither has a filesystem path to be deep in.
+        CandidateKind::App | CandidateKind::Action => 0,
         CandidateKind::File | CandidateKind::Folder => {
             let depth = candidate
                 .path
@@ -173,6 +177,7 @@ pub(crate) fn path_depth_penalty(candidate: &Candidate) -> i64 {
 pub(crate) fn default_browse_score(candidate: &Candidate, now_unix_s: i64) -> i64 {
     let kind_boost = match candidate.kind {
         CandidateKind::App => 600,
+        CandidateKind::Action => BROWSE_BOOST_ACTION,
         CandidateKind::Folder => 120,
         CandidateKind::File => 0,
     };

--- a/core/engine/src/search.rs
+++ b/core/engine/src/search.rs
@@ -19,6 +19,11 @@ const RERANK_MIN_QUERY_CHARS: usize = 3;
 const REGEX_SIZE_LIMIT_BYTES: usize = 1024 * 1024;
 const SCORE_ALIAS_TITLE_MATCH: i64 = 1_520;
 const SCORE_ALIAS_SUBTITLE_MATCH: i64 = 1_260;
+/// How much wider than `limit` to search when source rows may shadow walker
+/// rows. Only source blocks pointed inside a scan root can shadow anything, so
+/// every row being a duplicate is not a real shape; 2x absorbs it and costs one
+/// extra pass over an already-bounded heap.
+const SHADOW_OVERFETCH: usize = 2;
 
 fn top_limit(mut ranked: Vec<(u32, i64)>, limit: usize) -> Vec<(u32, i64)> {
     ranked.truncate(limit);
@@ -433,19 +438,25 @@ impl QueryEngine {
 
         let parsed_query = ParsedQuery::from_input(query);
         let kind_filter = parsed_query.kind_filter.as_ref();
+
+        // Shadowed rows are dropped AFTER ranking, so asking for exactly `limit`
+        // and then filtering would return fewer rows than the caller asked for
+        // and leave matches below the cutoff unshown. Over-fetch enough to
+        // absorb the drops, filter, then truncate.
+        let fetch = limit.saturating_mul(SHADOW_OVERFETCH).max(limit);
         let indices = if parsed_query.is_recent {
-            self.search_recent_query(&parsed_query.normalized_query, limit)
+            self.search_recent_query(&parsed_query.normalized_query, fetch)
         } else if parsed_query.normalized_query.is_empty() && !parsed_query.is_regex {
-            self.search_empty_query(kind_filter, limit)
+            self.search_empty_query(kind_filter, fetch)
         } else if parsed_query.is_regex {
-            self.search_regex_query(parsed_query.raw_query.as_ref(), kind_filter, limit)
+            self.search_regex_query(parsed_query.raw_query.as_ref(), kind_filter, fetch)
         } else {
-            self.search_text_query(&parsed_query.normalized_query, kind_filter, limit)
+            self.search_text_query(&parsed_query.normalized_query, kind_filter, fetch)
         };
 
         // Materialize Candidates only for the final top-K - the hot scoring loop
         // kept everything as (index, score) pairs to avoid per-push clones.
-        self.drop_source_shadowed(indices)
+        top_limit(self.drop_source_shadowed(indices), limit)
             .into_iter()
             .map(|(idx, score)| (self.candidates[idx as usize].candidate.clone(), score))
             .collect()
@@ -565,6 +576,42 @@ mod tests {
             ids.contains(&"folder:/u/dev/other".to_string()),
             "a different path is untouched: {ids:?}"
         );
+    }
+
+    #[test]
+    fn a_shadowed_pair_does_not_cost_the_caller_a_row() {
+        // Filtering after the limit would return 1 row for limit=2, hiding a
+        // match that was ranked below the cutoff.
+        let engine = QueryEngine::new(vec![
+            Candidate::new(
+                "folder:/u/dev/look",
+                CandidateKind::Folder,
+                "look",
+                "/u/dev/look",
+            ),
+            Candidate::new(
+                "src:projects:/u/dev/look",
+                CandidateKind::Folder,
+                "look",
+                "/u/dev/look",
+            ),
+            Candidate::new(
+                "folder:/u/dev/look-alike",
+                CandidateKind::Folder,
+                "look-alike",
+                "/u/dev/look-alike",
+            ),
+        ]);
+
+        let ids: Vec<String> = engine
+            .search_scored("look", 2)
+            .into_iter()
+            .map(|(candidate, _)| candidate.id.to_string())
+            .collect();
+
+        assert_eq!(ids.len(), 2, "the limit is still filled: {ids:?}");
+        assert!(ids.contains(&"src:projects:/u/dev/look".to_string()));
+        assert!(ids.contains(&"folder:/u/dev/look-alike".to_string()));
     }
 
     #[test]

--- a/core/engine/src/search.rs
+++ b/core/engine/src/search.rs
@@ -6,11 +6,11 @@ use crate::scoring::{
     is_system_settings_candidate, kind_bias, looks_like_settings_query, path_depth_penalty,
     path_match_score, push_top_k, query_kind_penalty_with_settings_flag,
 };
-use look_indexing::{Candidate, CandidateKind};
+use look_indexing::{Candidate, CandidateIdKind, CandidateKind};
 use look_matching::{fuzzy_quality_bonus_prepared, fuzzy_score_prepared, prepare_query};
 use look_ranking::rank_score;
 use regex::RegexBuilder;
-use std::collections::BinaryHeap;
+use std::collections::{BinaryHeap, HashSet};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const RERANK_POOL_MULTIPLIER: usize = 4;
@@ -443,10 +443,39 @@ impl QueryEngine {
 
         // Materialize Candidates only for the final top-K - the hot scoring loop
         // kept everything as (index, score) pairs to avoid per-push clones.
-        indices
+        self.drop_source_shadowed(indices)
             .into_iter()
             .map(|(idx, score)| (self.candidates[idx as usize].candidate.clone(), score))
             .collect()
+    }
+
+    /// A folder source pointed inside a scan root produces a row for a path the
+    /// file walker already indexed. Both are the same thing to the user, so only
+    /// one may appear, and the source's row is the one that carries the source's
+    /// name and its actions.
+    pub(crate) fn drop_source_shadowed(&self, ranked: Vec<(u32, i64)>) -> Vec<(u32, i64)> {
+        let source_paths: HashSet<&str> = ranked
+            .iter()
+            .map(|(idx, _)| &self.candidates[*idx as usize].candidate)
+            .filter(|candidate| Self::is_source_row(candidate))
+            .map(|candidate| candidate.path.as_ref())
+            .collect();
+
+        if source_paths.is_empty() {
+            return ranked;
+        }
+
+        ranked
+            .into_iter()
+            .filter(|(idx, _)| {
+                let candidate = &self.candidates[*idx as usize].candidate;
+                Self::is_source_row(candidate) || !source_paths.contains(candidate.path.as_ref())
+            })
+            .collect()
+    }
+
+    fn is_source_row(candidate: &Candidate) -> bool {
+        candidate.id.starts_with(CandidateIdKind::PREFIX_SOURCE)
     }
 }
 
@@ -493,6 +522,67 @@ fn location_folder(loc: &str) -> Option<&'static str> {
 mod tests {
     use super::QueryEngine;
     use look_indexing::{Candidate, CandidateKind};
+
+    #[test]
+    fn a_source_row_hides_the_file_walker_row_for_the_same_path() {
+        // A folder source pointed inside a scan root indexes paths the file
+        // walker already has. The user sees one project, not two, and the row
+        // they get is the source's, which knows its name and its actions.
+        let walked = Candidate::new(
+            "folder:/u/dev/look",
+            CandidateKind::Folder,
+            "look",
+            "/u/dev/look",
+        );
+        let from_source = Candidate::new(
+            "src:projects:/u/dev/look",
+            CandidateKind::Folder,
+            "look",
+            "/u/dev/look",
+        );
+        let unrelated = Candidate::new(
+            "folder:/u/dev/other",
+            CandidateKind::Folder,
+            "look-alike",
+            "/u/dev/other",
+        );
+        let engine = QueryEngine::new(vec![walked, from_source, unrelated]);
+
+        let ids: Vec<String> = engine
+            .search_scored("look", 10)
+            .into_iter()
+            .map(|(candidate, _)| candidate.id.to_string())
+            .collect();
+
+        assert!(ids.contains(&"src:projects:/u/dev/look".to_string()));
+        assert!(
+            !ids.contains(&"folder:/u/dev/look".to_string()),
+            "the walker row is shadowed by the source row: {ids:?}"
+        );
+        assert!(
+            ids.contains(&"folder:/u/dev/other".to_string()),
+            "a different path is untouched: {ids:?}"
+        );
+    }
+
+    #[test]
+    fn without_a_source_row_nothing_is_dropped() {
+        let engine = QueryEngine::new(vec![
+            Candidate::new(
+                "folder:/u/dev/look",
+                CandidateKind::Folder,
+                "look",
+                "/u/dev/look",
+            ),
+            Candidate::new(
+                "file:/u/dev/look.md",
+                CandidateKind::File,
+                "look.md",
+                "/u/dev/look.md",
+            ),
+        ]);
+        assert_eq!(engine.search_scored("look", 10).len(), 2);
+    }
 
     fn recent_engine() -> QueryEngine {
         let mut older = Candidate::new("file:old", CandidateKind::File, "old.txt", "/x/old.txt");

--- a/core/engine/src/search.rs
+++ b/core/engine/src/search.rs
@@ -302,6 +302,7 @@ impl QueryEngine {
 
             let final_score = regex_score
                 + kind_bias(&candidate.candidate)
+                + self.source_bias(&candidate.candidate)
                 + path_depth_penalty(&candidate.candidate);
             push_top_k(
                 &mut top,
@@ -386,6 +387,7 @@ impl QueryEngine {
                 &candidate.candidate,
                 &candidate.title_search,
             ) + kind_bias(&candidate.candidate)
+                + self.source_bias(&candidate.candidate)
                 // Reuse precomputed query kind to keep this hot loop allocation-free.
                 + query_kind_penalty_with_settings_flag(settings_query, &candidate.candidate)
                 + path_depth_penalty(&candidate.candidate);

--- a/core/indexing/src/lib.rs
+++ b/core/indexing/src/lib.rs
@@ -16,6 +16,10 @@ pub enum CandidateIdKind {
     File,
     Folder,
     Setting,
+    /// A row from a user-declared source. Its own namespace so a source refresh
+    /// prunes only its own rows, and so a row can be told apart from an
+    /// identically-shaped one the file walker produced.
+    Source,
 }
 
 impl CandidateIdKind {
@@ -23,6 +27,7 @@ impl CandidateIdKind {
     pub const PREFIX_FILE: &'static str = "file:";
     pub const PREFIX_FOLDER: &'static str = "folder:";
     pub const PREFIX_SETTING: &'static str = "setting:";
+    pub const PREFIX_SOURCE: &'static str = "src:";
 
     pub fn as_prefix(&self) -> &'static str {
         match self {
@@ -30,6 +35,7 @@ impl CandidateIdKind {
             CandidateIdKind::File => Self::PREFIX_FILE,
             CandidateIdKind::Folder => Self::PREFIX_FOLDER,
             CandidateIdKind::Setting => Self::PREFIX_SETTING,
+            CandidateIdKind::Source => Self::PREFIX_SOURCE,
         }
     }
 
@@ -42,9 +48,24 @@ impl CandidateIdKind {
             Some(Self::Folder)
         } else if id.starts_with(Self::PREFIX_SETTING) {
             Some(Self::Setting)
+        } else if id.starts_with(Self::PREFIX_SOURCE) {
+            Some(Self::Source)
         } else {
             None
         }
+    }
+
+    /// The source id inside a source row id (`src:<source>:<row>`).
+    pub fn source_id_of(candidate_id: &str) -> Option<&str> {
+        candidate_id
+            .strip_prefix(Self::PREFIX_SOURCE)?
+            .split_once(':')
+            .map(|(source, _)| source)
+    }
+
+    /// The id-prefix that scoped pruning uses for one source's rows.
+    pub fn source_row_prefix(source_id: &str) -> String {
+        format!("{}{source_id}:", Self::PREFIX_SOURCE)
     }
 }
 

--- a/core/indexing/src/lib.rs
+++ b/core/indexing/src/lib.rs
@@ -70,6 +70,47 @@ impl CandidateIdKind {
     pub fn source_row_prefix(source_id: &str) -> String {
         format!("{}{source_id}:", Self::PREFIX_SOURCE)
     }
+
+    /// The ROW's own id inside a source row id (`src:<source>:<row>`), which is
+    /// what a user's command expects `{id}` to be. Anything not namespaced is
+    /// returned as-is, so a caller can pass either shape.
+    pub fn source_row_id_of(candidate_id: &str) -> &str {
+        candidate_id
+            .strip_prefix(Self::PREFIX_SOURCE)
+            .and_then(|rest| rest.split_once(':'))
+            .map(|(_, row)| row)
+            .unwrap_or(candidate_id)
+    }
+}
+
+#[cfg(test)]
+mod id_tests {
+    use super::CandidateIdKind;
+
+    #[test]
+    fn a_row_id_is_what_a_users_command_sees() {
+        // Handing git the whole candidate id makes it read `src:branches:main`
+        // as rev:path and fail with "invalid object name 'src'".
+        let id = "src:branches:326-bug-battery-on-macos";
+        assert_eq!(CandidateIdKind::source_id_of(id), Some("branches"));
+        assert_eq!(
+            CandidateIdKind::source_row_id_of(id),
+            "326-bug-battery-on-macos"
+        );
+    }
+
+    #[test]
+    fn a_row_id_containing_colons_keeps_them() {
+        assert_eq!(
+            CandidateIdKind::source_row_id_of("src:hosts:user@host:22"),
+            "user@host:22"
+        );
+    }
+
+    #[test]
+    fn an_unnamespaced_id_passes_through() {
+        assert_eq!(CandidateIdKind::source_row_id_of("main"), "main");
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/core/indexing/src/lib.rs
+++ b/core/indexing/src/lib.rs
@@ -8,6 +8,9 @@ pub enum CandidateKind {
     App,
     File,
     Folder,
+    /// A row with no filesystem target: a bundle of steps, or a row a user's
+    /// list or command produced. It is performed, never opened.
+    Action,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -123,12 +126,14 @@ impl CandidateKind {
     pub const APP_KEY: &'static str = "app";
     pub const FILE_KEY: &'static str = "file";
     pub const FOLDER_KEY: &'static str = "folder";
+    pub const ACTION_KEY: &'static str = "action";
 
     pub fn as_str(&self) -> &'static str {
         match self {
             CandidateKind::App => Self::APP_KEY,
             CandidateKind::File => Self::FILE_KEY,
             CandidateKind::Folder => Self::FOLDER_KEY,
+            CandidateKind::Action => Self::ACTION_KEY,
         }
     }
 
@@ -137,6 +142,7 @@ impl CandidateKind {
             Self::APP_KEY => Some(CandidateKind::App),
             Self::FILE_KEY => Some(CandidateKind::File),
             Self::FOLDER_KEY => Some(CandidateKind::Folder),
+            Self::ACTION_KEY => Some(CandidateKind::Action),
             _ => None,
         }
     }

--- a/core/sources/Cargo.toml
+++ b/core/sources/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "look-sources"
+edition = "2024"
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+version = "0.1.0"
+
+[dependencies]
+globset = "0.4.18"
+serde = { version = "1", features = ["derive"] }
+toml = "0.9"

--- a/core/sources/example.toml
+++ b/core/sources/example.toml
@@ -10,6 +10,8 @@
 #   run   rows from a command's stdout
 #
 # Nothing is file-wide. Each block stands alone.
+#
+# Reload after editing: Cmd+Shift+;
 
 
 # ------------------------------------------------------------------ bundle --
@@ -17,6 +19,7 @@
 
 [work]
 name = "Work setup"
+icon = "🚀"                        # emoji, SF Symbol name, or an image path
 do = [
   "open -a Slack",
   "open -a Ghostty",
@@ -25,7 +28,8 @@ do = [
 
 
 # --------------------------------------------------------------------- dir --
-# Rows are the children of one or more directories.
+# Rows are the children of one or more directories. They stay real files and
+# folders, so preview, reveal, and open keep working on them.
 
 [projects]
 name  = "Projects"
@@ -34,21 +38,35 @@ depth = 1                         # 1 = immediate children
 only  = "dirs"                    # dirs | files | all
 # match   = ["*.md"]              # keep only these names
 # exclude = ["archive*"]          # drop these
-# bias    = -50                   # sit below apps and files
-# aliases = ["repo", "code"]      # extra words that find this block
 # enabled = false                 # keep the file, stop loading it
+
+aliases = ["repo", "code"]        # extra words that find this block's rows
+bias    = 0                       # score offset: negative sits below apps/files
+
+# Other blocks a picked row can go to. Cmd+K opens the menu, Cmd+J / Cmd+K move,
+# Enter runs. A target that performs steps is an action; one that produces rows
+# is a level to descend into.
+then = ["ghostty"]
 
 # What the standard keys do to a picked row. Each verb has one key across the
 # whole app, so Cmd+E always edits. Declare only what differs from your global
-# default in ~/.look.config.
+# default in ~/.look.config (see specs/preferred-tools.md).
 open     = "open {path}"
 edit     = "nvim {path}"
 terminal = "tmux new-session -As {title} -c {path}"
 
 
+# Reached through `then`. It mentions {path}, so it never appears as a row of
+# its own: it only means something against a selected project.
+[ghostty]
+name = "Open in Ghostty"
+do   = ["open -a Ghostty {path}"]
+
+
 # -------------------------------------------------------------------- file --
 # Rows from a text file, one per line: id<TAB>title<TAB>group
-# A bare line is both id and title. The id is what the verbs receive.
+# A bare line is both id and title. The id is what verbs and `then` receive, so
+# a row can show one thing and act on another.
 
 [hosts]
 name = "SSH hosts"
@@ -57,18 +75,38 @@ open = "ssh {id}"
 
 
 # --------------------------------------------------------------------- run --
-# Rows from stdout, same line format as a file block.
+# Rows from a command's stdout, same line format as a file block.
+#
+# The command runs on reload (Cmd+Shift+;), not on every keystroke. If it fails,
+# times out, or prints nothing, the rows it produced last time are KEPT: losing
+# them would also lose the usage ranking those rows had earned.
 
 [branches]
 name    = "Git branches"
 run     = "git -C ~/dev/look for-each-ref --format='%(refname:short)' refs/heads"
-refresh = "open"                  # startup | open | manual | 30s | 5m | 1h
-# cwd     = "~/dev/look"
-# timeout = "5s"
+# cwd     = "~/dev/look"          # where the command runs
+# timeout = "5s"                  # give up after this long
+
+# Runs for the SELECTED row only and shows its output in the right panel.
+preview = "git -C ~/dev/look log -10 --date=short --format='%h  %ad  %an  %s' {id}"
+
 open    = "git -C ~/dev/look checkout {id}"
+then    = ["drop-branch"]
 
 
-# Placeholders usable in verbs and preview:
-#   {id} {title} {subtitle} {group} {path} {dir} {query}
+# `confirm` asks before the block does anything. Anything destructive should
+# have one: a launcher makes Enter on the wrong row cheap.
+[drop-branch]
+name    = "Delete local branch"
+confirm = "Delete local branch {id}?"
+do      = ["git -C ~/dev/look branch -d {id}"]
+
+
+# Placeholders usable in do/verbs/preview:
+#   {id} {title} {path} {dir} {query}
+# {dir} is the row itself when it is a folder, its parent when it is a file.
 # They are shell-escaped on substitution, so they never need quoting and a row
 # named "; rm -rf ~" is inert.
+#
+# Every command runs through your login shell, so $EDITOR, $PATH, and shell
+# functions work exactly as they do in a terminal.

--- a/core/sources/example.toml
+++ b/core/sources/example.toml
@@ -1,0 +1,74 @@
+# Look sources: the whole format in one file.
+# Copy to ~/.look/sources/<anything>.toml and edit.
+#
+# A file is a set of blocks. Every block has a `name` you can type, and ONE
+# producer key that says what it is:
+#
+#   do    one row; Enter performs its steps
+#   dir   rows from the children of a directory
+#   file  rows from a text file
+#   run   rows from a command's stdout
+#
+# Nothing is file-wide. Each block stands alone.
+
+
+# ------------------------------------------------------------------ bundle --
+# One name, several things happen. No rows to pick, no placeholders needed.
+
+[work]
+name = "Work setup"
+do = [
+  "open -a Slack",
+  "open -a Ghostty",
+  "open -a Safari https://github.com",
+]
+
+
+# --------------------------------------------------------------------- dir --
+# Rows are the children of one or more directories.
+
+[projects]
+name  = "Projects"
+dir   = "~/dev"                   # or: dirs = ["~/dev", "~/work"]
+depth = 1                         # 1 = immediate children
+only  = "dirs"                    # dirs | files | all
+# match   = ["*.md"]              # keep only these names
+# exclude = ["archive*"]          # drop these
+# bias    = -50                   # sit below apps and files
+# aliases = ["repo", "code"]      # extra words that find this block
+# enabled = false                 # keep the file, stop loading it
+
+# What the standard keys do to a picked row. Each verb has one key across the
+# whole app, so Cmd+E always edits. Declare only what differs from your global
+# default in ~/.look.config.
+open     = "open {path}"
+edit     = "nvim {path}"
+terminal = "tmux new-session -As {title} -c {path}"
+
+
+# -------------------------------------------------------------------- file --
+# Rows from a text file, one per line: id<TAB>title<TAB>group
+# A bare line is both id and title. The id is what the verbs receive.
+
+[hosts]
+name = "SSH hosts"
+file = "~/.look/hosts.txt"
+open = "ssh {id}"
+
+
+# --------------------------------------------------------------------- run --
+# Rows from stdout, same line format as a file block.
+
+[branches]
+name    = "Git branches"
+run     = "git -C ~/dev/look for-each-ref --format='%(refname:short)' refs/heads"
+refresh = "open"                  # startup | open | manual | 30s | 5m | 1h
+# cwd     = "~/dev/look"
+# timeout = "5s"
+open    = "git -C ~/dev/look checkout {id}"
+
+
+# Placeholders usable in verbs and preview:
+#   {id} {title} {subtitle} {group} {path} {dir} {query}
+# They are shell-escaped on substitution, so they never need quoting and a row
+# named "; rm -rf ~" is inert.

--- a/core/sources/src/collect.rs
+++ b/core/sources/src/collect.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 
 use globset::{Glob, GlobSet, GlobSetBuilder};
 
-use crate::def::{Only, RowFormat, SourceDef, SourceSpec};
+use crate::def::{Block, Only, Producer, RowFormat};
 use crate::rows::{SourceRow, parse_lines};
 
 /// Hard ceiling on rows from one source. A source that hits this is a mistake
@@ -50,9 +50,16 @@ impl std::fmt::Display for CollectError {
 }
 
 /// Rows for `def`, with `~` in any declared path resolved against `home`.
-pub fn collect(def: &SourceDef, home: &Path) -> Result<Collected, CollectError> {
-    match &def.spec {
-        SourceSpec::Folder {
+pub fn collect(block: &Block, home: &Path) -> Result<Collected, CollectError> {
+    match &block.producer {
+        Producer::Bundle { .. } => Ok(Collected {
+            // A bundle is one row: itself. Its steps are what Enter performs,
+            // not something to pick from.
+            rows: vec![SourceRow::new(String::new(), block.name.clone())],
+            truncated: false,
+            unreadable: Vec::new(),
+        }),
+        Producer::Dir {
             roots,
             depth,
             only,
@@ -62,8 +69,8 @@ pub fn collect(def: &SourceDef, home: &Path) -> Result<Collected, CollectError> 
             let roots: Vec<PathBuf> = roots.iter().map(|root| expand_home(root, home)).collect();
             collect_folders(&roots, *depth, *only, include, exclude)
         }
-        SourceSpec::List { file, format } => collect_list(&expand_home(file, home), *format),
-        SourceSpec::Command { .. } => Err(CollectError::NeedsRunner),
+        Producer::File { path, format } => collect_list(&expand_home(path, home), *format),
+        Producer::Run { .. } => Err(CollectError::NeedsRunner),
     }
 }
 
@@ -243,7 +250,7 @@ fn is_hidden(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::def::parse;
+    use crate::def::parse_file;
 
     struct TempDir(PathBuf);
 
@@ -281,8 +288,10 @@ mod tests {
         }
     }
 
-    fn folder_def(body: &str) -> SourceDef {
-        parse("projects", body, None).expect("valid source")
+    fn folder_def(body: &str) -> Block {
+        let parsed = parse_file(&format!("[projects]\n{body}")).expect("valid file");
+        assert!(parsed.problems.is_empty(), "{:?}", parsed.problems);
+        parsed.blocks.into_iter().next().expect("one block")
     }
 
     #[test]
@@ -292,7 +301,7 @@ mod tests {
         tmp.dir("alpha");
         tmp.file("notes.md", "x");
 
-        let def = folder_def(&format!("root = {:?}\n", tmp.0.to_str().unwrap()));
+        let def = folder_def(&format!("dir = {:?}\n", tmp.0.to_str().unwrap()));
         let collected = collect(&def, Path::new("/nonexistent")).unwrap();
 
         let titles: Vec<&str> = collected.rows.iter().map(|r| r.title.as_str()).collect();
@@ -308,7 +317,7 @@ mod tests {
         tmp.file("readme.md", "x");
 
         let def = folder_def(&format!(
-            "root = {:?}\nonly = \"dirs\"\n",
+            "dir = {:?}\nonly = \"dirs\"\n",
             tmp.0.to_str().unwrap()
         ));
         let collected = collect(&def, Path::new("/nonexistent")).unwrap();
@@ -322,7 +331,7 @@ mod tests {
         tmp.dir("look");
         tmp.file("look/nested.txt", "x");
 
-        let shallow = folder_def(&format!("root = {:?}\n", tmp.0.to_str().unwrap()));
+        let shallow = folder_def(&format!("dir = {:?}\n", tmp.0.to_str().unwrap()));
         let titles: Vec<String> = collect(&shallow, Path::new("/nonexistent"))
             .unwrap()
             .rows
@@ -331,10 +340,7 @@ mod tests {
             .collect();
         assert_eq!(titles, ["look"]);
 
-        let deep = folder_def(&format!(
-            "root = {:?}\ndepth = 2\n",
-            tmp.0.to_str().unwrap()
-        ));
+        let deep = folder_def(&format!("dir = {:?}\ndepth = 2\n", tmp.0.to_str().unwrap()));
         let titles: Vec<String> = collect(&deep, Path::new("/nonexistent"))
             .unwrap()
             .rows
@@ -352,7 +358,7 @@ mod tests {
         tmp.file("skip.md", "x");
 
         let def = folder_def(&format!(
-            "root = {:?}\nmatch = [\"*.md\"]\nexclude = [\"skip.*\"]\n",
+            "dir = {:?}\nmatch = [\"*.md\"]\nexclude = [\"skip.*\"]\n",
             tmp.0.to_str().unwrap()
         ));
         let titles: Vec<String> = collect(&def, Path::new("/nonexistent"))
@@ -370,7 +376,7 @@ mod tests {
         tmp.dir(".git");
         tmp.dir("visible");
 
-        let def = folder_def(&format!("root = {:?}\n", tmp.0.to_str().unwrap()));
+        let def = folder_def(&format!("dir = {:?}\n", tmp.0.to_str().unwrap()));
         let titles: Vec<String> = collect(&def, Path::new("/nonexistent"))
             .unwrap()
             .rows
@@ -389,7 +395,7 @@ mod tests {
         fs::create_dir_all(work.join("atlas")).expect("dir");
 
         let def = folder_def(&format!(
-            "roots = [{:?}, {:?}]\nonly = \"dirs\"\n",
+            "dirs = [{:?}, {:?}]\nonly = \"dirs\"\n",
             dev.to_str().unwrap(),
             work.to_str().unwrap()
         ));
@@ -409,7 +415,7 @@ mod tests {
         fs::create_dir_all(work.join("atlas")).expect("dir");
 
         let def = folder_def(&format!(
-            "root = {:?}\nroots = [{:?}]\nonly = \"dirs\"\n",
+            "dir = {:?}\ndirs = [{:?}]\nonly = \"dirs\"\n",
             dev.to_str().unwrap(),
             work.to_str().unwrap()
         ));
@@ -431,7 +437,7 @@ mod tests {
         fs::create_dir_all(dev.join("look")).expect("dir");
 
         let def = folder_def(&format!(
-            "roots = [{:?}, \"/definitely/not/here\"]\nonly = \"dirs\"\n",
+            "dirs = [{:?}, \"/definitely/not/here\"]\nonly = \"dirs\"\n",
             dev.to_str().unwrap()
         ));
         let collected = collect(&def, Path::new("/nonexistent")).unwrap();
@@ -442,7 +448,7 @@ mod tests {
 
     #[test]
     fn a_missing_root_is_an_error_the_user_can_read() {
-        let def = folder_def("root = \"/definitely/not/here\"\n");
+        let def = folder_def("dir = \"/definitely/not/here\"\n");
         match collect(&def, Path::new("/nonexistent")) {
             Err(CollectError::Io(message)) => assert!(message.contains("/definitely/not/here")),
             other => panic!("expected an io error, got {other:?}"),
@@ -454,12 +460,7 @@ mod tests {
         let tmp = TempDir::new("list");
         let file = tmp.file("hosts.txt", "web1\tProduction web\tServers\ndb1\n\n");
 
-        let def = parse(
-            "hosts",
-            &format!("file = {:?}\n", file.to_str().unwrap()),
-            None,
-        )
-        .unwrap();
+        let def = folder_def(&format!("file = {:?}\n", file.to_str().unwrap()));
         let collected = collect(&def, Path::new("/nonexistent")).unwrap();
 
         assert_eq!(collected.rows.len(), 2);
@@ -474,7 +475,7 @@ mod tests {
         let tmp = TempDir::new("order");
         let file = tmp.file("ordered.txt", "zeta\nalpha\nmiddle\n");
 
-        let def = parse("o", &format!("file = {:?}\n", file.to_str().unwrap()), None).unwrap();
+        let def = folder_def(&format!("file = {:?}\n", file.to_str().unwrap()));
         let titles: Vec<String> = collect(&def, Path::new("/nonexistent"))
             .unwrap()
             .rows
@@ -486,7 +487,7 @@ mod tests {
 
     #[test]
     fn a_command_source_is_left_to_the_shell() {
-        let def = parse("c", "command = \"ls\"\n", None).unwrap();
+        let def = folder_def("run = \"ls\"\n");
         assert_eq!(
             collect(&def, Path::new("/nonexistent")),
             Err(CollectError::NeedsRunner)

--- a/core/sources/src/collect.rs
+++ b/core/sources/src/collect.rs
@@ -1,0 +1,508 @@
+//! Turning a declared source into rows. Folder and list sources are answered
+//! here; a command source needs a process, which is the shell's job, so this
+//! module only reports that it cannot run one.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use globset::{Glob, GlobSet, GlobSetBuilder};
+
+use crate::def::{Only, RowFormat, SourceDef, SourceSpec};
+use crate::rows::{SourceRow, parse_lines};
+
+/// Hard ceiling on rows from one source. A source that hits this is a mistake
+/// (a root pointed at the home directory, a runaway script), and the honest
+/// answer is a capped list plus a visible truncation, not a frozen launcher.
+pub const MAX_ROWS_PER_SOURCE: usize = 2_000;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Collected {
+    pub rows: Vec<SourceRow>,
+    /// Set when the cap dropped rows, so the caller can say so.
+    pub truncated: bool,
+    /// Roots that could not be read while others could. An external drive that
+    /// is not mounted must not take the rest of the list down with it, but it
+    /// must not vanish silently either.
+    pub unreadable: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CollectError {
+    /// The root, file, or an entry could not be read.
+    Io(String),
+    /// A `match` or `exclude` pattern is not a valid glob.
+    Glob(String),
+    /// Command sources are collected by the shell, which owns process
+    /// execution. Never a user error.
+    NeedsRunner,
+    Unsupported(String),
+}
+
+impl std::fmt::Display for CollectError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(message) => write!(f, "{message}"),
+            Self::Glob(message) => write!(f, "{message}"),
+            Self::NeedsRunner => write!(f, "command sources are run by the shell"),
+            Self::Unsupported(message) => write!(f, "{message}"),
+        }
+    }
+}
+
+/// Rows for `def`, with `~` in any declared path resolved against `home`.
+pub fn collect(def: &SourceDef, home: &Path) -> Result<Collected, CollectError> {
+    match &def.spec {
+        SourceSpec::Folder {
+            roots,
+            depth,
+            only,
+            include,
+            exclude,
+        } => {
+            let roots: Vec<PathBuf> = roots.iter().map(|root| expand_home(root, home)).collect();
+            collect_folders(&roots, *depth, *only, include, exclude)
+        }
+        SourceSpec::List { file, format } => collect_list(&expand_home(file, home), *format),
+        SourceSpec::Command { .. } => Err(CollectError::NeedsRunner),
+    }
+}
+
+/// Resolves a leading `~` only. A `~` anywhere else is a legitimate character in
+/// a path and is left alone.
+pub fn expand_home(path: &str, home: &Path) -> PathBuf {
+    match path.strip_prefix('~') {
+        Some(rest) => home.join(rest.trim_start_matches(['/', '\\'])),
+        None => PathBuf::from(path),
+    }
+}
+
+fn collect_folders(
+    roots: &[PathBuf],
+    depth: usize,
+    only: Only,
+    include: &[String],
+    exclude: &[String],
+) -> Result<Collected, CollectError> {
+    let include = build_globs(include)?;
+    let exclude = build_globs(exclude)?;
+
+    let mut collected = Collected::default();
+    let mut first_error = None;
+
+    for root in roots {
+        match collect_folder(root, depth, only, include.as_ref(), exclude.as_ref()) {
+            Ok(one) => {
+                collected.rows.extend(one.rows);
+                collected.truncated |= one.truncated;
+            }
+            Err(err) => {
+                collected.unreadable.push(root.display().to_string());
+                first_error.get_or_insert(err);
+            }
+        }
+    }
+
+    // Every root failing is a broken source. Some failing is a mounted-drive
+    // problem, and the rows that did resolve are still worth showing.
+    if collected.rows.is_empty()
+        && let Some(err) = first_error
+    {
+        return Err(err);
+    }
+
+    sort_rows(&mut collected.rows);
+    Ok(collected)
+}
+
+fn collect_folder(
+    root: &Path,
+    depth: usize,
+    only: Only,
+    include: Option<&GlobSet>,
+    exclude: Option<&GlobSet>,
+) -> Result<Collected, CollectError> {
+    let mut rows = Vec::new();
+    let mut truncated = false;
+    let mut pending = vec![(root.to_path_buf(), 1usize)];
+
+    while let Some((dir, level)) = pending.pop() {
+        let entries = fs::read_dir(&dir)
+            .map_err(|err| CollectError::Io(format!("{}: {err}", dir.display())))?;
+
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if is_hidden(&name) {
+                continue;
+            }
+            let is_dir = entry.file_type().is_ok_and(|kind| kind.is_dir());
+
+            if is_dir && level < depth {
+                pending.push((entry.path(), level + 1));
+            }
+
+            if !keeps(only, is_dir) {
+                continue;
+            }
+            if let Some(include) = include
+                && !include.is_match(&name)
+            {
+                continue;
+            }
+            if let Some(exclude) = exclude
+                && exclude.is_match(&name)
+            {
+                continue;
+            }
+
+            if rows.len() == MAX_ROWS_PER_SOURCE {
+                truncated = true;
+                break;
+            }
+
+            let path = entry.path();
+            let mut row = SourceRow::new(path.to_string_lossy().into_owned(), name);
+            row.subtitle = dir.to_str().map(String::from);
+            row.path = Some(path.to_string_lossy().into_owned());
+            rows.push(row);
+        }
+
+        if truncated {
+            break;
+        }
+    }
+
+    Ok(Collected {
+        rows,
+        truncated,
+        unreadable: Vec::new(),
+    })
+}
+
+/// Directory order is whatever the filesystem hands back, and it changes as
+/// entries are added and removed. Rows the user sees must not reshuffle, and
+/// with several roots the merged list needs one order, not one per root.
+fn sort_rows(rows: &mut [SourceRow]) {
+    rows.sort_by(|a, b| {
+        a.title
+            .to_lowercase()
+            .cmp(&b.title.to_lowercase())
+            .then_with(|| a.id.cmp(&b.id))
+    });
+}
+
+fn collect_list(file: &Path, format: RowFormat) -> Result<Collected, CollectError> {
+    let contents =
+        fs::read(file).map_err(|err| CollectError::Io(format!("{}: {err}", file.display())))?;
+    let text = String::from_utf8_lossy(&contents);
+
+    match format {
+        RowFormat::Lines => {
+            let (rows, truncated) = parse_lines(&text, MAX_ROWS_PER_SOURCE);
+            Ok(Collected {
+                rows,
+                truncated,
+                unreadable: Vec::new(),
+            })
+        }
+        RowFormat::Json => Err(CollectError::Unsupported(
+            "format = \"json\" is not implemented yet".into(),
+        )),
+    }
+}
+
+fn build_globs(patterns: &[String]) -> Result<Option<GlobSet>, CollectError> {
+    if patterns.is_empty() {
+        return Ok(None);
+    }
+    let mut builder = GlobSetBuilder::new();
+    for pattern in patterns {
+        let glob = Glob::new(pattern)
+            .map_err(|err| CollectError::Glob(format!("pattern \"{pattern}\": {err}")))?;
+        builder.add(glob);
+    }
+    builder
+        .build()
+        .map(Some)
+        .map_err(|err| CollectError::Glob(err.to_string()))
+}
+
+fn keeps(only: Only, is_dir: bool) -> bool {
+    match only {
+        Only::All => true,
+        Only::Dirs => is_dir,
+        Only::Files => !is_dir,
+    }
+}
+
+/// Dotfiles are skipped, matching what `ls` shows and what the user pictured
+/// when they pointed a source at a directory.
+fn is_hidden(name: &str) -> bool {
+    name.starts_with('.')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::def::parse;
+
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new(label: &str) -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "look-sources-{label}-{}-{:?}",
+                std::process::id(),
+                std::thread::current().id()
+            ));
+            let _ = fs::remove_dir_all(&path);
+            fs::create_dir_all(&path).expect("temp dir");
+            Self(path)
+        }
+
+        fn dir(&self, name: &str) -> PathBuf {
+            let path = self.0.join(name);
+            fs::create_dir_all(&path).expect("dir");
+            path
+        }
+
+        fn file(&self, name: &str, contents: &str) -> PathBuf {
+            let path = self.0.join(name);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("parent");
+            }
+            fs::write(&path, contents).expect("file");
+            path
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn folder_def(body: &str) -> SourceDef {
+        parse("projects", body, None).expect("valid source")
+    }
+
+    #[test]
+    fn a_folder_source_lists_its_children_in_a_stable_order() {
+        let tmp = TempDir::new("folder");
+        tmp.dir("zeta");
+        tmp.dir("alpha");
+        tmp.file("notes.md", "x");
+
+        let def = folder_def(&format!("root = {:?}\n", tmp.0.to_str().unwrap()));
+        let collected = collect(&def, Path::new("/nonexistent")).unwrap();
+
+        let titles: Vec<&str> = collected.rows.iter().map(|r| r.title.as_str()).collect();
+        assert_eq!(titles, ["alpha", "notes.md", "zeta"]);
+        assert!(!collected.truncated);
+        assert!(collected.rows[0].path.is_some());
+    }
+
+    #[test]
+    fn only_dirs_drops_the_files() {
+        let tmp = TempDir::new("only");
+        tmp.dir("look");
+        tmp.file("readme.md", "x");
+
+        let def = folder_def(&format!(
+            "root = {:?}\nonly = \"dirs\"\n",
+            tmp.0.to_str().unwrap()
+        ));
+        let collected = collect(&def, Path::new("/nonexistent")).unwrap();
+        let titles: Vec<&str> = collected.rows.iter().map(|r| r.title.as_str()).collect();
+        assert_eq!(titles, ["look"]);
+    }
+
+    #[test]
+    fn depth_one_stops_at_the_immediate_children() {
+        let tmp = TempDir::new("depth");
+        tmp.dir("look");
+        tmp.file("look/nested.txt", "x");
+
+        let shallow = folder_def(&format!("root = {:?}\n", tmp.0.to_str().unwrap()));
+        let titles: Vec<String> = collect(&shallow, Path::new("/nonexistent"))
+            .unwrap()
+            .rows
+            .into_iter()
+            .map(|r| r.title)
+            .collect();
+        assert_eq!(titles, ["look"]);
+
+        let deep = folder_def(&format!(
+            "root = {:?}\ndepth = 2\n",
+            tmp.0.to_str().unwrap()
+        ));
+        let titles: Vec<String> = collect(&deep, Path::new("/nonexistent"))
+            .unwrap()
+            .rows
+            .into_iter()
+            .map(|r| r.title)
+            .collect();
+        assert_eq!(titles, ["look", "nested.txt"]);
+    }
+
+    #[test]
+    fn match_and_exclude_filter_by_name() {
+        let tmp = TempDir::new("globs");
+        tmp.file("keep.md", "x");
+        tmp.file("drop.txt", "x");
+        tmp.file("skip.md", "x");
+
+        let def = folder_def(&format!(
+            "root = {:?}\nmatch = [\"*.md\"]\nexclude = [\"skip.*\"]\n",
+            tmp.0.to_str().unwrap()
+        ));
+        let titles: Vec<String> = collect(&def, Path::new("/nonexistent"))
+            .unwrap()
+            .rows
+            .into_iter()
+            .map(|r| r.title)
+            .collect();
+        assert_eq!(titles, ["keep.md"]);
+    }
+
+    #[test]
+    fn dotfiles_stay_out_of_the_list() {
+        let tmp = TempDir::new("hidden");
+        tmp.dir(".git");
+        tmp.dir("visible");
+
+        let def = folder_def(&format!("root = {:?}\n", tmp.0.to_str().unwrap()));
+        let titles: Vec<String> = collect(&def, Path::new("/nonexistent"))
+            .unwrap()
+            .rows
+            .into_iter()
+            .map(|r| r.title)
+            .collect();
+        assert_eq!(titles, ["visible"]);
+    }
+
+    #[test]
+    fn several_roots_merge_into_one_sorted_list() {
+        let tmp = TempDir::new("roots");
+        let dev = tmp.dir("dev");
+        let work = tmp.dir("work");
+        fs::create_dir_all(dev.join("look")).expect("dir");
+        fs::create_dir_all(work.join("atlas")).expect("dir");
+
+        let def = folder_def(&format!(
+            "roots = [{:?}, {:?}]\nonly = \"dirs\"\n",
+            dev.to_str().unwrap(),
+            work.to_str().unwrap()
+        ));
+        let collected = collect(&def, Path::new("/nonexistent")).unwrap();
+
+        let titles: Vec<&str> = collected.rows.iter().map(|r| r.title.as_str()).collect();
+        assert_eq!(titles, ["atlas", "look"], "one list, one order");
+        assert!(collected.unreadable.is_empty());
+    }
+
+    #[test]
+    fn root_and_roots_are_the_same_key_in_two_shapes() {
+        let tmp = TempDir::new("bothroots");
+        let dev = tmp.dir("dev");
+        let work = tmp.dir("work");
+        fs::create_dir_all(dev.join("look")).expect("dir");
+        fs::create_dir_all(work.join("atlas")).expect("dir");
+
+        let def = folder_def(&format!(
+            "root = {:?}\nroots = [{:?}]\nonly = \"dirs\"\n",
+            dev.to_str().unwrap(),
+            work.to_str().unwrap()
+        ));
+        let titles: Vec<String> = collect(&def, Path::new("/nonexistent"))
+            .unwrap()
+            .rows
+            .into_iter()
+            .map(|r| r.title)
+            .collect();
+        assert_eq!(titles, ["atlas", "look"]);
+    }
+
+    #[test]
+    fn one_unreadable_root_does_not_take_the_others_down() {
+        // An unmounted drive is a normal Tuesday. The rows that resolved are
+        // still worth showing, and the root that did not is still worth saying.
+        let tmp = TempDir::new("partial");
+        let dev = tmp.dir("dev");
+        fs::create_dir_all(dev.join("look")).expect("dir");
+
+        let def = folder_def(&format!(
+            "roots = [{:?}, \"/definitely/not/here\"]\nonly = \"dirs\"\n",
+            dev.to_str().unwrap()
+        ));
+        let collected = collect(&def, Path::new("/nonexistent")).unwrap();
+
+        assert_eq!(collected.rows.len(), 1);
+        assert_eq!(collected.unreadable, ["/definitely/not/here"]);
+    }
+
+    #[test]
+    fn a_missing_root_is_an_error_the_user_can_read() {
+        let def = folder_def("root = \"/definitely/not/here\"\n");
+        match collect(&def, Path::new("/nonexistent")) {
+            Err(CollectError::Io(message)) => assert!(message.contains("/definitely/not/here")),
+            other => panic!("expected an io error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_list_source_reads_its_rows_from_the_file() {
+        let tmp = TempDir::new("list");
+        let file = tmp.file("hosts.txt", "web1\tProduction web\tServers\ndb1\n\n");
+
+        let def = parse(
+            "hosts",
+            &format!("file = {:?}\n", file.to_str().unwrap()),
+            None,
+        )
+        .unwrap();
+        let collected = collect(&def, Path::new("/nonexistent")).unwrap();
+
+        assert_eq!(collected.rows.len(), 2);
+        assert_eq!(collected.rows[0].id, "web1");
+        assert_eq!(collected.rows[0].title, "Production web");
+        assert_eq!(collected.rows[0].group.as_deref(), Some("Servers"));
+        assert_eq!(collected.rows[1].title, "db1");
+    }
+
+    #[test]
+    fn list_rows_keep_the_order_the_file_gave_them() {
+        let tmp = TempDir::new("order");
+        let file = tmp.file("ordered.txt", "zeta\nalpha\nmiddle\n");
+
+        let def = parse("o", &format!("file = {:?}\n", file.to_str().unwrap()), None).unwrap();
+        let titles: Vec<String> = collect(&def, Path::new("/nonexistent"))
+            .unwrap()
+            .rows
+            .into_iter()
+            .map(|r| r.title)
+            .collect();
+        assert_eq!(titles, ["zeta", "alpha", "middle"]);
+    }
+
+    #[test]
+    fn a_command_source_is_left_to_the_shell() {
+        let def = parse("c", "command = \"ls\"\n", None).unwrap();
+        assert_eq!(
+            collect(&def, Path::new("/nonexistent")),
+            Err(CollectError::NeedsRunner)
+        );
+    }
+
+    #[test]
+    fn tilde_resolves_against_the_given_home_and_nothing_else() {
+        let home = Path::new("/home/u");
+        assert_eq!(expand_home("~/dev", home), PathBuf::from("/home/u/dev"));
+        assert_eq!(expand_home("~", home), PathBuf::from("/home/u"));
+        assert_eq!(expand_home("/etc", home), PathBuf::from("/etc"));
+        assert_eq!(
+            expand_home("/tmp/a~b", home),
+            PathBuf::from("/tmp/a~b"),
+            "a tilde inside a path is a normal character"
+        );
+    }
+}

--- a/core/sources/src/def.rs
+++ b/core/sources/src/def.rs
@@ -1,0 +1,575 @@
+//! The declared shape of a source: what it is, how it refreshes, what its rows
+//! can do. Parsing only. Nothing here reads a directory or runs a command.
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use serde::Deserialize;
+
+/// Immediate children only. Deep walks belong to the file index, not to a
+/// source the user declared to get one short list.
+pub const DEFAULT_FOLDER_DEPTH: usize = 1;
+
+/// The action Enter runs. Any other key is an entry in the actions panel.
+pub const DEFAULT_ACTION_KEY: &str = "default";
+
+const SECONDS_PER_MINUTE: u64 = 60;
+const SECONDS_PER_HOUR: u64 = 60 * SECONDS_PER_MINUTE;
+const SECONDS_PER_DAY: u64 = 24 * SECONDS_PER_HOUR;
+
+const REFRESH_STARTUP: &str = "startup";
+const REFRESH_OPEN: &str = "open";
+const REFRESH_MANUAL: &str = "manual";
+
+/// Which entries a folder source keeps.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Only {
+    Dirs,
+    Files,
+    #[default]
+    All,
+}
+
+/// Whether the rows join the main result list or only their own scope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Scope {
+    #[default]
+    Global,
+    Prefix,
+}
+
+/// How the rows a source emits are encoded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RowFormat {
+    #[default]
+    Lines,
+    Json,
+}
+
+/// Where an action runs. A launcher cannot host an interactive process, so
+/// anything that needs a TTY is handed to the user's terminal instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ActionMode {
+    /// Detached, no window; the outcome is a banner.
+    #[default]
+    Background,
+    /// Spawned in the user's terminal emulator.
+    Terminal,
+    /// Run, then show stdout in the panel.
+    Output,
+    /// Stdout becomes the next level of rows.
+    Push,
+}
+
+/// When a command source re-runs. Never per keystroke.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Refresh {
+    #[default]
+    Startup,
+    Open,
+    Manual,
+    Interval(Duration),
+}
+
+impl Refresh {
+    /// `startup` | `open` | `manual` | a duration such as `30s`, `5m`, `1h`, `2d`.
+    pub fn parse(value: &str) -> Result<Self, String> {
+        let trimmed = value.trim();
+        match trimmed {
+            REFRESH_STARTUP => return Ok(Self::Startup),
+            REFRESH_OPEN => return Ok(Self::Open),
+            REFRESH_MANUAL => return Ok(Self::Manual),
+            _ => {}
+        }
+
+        let (digits, unit) = trimmed.split_at(
+            trimmed
+                .find(|c: char| !c.is_ascii_digit())
+                .ok_or_else(|| format!("refresh \"{trimmed}\" has no unit, try \"5m\""))?,
+        );
+        let amount: u64 = digits
+            .parse()
+            .map_err(|_| format!("refresh \"{trimmed}\" is not a duration"))?;
+        let seconds = match unit {
+            "s" => amount,
+            "m" => amount * SECONDS_PER_MINUTE,
+            "h" => amount * SECONDS_PER_HOUR,
+            "d" => amount * SECONDS_PER_DAY,
+            other => return Err(format!("refresh unit \"{other}\" is not one of s, m, h, d")),
+        };
+        if seconds == 0 {
+            return Err("refresh interval must be greater than zero".into());
+        }
+        Ok(Self::Interval(Duration::from_secs(seconds)))
+    }
+}
+
+/// One thing the user can do with a selected row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Action {
+    pub key: String,
+    pub label: String,
+    pub run: String,
+    pub mode: ActionMode,
+    /// Prompt for a typed value, substituted as `{input}`.
+    pub input: Option<String>,
+    /// Yes or no gate before running.
+    pub confirm: Option<String>,
+    /// Actions on the rows a `push` action returned.
+    pub actions: Vec<Action>,
+}
+
+/// The kind-specific half of a declaration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SourceSpec {
+    Folder {
+        /// One list can gather several places: projects live under `~/dev` and
+        /// `~/work` and are still one thing to the user. Written as `root` for
+        /// the single case or `roots` for many; both land here.
+        roots: Vec<String>,
+        depth: usize,
+        only: Only,
+        include: Vec<String>,
+        exclude: Vec<String>,
+    },
+    List {
+        file: String,
+        format: RowFormat,
+    },
+    Command {
+        command: String,
+        cwd: Option<String>,
+        refresh: Refresh,
+        timeout: Option<Duration>,
+        format: RowFormat,
+    },
+}
+
+impl SourceSpec {
+    pub fn kind_key(&self) -> &'static str {
+        match self {
+            Self::Folder { .. } => "folder",
+            Self::List { .. } => "list",
+            Self::Command { .. } => "command",
+        }
+    }
+}
+
+/// A validated source. `id` is the file stem, which is what row ids and scoped
+/// pruning key on, so it is never read from the file's own contents.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceDef {
+    pub id: String,
+    pub name: String,
+    pub spec: SourceSpec,
+    pub scope: Scope,
+    pub prefix: Option<String>,
+    pub aliases: Vec<String>,
+    pub bias: i64,
+    pub icon: Option<String>,
+    pub subtitle: Option<String>,
+    pub enabled: bool,
+    pub preview: Option<String>,
+    pub actions: Vec<Action>,
+    /// Keys the parser did not recognize. Reported, never fatal, so a file
+    /// written for a newer version still loads.
+    pub unknown_keys: Vec<String>,
+}
+
+impl SourceDef {
+    pub fn action(&self, key: &str) -> Option<&Action> {
+        self.actions.iter().find(|action| action.key == key)
+    }
+
+    pub fn default_action(&self) -> Option<&Action> {
+        self.action(DEFAULT_ACTION_KEY)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RawAction {
+    label: Option<String>,
+    run: Option<String>,
+    mode: Option<ActionMode>,
+    input: Option<String>,
+    confirm: Option<String>,
+    #[serde(default)]
+    actions: BTreeMap<String, RawAction>,
+    #[serde(flatten)]
+    extra: BTreeMap<String, toml::Value>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawSource {
+    name: Option<String>,
+    kind: Option<String>,
+    scope: Option<Scope>,
+    prefix: Option<String>,
+    aliases: Option<Vec<String>>,
+    bias: Option<i64>,
+    icon: Option<String>,
+    subtitle: Option<String>,
+    enabled: Option<bool>,
+    preview: Option<String>,
+
+    root: Option<String>,
+    roots: Option<Vec<String>>,
+    depth: Option<usize>,
+    only: Option<Only>,
+    #[serde(rename = "match")]
+    include: Option<Vec<String>>,
+    exclude: Option<Vec<String>>,
+
+    file: Option<String>,
+
+    command: Option<String>,
+    cwd: Option<String>,
+    refresh: Option<String>,
+    timeout: Option<String>,
+    format: Option<RowFormat>,
+
+    #[serde(default)]
+    actions: BTreeMap<String, RawAction>,
+    #[serde(flatten)]
+    extra: BTreeMap<String, toml::Value>,
+}
+
+/// Parse a declared source. `id` is the caller's (the file stem);
+/// `inferred_command` is the sibling or self executable used when the file
+/// names no command of its own.
+pub fn parse(
+    id: &str,
+    contents: &str,
+    inferred_command: Option<&str>,
+) -> Result<SourceDef, String> {
+    let raw: RawSource = toml::from_str(contents).map_err(|err| err.to_string())?;
+    build(id, raw, inferred_command)
+}
+
+/// A source with no declaration file at all: an executable dropped in the
+/// directory, where everything comes from defaults.
+pub fn inferred(id: &str, command: &str) -> SourceDef {
+    build(id, RawSource::default(), Some(command))
+        .expect("an inferred command source has every required field")
+}
+
+fn build(id: &str, raw: RawSource, inferred_command: Option<&str>) -> Result<SourceDef, String> {
+    let mut unknown_keys: Vec<String> = raw.extra.keys().cloned().collect();
+
+    let kind = match raw.kind.as_deref() {
+        Some(value) => value.to_string(),
+        None if raw.root.is_some() || raw.roots.is_some() => "folder".into(),
+        None if raw.file.is_some() => "list".into(),
+        None if raw.command.is_some() || inferred_command.is_some() => "command".into(),
+        None => return Err("kind is missing and cannot be inferred".into()),
+    };
+
+    let spec = match kind.as_str() {
+        "folder" => SourceSpec::Folder {
+            roots: folder_roots(raw.root, raw.roots)?,
+            depth: raw.depth.unwrap_or(DEFAULT_FOLDER_DEPTH),
+            only: raw.only.unwrap_or_default(),
+            include: raw.include.unwrap_or_default(),
+            exclude: raw.exclude.unwrap_or_default(),
+        },
+        "list" => SourceSpec::List {
+            file: raw.file.ok_or("list source needs a file")?,
+            format: raw.format.unwrap_or_default(),
+        },
+        "command" => SourceSpec::Command {
+            command: raw
+                .command
+                .or_else(|| inferred_command.map(String::from))
+                .ok_or("command source needs a command")?,
+            cwd: raw.cwd,
+            refresh: raw
+                .refresh
+                .as_deref()
+                .map(Refresh::parse)
+                .transpose()?
+                .unwrap_or_default(),
+            timeout: raw
+                .timeout
+                .as_deref()
+                .map(|value| match Refresh::parse(value)? {
+                    Refresh::Interval(duration) => Ok(duration),
+                    _ => Err(format!("timeout \"{value}\" must be a duration")),
+                })
+                .transpose()?,
+            format: raw.format.unwrap_or_default(),
+        },
+        other => return Err(format!("kind \"{other}\" is not folder, list, or command")),
+    };
+
+    let scope = raw.scope.unwrap_or_default();
+    if scope == Scope::Prefix && raw.prefix.is_none() {
+        return Err("scope = \"prefix\" needs a prefix".into());
+    }
+
+    let mut actions = Vec::new();
+    for (key, raw_action) in raw.actions {
+        actions.push(build_action(&key, raw_action, &mut unknown_keys)?);
+    }
+    // The panel and Enter both read this list, so `default` leads and the rest
+    // stay in a stable order rather than TOML's.
+    actions.sort_by(|a, b| {
+        let rank = |action: &Action| u8::from(action.key != DEFAULT_ACTION_KEY);
+        rank(a).cmp(&rank(b)).then_with(|| a.key.cmp(&b.key))
+    });
+
+    Ok(SourceDef {
+        id: id.to_string(),
+        name: raw.name.unwrap_or_else(|| id.to_string()),
+        spec,
+        scope,
+        prefix: raw.prefix,
+        aliases: raw.aliases.unwrap_or_default(),
+        bias: raw.bias.unwrap_or_default(),
+        icon: raw.icon,
+        subtitle: raw.subtitle,
+        enabled: raw.enabled.unwrap_or(true),
+        preview: raw.preview,
+        actions,
+        unknown_keys,
+    })
+}
+
+/// `root` and `roots` are the same key in two shapes, so a user who starts with
+/// one place and later adds another never has to restructure the file.
+fn folder_roots(root: Option<String>, roots: Option<Vec<String>>) -> Result<Vec<String>, String> {
+    let mut out = Vec::new();
+    out.extend(root);
+    out.extend(roots.unwrap_or_default());
+    out.retain(|value| !value.trim().is_empty());
+    if out.is_empty() {
+        return Err("folder source needs a root (or roots)".into());
+    }
+    Ok(out)
+}
+
+fn build_action(
+    key: &str,
+    raw: RawAction,
+    unknown_keys: &mut Vec<String>,
+) -> Result<Action, String> {
+    for extra in raw.extra.keys() {
+        unknown_keys.push(format!("actions.{key}.{extra}"));
+    }
+
+    let mut nested = Vec::new();
+    for (nested_key, nested_raw) in raw.actions {
+        nested.push(build_action(&nested_key, nested_raw, unknown_keys)?);
+    }
+
+    Ok(Action {
+        key: key.to_string(),
+        label: raw.label.unwrap_or_else(|| key.to_string()),
+        run: raw
+            .run
+            .ok_or_else(|| format!("action \"{key}\" needs a run"))?,
+        mode: raw.mode.unwrap_or_default(),
+        input: raw.input,
+        confirm: raw.confirm,
+        actions: nested,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn folder_source_takes_its_defaults() {
+        let def = parse("projects", "kind = \"folder\"\nroot = \"~/dev\"\n", None).unwrap();
+        assert_eq!(def.name, "projects");
+        assert_eq!(def.scope, Scope::Global);
+        assert!(def.enabled);
+        match def.spec {
+            SourceSpec::Folder { depth, only, .. } => {
+                assert_eq!(depth, DEFAULT_FOLDER_DEPTH);
+                assert_eq!(only, Only::All);
+            }
+            other => panic!("expected a folder spec, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn kind_is_inferred_from_the_key_that_is_present() {
+        let folder = parse("a", "root = \"~/dev\"\n", None).unwrap();
+        assert_eq!(folder.spec.kind_key(), "folder");
+        let list = parse("b", "file = \"~/hosts.txt\"\n", None).unwrap();
+        assert_eq!(list.spec.kind_key(), "list");
+        let command = parse("c", "command = \"ls\"\n", None).unwrap();
+        assert_eq!(command.spec.kind_key(), "command");
+    }
+
+    #[test]
+    fn an_executable_alone_is_a_whole_source() {
+        let def = inferred("projects", "/home/u/.look/sources/projects");
+        assert_eq!(def.name, "projects");
+        assert!(def.enabled);
+        match def.spec {
+            SourceSpec::Command {
+                command, refresh, ..
+            } => {
+                assert_eq!(command, "/home/u/.look/sources/projects");
+                assert_eq!(refresh, Refresh::Startup);
+            }
+            other => panic!("expected a command spec, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn actions_put_default_first_then_stay_stable() {
+        let def = parse(
+            "repos",
+            r#"
+root = "~/dev"
+
+[actions.zeta]
+run = "z {path}"
+
+[actions.default]
+label = "Open"
+run = "code {path}"
+
+[actions.alpha]
+run = "a {path}"
+"#,
+            None,
+        )
+        .unwrap();
+        let keys: Vec<&str> = def.actions.iter().map(|a| a.key.as_str()).collect();
+        assert_eq!(keys, ["default", "alpha", "zeta"]);
+        assert_eq!(def.default_action().unwrap().label, "Open");
+        // An action with no label is still usable; the key names it.
+        assert_eq!(def.action("alpha").unwrap().label, "alpha");
+    }
+
+    #[test]
+    fn run_values_survive_pipes_and_quotes_verbatim() {
+        // The reason this format is TOML: a run value is shell text, and any
+        // separator we invented would need escaping rules for it.
+        let def = parse(
+            "hosts",
+            r#"
+command = "awk '/^Host /{print $2}' ~/.ssh/config | sort"
+
+[actions.default]
+run = "$TERMINAL -e ssh {title} # connect"
+"#,
+            None,
+        )
+        .unwrap();
+        match &def.spec {
+            SourceSpec::Command { command, .. } => {
+                assert_eq!(command, "awk '/^Host /{print $2}' ~/.ssh/config | sort");
+            }
+            other => panic!("expected a command spec, got {other:?}"),
+        }
+        assert_eq!(
+            def.default_action().unwrap().run,
+            "$TERMINAL -e ssh {title} # connect"
+        );
+    }
+
+    #[test]
+    fn nested_actions_describe_a_pushed_level() {
+        let def = parse(
+            "repos",
+            r#"
+root = "~/dev"
+
+[actions.branches]
+mode = "push"
+run = "git -C {path} branch"
+
+[actions.branches.actions.default]
+label = "Checkout"
+run = "git checkout {id}"
+
+[actions.branches.actions.new]
+input = "New branch name"
+run = "git checkout -b {input}"
+"#,
+            None,
+        )
+        .unwrap();
+        let branches = def.action("branches").unwrap();
+        assert_eq!(branches.mode, ActionMode::Push);
+        let keys: Vec<&str> = branches.actions.iter().map(|a| a.key.as_str()).collect();
+        assert_eq!(keys, ["default", "new"]);
+        assert_eq!(
+            branches.actions[1].input.as_deref(),
+            Some("New branch name")
+        );
+    }
+
+    #[test]
+    fn unknown_keys_are_reported_but_never_fatal() {
+        let def = parse(
+            "projects",
+            r#"
+root = "~/dev"
+future_key = "whatever"
+
+[actions.default]
+run = "code {path}"
+also_new = true
+"#,
+            None,
+        )
+        .unwrap();
+        assert_eq!(def.unknown_keys, ["future_key", "actions.default.also_new"]);
+    }
+
+    #[test]
+    fn missing_required_fields_name_what_is_missing() {
+        assert!(
+            parse("a", "kind = \"folder\"\n", None)
+                .unwrap_err()
+                .contains("root")
+        );
+        assert!(
+            parse("b", "kind = \"list\"\n", None)
+                .unwrap_err()
+                .contains("file")
+        );
+        assert!(
+            parse("c", "root = \"~/dev\"\nscope = \"prefix\"\n", None)
+                .unwrap_err()
+                .contains("prefix")
+        );
+        assert!(
+            parse(
+                "d",
+                "root = \"~/dev\"\n\n[actions.default]\nlabel = \"x\"\n",
+                None
+            )
+            .unwrap_err()
+            .contains("run")
+        );
+    }
+
+    #[test]
+    fn refresh_accepts_keywords_and_durations() {
+        assert_eq!(Refresh::parse("startup").unwrap(), Refresh::Startup);
+        assert_eq!(Refresh::parse("open").unwrap(), Refresh::Open);
+        assert_eq!(Refresh::parse("manual").unwrap(), Refresh::Manual);
+        assert_eq!(
+            Refresh::parse("90s").unwrap(),
+            Refresh::Interval(Duration::from_secs(90))
+        );
+        assert_eq!(
+            Refresh::parse("2h").unwrap(),
+            Refresh::Interval(Duration::from_secs(2 * SECONDS_PER_HOUR))
+        );
+        assert!(Refresh::parse("1w").is_err());
+        assert!(Refresh::parse("0m").is_err());
+        assert!(Refresh::parse("soon").is_err());
+    }
+}

--- a/core/sources/src/def.rs
+++ b/core/sources/src/def.rs
@@ -25,10 +25,6 @@ const SECONDS_PER_MINUTE: u64 = 60;
 const SECONDS_PER_HOUR: u64 = 60 * SECONDS_PER_MINUTE;
 const SECONDS_PER_DAY: u64 = 24 * SECONDS_PER_HOUR;
 
-const REFRESH_STARTUP: &str = "startup";
-const REFRESH_OPEN: &str = "open";
-const REFRESH_MANUAL: &str = "manual";
-
 /// Which entries a `dir` block keeps.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -48,46 +44,27 @@ pub enum RowFormat {
     Json,
 }
 
-/// When a `run` block re-runs. Never per keystroke.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum Refresh {
-    #[default]
-    Startup,
-    Open,
-    Manual,
-    Interval(Duration),
-}
-
-impl Refresh {
-    /// `startup` | `open` | `manual` | a duration such as `30s`, `5m`, `1h`, `2d`.
-    pub fn parse(value: &str) -> Result<Self, String> {
-        let trimmed = value.trim();
-        match trimmed {
-            REFRESH_STARTUP => return Ok(Self::Startup),
-            REFRESH_OPEN => return Ok(Self::Open),
-            REFRESH_MANUAL => return Ok(Self::Manual),
-            _ => {}
-        }
-
-        let split = trimmed
-            .find(|c: char| !c.is_ascii_digit())
-            .ok_or_else(|| format!("refresh \"{trimmed}\" has no unit, try \"5m\""))?;
-        let (digits, unit) = trimmed.split_at(split);
-        let amount: u64 = digits
-            .parse()
-            .map_err(|_| format!("refresh \"{trimmed}\" is not a duration"))?;
-        let seconds = match unit {
-            "s" => amount,
-            "m" => amount * SECONDS_PER_MINUTE,
-            "h" => amount * SECONDS_PER_HOUR,
-            "d" => amount * SECONDS_PER_DAY,
-            other => return Err(format!("refresh unit \"{other}\" is not one of s, m, h, d")),
-        };
-        if seconds == 0 {
-            return Err("refresh interval must be greater than zero".into());
-        }
-        Ok(Self::Interval(Duration::from_secs(seconds)))
+/// Parses a duration such as `30s`, `5m`, `1h`, `2d`.
+pub fn parse_duration(value: &str) -> Result<Duration, String> {
+    let trimmed = value.trim();
+    let split = trimmed
+        .find(|c: char| !c.is_ascii_digit())
+        .ok_or_else(|| format!("\"{trimmed}\" has no unit, try \"5s\""))?;
+    let (digits, unit) = trimmed.split_at(split);
+    let amount: u64 = digits
+        .parse()
+        .map_err(|_| format!("\"{trimmed}\" is not a duration"))?;
+    let seconds = match unit {
+        "s" => amount,
+        "m" => amount * SECONDS_PER_MINUTE,
+        "h" => amount * SECONDS_PER_HOUR,
+        "d" => amount * SECONDS_PER_DAY,
+        other => return Err(format!("unit \"{other}\" is not one of s, m, h, d")),
+    };
+    if seconds == 0 {
+        return Err("a duration must be greater than zero".into());
     }
+    Ok(Duration::from_secs(seconds))
 }
 
 /// What a block produces.
@@ -109,7 +86,6 @@ pub enum Producer {
     Run {
         command: String,
         cwd: Option<String>,
-        refresh: Refresh,
         timeout: Option<Duration>,
         format: RowFormat,
     },
@@ -253,7 +229,6 @@ struct RawBlock {
 
     run: Option<String>,
     cwd: Option<String>,
-    refresh: Option<String>,
     timeout: Option<String>,
     format: Option<RowFormat>,
 
@@ -399,19 +374,10 @@ fn producer_from(raw: &RawBlock) -> Result<Producer, String> {
         [KEY_RUN] => Ok(Producer::Run {
             command: raw.run.clone().unwrap_or_default(),
             cwd: raw.cwd.clone(),
-            refresh: raw
-                .refresh
-                .as_deref()
-                .map(Refresh::parse)
-                .transpose()?
-                .unwrap_or_default(),
             timeout: raw
                 .timeout
                 .as_deref()
-                .map(|value| match Refresh::parse(value)? {
-                    Refresh::Interval(duration) => Ok(duration),
-                    _ => Err(format!("timeout \"{value}\" must be a duration")),
-                })
+                .map(|value| parse_duration(value).map_err(|err| format!("timeout {err}")))
                 .transpose()?,
             format: raw.format.unwrap_or_default(),
         }),
@@ -691,14 +657,22 @@ run = "git -C {path} branch"
     }
 
     #[test]
-    fn refresh_accepts_keywords_and_durations() {
-        assert_eq!(Refresh::parse("startup").unwrap(), Refresh::Startup);
-        assert_eq!(Refresh::parse("open").unwrap(), Refresh::Open);
+    fn timeout_takes_a_duration_and_nothing_else() {
+        assert_eq!(parse_duration("90s").unwrap(), Duration::from_secs(90));
         assert_eq!(
-            Refresh::parse("90s").unwrap(),
-            Refresh::Interval(Duration::from_secs(90))
+            parse_duration("2h").unwrap(),
+            Duration::from_secs(2 * SECONDS_PER_HOUR)
         );
-        assert!(Refresh::parse("1w").is_err());
-        assert!(Refresh::parse("0m").is_err());
+        assert!(parse_duration("1w").is_err());
+        assert!(parse_duration("0m").is_err());
+        assert!(parse_duration("soon").is_err());
+    }
+
+    #[test]
+    fn refresh_is_no_longer_a_key() {
+        // `run` blocks refresh on reload, one gesture for everything. A leftover
+        // `refresh = ...` is reported as unknown rather than silently ignored.
+        let block = one("[a]\nrun = \"ls\"\nrefresh = \"open\"\n");
+        assert_eq!(block.unknown_keys, ["refresh"]);
     }
 }

--- a/core/sources/src/def.rs
+++ b/core/sources/src/def.rs
@@ -294,6 +294,12 @@ pub fn inferred(id: &str, command: &str) -> Block {
 }
 
 fn build(id: &str, raw: RawBlock) -> Result<Block, String> {
+    // Row ids are `src:<block>:<row>` and split on the first colon, so a block
+    // id carrying one would resolve to a different block than it names. TOML
+    // allows it through a quoted header, so it has to be refused here.
+    if id.contains(':') {
+        return Err("a block id cannot contain \":\"".into());
+    }
     let producer = producer_from(&raw)?;
 
     let verbs = Verbs {
@@ -551,6 +557,15 @@ dir = "~/notes"
         let block = one("[drop]\nconfirm = \"Delete {id}?\"\ndo = [\"git branch -D {id}\"]\n");
         assert_eq!(block.confirm.as_deref(), Some("Delete {id}?"));
         assert!(block.needs_row());
+    }
+
+    #[test]
+    fn a_block_id_with_a_colon_is_refused() {
+        // `["team:prod"]` is valid TOML, and its rows would be `src:team:prod:x`,
+        // which reads back as block `team` and row `prod:x`.
+        let parsed = parse_file("[\"team:prod\"]\ndir = \"~/dev\"\n").unwrap();
+        assert!(parsed.blocks.is_empty());
+        assert!(parsed.problems[0].contains(':'), "{:?}", parsed.problems);
     }
 
     #[test]

--- a/core/sources/src/def.rs
+++ b/core/sources/src/def.rs
@@ -188,6 +188,9 @@ pub struct Block {
     pub icon: Option<String>,
     pub enabled: bool,
     pub preview: Option<String>,
+    /// A yes/no question asked before this block performs anything. Destructive
+    /// steps get one, because a launcher makes Enter on the wrong row cheap.
+    pub confirm: Option<String>,
     /// The file this block was declared in, so the app can show it and reveal
     /// it. Set by the loader; parsing a string alone has no file to name.
     pub source_file: Option<String>,
@@ -232,6 +235,7 @@ struct RawBlock {
     icon: Option<String>,
     enabled: Option<bool>,
     preview: Option<String>,
+    confirm: Option<String>,
 
     #[serde(rename = "do")]
     steps: Option<Vec<String>>,
@@ -347,6 +351,7 @@ fn build(id: &str, raw: RawBlock) -> Result<Block, String> {
         icon: raw.icon,
         enabled: raw.enabled.unwrap_or(true),
         preview: raw.preview,
+        confirm: raw.confirm.filter(|question| !question.trim().is_empty()),
         source_file: None,
         unknown_keys: raw.extra.keys().cloned().collect(),
     })
@@ -576,6 +581,23 @@ dir = "~/notes"
     }
 
     #[test]
+    fn a_destructive_block_can_ask_before_it_acts() {
+        let block = one("[drop]\nconfirm = \"Delete {id}?\"\ndo = [\"git branch -D {id}\"]\n");
+        assert_eq!(block.confirm.as_deref(), Some("Delete {id}?"));
+        assert!(block.needs_row());
+    }
+
+    #[test]
+    fn a_blank_confirm_is_no_confirm() {
+        // An empty string would otherwise mean "ask", with nothing to read.
+        assert!(
+            one("[a]\nconfirm = \"  \"\ndo = [\"true\"]\n")
+                .confirm
+                .is_none()
+        );
+    }
+
+    #[test]
     fn the_shipped_example_parses_with_nothing_left_unexplained() {
         // example.toml is what users copy, so a key renamed here without
         // updating it would hand everyone a file full of ignored settings.
@@ -583,7 +605,38 @@ dir = "~/notes"
         assert!(parsed.problems.is_empty(), "{:?}", parsed.problems);
 
         let ids: Vec<&str> = parsed.blocks.iter().map(|b| b.id.as_str()).collect();
-        assert_eq!(ids, ["branches", "hosts", "projects", "work"]);
+        assert_eq!(
+            ids,
+            [
+                "branches",
+                "drop-branch",
+                "ghostty",
+                "hosts",
+                "projects",
+                "work"
+            ]
+        );
+
+        // Anything the example shows as destructive must ask first, or it
+        // teaches the wrong habit to everyone who copies it.
+        let destructive = parsed
+            .blocks
+            .iter()
+            .find(|block| block.id == "drop-branch")
+            .expect("the delete example");
+        assert!(destructive.confirm.is_some());
+
+        // Every `then` target the example names must exist, or the file it
+        // hands new users would load with a reported error.
+        for block in &parsed.blocks {
+            for target in &block.then {
+                assert!(
+                    parsed.blocks.iter().any(|other| &other.id == target),
+                    "[{}] then names unknown block \"{target}\"",
+                    block.id
+                );
+            }
+        }
 
         for block in &parsed.blocks {
             assert!(

--- a/core/sources/src/def.rs
+++ b/core/sources/src/def.rs
@@ -178,6 +178,11 @@ pub struct Block {
     pub name: String,
     pub producer: Producer,
     pub verbs: Verbs,
+    /// Other blocks reachable from a row of this one. A target that performs
+    /// steps (`do`) is an action; a target that produces rows is a drill-down.
+    /// The target's own producer decides which, so `then` stays a plain list of
+    /// names with no mode to declare.
+    pub then: Vec<String>,
     pub aliases: Vec<String>,
     pub bias: i64,
     pub icon: Option<String>,
@@ -195,7 +200,29 @@ impl Block {
     pub fn is_bundle(&self) -> bool {
         matches!(self.producer, Producer::Bundle { .. })
     }
+
+    /// True when this block only makes sense against a selected row, because
+    /// what it produces refers to one. Such a block is reachable through another
+    /// block's `then`, never as a top-level row: running `make -C {path} deploy`
+    /// with nothing selected would substitute an empty path.
+    pub fn needs_row(&self) -> bool {
+        self.producer_text()
+            .iter()
+            .any(|text| text.contains(PLACEHOLDER_OPEN))
+    }
+
+    fn producer_text(&self) -> Vec<&str> {
+        match &self.producer {
+            Producer::Bundle { steps } => steps.iter().map(String::as_str).collect(),
+            Producer::Dir { roots, .. } => roots.iter().map(String::as_str).collect(),
+            Producer::File { path, .. } => vec![path.as_str()],
+            Producer::Run { command, .. } => vec![command.as_str()],
+        }
+    }
 }
+
+/// Opens a row placeholder such as `{path}`.
+const PLACEHOLDER_OPEN: char = '{';
 
 #[derive(Debug, Default, Deserialize)]
 struct RawBlock {
@@ -208,6 +235,7 @@ struct RawBlock {
 
     #[serde(rename = "do")]
     steps: Option<Vec<String>>,
+    then: Option<Vec<String>>,
 
     dir: Option<String>,
     dirs: Option<Vec<String>>,
@@ -308,6 +336,12 @@ fn build(id: &str, raw: RawBlock) -> Result<Block, String> {
         name: raw.name.unwrap_or_else(|| id.to_string()),
         producer,
         verbs,
+        then: raw
+            .then
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|name| !name.trim().is_empty())
+            .collect(),
         aliases: raw.aliases.unwrap_or_default(),
         bias: raw.bias.unwrap_or_default(),
         icon: raw.icon,
@@ -559,6 +593,48 @@ dir = "~/notes"
                 block.unknown_keys
             );
         }
+    }
+
+    #[test]
+    fn then_names_the_blocks_a_row_can_reach() {
+        let block = one("[projects]\ndir = \"~/dev\"\nthen = [\"deploy\", \"branches\"]\n");
+        assert_eq!(block.then, ["deploy", "branches"]);
+    }
+
+    #[test]
+    fn the_target_producer_decides_action_or_drill_down() {
+        // `then` carries no mode: a target that performs steps is an action, a
+        // target that produces rows is a level to descend into.
+        let parsed = parse_file(
+            r#"
+[projects]
+dir  = "~/dev"
+then = ["deploy", "branches"]
+
+[deploy]
+do = ["make -C {path} deploy"]
+
+[branches]
+run = "git -C {path} branch"
+"#,
+        )
+        .unwrap();
+        assert!(parsed.problems.is_empty());
+        let deploy = parsed.blocks.iter().find(|b| b.id == "deploy").unwrap();
+        let branches = parsed.blocks.iter().find(|b| b.id == "branches").unwrap();
+        assert!(deploy.is_bundle(), "performs its steps");
+        assert!(!branches.is_bundle(), "produces rows");
+    }
+
+    #[test]
+    fn a_block_that_refers_to_a_row_cannot_stand_alone() {
+        // Running `make -C {path} deploy` with nothing selected would substitute
+        // an empty path, so it is reachable only through `then`.
+        let deploy = one("[deploy]\ndo = [\"make -C {path} deploy\"]\n");
+        assert!(deploy.needs_row());
+
+        let work = one("[work]\ndo = [\"open -a Slack\"]\n");
+        assert!(!work.needs_row(), "names no row, so it is a top-level row");
     }
 
     #[test]

--- a/core/sources/src/def.rs
+++ b/core/sources/src/def.rs
@@ -1,5 +1,16 @@
-//! The declared shape of a source: what it is, how it refreshes, what its rows
-//! can do. Parsing only. Nothing here reads a directory or runs a command.
+//! What a user declares. Parsing only: nothing here reads a directory or runs a
+//! command.
+//!
+//! A file is a set of blocks. Every block has a `name` you can type, and one
+//! producer key that decides what it is:
+//!
+//! - `do`   a bundle. One row; Enter performs its steps.
+//! - `dir`  a list of the children of one or more directories.
+//! - `file` a list read from a text file.
+//! - `run`  a list read from a command's stdout.
+//!
+//! The producer key is the only thing that distinguishes them, so there is no
+//! `kind` to remember and no way for the two to disagree.
 
 use std::collections::BTreeMap;
 use std::time::Duration;
@@ -7,11 +18,8 @@ use std::time::Duration;
 use serde::Deserialize;
 
 /// Immediate children only. Deep walks belong to the file index, not to a
-/// source the user declared to get one short list.
+/// block the user declared to get one short list.
 pub const DEFAULT_FOLDER_DEPTH: usize = 1;
-
-/// The action Enter runs. Any other key is an entry in the actions panel.
-pub const DEFAULT_ACTION_KEY: &str = "default";
 
 const SECONDS_PER_MINUTE: u64 = 60;
 const SECONDS_PER_HOUR: u64 = 60 * SECONDS_PER_MINUTE;
@@ -21,7 +29,7 @@ const REFRESH_STARTUP: &str = "startup";
 const REFRESH_OPEN: &str = "open";
 const REFRESH_MANUAL: &str = "manual";
 
-/// Which entries a folder source keeps.
+/// Which entries a `dir` block keeps.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Only {
@@ -31,16 +39,7 @@ pub enum Only {
     All,
 }
 
-/// Whether the rows join the main result list or only their own scope.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Scope {
-    #[default]
-    Global,
-    Prefix,
-}
-
-/// How the rows a source emits are encoded.
+/// How the rows a `file` or `run` block emits are encoded.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum RowFormat {
@@ -49,23 +48,7 @@ pub enum RowFormat {
     Json,
 }
 
-/// Where an action runs. A launcher cannot host an interactive process, so
-/// anything that needs a TTY is handed to the user's terminal instead.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum ActionMode {
-    /// Detached, no window; the outcome is a banner.
-    #[default]
-    Background,
-    /// Spawned in the user's terminal emulator.
-    Terminal,
-    /// Run, then show stdout in the panel.
-    Output,
-    /// Stdout becomes the next level of rows.
-    Push,
-}
-
-/// When a command source re-runs. Never per keystroke.
+/// When a `run` block re-runs. Never per keystroke.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Refresh {
     #[default]
@@ -86,11 +69,10 @@ impl Refresh {
             _ => {}
         }
 
-        let (digits, unit) = trimmed.split_at(
-            trimmed
-                .find(|c: char| !c.is_ascii_digit())
-                .ok_or_else(|| format!("refresh \"{trimmed}\" has no unit, try \"5m\""))?,
-        );
+        let split = trimmed
+            .find(|c: char| !c.is_ascii_digit())
+            .ok_or_else(|| format!("refresh \"{trimmed}\" has no unit, try \"5m\""))?;
+        let (digits, unit) = trimmed.split_at(split);
         let amount: u64 = digits
             .parse()
             .map_err(|_| format!("refresh \"{trimmed}\" is not a duration"))?;
@@ -108,39 +90,23 @@ impl Refresh {
     }
 }
 
-/// One thing the user can do with a selected row.
+/// What a block produces.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Action {
-    pub key: String,
-    pub label: String,
-    pub run: String,
-    pub mode: ActionMode,
-    /// Prompt for a typed value, substituted as `{input}`.
-    pub input: Option<String>,
-    /// Yes or no gate before running.
-    pub confirm: Option<String>,
-    /// Actions on the rows a `push` action returned.
-    pub actions: Vec<Action>,
-}
-
-/// The kind-specific half of a declaration.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SourceSpec {
-    Folder {
-        /// One list can gather several places: projects live under `~/dev` and
-        /// `~/work` and are still one thing to the user. Written as `root` for
-        /// the single case or `roots` for many; both land here.
+pub enum Producer {
+    /// One row. Enter performs every step in order.
+    Bundle { steps: Vec<String> },
+    /// Rows from the children of one or more directories.
+    Dir {
         roots: Vec<String>,
         depth: usize,
         only: Only,
         include: Vec<String>,
         exclude: Vec<String>,
     },
-    List {
-        file: String,
-        format: RowFormat,
-    },
-    Command {
+    /// Rows from a text file.
+    File { path: String, format: RowFormat },
+    /// Rows from a command's stdout.
+    Run {
         command: String,
         cwd: Option<String>,
         refresh: Refresh,
@@ -149,75 +115,102 @@ pub enum SourceSpec {
     },
 }
 
-impl SourceSpec {
-    pub fn kind_key(&self) -> &'static str {
+impl Producer {
+    pub fn key(&self) -> &'static str {
         match self {
-            Self::Folder { .. } => "folder",
-            Self::List { .. } => "list",
-            Self::Command { .. } => "command",
+            Self::Bundle { .. } => KEY_DO,
+            Self::Dir { .. } => KEY_DIR,
+            Self::File { .. } => KEY_FILE,
+            Self::Run { .. } => KEY_RUN,
         }
     }
 }
 
-/// A validated source. `id` is the file stem, which is what row ids and scoped
-/// pruning key on, so it is never read from the file's own contents.
+pub const KEY_DO: &str = "do";
+pub const KEY_DIR: &str = "dir";
+pub const KEY_FILE: &str = "file";
+pub const KEY_RUN: &str = "run";
+
+/// The standard things a user does to a row. Each has one key across the whole
+/// app, so Cmd+E edits whatever the row is and wherever it came from. A block
+/// only names the ones whose command differs from the global default.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Verbs {
+    pub open: Option<String>,
+    pub edit: Option<String>,
+    pub terminal: Option<String>,
+    pub reveal: Option<String>,
+}
+
+impl Verbs {
+    pub const OPEN: &'static str = "open";
+    pub const EDIT: &'static str = "edit";
+    pub const TERMINAL: &'static str = "terminal";
+    pub const REVEAL: &'static str = "reveal";
+
+    pub fn is_empty(&self) -> bool {
+        self.open.is_none()
+            && self.edit.is_none()
+            && self.terminal.is_none()
+            && self.reveal.is_none()
+    }
+
+    /// Declared verbs in a stable order, for the action menu.
+    pub fn declared(&self) -> Vec<(&'static str, &str)> {
+        [
+            (Self::OPEN, self.open.as_deref()),
+            (Self::EDIT, self.edit.as_deref()),
+            (Self::TERMINAL, self.terminal.as_deref()),
+            (Self::REVEAL, self.reveal.as_deref()),
+        ]
+        .into_iter()
+        .filter_map(|(name, command)| command.map(|command| (name, command)))
+        .collect()
+    }
+}
+
+/// One declared block. `id` is the table header, which is what row ids and
+/// scoped pruning key on, so it never comes from the block's own contents.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SourceDef {
+pub struct Block {
     pub id: String,
+    /// What the user types to see this block's rows. Defaults to the id.
     pub name: String,
-    pub spec: SourceSpec,
-    pub scope: Scope,
-    pub prefix: Option<String>,
+    pub producer: Producer,
+    pub verbs: Verbs,
     pub aliases: Vec<String>,
     pub bias: i64,
     pub icon: Option<String>,
-    pub subtitle: Option<String>,
     pub enabled: bool,
     pub preview: Option<String>,
-    pub actions: Vec<Action>,
+    /// The file this block was declared in, so the app can show it and reveal
+    /// it. Set by the loader; parsing a string alone has no file to name.
+    pub source_file: Option<String>,
     /// Keys the parser did not recognize. Reported, never fatal, so a file
     /// written for a newer version still loads.
     pub unknown_keys: Vec<String>,
 }
 
-impl SourceDef {
-    pub fn action(&self, key: &str) -> Option<&Action> {
-        self.actions.iter().find(|action| action.key == key)
+impl Block {
+    pub fn is_bundle(&self) -> bool {
+        matches!(self.producer, Producer::Bundle { .. })
     }
-
-    pub fn default_action(&self) -> Option<&Action> {
-        self.action(DEFAULT_ACTION_KEY)
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct RawAction {
-    label: Option<String>,
-    run: Option<String>,
-    mode: Option<ActionMode>,
-    input: Option<String>,
-    confirm: Option<String>,
-    #[serde(default)]
-    actions: BTreeMap<String, RawAction>,
-    #[serde(flatten)]
-    extra: BTreeMap<String, toml::Value>,
 }
 
 #[derive(Debug, Default, Deserialize)]
-struct RawSource {
+struct RawBlock {
     name: Option<String>,
-    kind: Option<String>,
-    scope: Option<Scope>,
-    prefix: Option<String>,
     aliases: Option<Vec<String>>,
     bias: Option<i64>,
     icon: Option<String>,
-    subtitle: Option<String>,
     enabled: Option<bool>,
     preview: Option<String>,
 
-    root: Option<String>,
-    roots: Option<Vec<String>>,
+    #[serde(rename = "do")]
+    steps: Option<Vec<String>>,
+
+    dir: Option<String>,
+    dirs: Option<Vec<String>>,
     depth: Option<usize>,
     only: Option<Only>,
     #[serde(rename = "match")]
@@ -226,66 +219,147 @@ struct RawSource {
 
     file: Option<String>,
 
-    command: Option<String>,
+    run: Option<String>,
     cwd: Option<String>,
     refresh: Option<String>,
     timeout: Option<String>,
     format: Option<RowFormat>,
 
-    #[serde(default)]
-    actions: BTreeMap<String, RawAction>,
+    open: Option<String>,
+    edit: Option<String>,
+    terminal: Option<String>,
+    reveal: Option<String>,
+
     #[serde(flatten)]
     extra: BTreeMap<String, toml::Value>,
 }
 
-/// Parse a declared source. `id` is the caller's (the file stem);
-/// `inferred_command` is the sibling or self executable used when the file
-/// names no command of its own.
-pub fn parse(
-    id: &str,
-    contents: &str,
-    inferred_command: Option<&str>,
-) -> Result<SourceDef, String> {
-    let raw: RawSource = toml::from_str(contents).map_err(|err| err.to_string())?;
-    build(id, raw, inferred_command)
+/// Everything one file declared. A block that does not validate is reported
+/// without taking its neighbours down.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ParsedFile {
+    pub blocks: Vec<Block>,
+    pub problems: Vec<String>,
 }
 
-/// A source with no declaration file at all: an executable dropped in the
-/// directory, where everything comes from defaults.
-pub fn inferred(id: &str, command: &str) -> SourceDef {
-    build(id, RawSource::default(), Some(command))
-        .expect("an inferred command source has every required field")
+/// Parse a file of blocks. Every top-level table is one block, keyed by its
+/// header.
+pub fn parse_file(contents: &str) -> Result<ParsedFile, String> {
+    let value: toml::Value = toml::from_str(contents).map_err(|err| err.to_string())?;
+    let table = value
+        .as_table()
+        .ok_or("a source file must be a table of blocks")?;
+
+    let mut parsed = ParsedFile::default();
+    for (id, block) in table {
+        let Some(block) = block.as_table() else {
+            parsed.problems.push(format!(
+                "[{id}] must be a table, like [{id}]\\nname = \"…\""
+            ));
+            continue;
+        };
+        let raw: RawBlock = match toml::Value::Table(block.clone()).try_into() {
+            Ok(raw) => raw,
+            Err(err) => {
+                parsed.problems.push(format!("[{id}]: {err}"));
+                continue;
+            }
+        };
+        match build(id, raw) {
+            Ok(block) => parsed.blocks.push(block),
+            Err(message) => parsed.problems.push(format!("[{id}]: {message}")),
+        }
+    }
+    Ok(parsed)
 }
 
-fn build(id: &str, raw: RawSource, inferred_command: Option<&str>) -> Result<SourceDef, String> {
-    let mut unknown_keys: Vec<String> = raw.extra.keys().cloned().collect();
+/// A block with no declaration at all: an executable dropped in the directory,
+/// where the file itself is the command and everything else is a default.
+pub fn inferred(id: &str, command: &str) -> Block {
+    build(
+        id,
+        RawBlock {
+            run: Some(command.to_string()),
+            ..Default::default()
+        },
+    )
+    .expect("an inferred run block has every required field")
+}
 
-    let kind = match raw.kind.as_deref() {
-        Some(value) => value.to_string(),
-        None if raw.root.is_some() || raw.roots.is_some() => "folder".into(),
-        None if raw.file.is_some() => "list".into(),
-        None if raw.command.is_some() || inferred_command.is_some() => "command".into(),
-        None => return Err("kind is missing and cannot be inferred".into()),
+fn build(id: &str, raw: RawBlock) -> Result<Block, String> {
+    let producer = producer_from(&raw)?;
+
+    let verbs = Verbs {
+        open: raw.open,
+        edit: raw.edit,
+        terminal: raw.terminal,
+        reveal: raw.reveal,
     };
+    // A bundle IS the action, so a verb on it would be a second, hidden meaning
+    // for Enter.
+    if matches!(producer, Producer::Bundle { .. }) && !verbs.is_empty() {
+        return Err(format!(
+            "a `{KEY_DO}` block performs its own steps, so it cannot also declare open/edit/terminal/reveal"
+        ));
+    }
 
-    let spec = match kind.as_str() {
-        "folder" => SourceSpec::Folder {
-            roots: folder_roots(raw.root, raw.roots)?,
+    Ok(Block {
+        id: id.to_string(),
+        name: raw.name.unwrap_or_else(|| id.to_string()),
+        producer,
+        verbs,
+        aliases: raw.aliases.unwrap_or_default(),
+        bias: raw.bias.unwrap_or_default(),
+        icon: raw.icon,
+        enabled: raw.enabled.unwrap_or(true),
+        preview: raw.preview,
+        source_file: None,
+        unknown_keys: raw.extra.keys().cloned().collect(),
+    })
+}
+
+fn producer_from(raw: &RawBlock) -> Result<Producer, String> {
+    let declared: Vec<&str> = [
+        (KEY_DO, raw.steps.is_some()),
+        (KEY_DIR, raw.dir.is_some() || raw.dirs.is_some()),
+        (KEY_FILE, raw.file.is_some()),
+        (KEY_RUN, raw.run.is_some()),
+    ]
+    .into_iter()
+    .filter_map(|(key, present)| present.then_some(key))
+    .collect();
+
+    match declared.as_slice() {
+        [] => Err(format!(
+            "needs one of {KEY_DO}, {KEY_DIR}, {KEY_FILE}, or {KEY_RUN}"
+        )),
+        [KEY_DO] => {
+            let steps: Vec<String> = raw
+                .steps
+                .clone()
+                .unwrap_or_default()
+                .into_iter()
+                .filter(|step| !step.trim().is_empty())
+                .collect();
+            if steps.is_empty() {
+                return Err(format!("`{KEY_DO}` needs at least one step"));
+            }
+            Ok(Producer::Bundle { steps })
+        }
+        [KEY_DIR] => Ok(Producer::Dir {
+            roots: dir_roots(raw)?,
             depth: raw.depth.unwrap_or(DEFAULT_FOLDER_DEPTH),
             only: raw.only.unwrap_or_default(),
-            include: raw.include.unwrap_or_default(),
-            exclude: raw.exclude.unwrap_or_default(),
-        },
-        "list" => SourceSpec::List {
-            file: raw.file.ok_or("list source needs a file")?,
+            include: raw.include.clone().unwrap_or_default(),
+            exclude: raw.exclude.clone().unwrap_or_default(),
+        }),
+        [KEY_FILE] => Ok(Producer::File {
+            path: raw.file.clone().unwrap_or_default(),
             format: raw.format.unwrap_or_default(),
-        },
-        "command" => SourceSpec::Command {
-            command: raw
-                .command
-                .or_else(|| inferred_command.map(String::from))
-                .ok_or("command source needs a command")?,
-            cwd: raw.cwd,
+        }),
+        [KEY_RUN] => Ok(Producer::Run {
+            command: raw.run.clone().unwrap_or_default(),
+            cwd: raw.cwd.clone(),
             refresh: raw
                 .refresh
                 .as_deref()
@@ -301,275 +375,201 @@ fn build(id: &str, raw: RawSource, inferred_command: Option<&str>) -> Result<Sou
                 })
                 .transpose()?,
             format: raw.format.unwrap_or_default(),
-        },
-        other => return Err(format!("kind \"{other}\" is not folder, list, or command")),
-    };
-
-    let scope = raw.scope.unwrap_or_default();
-    if scope == Scope::Prefix && raw.prefix.is_none() {
-        return Err("scope = \"prefix\" needs a prefix".into());
+        }),
+        many => Err(format!(
+            "declares {}, but a block is one thing: pick one",
+            many.join(" and ")
+        )),
     }
-
-    let mut actions = Vec::new();
-    for (key, raw_action) in raw.actions {
-        actions.push(build_action(&key, raw_action, &mut unknown_keys)?);
-    }
-    // The panel and Enter both read this list, so `default` leads and the rest
-    // stay in a stable order rather than TOML's.
-    actions.sort_by(|a, b| {
-        let rank = |action: &Action| u8::from(action.key != DEFAULT_ACTION_KEY);
-        rank(a).cmp(&rank(b)).then_with(|| a.key.cmp(&b.key))
-    });
-
-    Ok(SourceDef {
-        id: id.to_string(),
-        name: raw.name.unwrap_or_else(|| id.to_string()),
-        spec,
-        scope,
-        prefix: raw.prefix,
-        aliases: raw.aliases.unwrap_or_default(),
-        bias: raw.bias.unwrap_or_default(),
-        icon: raw.icon,
-        subtitle: raw.subtitle,
-        enabled: raw.enabled.unwrap_or(true),
-        preview: raw.preview,
-        actions,
-        unknown_keys,
-    })
 }
 
-/// `root` and `roots` are the same key in two shapes, so a user who starts with
-/// one place and later adds another never has to restructure the file.
-fn folder_roots(root: Option<String>, roots: Option<Vec<String>>) -> Result<Vec<String>, String> {
+/// `dir` and `dirs` are the same key in two shapes, so a block that starts with
+/// one place and later gathers another never has to be restructured.
+fn dir_roots(raw: &RawBlock) -> Result<Vec<String>, String> {
     let mut out = Vec::new();
-    out.extend(root);
-    out.extend(roots.unwrap_or_default());
+    out.extend(raw.dir.clone());
+    out.extend(raw.dirs.clone().unwrap_or_default());
     out.retain(|value| !value.trim().is_empty());
     if out.is_empty() {
-        return Err("folder source needs a root (or roots)".into());
+        return Err(format!("`{KEY_DIR}` cannot be empty"));
     }
     Ok(out)
-}
-
-fn build_action(
-    key: &str,
-    raw: RawAction,
-    unknown_keys: &mut Vec<String>,
-) -> Result<Action, String> {
-    for extra in raw.extra.keys() {
-        unknown_keys.push(format!("actions.{key}.{extra}"));
-    }
-
-    let mut nested = Vec::new();
-    for (nested_key, nested_raw) in raw.actions {
-        nested.push(build_action(&nested_key, nested_raw, unknown_keys)?);
-    }
-
-    Ok(Action {
-        key: key.to_string(),
-        label: raw.label.unwrap_or_else(|| key.to_string()),
-        run: raw
-            .run
-            .ok_or_else(|| format!("action \"{key}\" needs a run"))?,
-        mode: raw.mode.unwrap_or_default(),
-        input: raw.input,
-        confirm: raw.confirm,
-        actions: nested,
-    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn one(contents: &str) -> Block {
+        let parsed = parse_file(contents).expect("valid file");
+        assert!(parsed.problems.is_empty(), "{:?}", parsed.problems);
+        parsed.blocks.into_iter().next().expect("one block")
+    }
+
     #[test]
-    fn folder_source_takes_its_defaults() {
-        let def = parse("projects", "kind = \"folder\"\nroot = \"~/dev\"\n", None).unwrap();
-        assert_eq!(def.name, "projects");
-        assert_eq!(def.scope, Scope::Global);
-        assert!(def.enabled);
-        match def.spec {
-            SourceSpec::Folder { depth, only, .. } => {
-                assert_eq!(depth, DEFAULT_FOLDER_DEPTH);
-                assert_eq!(only, Only::All);
-            }
-            other => panic!("expected a folder spec, got {other:?}"),
+    fn a_bundle_is_a_name_and_a_list_of_steps() {
+        let block = one(r#"
+[work]
+name = "Work setup"
+do = [
+  "open -a Slack",
+  "open -a Safari https://github.com",
+]
+"#);
+        assert_eq!(block.id, "work");
+        assert_eq!(block.name, "Work setup");
+        assert!(block.is_bundle());
+        match block.producer {
+            Producer::Bundle { steps } => assert_eq!(steps.len(), 2),
+            other => panic!("expected a bundle, got {other:?}"),
         }
     }
 
     #[test]
-    fn kind_is_inferred_from_the_key_that_is_present() {
-        let folder = parse("a", "root = \"~/dev\"\n", None).unwrap();
-        assert_eq!(folder.spec.kind_key(), "folder");
-        let list = parse("b", "file = \"~/hosts.txt\"\n", None).unwrap();
-        assert_eq!(list.spec.kind_key(), "list");
-        let command = parse("c", "command = \"ls\"\n", None).unwrap();
-        assert_eq!(command.spec.kind_key(), "command");
+    fn the_producer_key_is_the_only_thing_that_says_what_a_block_is() {
+        assert_eq!(one("[a]\ndir = \"~/dev\"\n").producer.key(), KEY_DIR);
+        assert_eq!(one("[b]\nfile = \"~/hosts\"\n").producer.key(), KEY_FILE);
+        assert_eq!(one("[c]\nrun = \"ls\"\n").producer.key(), KEY_RUN);
+        assert_eq!(one("[d]\ndo = [\"ls\"]\n").producer.key(), KEY_DO);
     }
 
     #[test]
-    fn an_executable_alone_is_a_whole_source() {
-        let def = inferred("projects", "/home/u/.look/sources/projects");
-        assert_eq!(def.name, "projects");
-        assert!(def.enabled);
-        match def.spec {
-            SourceSpec::Command {
-                command, refresh, ..
-            } => {
-                assert_eq!(command, "/home/u/.look/sources/projects");
-                assert_eq!(refresh, Refresh::Startup);
-            }
-            other => panic!("expected a command spec, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn actions_put_default_first_then_stay_stable() {
-        let def = parse(
-            "repos",
-            r#"
-root = "~/dev"
-
-[actions.zeta]
-run = "z {path}"
-
-[actions.default]
-label = "Open"
-run = "code {path}"
-
-[actions.alpha]
-run = "a {path}"
-"#,
-            None,
-        )
-        .unwrap();
-        let keys: Vec<&str> = def.actions.iter().map(|a| a.key.as_str()).collect();
-        assert_eq!(keys, ["default", "alpha", "zeta"]);
-        assert_eq!(def.default_action().unwrap().label, "Open");
-        // An action with no label is still usable; the key names it.
-        assert_eq!(def.action("alpha").unwrap().label, "alpha");
-    }
-
-    #[test]
-    fn run_values_survive_pipes_and_quotes_verbatim() {
-        // The reason this format is TOML: a run value is shell text, and any
-        // separator we invented would need escaping rules for it.
-        let def = parse(
-            "hosts",
-            r#"
-command = "awk '/^Host /{print $2}' ~/.ssh/config | sort"
-
-[actions.default]
-run = "$TERMINAL -e ssh {title} # connect"
-"#,
-            None,
-        )
-        .unwrap();
-        match &def.spec {
-            SourceSpec::Command { command, .. } => {
-                assert_eq!(command, "awk '/^Host /{print $2}' ~/.ssh/config | sort");
-            }
-            other => panic!("expected a command spec, got {other:?}"),
-        }
-        assert_eq!(
-            def.default_action().unwrap().run,
-            "$TERMINAL -e ssh {title} # connect"
+    fn a_block_that_is_two_things_at_once_is_refused() {
+        let parsed = parse_file("[a]\ndir = \"~/dev\"\nrun = \"ls\"\n").unwrap();
+        assert!(parsed.blocks.is_empty());
+        assert!(
+            parsed.problems[0].contains("pick one"),
+            "{:?}",
+            parsed.problems
         );
     }
 
     #[test]
-    fn nested_actions_describe_a_pushed_level() {
-        let def = parse(
-            "repos",
+    fn a_block_with_no_producer_says_what_it_needs() {
+        let parsed = parse_file("[a]\nname = \"Nothing\"\n").unwrap();
+        assert!(
+            parsed.problems[0].contains(KEY_DIR),
+            "{:?}",
+            parsed.problems
+        );
+    }
+
+    #[test]
+    fn verbs_are_the_commands_a_row_can_run() {
+        let block = one(r#"
+[projects]
+name = "Projects"
+dir  = "~/dev"
+only = "dirs"
+open = "open {path}"
+edit = "nvim {path}"
+"#);
+        assert_eq!(
+            block.verbs.declared(),
+            [("open", "open {path}"), ("edit", "nvim {path}")]
+        );
+    }
+
+    #[test]
+    fn a_bundle_cannot_also_declare_a_verb() {
+        // Enter already means "perform the steps", so a verb would be a second
+        // hidden meaning for the same key.
+        let parsed = parse_file("[a]\ndo = [\"ls\"]\nedit = \"nvim\"\n").unwrap();
+        assert!(
+            parsed.problems[0].contains("cannot also"),
+            "{:?}",
+            parsed.problems
+        );
+    }
+
+    #[test]
+    fn name_falls_back_to_the_block_header() {
+        assert_eq!(
+            one("[downloads]\ndir = \"~/Downloads\"\n").name,
+            "downloads"
+        );
+    }
+
+    #[test]
+    fn one_file_holds_as_many_blocks_as_you_like() {
+        let parsed = parse_file(
             r#"
-root = "~/dev"
+[projects]
+dir = "~/dev"
 
-[actions.branches]
-mode = "push"
-run = "git -C {path} branch"
+[work]
+do = ["open -a Slack"]
 
-[actions.branches.actions.default]
-label = "Checkout"
-run = "git checkout {id}"
-
-[actions.branches.actions.new]
-input = "New branch name"
-run = "git checkout -b {input}"
+[notes]
+dir = "~/notes"
 "#,
-            None,
         )
         .unwrap();
-        let branches = def.action("branches").unwrap();
-        assert_eq!(branches.mode, ActionMode::Push);
-        let keys: Vec<&str> = branches.actions.iter().map(|a| a.key.as_str()).collect();
-        assert_eq!(keys, ["default", "new"]);
-        assert_eq!(
-            branches.actions[1].input.as_deref(),
-            Some("New branch name")
-        );
+        let ids: Vec<&str> = parsed.blocks.iter().map(|b| b.id.as_str()).collect();
+        assert_eq!(ids, ["notes", "projects", "work"]);
+        assert!(parsed.problems.is_empty());
+    }
+
+    #[test]
+    fn a_broken_block_is_reported_and_its_neighbours_still_load() {
+        let parsed = parse_file("[good]\ndir = \"~/dev\"\n\n[bad]\nname = \"x\"\n").unwrap();
+        let ids: Vec<&str> = parsed.blocks.iter().map(|b| b.id.as_str()).collect();
+        assert_eq!(ids, ["good"]);
+        assert_eq!(parsed.problems.len(), 1);
+        assert!(parsed.problems[0].contains("[bad]"));
+    }
+
+    #[test]
+    fn dir_and_dirs_are_the_same_key_in_two_shapes() {
+        let block = one("[a]\ndir = \"~/dev\"\ndirs = [\"~/work\"]\n");
+        match block.producer {
+            Producer::Dir { roots, .. } => assert_eq!(roots, ["~/dev", "~/work"]),
+            other => panic!("expected a dir block, got {other:?}"),
+        }
     }
 
     #[test]
     fn unknown_keys_are_reported_but_never_fatal() {
-        let def = parse(
-            "projects",
-            r#"
-root = "~/dev"
-future_key = "whatever"
-
-[actions.default]
-run = "code {path}"
-also_new = true
-"#,
-            None,
-        )
-        .unwrap();
-        assert_eq!(def.unknown_keys, ["future_key", "actions.default.also_new"]);
+        let block = one("[a]\ndir = \"~/dev\"\nfuture_key = 1\n");
+        assert_eq!(block.unknown_keys, ["future_key"]);
     }
 
     #[test]
-    fn missing_required_fields_name_what_is_missing() {
-        assert!(
-            parse("a", "kind = \"folder\"\n", None)
-                .unwrap_err()
-                .contains("root")
-        );
-        assert!(
-            parse("b", "kind = \"list\"\n", None)
-                .unwrap_err()
-                .contains("file")
-        );
-        assert!(
-            parse("c", "root = \"~/dev\"\nscope = \"prefix\"\n", None)
-                .unwrap_err()
-                .contains("prefix")
-        );
-        assert!(
-            parse(
-                "d",
-                "root = \"~/dev\"\n\n[actions.default]\nlabel = \"x\"\n",
-                None
-            )
-            .unwrap_err()
-            .contains("run")
-        );
+    fn an_executable_alone_is_a_whole_block() {
+        let block = inferred("hosts", "/home/u/.look/sources/hosts");
+        assert_eq!(block.name, "hosts");
+        assert_eq!(block.producer.key(), KEY_RUN);
+    }
+
+    #[test]
+    fn the_shipped_example_parses_with_nothing_left_unexplained() {
+        // example.toml is what users copy, so a key renamed here without
+        // updating it would hand everyone a file full of ignored settings.
+        let parsed = parse_file(include_str!("../example.toml")).expect("valid example");
+        assert!(parsed.problems.is_empty(), "{:?}", parsed.problems);
+
+        let ids: Vec<&str> = parsed.blocks.iter().map(|b| b.id.as_str()).collect();
+        assert_eq!(ids, ["branches", "hosts", "projects", "work"]);
+
+        for block in &parsed.blocks {
+            assert!(
+                block.unknown_keys.is_empty(),
+                "[{}] has unknown keys: {:?}",
+                block.id,
+                block.unknown_keys
+            );
+        }
     }
 
     #[test]
     fn refresh_accepts_keywords_and_durations() {
         assert_eq!(Refresh::parse("startup").unwrap(), Refresh::Startup);
         assert_eq!(Refresh::parse("open").unwrap(), Refresh::Open);
-        assert_eq!(Refresh::parse("manual").unwrap(), Refresh::Manual);
         assert_eq!(
             Refresh::parse("90s").unwrap(),
             Refresh::Interval(Duration::from_secs(90))
         );
-        assert_eq!(
-            Refresh::parse("2h").unwrap(),
-            Refresh::Interval(Duration::from_secs(2 * SECONDS_PER_HOUR))
-        );
         assert!(Refresh::parse("1w").is_err());
         assert!(Refresh::parse("0m").is_err());
-        assert!(Refresh::parse("soon").is_err());
     }
 }

--- a/core/sources/src/lib.rs
+++ b/core/sources/src/lib.rs
@@ -1,12 +1,11 @@
-//! User-defined sources: rows the user declares, which join the launcher's own
-//! index rather than living behind a picker of their own.
+//! User-defined blocks: lists and bundles the user declares, which join the
+//! launcher's own index rather than living behind a picker of their own.
 //!
 //! This crate is the platform-neutral half. It reads the sources directory,
-//! validates declarations, and produces rows for the kinds that need nothing but
-//! the filesystem (folder and list). It deliberately does NOT know about
-//! candidates, ids, ranking, or process execution: mapping rows into the index
-//! is the engine's job, and running a user's command is the shell's, since only
-//! the shells own a process seam and a terminal.
+//! validates declarations, and produces rows for the producers that need
+//! nothing but the filesystem. It deliberately does NOT know about candidates,
+//! ids, ranking, or process execution: mapping rows into the index is the
+//! engine's job, and running a user's command is the shell's.
 //!
 //! See `specs/user-sources.md`.
 
@@ -14,11 +13,13 @@ mod collect;
 mod def;
 mod load;
 mod rows;
+mod run;
 
 pub use collect::{CollectError, Collected, MAX_ROWS_PER_SOURCE, collect, expand_home};
 pub use def::{
-    Action, ActionMode, DEFAULT_ACTION_KEY, DEFAULT_FOLDER_DEPTH, Only, Refresh, RowFormat, Scope,
-    SourceDef, SourceSpec, inferred, parse,
+    Block, DEFAULT_FOLDER_DEPTH, KEY_DIR, KEY_DO, KEY_FILE, KEY_RUN, Only, ParsedFile, Producer,
+    Refresh, RowFormat, Verbs, inferred, parse_file,
 };
 pub use load::{Loaded, Problem, SOURCES_DIR_ENV, load_dir, sources_dir};
 pub use rows::{SourceRow, parse_line, parse_lines};
+pub use run::{ENV_ID, ENV_PATH, ENV_TITLE, RowContext, StepOutcome, perform};

--- a/core/sources/src/lib.rs
+++ b/core/sources/src/lib.rs
@@ -18,7 +18,7 @@ mod run;
 pub use collect::{CollectError, Collected, MAX_ROWS_PER_SOURCE, collect, expand_home};
 pub use def::{
     Block, DEFAULT_FOLDER_DEPTH, KEY_DIR, KEY_DO, KEY_FILE, KEY_RUN, Only, ParsedFile, Producer,
-    Refresh, RowFormat, Verbs, inferred, parse_file,
+    RowFormat, Verbs, inferred, parse_duration, parse_file,
 };
 pub use load::{Loaded, Problem, SOURCES_DIR_ENV, load_dir, sources_dir};
 pub use rows::{SourceRow, parse_line, parse_lines};

--- a/core/sources/src/lib.rs
+++ b/core/sources/src/lib.rs
@@ -1,0 +1,24 @@
+//! User-defined sources: rows the user declares, which join the launcher's own
+//! index rather than living behind a picker of their own.
+//!
+//! This crate is the platform-neutral half. It reads the sources directory,
+//! validates declarations, and produces rows for the kinds that need nothing but
+//! the filesystem (folder and list). It deliberately does NOT know about
+//! candidates, ids, ranking, or process execution: mapping rows into the index
+//! is the engine's job, and running a user's command is the shell's, since only
+//! the shells own a process seam and a terminal.
+//!
+//! See `specs/user-sources.md`.
+
+mod collect;
+mod def;
+mod load;
+mod rows;
+
+pub use collect::{CollectError, Collected, MAX_ROWS_PER_SOURCE, collect, expand_home};
+pub use def::{
+    Action, ActionMode, DEFAULT_ACTION_KEY, DEFAULT_FOLDER_DEPTH, Only, Refresh, RowFormat, Scope,
+    SourceDef, SourceSpec, inferred, parse,
+};
+pub use load::{Loaded, Problem, SOURCES_DIR_ENV, load_dir, sources_dir};
+pub use rows::{SourceRow, parse_line, parse_lines};

--- a/core/sources/src/lib.rs
+++ b/core/sources/src/lib.rs
@@ -22,4 +22,4 @@ pub use def::{
 };
 pub use load::{Loaded, Problem, SOURCES_DIR_ENV, load_dir, sources_dir};
 pub use rows::{SourceRow, parse_line, parse_lines};
-pub use run::{ENV_ID, ENV_PATH, ENV_TITLE, RowContext, StepOutcome, perform};
+pub use run::{ENV_ID, ENV_PATH, ENV_TITLE, RowContext, StepOutcome, capture, expand, perform};

--- a/core/sources/src/load.rs
+++ b/core/sources/src/load.rs
@@ -1,18 +1,15 @@
 //! Reading the sources directory.
 //!
-//! What a file is, is decided by the file itself: an executable is a command
-//! source with everything inferred, a `.toml` is a declared source of any kind,
-//! and anything else is ignored with a reason the user can see. A `.toml` and an
-//! executable sharing a stem are one source: the declaration wins and the script
-//! supplies its command, so a script gains actions without moving its logic into
-//! a config value.
+//! A `.toml` file is a set of blocks. An executable is a `run` block with
+//! everything inferred, so a script that prints rows needs no declaration at
+//! all. Anything else is ignored with a reason the user can see.
 
 use std::collections::BTreeMap;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use crate::def::{SourceDef, inferred, parse};
+use crate::def::{Block, inferred, parse_file};
 
 /// Overrides where sources are read from, for dotfiles kept elsewhere. Mirrors
 /// `LOOK_CONFIG_PATH` in the engine config.
@@ -21,7 +18,7 @@ pub const SOURCES_DIR_ENV: &str = "LOOK_SOURCES_DIR";
 const SOURCES_DIR_NAME: &str = ".look/sources";
 const DECLARATION_EXTENSION: &str = "toml";
 
-/// A file the loader could not use, kept so `:source` can show it instead of
+/// A file the loader could not use, kept so the app can show it instead of
 /// failing silently.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Problem {
@@ -32,8 +29,8 @@ pub struct Problem {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Loaded {
     /// Enabled and disabled alike; the caller decides what to do with disabled
-    /// ones, and `:source` needs to list them either way.
-    pub sources: Vec<SourceDef>,
+    /// ones, and a management screen needs to list them either way.
+    pub blocks: Vec<Block>,
     pub problems: Vec<Problem>,
 }
 
@@ -48,8 +45,8 @@ pub fn sources_dir(home: &Path) -> PathBuf {
     home.join(SOURCES_DIR_NAME)
 }
 
-/// Loads every source in `dir`. A directory that does not exist is not a
-/// problem to report: it is the ordinary state of a user who has not made one.
+/// Loads every block in `dir`. A directory that does not exist is not a problem
+/// to report: it is the ordinary state of a user who has not made one.
 pub fn load_dir(dir: &Path) -> Loaded {
     let mut loaded = Loaded::default();
     let Ok(entries) = fs::read_dir(dir) else {
@@ -84,13 +81,23 @@ pub fn load_dir(dir: &Path) -> Loaded {
         }
     }
 
-    for (stem, path) in &declarations {
-        let script = executables
-            .get(stem)
-            .map(|path| path.to_string_lossy().into_owned());
+    for path in declarations.values() {
         match fs::read_to_string(path) {
-            Ok(contents) => match parse(stem, &contents, script.as_deref()) {
-                Ok(def) => loaded.sources.push(def),
+            Ok(contents) => match parse_file(&contents) {
+                Ok(parsed) => {
+                    loaded
+                        .blocks
+                        .extend(parsed.blocks.into_iter().map(|mut block| {
+                            block.source_file = Some(path.to_string_lossy().into_owned());
+                            block
+                        }));
+                    for message in parsed.problems {
+                        loaded.problems.push(Problem {
+                            file: path.clone(),
+                            message,
+                        });
+                    }
+                }
                 Err(message) => loaded.problems.push(Problem {
                     file: path.clone(),
                     message,
@@ -104,14 +111,27 @@ pub fn load_dir(dir: &Path) -> Loaded {
     }
 
     for (stem, path) in &executables {
-        if declarations.contains_key(stem) {
-            continue;
-        }
-        loaded.sources.push(inferred(stem, &path.to_string_lossy()));
+        let mut block = inferred(stem, &path.to_string_lossy());
+        block.source_file = Some(path.to_string_lossy().into_owned());
+        loaded.blocks.push(block);
     }
 
+    // The id namespaces a block's row ids, its usage history, and its scoped
+    // prune. Two blocks answering to one id would quietly share all three.
+    let mut taken: BTreeMap<String, ()> = BTreeMap::new();
+    loaded.blocks.retain(|block| {
+        if taken.insert(block.id.clone(), ()).is_none() {
+            return true;
+        }
+        loaded.problems.push(Problem {
+            file: dir.join(&block.id),
+            message: format!("duplicate block [{}]: only the first is loaded", block.id),
+        });
+        false
+    });
+
     for path in ignored {
-        // Not an error, but silence here reads as "my source is broken" when the
+        // Not an error, but silence here reads as "my block is broken" when the
         // real answer is that the file is neither executable nor a declaration.
         loaded.problems.push(Problem {
             file: path,
@@ -119,7 +139,7 @@ pub fn load_dir(dir: &Path) -> Loaded {
         });
     }
 
-    loaded.sources.sort_by(|a, b| a.id.cmp(&b.id));
+    loaded.blocks.sort_by(|a, b| a.id.cmp(&b.id));
     loaded.problems.sort_by(|a, b| a.file.cmp(&b.file));
     loaded
 }
@@ -145,7 +165,7 @@ fn is_executable(path: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::def::SourceSpec;
+    use crate::def::KEY_RUN;
 
     struct TempDir(PathBuf);
 
@@ -189,84 +209,73 @@ mod tests {
     #[test]
     fn a_missing_directory_is_not_an_error() {
         let loaded = load_dir(Path::new("/definitely/not/here"));
-        assert!(loaded.sources.is_empty());
+        assert!(loaded.blocks.is_empty());
         assert!(loaded.problems.is_empty());
     }
 
     #[test]
-    fn a_declaration_loads_under_its_file_stem() {
-        let tmp = TempDir::new("declared");
-        tmp.write("projects.toml", "root = \"~/dev\"\nname = \"Projects\"\n");
+    fn every_block_in_every_file_is_loaded() {
+        let tmp = TempDir::new("blocks");
+        tmp.write(
+            "mine.toml",
+            "[projects]\ndir = \"~/dev\"\n\n[work]\ndo = [\"open -a Slack\"]\n",
+        );
+        tmp.write("more.toml", "[notes]\ndir = \"~/notes\"\n");
 
         let loaded = load_dir(&tmp.0);
-        assert_eq!(loaded.sources.len(), 1);
-        assert_eq!(loaded.sources[0].id, "projects");
-        assert_eq!(loaded.sources[0].name, "Projects");
+        let ids: Vec<&str> = loaded.blocks.iter().map(|b| b.id.as_str()).collect();
+        assert_eq!(ids, ["notes", "projects", "work"]);
         assert!(loaded.problems.is_empty());
     }
 
     #[cfg(unix)]
     #[test]
-    fn an_executable_alone_needs_no_declaration() {
+    fn an_executable_needs_no_declaration() {
         let tmp = TempDir::new("executable");
         tmp.write_executable("hosts", "#!/bin/sh\necho web1\n");
 
         let loaded = load_dir(&tmp.0);
-        assert_eq!(loaded.sources.len(), 1);
-        assert_eq!(loaded.sources[0].id, "hosts");
-        assert_eq!(loaded.sources[0].spec.kind_key(), "command");
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn a_declaration_beside_a_script_is_one_source_that_runs_the_script() {
-        let tmp = TempDir::new("paired");
-        let script = tmp.write_executable("hosts", "#!/bin/sh\necho web1\n");
-        tmp.write(
-            "hosts.toml",
-            "name = \"SSH hosts\"\n\n[actions.default]\nrun = \"ssh {id}\"\n",
-        );
-
-        let loaded = load_dir(&tmp.0);
-        assert_eq!(loaded.sources.len(), 1, "the pair is one source, not two");
-        let def = &loaded.sources[0];
-        assert_eq!(def.name, "SSH hosts");
-        match &def.spec {
-            SourceSpec::Command { command, .. } => {
-                assert_eq!(command, script.to_str().unwrap());
-            }
-            other => panic!("expected a command spec, got {other:?}"),
-        }
-        assert_eq!(def.default_action().unwrap().run, "ssh {id}");
+        assert_eq!(loaded.blocks.len(), 1);
+        assert_eq!(loaded.blocks[0].id, "hosts");
+        assert_eq!(loaded.blocks[0].producer.key(), KEY_RUN);
     }
 
     #[test]
-    fn a_broken_declaration_is_reported_and_the_others_still_load() {
-        let tmp = TempDir::new("broken");
-        tmp.write("good.toml", "root = \"~/dev\"\n");
-        tmp.write("bad.toml", "kind = \"folder\"\n");
+    fn a_duplicate_block_id_loads_once_and_says_so() {
+        let tmp = TempDir::new("collide");
+        tmp.write("a.toml", "[projects]\ndir = \"~/dev\"\n");
+        tmp.write("b.toml", "[projects]\ndir = \"~/other\"\n");
 
         let loaded = load_dir(&tmp.0);
-        assert_eq!(loaded.sources.len(), 1);
-        assert_eq!(loaded.sources[0].id, "good");
+        assert_eq!(loaded.blocks.len(), 1);
         assert_eq!(loaded.problems.len(), 1);
-        assert!(loaded.problems[0].message.contains("root"));
+        assert!(loaded.problems[0].message.contains("duplicate block"));
+    }
+
+    #[test]
+    fn a_broken_file_is_reported_and_the_others_still_load() {
+        let tmp = TempDir::new("broken");
+        tmp.write("good.toml", "[good]\ndir = \"~/dev\"\n");
+        tmp.write("bad.toml", "[bad]\nname = \"no producer\"\n");
+
+        let loaded = load_dir(&tmp.0);
+        assert_eq!(loaded.blocks.len(), 1);
+        assert_eq!(loaded.problems.len(), 1);
+        assert!(loaded.problems[0].message.contains("[bad]"));
     }
 
     #[test]
     fn an_unusable_file_says_why_instead_of_vanishing() {
         let tmp = TempDir::new("ignored");
-        tmp.write("notes.md", "not a source");
+        tmp.write("notes.md", "not a block");
 
         let loaded = load_dir(&tmp.0);
-        assert!(loaded.sources.is_empty());
-        assert_eq!(loaded.problems.len(), 1);
+        assert!(loaded.blocks.is_empty());
         assert!(loaded.problems[0].message.contains("ignored"));
     }
 
     #[test]
     fn the_directory_falls_back_to_the_home_relative_default() {
-        // The env override is process-wide, so this asserts the default only.
         if env::var(SOURCES_DIR_ENV).is_ok() {
             return;
         }

--- a/core/sources/src/load.rs
+++ b/core/sources/src/load.rs
@@ -1,0 +1,278 @@
+//! Reading the sources directory.
+//!
+//! What a file is, is decided by the file itself: an executable is a command
+//! source with everything inferred, a `.toml` is a declared source of any kind,
+//! and anything else is ignored with a reason the user can see. A `.toml` and an
+//! executable sharing a stem are one source: the declaration wins and the script
+//! supplies its command, so a script gains actions without moving its logic into
+//! a config value.
+
+use std::collections::BTreeMap;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::def::{SourceDef, inferred, parse};
+
+/// Overrides where sources are read from, for dotfiles kept elsewhere. Mirrors
+/// `LOOK_CONFIG_PATH` in the engine config.
+pub const SOURCES_DIR_ENV: &str = "LOOK_SOURCES_DIR";
+
+const SOURCES_DIR_NAME: &str = ".look/sources";
+const DECLARATION_EXTENSION: &str = "toml";
+
+/// A file the loader could not use, kept so `:source` can show it instead of
+/// failing silently.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Problem {
+    pub file: PathBuf,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Loaded {
+    /// Enabled and disabled alike; the caller decides what to do with disabled
+    /// ones, and `:source` needs to list them either way.
+    pub sources: Vec<SourceDef>,
+    pub problems: Vec<Problem>,
+}
+
+/// Where sources live: `$LOOK_SOURCES_DIR`, else `~/.look/sources`.
+pub fn sources_dir(home: &Path) -> PathBuf {
+    if let Ok(custom) = env::var(SOURCES_DIR_ENV) {
+        let trimmed = custom.trim();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed);
+        }
+    }
+    home.join(SOURCES_DIR_NAME)
+}
+
+/// Loads every source in `dir`. A directory that does not exist is not a
+/// problem to report: it is the ordinary state of a user who has not made one.
+pub fn load_dir(dir: &Path) -> Loaded {
+    let mut loaded = Loaded::default();
+    let Ok(entries) = fs::read_dir(dir) else {
+        return loaded;
+    };
+
+    let mut declarations: BTreeMap<String, PathBuf> = BTreeMap::new();
+    let mut executables: BTreeMap<String, PathBuf> = BTreeMap::new();
+    let mut ignored: Vec<PathBuf> = Vec::new();
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if entry.file_type().is_ok_and(|kind| kind.is_dir()) {
+            continue;
+        }
+        let Some(stem) = path
+            .file_stem()
+            .map(|stem| stem.to_string_lossy().into_owned())
+        else {
+            continue;
+        };
+
+        if path
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case(DECLARATION_EXTENSION))
+        {
+            declarations.insert(stem, path);
+        } else if is_executable(&path) {
+            executables.insert(stem, path);
+        } else {
+            ignored.push(path);
+        }
+    }
+
+    for (stem, path) in &declarations {
+        let script = executables
+            .get(stem)
+            .map(|path| path.to_string_lossy().into_owned());
+        match fs::read_to_string(path) {
+            Ok(contents) => match parse(stem, &contents, script.as_deref()) {
+                Ok(def) => loaded.sources.push(def),
+                Err(message) => loaded.problems.push(Problem {
+                    file: path.clone(),
+                    message,
+                }),
+            },
+            Err(err) => loaded.problems.push(Problem {
+                file: path.clone(),
+                message: err.to_string(),
+            }),
+        }
+    }
+
+    for (stem, path) in &executables {
+        if declarations.contains_key(stem) {
+            continue;
+        }
+        loaded.sources.push(inferred(stem, &path.to_string_lossy()));
+    }
+
+    for path in ignored {
+        // Not an error, but silence here reads as "my source is broken" when the
+        // real answer is that the file is neither executable nor a declaration.
+        loaded.problems.push(Problem {
+            file: path,
+            message: "ignored: not executable and not a .toml declaration".into(),
+        });
+    }
+
+    loaded.sources.sort_by(|a, b| a.id.cmp(&b.id));
+    loaded.problems.sort_by(|a, b| a.file.cmp(&b.file));
+    loaded
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    const ANY_EXECUTE_BIT: u32 = 0o111;
+    fs::metadata(path).is_ok_and(|meta| meta.permissions().mode() & ANY_EXECUTE_BIT != 0)
+}
+
+#[cfg(windows)]
+fn is_executable(path: &Path) -> bool {
+    const EXECUTABLE_EXTENSIONS: [&str; 5] = ["exe", "cmd", "bat", "ps1", "com"];
+
+    path.extension().is_some_and(|extension| {
+        let extension = extension.to_string_lossy().to_lowercase();
+        EXECUTABLE_EXTENSIONS.contains(&extension.as_str())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::def::SourceSpec;
+
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new(label: &str) -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "look-sources-load-{label}-{}-{:?}",
+                std::process::id(),
+                std::thread::current().id()
+            ));
+            let _ = fs::remove_dir_all(&path);
+            fs::create_dir_all(&path).expect("temp dir");
+            Self(path)
+        }
+
+        fn write(&self, name: &str, contents: &str) -> PathBuf {
+            let path = self.0.join(name);
+            fs::write(&path, contents).expect("write");
+            path
+        }
+
+        fn write_executable(&self, name: &str, contents: &str) -> PathBuf {
+            let path = self.write(name, contents);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mut perms = fs::metadata(&path).expect("metadata").permissions();
+                perms.set_mode(0o755);
+                fs::set_permissions(&path, perms).expect("chmod");
+            }
+            path
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn a_missing_directory_is_not_an_error() {
+        let loaded = load_dir(Path::new("/definitely/not/here"));
+        assert!(loaded.sources.is_empty());
+        assert!(loaded.problems.is_empty());
+    }
+
+    #[test]
+    fn a_declaration_loads_under_its_file_stem() {
+        let tmp = TempDir::new("declared");
+        tmp.write("projects.toml", "root = \"~/dev\"\nname = \"Projects\"\n");
+
+        let loaded = load_dir(&tmp.0);
+        assert_eq!(loaded.sources.len(), 1);
+        assert_eq!(loaded.sources[0].id, "projects");
+        assert_eq!(loaded.sources[0].name, "Projects");
+        assert!(loaded.problems.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn an_executable_alone_needs_no_declaration() {
+        let tmp = TempDir::new("executable");
+        tmp.write_executable("hosts", "#!/bin/sh\necho web1\n");
+
+        let loaded = load_dir(&tmp.0);
+        assert_eq!(loaded.sources.len(), 1);
+        assert_eq!(loaded.sources[0].id, "hosts");
+        assert_eq!(loaded.sources[0].spec.kind_key(), "command");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_declaration_beside_a_script_is_one_source_that_runs_the_script() {
+        let tmp = TempDir::new("paired");
+        let script = tmp.write_executable("hosts", "#!/bin/sh\necho web1\n");
+        tmp.write(
+            "hosts.toml",
+            "name = \"SSH hosts\"\n\n[actions.default]\nrun = \"ssh {id}\"\n",
+        );
+
+        let loaded = load_dir(&tmp.0);
+        assert_eq!(loaded.sources.len(), 1, "the pair is one source, not two");
+        let def = &loaded.sources[0];
+        assert_eq!(def.name, "SSH hosts");
+        match &def.spec {
+            SourceSpec::Command { command, .. } => {
+                assert_eq!(command, script.to_str().unwrap());
+            }
+            other => panic!("expected a command spec, got {other:?}"),
+        }
+        assert_eq!(def.default_action().unwrap().run, "ssh {id}");
+    }
+
+    #[test]
+    fn a_broken_declaration_is_reported_and_the_others_still_load() {
+        let tmp = TempDir::new("broken");
+        tmp.write("good.toml", "root = \"~/dev\"\n");
+        tmp.write("bad.toml", "kind = \"folder\"\n");
+
+        let loaded = load_dir(&tmp.0);
+        assert_eq!(loaded.sources.len(), 1);
+        assert_eq!(loaded.sources[0].id, "good");
+        assert_eq!(loaded.problems.len(), 1);
+        assert!(loaded.problems[0].message.contains("root"));
+    }
+
+    #[test]
+    fn an_unusable_file_says_why_instead_of_vanishing() {
+        let tmp = TempDir::new("ignored");
+        tmp.write("notes.md", "not a source");
+
+        let loaded = load_dir(&tmp.0);
+        assert!(loaded.sources.is_empty());
+        assert_eq!(loaded.problems.len(), 1);
+        assert!(loaded.problems[0].message.contains("ignored"));
+    }
+
+    #[test]
+    fn the_directory_falls_back_to_the_home_relative_default() {
+        // The env override is process-wide, so this asserts the default only.
+        if env::var(SOURCES_DIR_ENV).is_ok() {
+            return;
+        }
+        assert_eq!(
+            sources_dir(Path::new("/home/u")),
+            PathBuf::from("/home/u").join(SOURCES_DIR_NAME)
+        );
+    }
+}

--- a/core/sources/src/load.rs
+++ b/core/sources/src/load.rs
@@ -130,6 +130,33 @@ pub fn load_dir(dir: &Path) -> Loaded {
         false
     });
 
+    // `then` names are checked once every block is known, so a reference to a
+    // block declared in another file is fine and only a genuine typo reports.
+    let known: BTreeMap<&str, ()> = loaded
+        .blocks
+        .iter()
+        .map(|block| (block.id.as_str(), ()))
+        .collect();
+    let unknown: Vec<Problem> = loaded
+        .blocks
+        .iter()
+        .flat_map(|block| {
+            block
+                .then
+                .iter()
+                .filter(|target| !known.contains_key(target.as_str()))
+                .map(|target| Problem {
+                    file: block
+                        .source_file
+                        .as_ref()
+                        .map(PathBuf::from)
+                        .unwrap_or_else(|| dir.join(&block.id)),
+                    message: format!("[{}] then names unknown block \"{target}\"", block.id),
+                })
+        })
+        .collect();
+    loaded.problems.extend(unknown);
+
     for path in ignored {
         // Not an error, but silence here reads as "my block is broken" when the
         // real answer is that the file is neither executable nor a declaration.
@@ -262,6 +289,32 @@ mod tests {
         assert_eq!(loaded.blocks.len(), 1);
         assert_eq!(loaded.problems.len(), 1);
         assert!(loaded.problems[0].message.contains("[bad]"));
+    }
+
+    #[test]
+    fn then_may_name_a_block_from_another_file() {
+        let tmp = TempDir::new("thencross");
+        tmp.write(
+            "a.toml",
+            "[projects]\ndir = \"~/dev\"\nthen = [\"deploy\"]\n",
+        );
+        tmp.write("b.toml", "[deploy]\ndo = [\"make -C {path} deploy\"]\n");
+
+        let loaded = load_dir(&tmp.0);
+        assert_eq!(loaded.blocks.len(), 2);
+        assert!(loaded.problems.is_empty(), "{:?}", loaded.problems);
+    }
+
+    #[test]
+    fn a_then_typo_is_reported_against_the_file_that_wrote_it() {
+        let tmp = TempDir::new("thentypo");
+        tmp.write("a.toml", "[projects]\ndir = \"~/dev\"\nthen = [\"edt\"]\n");
+
+        let loaded = load_dir(&tmp.0);
+        assert_eq!(loaded.blocks.len(), 1, "the block still loads");
+        assert_eq!(loaded.problems.len(), 1);
+        assert!(loaded.problems[0].message.contains("unknown block \"edt\""));
+        assert!(loaded.problems[0].file.ends_with("a.toml"));
     }
 
     #[test]

--- a/core/sources/src/rows.rs
+++ b/core/sources/src/rows.rs
@@ -1,0 +1,136 @@
+//! The row wire format shared by list and command sources.
+//!
+//! `id<TAB>title<TAB>group`, where a bare line is a row whose id and title are
+//! the same text. Tab separated rather than anything richer so a naive `ls` or
+//! `awk` one-liner is already a valid source, while a script that wants stable
+//! ranking can still say what the id is.
+
+/// The id is what actions receive and what usage is recorded against, so a row
+/// can display one thing and act on another.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceRow {
+    pub id: String,
+    pub title: String,
+    pub subtitle: Option<String>,
+    /// Section header this row sits under, within its own source.
+    pub group: Option<String>,
+    /// Filesystem target, when the row has one. Folder sources always do.
+    pub path: Option<String>,
+}
+
+impl SourceRow {
+    pub fn new(id: impl Into<String>, title: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            title: title.into(),
+            subtitle: None,
+            group: None,
+            path: None,
+        }
+    }
+}
+
+const FIELD_SEPARATOR: char = '\t';
+
+/// Parses one line. Blank lines are not rows; a line that is only whitespace is
+/// almost always an artifact of the script, not something the user wants to see.
+pub fn parse_line(line: &str) -> Option<SourceRow> {
+    let line = line.strip_suffix('\r').unwrap_or(line);
+    if line.trim().is_empty() {
+        return None;
+    }
+
+    let mut fields = line.split(FIELD_SEPARATOR);
+    let id = fields.next()?.trim();
+    if id.is_empty() {
+        return None;
+    }
+    let title = fields
+        .next()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let group = fields
+        .next()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+
+    Some(SourceRow {
+        id: id.to_string(),
+        title: title.unwrap_or(id).to_string(),
+        subtitle: None,
+        group: group.map(String::from),
+        path: None,
+    })
+}
+
+/// Parses stdout or a list file, dropping rows past `limit` so a runaway
+/// producer cannot flood the index. The caller reports the truncation.
+pub fn parse_lines(text: &str, limit: usize) -> (Vec<SourceRow>, bool) {
+    let mut rows = Vec::new();
+    for line in text.lines() {
+        if rows.len() == limit {
+            return (rows, true);
+        }
+        if let Some(row) = parse_line(line) {
+            rows.push(row);
+        }
+    }
+    (rows, false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_bare_line_is_its_own_id_and_title() {
+        let row = parse_line("look").unwrap();
+        assert_eq!(row.id, "look");
+        assert_eq!(row.title, "look");
+        assert_eq!(row.group, None);
+    }
+
+    #[test]
+    fn id_and_title_can_differ_so_a_row_shows_one_thing_and_acts_on_another() {
+        let row = parse_line("look\tlook (main, 3 windows)\tSession").unwrap();
+        assert_eq!(row.id, "look");
+        assert_eq!(row.title, "look (main, 3 windows)");
+        assert_eq!(row.group.as_deref(), Some("Session"));
+    }
+
+    #[test]
+    fn blank_and_idless_lines_are_not_rows() {
+        assert!(parse_line("").is_none());
+        assert!(parse_line("   ").is_none());
+        assert!(parse_line("\tonly a title").is_none());
+    }
+
+    #[test]
+    fn empty_trailing_fields_fall_back_rather_than_showing_blanks() {
+        let row = parse_line("look\t\t").unwrap();
+        assert_eq!(row.title, "look");
+        assert_eq!(row.group, None);
+    }
+
+    #[test]
+    fn windows_line_endings_do_not_end_up_in_the_text() {
+        let (rows, _) = parse_lines("alpha\r\nbeta\r\n", 10);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[1].title, "beta");
+    }
+
+    #[test]
+    fn output_past_the_limit_is_dropped_and_reported() {
+        let text = (0..10)
+            .map(|i| i.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let (rows, truncated) = parse_lines(&text, 4);
+        assert_eq!(rows.len(), 4);
+        assert!(truncated);
+
+        let (rows, truncated) = parse_lines(&text, 100);
+        assert_eq!(rows.len(), 10);
+        assert!(!truncated);
+    }
+}

--- a/core/sources/src/run.rs
+++ b/core/sources/src/run.rs
@@ -10,10 +10,15 @@
 //! after Enter, and an app it launched must outlive it.
 
 use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
 /// Used when `$SHELL` is unset, which happens for processes the window server
 /// starts without a user session environment.
 const FALLBACK_SHELL: &str = "/bin/sh";
+
+/// How often a captured command is checked for having finished. Short enough
+/// that a fast command is not held up, long enough not to spin.
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 /// Environment the step can read to know which row it was performed on.
 pub const ENV_ID: &str = "LOOK_ID";
@@ -122,6 +127,65 @@ fn spawn(step: &str, row: Option<&RowContext>) -> Result<(), String> {
         .map_err(|err| format!("{shell}: {err}"))
 }
 
+/// Runs `command` and returns its stdout, for the producers whose output IS the
+/// answer (a `run` block's rows, a `preview`).
+///
+/// Bounded three ways, because this is arbitrary user code on a path the user is
+/// waiting on: a timeout, a byte cap, and no stdin. Unlike `perform`, this waits
+/// - the caller is asking for the output, so there is nothing to detach from.
+pub fn capture(
+    command: &str,
+    cwd: Option<&str>,
+    timeout: Duration,
+    max_bytes: usize,
+) -> Result<String, String> {
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| FALLBACK_SHELL.to_string());
+    let mut spawned = Command::new(&shell)
+        .arg("-lc")
+        .arg(command)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .current_dir(cwd.filter(|dir| !dir.is_empty()).unwrap_or("/"))
+        .spawn()
+        .map_err(|err| format!("{shell}: {err}"))?;
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        match spawned.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = spawned.kill();
+                    let _ = spawned.wait();
+                    return Err(format!("timed out after {}s", timeout.as_secs()));
+                }
+                std::thread::sleep(POLL_INTERVAL);
+            }
+            Err(err) => return Err(err.to_string()),
+        }
+    }
+
+    let output = spawned.wait_with_output().map_err(|err| err.to_string())?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let reason = stderr.lines().next().unwrap_or("exited non-zero").trim();
+        return Err(reason.to_string());
+    }
+
+    let mut text = String::from_utf8_lossy(&output.stdout).into_owned();
+    if text.len() > max_bytes {
+        // Cut on a char boundary so a multi-byte glyph at the cap does not
+        // produce a panic or a replacement character.
+        let mut cut = max_bytes;
+        while cut > 0 && !text.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        text.truncate(cut);
+    }
+    Ok(text)
+}
+
 /// Its own process group, so closing the launcher never signals what it started.
 #[cfg(unix)]
 fn detach(command: &mut Command) {
@@ -208,6 +272,38 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn capture_returns_what_the_command_printed() {
+        let out = capture("printf 'a\nb\n'", None, Duration::from_secs(5), 1024).unwrap();
+        assert_eq!(out, "a\nb\n");
+    }
+
+    #[test]
+    fn a_command_that_fails_reports_its_first_stderr_line() {
+        let err = capture("echo boom >&2; exit 1", None, Duration::from_secs(5), 1024).unwrap_err();
+        assert_eq!(err, "boom");
+    }
+
+    #[test]
+    fn a_hung_command_is_killed_rather_than_waited_on() {
+        let err = capture("sleep 30", None, Duration::from_millis(150), 1024).unwrap_err();
+        assert!(err.contains("timed out"), "{err}");
+    }
+
+    #[test]
+    fn output_past_the_cap_is_cut_on_a_char_boundary() {
+        // A multi-byte glyph straddling the cap must not panic or corrupt.
+        let out = capture(
+            "printf 'é%.0s' $(seq 1 100)",
+            None,
+            Duration::from_secs(5),
+            15,
+        )
+        .unwrap();
+        assert!(out.len() <= 15);
+        assert!(out.chars().all(|c| c == 'é'), "{out:?}");
     }
 
     #[test]

--- a/core/sources/src/run.rs
+++ b/core/sources/src/run.rs
@@ -8,6 +8,11 @@
 //!
 //! Steps are detached and not waited on: the launcher window closes immediately
 //! after Enter, and an app it launched must outlive it.
+//!
+//! A step is POSIX shell text down to its punctuation - `&&`, `>`, and the
+//! single quotes `expand` wraps every placeholder in. Windows has no shell that
+//! reads it, and handing it to `cmd` would run the command with mangled
+//! arguments rather than not run it, so there the step is refused outright.
 
 use std::io::Read;
 use std::process::{Command, Stdio};
@@ -16,7 +21,13 @@ use std::time::{Duration, Instant};
 
 /// Used when `$SHELL` is unset, which happens for processes the window server
 /// starts without a user session environment.
+#[cfg(unix)]
 const FALLBACK_SHELL: &str = "/bin/sh";
+
+/// Said instead of running anything, so a source that cannot work on this
+/// platform reports why rather than failing as a missing program.
+#[cfg(not(unix))]
+const NO_POSIX_SHELL: &str = "steps are POSIX shell commands, which this platform has no shell for";
 
 /// How often a captured command is checked for having finished. Short enough
 /// that a fast command is not held up, long enough not to spin.
@@ -108,12 +119,30 @@ fn quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
 }
 
-fn spawn(step: &str, row: Option<&RowContext>) -> Result<(), String> {
+/// The one place a step becomes a process: `$SHELL -lc <step>`, or nothing at
+/// all where there is no POSIX shell to read it.
+#[cfg(unix)]
+fn shell_command(step: &str) -> Result<Command, String> {
     let shell = std::env::var("SHELL").unwrap_or_else(|_| FALLBACK_SHELL.to_string());
-    let mut command = Command::new(&shell);
+    let mut command = Command::new(shell);
+    command.arg("-lc").arg(step);
+    Ok(command)
+}
+
+#[cfg(not(unix))]
+fn shell_command(_step: &str) -> Result<Command, String> {
+    Err(NO_POSIX_SHELL.to_string())
+}
+
+/// What a failed spawn is reported as: the shell that could not start, since
+/// "no such file or directory" alone names nothing the user can act on.
+fn spawn_failure(command: &Command, err: std::io::Error) -> String {
+    format!("{}: {err}", command.get_program().to_string_lossy())
+}
+
+fn spawn(step: &str, row: Option<&RowContext>) -> Result<(), String> {
+    let mut command = shell_command(step)?;
     command
-        .arg("-lc")
-        .arg(step)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null());
@@ -133,10 +162,10 @@ fn spawn(step: &str, row: Option<&RowContext>) -> Result<(), String> {
     }
 
     detach(&mut command);
-    command
-        .spawn()
-        .map(|_| ())
-        .map_err(|err| format!("{shell}: {err}"))
+    match command.spawn() {
+        Ok(_) => Ok(()),
+        Err(err) => Err(spawn_failure(&command, err)),
+    }
 }
 
 /// Runs `command` and returns its stdout, for the producers whose output IS the
@@ -151,16 +180,13 @@ pub fn capture(
     timeout: Duration,
     max_bytes: usize,
 ) -> Result<String, String> {
-    let shell = std::env::var("SHELL").unwrap_or_else(|_| FALLBACK_SHELL.to_string());
-    let mut spawned = Command::new(&shell)
-        .arg("-lc")
-        .arg(command)
+    let mut shell = shell_command(command)?;
+    shell
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .current_dir(cwd.filter(|dir| !dir.is_empty()).unwrap_or("/"))
-        .spawn()
-        .map_err(|err| format!("{shell}: {err}"))?;
+        .current_dir(cwd.filter(|dir| !dir.is_empty()).unwrap_or("/"));
+    let mut spawned = shell.spawn().map_err(|err| spawn_failure(&shell, err))?;
 
     // Both pipes are drained on their own threads for the whole run. Polling
     // `try_wait` and reading afterwards deadlocks the moment a command writes
@@ -327,102 +353,123 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    #[test]
-    fn capture_returns_what_the_command_printed() {
-        let out = capture("printf 'a\nb\n'", None, Duration::from_secs(5), 1024).unwrap();
-        assert_eq!(out, "a\nb\n");
-    }
+    /// Everything below performs a real command, so it exists only where there
+    /// is a shell to perform it with.
+    #[cfg(unix)]
+    mod shell {
+        use super::*;
 
-    #[test]
-    fn a_command_that_fails_reports_its_first_stderr_line() {
-        let err = capture("echo boom >&2; exit 1", None, Duration::from_secs(5), 1024).unwrap_err();
-        assert_eq!(err, "boom");
-    }
-
-    #[test]
-    fn a_hung_command_is_killed_rather_than_waited_on() {
-        let err = capture("sleep 30", None, Duration::from_millis(150), 1024).unwrap_err();
-        assert!(err.contains("timed out"), "{err}");
-    }
-
-    #[test]
-    fn output_larger_than_the_pipe_buffer_does_not_deadlock() {
-        // The OS pipe buffer is ~64 KiB. Reading only after the child exits
-        // means it blocks on write and never exits, and the deadline then
-        // reports a timeout for a command that was working fine.
-        let out = capture(
-            "head -c 200000 /dev/zero | tr '\\0' 'a'",
-            None,
-            Duration::from_secs(10),
-            256 * 1024,
-        )
-        .expect("a long-output command must finish");
-        assert_eq!(out.len(), 200_000);
-    }
-
-    #[test]
-    fn output_past_the_cap_is_cut_on_a_char_boundary() {
-        // A multi-byte glyph straddling the cap must not panic or corrupt.
-        let out = capture(
-            "printf 'é%.0s' $(seq 1 100)",
-            None,
-            Duration::from_secs(5),
-            15,
-        )
-        .unwrap();
-        assert!(out.len() <= 15);
-        assert!(out.chars().all(|c| c == 'é'), "{out:?}");
-    }
-
-    #[test]
-    fn a_step_on_a_file_row_runs_in_the_files_folder() {
-        // `current_dir` on a file path fails the spawn outright, so this is the
-        // difference between file rows working and every one of them erroring.
-        let dir = std::env::temp_dir().join(format!("look-run-cwd-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).expect("probe dir");
-        let file = dir.join("row.txt");
-        std::fs::write(&file, "x").expect("probe file");
-
-        let mut context = row("");
-        context.path = file.to_string_lossy().into_owned();
-        let outcomes = perform(&["true".to_string()], Some(&context));
-
-        assert_eq!(outcomes[0].error, None, "a file row must not fail to spawn");
-        let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    #[test]
-    fn every_step_is_attempted_even_when_one_fails() {
-        // A bundle that opens four apps should open the three that exist, so a
-        // failure is recorded against its own step and the rest still run.
-        let steps = vec!["true".to_string(), "false".to_string(), "true".to_string()];
-        let outcomes = perform(&steps, None);
-        assert_eq!(outcomes.len(), 3);
-        // Spawning succeeds for all three: a nonzero exit is the command's
-        // business, not a spawn failure, and we never wait for it.
-        assert!(outcomes.iter().all(|outcome| outcome.error.is_none()));
-    }
-
-    #[test]
-    fn a_step_runs_through_a_shell_so_shell_syntax_works() {
-        let path = std::env::temp_dir().join(format!("look-run-{}", std::process::id()));
-        let _ = std::fs::remove_file(&path);
-        let steps = vec![format!("echo hi > {}", path.display())];
-
-        let outcomes = perform(&steps, None);
-        assert!(outcomes[0].error.is_none());
-
-        // The step is detached, so give it a moment before reading.
-        for _ in 0..50 {
-            if path.exists() {
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(20));
+        #[test]
+        fn capture_returns_what_the_command_printed() {
+            let out = capture("printf 'a\nb\n'", None, Duration::from_secs(5), 1024).unwrap();
+            assert_eq!(out, "a\nb\n");
         }
-        assert!(
-            path.exists(),
-            "redirection is shell syntax, so it needs a shell"
-        );
-        let _ = std::fs::remove_file(&path);
+
+        #[test]
+        fn a_command_that_fails_reports_its_first_stderr_line() {
+            let err =
+                capture("echo boom >&2; exit 1", None, Duration::from_secs(5), 1024).unwrap_err();
+            assert_eq!(err, "boom");
+        }
+
+        #[test]
+        fn a_hung_command_is_killed_rather_than_waited_on() {
+            let err = capture("sleep 30", None, Duration::from_millis(150), 1024).unwrap_err();
+            assert!(err.contains("timed out"), "{err}");
+        }
+
+        #[test]
+        fn output_larger_than_the_pipe_buffer_does_not_deadlock() {
+            // The OS pipe buffer is ~64 KiB. Reading only after the child exits
+            // means it blocks on write and never exits, and the deadline then
+            // reports a timeout for a command that was working fine.
+            let out = capture(
+                "head -c 200000 /dev/zero | tr '\\0' 'a'",
+                None,
+                Duration::from_secs(10),
+                256 * 1024,
+            )
+            .expect("a long-output command must finish");
+            assert_eq!(out.len(), 200_000);
+        }
+
+        #[test]
+        fn output_past_the_cap_is_cut_on_a_char_boundary() {
+            // A multi-byte glyph straddling the cap must not panic or corrupt.
+            let out = capture(
+                "printf 'é%.0s' $(seq 1 100)",
+                None,
+                Duration::from_secs(5),
+                15,
+            )
+            .unwrap();
+            assert!(out.len() <= 15);
+            assert!(out.chars().all(|c| c == 'é'), "{out:?}");
+        }
+
+        #[test]
+        fn a_step_on_a_file_row_runs_in_the_files_folder() {
+            // `current_dir` on a file path fails the spawn outright, so this is the
+            // difference between file rows working and every one of them erroring.
+            let dir = std::env::temp_dir().join(format!("look-run-cwd-{}", std::process::id()));
+            std::fs::create_dir_all(&dir).expect("probe dir");
+            let file = dir.join("row.txt");
+            std::fs::write(&file, "x").expect("probe file");
+
+            let mut context = row("");
+            context.path = file.to_string_lossy().into_owned();
+            let outcomes = perform(&["true".to_string()], Some(&context));
+
+            assert_eq!(outcomes[0].error, None, "a file row must not fail to spawn");
+            let _ = std::fs::remove_dir_all(&dir);
+        }
+
+        #[test]
+        fn every_step_is_attempted_even_when_one_fails() {
+            // A bundle that opens four apps should open the three that exist, so a
+            // failure is recorded against its own step and the rest still run.
+            let steps = vec!["true".to_string(), "false".to_string(), "true".to_string()];
+            let outcomes = perform(&steps, None);
+            assert_eq!(outcomes.len(), 3);
+            // Spawning succeeds for all three: a nonzero exit is the command's
+            // business, not a spawn failure, and we never wait for it.
+            assert!(outcomes.iter().all(|outcome| outcome.error.is_none()));
+        }
+
+        #[test]
+        fn a_step_runs_through_a_shell_so_shell_syntax_works() {
+            let path = std::env::temp_dir().join(format!("look-run-{}", std::process::id()));
+            let _ = std::fs::remove_file(&path);
+            let steps = vec![format!("echo hi > {}", path.display())];
+
+            let outcomes = perform(&steps, None);
+            assert!(outcomes[0].error.is_none());
+
+            // The step is detached, so it is waited for rather than assumed
+            // done. A login shell reads the user's profile before it runs
+            // anything, which on a loaded machine is not instant, so the
+            // deadline is long and the loop leaves the moment the file lands.
+            let deadline = Instant::now() + Duration::from_secs(10);
+            while !path.exists() && Instant::now() < deadline {
+                std::thread::sleep(POLL_INTERVAL);
+            }
+            assert!(
+                path.exists(),
+                "redirection is shell syntax, so it needs a shell"
+            );
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+
+    /// Off Unix the step is refused, and the refusal says why: a source that
+    /// cannot run here must read as unsupported, not as a broken command.
+    #[cfg(not(unix))]
+    #[test]
+    fn a_step_without_a_posix_shell_is_refused_by_name() {
+        let outcomes = perform(&["true".to_string()], None);
+        assert_eq!(outcomes[0].error.as_deref(), Some(NO_POSIX_SHELL));
+
+        let err = capture("true", None, Duration::from_secs(5), 1024).unwrap_err();
+        assert_eq!(err, NO_POSIX_SHELL);
     }
 }

--- a/core/sources/src/run.rs
+++ b/core/sources/src/run.rs
@@ -1,0 +1,141 @@
+//! Performing a block's steps.
+//!
+//! Every step goes through the user's LOGIN shell. A launcher is started by the
+//! window server, so it inherits a minimal environment: no `$EDITOR`, no
+//! `$TERMINAL`, and a `PATH` without Homebrew, nvm, or anything a profile adds.
+//! Without `-l`, a command that works when pasted into a terminal fails here and
+//! the user has no way to see why.
+//!
+//! Steps are detached and not waited on: the launcher window closes immediately
+//! after Enter, and an app it launched must outlive it.
+
+use std::process::{Command, Stdio};
+
+/// Used when `$SHELL` is unset, which happens for processes the window server
+/// starts without a user session environment.
+const FALLBACK_SHELL: &str = "/bin/sh";
+
+/// Environment the step can read to know which row it was performed on.
+pub const ENV_ID: &str = "LOOK_ID";
+pub const ENV_TITLE: &str = "LOOK_TITLE";
+pub const ENV_PATH: &str = "LOOK_PATH";
+
+/// What a step was performed with, so a caller can report it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StepOutcome {
+    pub step: String,
+    pub error: Option<String>,
+}
+
+/// Runs every step in order, detached. One failing step does not stop the rest:
+/// a bundle that opens four apps should open the three that are installed.
+pub fn perform(steps: &[String], row: Option<&RowContext>) -> Vec<StepOutcome> {
+    steps
+        .iter()
+        .map(|step| StepOutcome {
+            step: step.clone(),
+            error: spawn(step, row).err(),
+        })
+        .collect()
+}
+
+/// The row a step is being performed on, exported so a script can read it.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RowContext {
+    pub id: String,
+    pub title: String,
+    pub path: String,
+}
+
+fn spawn(step: &str, row: Option<&RowContext>) -> Result<(), String> {
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| FALLBACK_SHELL.to_string());
+    let mut command = Command::new(&shell);
+    command
+        .arg("-lc")
+        .arg(step)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    if let Some(row) = row {
+        command
+            .env(ENV_ID, &row.id)
+            .env(ENV_TITLE, &row.title)
+            .env(ENV_PATH, &row.path);
+        if !row.path.is_empty() {
+            command.current_dir(&row.path);
+        }
+    }
+
+    detach(&mut command);
+    command
+        .spawn()
+        .map(|_| ())
+        .map_err(|err| format!("{shell}: {err}"))
+}
+
+/// Its own process group, so closing the launcher never signals what it started.
+#[cfg(unix)]
+fn detach(command: &mut Command) {
+    use std::os::unix::process::CommandExt;
+
+    unsafe {
+        command.pre_exec(|| {
+            libc_setsid();
+            Ok(())
+        });
+    }
+}
+
+#[cfg(unix)]
+fn libc_setsid() {
+    unsafe extern "C" {
+        fn setsid() -> i32;
+    }
+    unsafe {
+        setsid();
+    }
+}
+
+#[cfg(not(unix))]
+fn detach(_command: &mut Command) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_step_is_attempted_even_when_one_fails() {
+        // A bundle that opens four apps should open the three that exist, so a
+        // failure is recorded against its own step and the rest still run.
+        let steps = vec!["true".to_string(), "false".to_string(), "true".to_string()];
+        let outcomes = perform(&steps, None);
+        assert_eq!(outcomes.len(), 3);
+        // Spawning succeeds for all three: a nonzero exit is the command's
+        // business, not a spawn failure, and we never wait for it.
+        assert!(outcomes.iter().all(|outcome| outcome.error.is_none()));
+    }
+
+    #[test]
+    fn a_step_runs_through_a_shell_so_shell_syntax_works() {
+        let path = std::env::temp_dir().join(format!("look-run-{}", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        let steps = vec![format!("echo hi > {}", path.display())];
+
+        let outcomes = perform(&steps, None);
+        assert!(outcomes[0].error.is_none());
+
+        // The step is detached, so give it a moment before reading.
+        for _ in 0..50 {
+            if path.exists() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        assert!(
+            path.exists(),
+            "redirection is shell syntax, so it needs a shell"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/core/sources/src/run.rs
+++ b/core/sources/src/run.rs
@@ -32,19 +32,67 @@ pub struct StepOutcome {
 pub fn perform(steps: &[String], row: Option<&RowContext>) -> Vec<StepOutcome> {
     steps
         .iter()
-        .map(|step| StepOutcome {
-            step: step.clone(),
-            error: spawn(step, row).err(),
+        .map(|step| {
+            let expanded = match row {
+                Some(row) => expand(step, row),
+                None => step.clone(),
+            };
+            let error = spawn(&expanded, row).err();
+            StepOutcome {
+                step: expanded,
+                error,
+            }
         })
         .collect()
 }
 
-/// The row a step is being performed on, exported so a script can read it.
+/// The row a step is being performed on: what its placeholders expand to, and
+/// what it exports to the process.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RowContext {
     pub id: String,
     pub title: String,
     pub path: String,
+    /// What the user had typed when they picked the row.
+    pub query: String,
+}
+
+/// Substitutes `{id}`, `{title}`, `{path}`, `{dir}`, and `{query}`.
+///
+/// Every value is quoted on the way in, which is a correctness requirement
+/// before it is a safety one: rows come from directory listings and command
+/// output, so a folder called `my project` must stay one argument and a row
+/// titled `; rm -rf ~` must not execute. A template therefore never quotes its
+/// own placeholders.
+pub fn expand(template: &str, row: &RowContext) -> String {
+    let dir = parent_dir(&row.path);
+    template
+        .replace("{id}", &quote(&row.id))
+        .replace("{title}", &quote(&row.title))
+        .replace("{path}", &quote(&row.path))
+        .replace("{dir}", &quote(&dir))
+        .replace("{query}", &quote(&row.query))
+}
+
+/// The row's own folder: itself when it is one, its parent otherwise.
+fn parent_dir(path: &str) -> String {
+    if path.is_empty() {
+        return String::new();
+    }
+    let as_path = std::path::Path::new(path);
+    if as_path.is_dir() {
+        return path.to_string();
+    }
+    as_path
+        .parent()
+        .map(|parent| parent.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
+
+/// POSIX single-quoting: everything inside is literal, and an embedded quote is
+/// closed, escaped, and reopened.
+fn quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 fn spawn(step: &str, row: Option<&RowContext>) -> Result<(), String> {
@@ -103,6 +151,64 @@ fn detach(_command: &mut Command) {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn row(path: &str) -> RowContext {
+        RowContext {
+            id: "look".into(),
+            title: "look".into(),
+            path: path.into(),
+            query: "loo".into(),
+        }
+    }
+
+    #[test]
+    fn placeholders_expand_to_the_selected_row() {
+        let expanded = expand("nvim {path} # {title} {query}", &row("/tmp/look"));
+        assert_eq!(expanded, "nvim '/tmp/look' # 'look' 'loo'");
+    }
+
+    #[test]
+    fn a_path_with_spaces_stays_one_argument() {
+        assert_eq!(
+            expand("code {path}", &row("/tmp/my project")),
+            "code '/tmp/my project'"
+        );
+    }
+
+    #[test]
+    fn a_row_named_like_a_command_cannot_execute() {
+        // Rows come from directory listings and command output, so this is the
+        // difference between quoting and a deleted home directory.
+        let mut hostile = row("");
+        hostile.title = "; rm -rf ~".into();
+        assert_eq!(expand("echo {title}", &hostile), "echo '; rm -rf ~'");
+    }
+
+    #[test]
+    fn an_embedded_quote_survives_intact() {
+        let mut tricky = row("");
+        tricky.title = "it's".into();
+        assert_eq!(expand("echo {title}", &tricky), "echo 'it'\\''s'");
+    }
+
+    #[test]
+    fn dir_is_the_row_when_it_is_a_folder_and_its_parent_otherwise() {
+        let dir = std::env::temp_dir().join(format!("look-expand-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("probe dir");
+        let dir_text = dir.to_str().expect("utf8 path");
+
+        assert_eq!(expand("{dir}", &row(dir_text)), format!("'{dir_text}'"));
+
+        let file = dir.join("probe.txt");
+        std::fs::write(&file, "x").expect("probe file");
+        assert_eq!(
+            expand("{dir}", &row(file.to_str().unwrap())),
+            format!("'{dir_text}'"),
+            "a file row hands its command the folder it lives in"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     #[test]
     fn every_step_is_attempted_even_when_one_fails() {

--- a/core/sources/src/run.rs
+++ b/core/sources/src/run.rs
@@ -9,7 +9,9 @@
 //! Steps are detached and not waited on: the launcher window closes immediately
 //! after Enter, and an app it launched must outlive it.
 
+use std::io::Read;
 use std::process::{Command, Stdio};
+use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 /// Used when `$SHELL` is unset, which happens for processes the window server
@@ -19,6 +21,12 @@ const FALLBACK_SHELL: &str = "/bin/sh";
 /// How often a captured command is checked for having finished. Short enough
 /// that a fast command is not held up, long enough not to spin.
 const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Only the first line of stderr is ever shown, so there is no reason to hold
+/// a failing command's whole diagnostic output in memory.
+const MAX_STDERR_BYTES: usize = 8 * 1024;
+
+const DRAIN_CHUNK_BYTES: usize = 8 * 1024;
 
 /// Environment the step can read to know which row it was performed on.
 pub const ENV_ID: &str = "LOOK_ID";
@@ -115,8 +123,12 @@ fn spawn(step: &str, row: Option<&RowContext>) -> Result<(), String> {
             .env(ENV_ID, &row.id)
             .env(ENV_TITLE, &row.title)
             .env(ENV_PATH, &row.path);
-        if !row.path.is_empty() {
-            command.current_dir(&row.path);
+        // The row's FOLDER, never the row itself: `path` is a file for most
+        // rows, and `current_dir` on a file makes every spawn fail with
+        // ENOTDIR. Same rule as `{dir}`.
+        let dir = parent_dir(&row.path);
+        if !dir.is_empty() {
+            command.current_dir(&dir);
         }
     }
 
@@ -150,10 +162,20 @@ pub fn capture(
         .spawn()
         .map_err(|err| format!("{shell}: {err}"))?;
 
+    // Both pipes are drained on their own threads for the whole run. Polling
+    // `try_wait` and reading afterwards deadlocks the moment a command writes
+    // more than the OS pipe buffer (~64 KiB): the child blocks on write, never
+    // exits, and the deadline then reports a timeout for a healthy command.
+    let stdout = spawned.stdout.take().map(|pipe| drain(pipe, max_bytes));
+    let stderr = spawned
+        .stderr
+        .take()
+        .map(|pipe| drain(pipe, MAX_STDERR_BYTES));
+
     let deadline = Instant::now() + timeout;
-    loop {
+    let status = loop {
         match spawned.try_wait() {
-            Ok(Some(_)) => break,
+            Ok(Some(status)) => break status,
             Ok(None) => {
                 if Instant::now() >= deadline {
                     let _ = spawned.kill();
@@ -164,26 +186,57 @@ pub fn capture(
             }
             Err(err) => return Err(err.to_string()),
         }
-    }
+    };
 
-    let output = spawned.wait_with_output().map_err(|err| err.to_string())?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let reason = stderr.lines().next().unwrap_or("exited non-zero").trim();
-        return Err(reason.to_string());
+    let out = stdout.map(join_drained).unwrap_or_default();
+    if !status.success() {
+        let errors = stderr.map(join_drained).unwrap_or_default();
+        let reason = errors.lines().next().unwrap_or("exited non-zero").trim();
+        return Err(if reason.is_empty() {
+            "exited non-zero".to_string()
+        } else {
+            reason.to_string()
+        });
     }
+    Ok(out)
+}
 
-    let mut text = String::from_utf8_lossy(&output.stdout).into_owned();
-    if text.len() > max_bytes {
-        // Cut on a char boundary so a multi-byte glyph at the cap does not
-        // produce a panic or a replacement character.
-        let mut cut = max_bytes;
-        while cut > 0 && !text.is_char_boundary(cut) {
-            cut -= 1;
+/// Reads a pipe to its end on its own thread, keeping at most `max_bytes`.
+///
+/// It keeps reading past the cap rather than stopping, because closing the pipe
+/// early would hand the child a SIGPIPE and turn "your output was long" into
+/// "your command failed".
+fn drain<R: Read + Send + 'static>(mut pipe: R, max_bytes: usize) -> JoinHandle<Vec<u8>> {
+    std::thread::spawn(move || {
+        let mut kept: Vec<u8> = Vec::new();
+        let mut chunk = [0u8; DRAIN_CHUNK_BYTES];
+        while let Ok(read) = pipe.read(&mut chunk) {
+            if read == 0 {
+                break;
+            }
+            let room = max_bytes.saturating_sub(kept.len());
+            if room > 0 {
+                kept.extend_from_slice(&chunk[..read.min(room)]);
+            }
         }
-        text.truncate(cut);
+        kept
+    })
+}
+
+/// The drained bytes as text, ending on a whole character.
+///
+/// Mid-stream invalid bytes still decode lossily, since genuinely non-UTF8
+/// output is worth showing. Only a trailing replacement character is dropped:
+/// there it is not the command's data but an artifact of the byte cap landing
+/// inside a multi-byte glyph.
+fn join_drained(handle: JoinHandle<Vec<u8>>) -> String {
+    let bytes = handle.join().unwrap_or_default();
+    let mut text = String::from_utf8_lossy(&bytes).into_owned();
+    let cut_a_glyph = std::str::from_utf8(&bytes).is_err();
+    if cut_a_glyph && text.ends_with(char::REPLACEMENT_CHARACTER) {
+        text.pop();
     }
-    Ok(text)
+    text
 }
 
 /// Its own process group, so closing the launcher never signals what it started.
@@ -293,6 +346,21 @@ mod tests {
     }
 
     #[test]
+    fn output_larger_than_the_pipe_buffer_does_not_deadlock() {
+        // The OS pipe buffer is ~64 KiB. Reading only after the child exits
+        // means it blocks on write and never exits, and the deadline then
+        // reports a timeout for a command that was working fine.
+        let out = capture(
+            "head -c 200000 /dev/zero | tr '\\0' 'a'",
+            None,
+            Duration::from_secs(10),
+            256 * 1024,
+        )
+        .expect("a long-output command must finish");
+        assert_eq!(out.len(), 200_000);
+    }
+
+    #[test]
     fn output_past_the_cap_is_cut_on_a_char_boundary() {
         // A multi-byte glyph straddling the cap must not panic or corrupt.
         let out = capture(
@@ -304,6 +372,23 @@ mod tests {
         .unwrap();
         assert!(out.len() <= 15);
         assert!(out.chars().all(|c| c == 'é'), "{out:?}");
+    }
+
+    #[test]
+    fn a_step_on_a_file_row_runs_in_the_files_folder() {
+        // `current_dir` on a file path fails the spawn outright, so this is the
+        // difference between file rows working and every one of them erroring.
+        let dir = std::env::temp_dir().join(format!("look-run-cwd-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("probe dir");
+        let file = dir.join("row.txt");
+        std::fs::write(&file, "x").expect("probe file");
+
+        let mut context = row("");
+        context.path = file.to_string_lossy().into_owned();
+        let outcomes = perform(&["true".to_string()], Some(&context));
+
+        assert_eq!(outcomes[0].error, None, "a file row must not fail to spawn");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/core/sources/src/run.rs
+++ b/core/sources/src/run.rs
@@ -10,9 +10,9 @@
 //! after Enter, and an app it launched must outlive it.
 //!
 //! A step is POSIX shell text down to its punctuation - `&&`, `>`, and the
-//! single quotes `expand` wraps every placeholder in. Windows has no shell that
-//! reads it, and handing it to `cmd` would run the command with mangled
-//! arguments rather than not run it, so there the step is refused outright.
+//! single quotes `expand` wraps every placeholder in. A `$SHELL` reading
+//! another language is passed over for `/bin/sh`; Windows, having none, refuses
+//! the step rather than hand `cmd` arguments it would mangle.
 
 use std::io::Read;
 use std::process::{Command, Stdio};
@@ -20,12 +20,20 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 /// Used when `$SHELL` is unset, which happens for processes the window server
-/// starts without a user session environment.
+/// starts without a user session environment, and when it names a shell that
+/// cannot read a POSIX step.
 #[cfg(unix)]
 const FALLBACK_SHELL: &str = "/bin/sh";
 
-/// Said instead of running anything, so a source that cannot work on this
-/// platform reports why rather than failing as a missing program.
+/// `$SHELL` is honoured only when it is one of these. `fish` and `nu` take
+/// `-lc` too, so the spawn succeeds and the script is then rejected whole.
+#[cfg(unix)]
+const POSIX_SHELLS: [&str; 9] = [
+    "sh", "bash", "dash", "ash", "zsh", "ksh", "ksh93", "mksh", "yash",
+];
+
+/// Said instead of running anything, so the step reads as unsupported rather
+/// than as a missing program.
 #[cfg(not(unix))]
 const NO_POSIX_SHELL: &str = "steps are POSIX shell commands, which this platform has no shell for";
 
@@ -119,12 +127,28 @@ fn quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
 }
 
-/// The one place a step becomes a process: `$SHELL -lc <step>`, or nothing at
+/// The login shell to run a step with: the user's own where it speaks POSIX,
+/// the system one otherwise. Set-but-empty reads as `Ok("")`, so it falls here
+/// too.
+#[cfg(unix)]
+fn posix_shell(configured: &str) -> &str {
+    let name = std::path::Path::new(configured)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
+    if POSIX_SHELLS.contains(&name) {
+        configured
+    } else {
+        FALLBACK_SHELL
+    }
+}
+
+/// The one place a step becomes a process: `<shell> -lc <step>`, or nothing at
 /// all where there is no POSIX shell to read it.
 #[cfg(unix)]
 fn shell_command(step: &str) -> Result<Command, String> {
-    let shell = std::env::var("SHELL").unwrap_or_else(|_| FALLBACK_SHELL.to_string());
-    let mut command = Command::new(shell);
+    let configured = std::env::var("SHELL").unwrap_or_default();
+    let mut command = Command::new(posix_shell(&configured));
     command.arg("-lc").arg(step);
     Ok(command)
 }
@@ -134,8 +158,8 @@ fn shell_command(_step: &str) -> Result<Command, String> {
     Err(NO_POSIX_SHELL.to_string())
 }
 
-/// What a failed spawn is reported as: the shell that could not start, since
-/// "no such file or directory" alone names nothing the user can act on.
+/// Names the shell that could not start: "no such file or directory" alone
+/// names nothing the user can act on.
 fn spawn_failure(command: &Command, err: std::io::Error) -> String {
     format!("{}: {err}", command.get_program().to_string_lossy())
 }
@@ -353,8 +377,26 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// Everything below performs a real command, so it exists only where there
-    /// is a shell to perform it with.
+    #[cfg(unix)]
+    #[test]
+    fn a_shell_that_cannot_read_a_posix_step_is_not_the_one_used() {
+        // What the user logs in with is kept wherever it can read the step:
+        // that is where `$PATH` comes from.
+        assert_eq!(
+            posix_shell("/opt/homebrew/bin/bash"),
+            "/opt/homebrew/bin/bash"
+        );
+        assert_eq!(posix_shell("/bin/zsh"), "/bin/zsh");
+        assert_eq!(posix_shell("/usr/bin/fish"), FALLBACK_SHELL);
+        assert_eq!(posix_shell("/usr/local/bin/nu"), FALLBACK_SHELL);
+        assert_eq!(
+            posix_shell(""),
+            FALLBACK_SHELL,
+            "set but empty is not a shell"
+        );
+    }
+
+    /// Everything below performs a real command.
     #[cfg(unix)]
     mod shell {
         use super::*;
@@ -445,10 +487,8 @@ mod tests {
             let outcomes = perform(&steps, None);
             assert!(outcomes[0].error.is_none());
 
-            // The step is detached, so it is waited for rather than assumed
-            // done. A login shell reads the user's profile before it runs
-            // anything, which on a loaded machine is not instant, so the
-            // deadline is long and the loop leaves the moment the file lands.
+            // Detached, so waited for: a login shell reads the profile first,
+            // which on a loaded machine is not instant.
             let deadline = Instant::now() + Duration::from_secs(10);
             while !path.exists() && Instant::now() < deadline {
                 std::thread::sleep(POLL_INTERVAL);
@@ -461,8 +501,7 @@ mod tests {
         }
     }
 
-    /// Off Unix the step is refused, and the refusal says why: a source that
-    /// cannot run here must read as unsupported, not as a broken command.
+    /// Off Unix the step is refused by name, not run wrongly.
     #[cfg(not(unix))]
     #[test]
     fn a_step_without_a_posix_shell_is_refused_by_name() {

--- a/scripts/Makefile.mac
+++ b/scripts/Makefile.mac
@@ -31,7 +31,9 @@ DEV_APP_INSTALL_BUNDLE := /Applications/$(DEV_APP_NAME).app
 LOG_PREDICATE ?= subsystem == "noah-code.Look"
 
 REAL_DB_PATH := $(HOME)/Library/Application Support/look/look.db
-DEV_CONFIG_PATH ?= $(HOME)/.look.dev.config
+# The dev file Look itself names (core/engine/src/config_path.rs). Never
+# migrated: a dev who had ~/.look.dev.config moves it across themselves.
+DEV_CONFIG_PATH ?= $(HOME)/.look/config.dev
 DEV_OPEN_ENV = env -u LOOK_DB_PATH LOOK_CONFIG_PATH="$(DEV_CONFIG_PATH)" LOOK_DEV_HINT=1 LOOK_LOG_LEVEL=debug LOOK_UI_DEBUG_EVENTS=1
 
 .PHONY: help core-check ffi-check ffi-build ffi-build-release ffi-unstale app-build app-ensure-bundle app-stop app-run app-open app-install-dev app-run-dev app-uninstall-dev app-logs app-logs-all symbols db-path db-status db-shell db-reset db-refresh ffi-run
@@ -55,7 +57,7 @@ help:
 	@printf "  make app-uninstall-dev - remove side-by-side dev app from /Applications\n"
 	@printf "  make app-logs     - stream app logs (predicate: $(LOG_PREDICATE))\n"
 	@printf "  make app-logs-all - stream all logs for process Look\n"
-	@printf "  (override config) make app-run DEV_CONFIG_PATH=\"$$HOME/.look.dev.config\"\n\n"
+	@printf "  (override config) make app-run DEV_CONFIG_PATH=\"$$HOME/.look/config.dev\"\n\n"
 	@printf "database\n"
 	@printf "  make db-path      - print real db path\n"
 	@printf "  make db-status    - inspect candidates/usage tables\n"
@@ -102,6 +104,7 @@ app-stop:
 
 app-run: app-build app-stop app-ensure-bundle
 	@echo "Opening local app with config: $(DEV_CONFIG_PATH)"
+	@mkdir -p "$(dir $(DEV_CONFIG_PATH))"
 	@$(DEV_OPEN_ENV) open -n "$(APP_BUNDLE)"
 
 app-open: app-build app-ensure-bundle
@@ -129,6 +132,7 @@ app-install-dev: app-build app-ensure-bundle
 
 app-run-dev: app-install-dev app-stop
 	@echo "Opening side-by-side dev app with config: $(DEV_CONFIG_PATH)"
+	@mkdir -p "$(dir $(DEV_CONFIG_PATH))"
 	@$(DEV_OPEN_ENV) open -a "$(DEV_APP_INSTALL_BUNDLE)"
 
 app-uninstall-dev:

--- a/scripts/Makefile.mac
+++ b/scripts/Makefile.mac
@@ -104,7 +104,6 @@ app-stop:
 
 app-run: app-build app-stop app-ensure-bundle
 	@echo "Opening local app with config: $(DEV_CONFIG_PATH)"
-	@mkdir -p "$(dir $(DEV_CONFIG_PATH))"
 	@$(DEV_OPEN_ENV) open -n "$(APP_BUNDLE)"
 
 app-open: app-build app-ensure-bundle
@@ -132,7 +131,6 @@ app-install-dev: app-build app-ensure-bundle
 
 app-run-dev: app-install-dev app-stop
 	@echo "Opening side-by-side dev app with config: $(DEV_CONFIG_PATH)"
-	@mkdir -p "$(dir $(DEV_CONFIG_PATH))"
 	@$(DEV_OPEN_ENV) open -a "$(DEV_APP_INSTALL_BUNDLE)"
 
 app-uninstall-dev:


### PR DESCRIPTION
## Summary

- User defined source: User can define their rules, steps, actions... in a toml file under .look/source folder. Look can load it and do the jobs. Refer in example file
- Add actions for objects in Look, now works only with objects related to the user defined source feature
- Look needs a folder, so move config file from .look.config into .look/config -> existing file still works but the file in the folder will be priotized. (Done implement for linows aswell, haven't tested yet)
- Add testcases

### TODO

- [x] check config file migration on Linows
- [ ] Next PR
  - [ ] More verbs (a PR)
  - [ ] Default terms for config file (a PR)

## Why

Closes: #385 


## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [x] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)


## Checklist

- [x] I have read and agree to the CLA (CLA.md)
- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-defined source blocks for files, folders, commands, and custom actions.
  * Added a Cmd+K action menu with keyboard navigation, previews, icons, confirmations, and quick actions.
  * Added support for launching apps, opening files, running commands, and navigating related results.
  * Added run-block results with refresh support and caching.
* **Bug Fixes**
  * Improved configuration path handling, including legacy migration and custom paths.
  * Prevented unnecessary refreshes of unrelated data.
  * Improved hint-bar layout for longer text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->