### PR TITLE
fix niri issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ binds {
 
 `allow-inhibiting=false` matters: without it niri passes the key to a window holding a keyboard-shortcuts inhibitor, which fullscreen games, browsers and virtual machines all take, and Look never opens over them.
 
-Any key works, it is the same `spawn` line: Look only ever sees the D-Bus call. Bind a key niri already uses (`Mod+D` spawns fuzzel in the default config) and niri rejects the whole config as a duplicate keybind, keeping the last good one, so drop the existing bind first and check with `niri validate`.
+Any key works, it is the same `spawn` line: Look only ever sees the D-Bus call. Bind a key niri already uses (`Mod+D` spawns fuzzel in the default config) and niri rejects the whole config as a duplicate keybind, keeping the last good one, so drop the existing bind first and check with `niri validate`, or `niri --config <path> validate` if you start niri with `-c`. The setup notice names the file Look actually read, which is that `-c` path, then `NIRI_CONFIG`, then `~/.config/niri/config.kdl`, then `/etc/niri/config.kdl` - niri loads one of them and never merges.
 
 Floating is applied at runtime over niri's IPC; add a rule only if you also want the focus ring and shadow off:
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ exec-once = lookapp
 # (Alt+Space, float, and border rules are injected automatically via hyprctl)
 ```
 
-niri has no API to add binds at runtime, so `Alt+Space` has to go in `~/.config/niri/config.kdl` yourself. Look shows the exact stanza for your system (the `gdbus` path differs on NixOS) in its setup notice on first run:
+niri has no API to add binds at runtime, so `Alt+Space` has to go in `~/.config/niri/config.kdl` yourself, or in any file that config includes. Look shows the exact stanza for your system (the `gdbus` path differs on NixOS) in its setup notice on first run:
 
 ```kdl
 spawn-at-startup "lookapp"
@@ -163,6 +163,8 @@ binds {
     Alt+Space { spawn "gdbus" "call" "--session" "--dest" "com.look.Desktop" "--object-path" "/com/look/Desktop" "--method" "com.look.Desktop.Toggle"; }
 }
 ```
+
+Any key works, it is the same `spawn` line: Look only ever sees the D-Bus call. Bind a key niri already uses (`Mod+D` spawns fuzzel in the default config) and niri rejects the whole config as a duplicate keybind, keeping the last good one, so drop the existing bind first and check with `niri validate`.
 
 Floating is applied at runtime over niri's IPC; add a rule only if you also want the focus ring and shadow off:
 

--- a/README.md
+++ b/README.md
@@ -160,9 +160,11 @@ niri has no API to add binds at runtime, so `Alt+Space` has to go in `~/.config/
 spawn-at-startup "lookapp"
 
 binds {
-    Alt+Space { spawn "gdbus" "call" "--session" "--dest" "com.look.Desktop" "--object-path" "/com/look/Desktop" "--method" "com.look.Desktop.Toggle"; }
+    Alt+Space allow-inhibiting=false { spawn "gdbus" "call" "--session" "--dest" "com.look.Desktop" "--object-path" "/com/look/Desktop" "--method" "com.look.Desktop.Toggle"; }
 }
 ```
+
+`allow-inhibiting=false` matters: without it niri passes the key to a window holding a keyboard-shortcuts inhibitor, which fullscreen games, browsers and virtual machines all take, and Look never opens over them.
 
 Any key works, it is the same `spawn` line: Look only ever sees the D-Bus call. Bind a key niri already uses (`Mod+D` spawns fuzzel in the default config) and niri rejects the whole config as a duplicate keybind, keeping the last good one, so drop the existing bind first and check with `niri validate`.
 

--- a/apps/linows/flake.nix
+++ b/apps/linows/flake.nix
@@ -85,6 +85,7 @@
             openssl
             webkitgtk_4_1
             gtk3
+            gtk-layer-shell
             libsoup_3
             glib
             cairo

--- a/apps/linows/nix/package.nix
+++ b/apps/linows/nix/package.nix
@@ -6,6 +6,7 @@
   wrapGAppsHook3,
   webkitgtk_4_1,
   gtk3,
+  gtk-layer-shell,
   libsoup_3,
   glib,
   cairo,
@@ -70,6 +71,11 @@ rustPlatform.buildRustPackage {
     pkg-config
     wrapGAppsHook3
   ];
+
+  # dlopened at runtime, never linked, so it is not a buildInput: the absolute
+  # store path is compiled in instead. A wrapper exporting LD_LIBRARY_PATH
+  # would leak into every app Look launches.
+  LOOK_GTK_LAYER_SHELL = "${gtk-layer-shell}/lib/libgtk-layer-shell.so.0";
 
   buildInputs = [
     webkitgtk_4_1

--- a/apps/linows/src-tauri/Cargo.lock
+++ b/apps/linows/src-tauri/Cargo.lock
@@ -2572,6 +2572,7 @@ dependencies = [
  "dirs",
  "futures-util",
  "gtk",
+ "libloading 0.8.9",
  "look-answers",
  "look-calc",
  "look-engine",

--- a/apps/linows/src-tauri/Cargo.toml
+++ b/apps/linows/src-tauri/Cargo.toml
@@ -40,6 +40,9 @@ zbus = "5"
 # StreamExt for zbus signal streams.
 futures-util = { version = "0.3", default-features = false }
 webkit2gtk = "2.0"
+# dlopen for libgtk-layer-shell: absent on some distros, so it must not be a
+# link-time dependency.
+libloading = "0.8"
 # Owning the clipboard in-process, which is the only way to offer a path as
 # BOTH a file (for a file manager) and text (for everything else): wl-copy and
 # xclip each advertise a single MIME type per invocation. Pinned to the version

--- a/apps/linows/src-tauri/src/commands.rs
+++ b/apps/linows/src-tauri/src/commands.rs
@@ -303,7 +303,7 @@ pub async fn open_elevated(
             // Declined, refused, or the task died: don't leave Look hidden.
             eprintln!("[open_elevated] {e}");
             show_launcher(&window);
-            let _ = window.set_focus();
+            focus_launcher(&window);
         }
         result
     }
@@ -386,7 +386,7 @@ pub fn hide_armed(window: &tauri::WebviewWindow) {
             .compare_exchange(arm, 0, Ordering::Relaxed, Ordering::Relaxed)
             .is_ok()
         {
-            let _ = window.hide();
+            hide_now(&window);
         }
     });
 }
@@ -401,14 +401,51 @@ pub fn confirm_hide(window: tauri::WebviewWindow, arm: NonZeroU64) {
         .compare_exchange(arm.get(), 0, Ordering::Relaxed, Ordering::Relaxed)
         .is_ok()
     {
-        let _ = window.hide();
+        hide_now(&window);
     }
+}
+
+/// Take the launcher off screen. With layer shell attached, the surface on
+/// screen is not the one Tauri hands out.
+pub fn hide_now(window: &tauri::WebviewWindow) {
+    #[cfg(target_os = "linux")]
+    if crate::platform::linux::layer_shell::is_active() {
+        crate::platform::linux::layer_shell::hide();
+        return;
+    }
+    let _ = window.hide();
+}
+
+/// Give the launcher keyboard focus. A layer surface takes it on its own
+/// through `keyboard-interactivity`, and `set_focus` would be harmful there:
+/// it reaches `gtk_window_present` and maps the husk toplevel.
+pub fn focus_launcher(window: &tauri::WebviewWindow) {
+    #[cfg(target_os = "linux")]
+    if crate::platform::linux::layer_shell::is_active() {
+        return;
+    }
+    let _ = window.set_focus();
+}
+
+/// Whether the launcher is on screen. The husk toplevel never maps, so its own
+/// `is_visible` reports false for a launcher that is plainly up.
+pub fn launcher_visible(window: &tauri::WebviewWindow) -> bool {
+    #[cfg(target_os = "linux")]
+    if let Some(visible) = crate::platform::linux::layer_shell::visible() {
+        return visible;
+    }
+    window.is_visible().unwrap_or(false)
 }
 
 /// Drop any dismissal in flight, show, and keep niri from tiling the window.
 /// Every show goes through here.
 pub fn show_launcher(window: &tauri::WebviewWindow) {
     PENDING_HIDE.store(0, Ordering::Relaxed);
+    #[cfg(target_os = "linux")]
+    if crate::platform::linux::layer_shell::is_active() {
+        crate::platform::linux::layer_shell::show();
+        return;
+    }
     let _ = window.show();
     #[cfg(target_os = "linux")]
     if crate::platform::linux::wm::is_niri() {
@@ -418,11 +455,11 @@ pub fn show_launcher(window: &tauri::WebviewWindow) {
 
 #[tauri::command]
 pub fn toggle_window(window: tauri::WebviewWindow) {
-    if window.is_visible().unwrap_or(false) {
+    if launcher_visible(&window) {
         hide_armed(&window);
     } else {
         show_launcher(&window);
-        let _ = window.set_focus();
+        focus_launcher(&window);
     }
 }
 

--- a/apps/linows/src-tauri/src/health.rs
+++ b/apps/linows/src-tauri/src/health.rs
@@ -15,8 +15,7 @@ use tauri::Emitter;
 
 pub const EVENT_HEALTH_CHANGED: &str = "health-changed";
 
-/// Stable issue ids: reports are deduped by id and the frontend keys
-/// dismissal persistence on them.
+/// Stable issue ids: reports are deduped by id.
 pub const ISSUE_HOTKEY: &str = "hotkey";
 #[cfg(target_os = "linux")]
 pub const ISSUE_GNOME_EXT: &str = "gnome-ext";
@@ -24,6 +23,9 @@ pub const ISSUE_GNOME_EXT: &str = "gnome-ext";
 #[derive(Debug, Clone, Serialize)]
 pub struct HealthIssue {
     pub id: &'static str,
+    /// What the frontend keys dismissal on, with the id. Stable where the
+    /// message is not: messages carry store paths and error text that churn.
+    pub kind: &'static str,
     pub message: String,
 }
 
@@ -33,6 +35,11 @@ static ISSUES: Mutex<Vec<HealthIssue>> = Mutex::new(Vec::new());
 /// repeat reports (e.g. the stale-extension warning firing on every search)
 /// are silently dropped.
 pub fn report(id: &'static str, message: String) {
+    report_as(id, id, message);
+}
+
+/// For an id with more than one failure mode: `kind` tells them apart.
+pub fn report_as(id: &'static str, kind: &'static str, message: String) {
     {
         let Ok(mut issues) = ISSUES.lock() else {
             return;
@@ -41,7 +48,7 @@ pub fn report(id: &'static str, message: String) {
             return;
         }
         eprintln!("[look:health] {message}");
-        issues.push(HealthIssue { id, message });
+        issues.push(HealthIssue { id, kind, message });
     }
     if let Some(handle) = crate::state::app_handle() {
         let _ = handle.emit(EVENT_HEALTH_CHANGED, snapshot());

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -649,6 +649,10 @@ fn main() {
             // comes off the window handle.
             #[cfg(target_os = "linux")]
             platform::linux::blur::init(&window);
+            // Before the first show: on the layer-shell path focus arrives as
+            // a GTK signal, and a handler connected afterwards misses the one
+            // that would focus the query input.
+            setup_window_events(&window);
             #[cfg(target_os = "linux")]
             if supports_transparency() {
                 commands::show_launcher(&window);
@@ -666,7 +670,6 @@ fn main() {
                 // from `border-radius` on `.launcher-window` in `layout.css`.
                 let _ = window.set_background_color(Some(tauri::window::Color(0, 0, 0, 0)));
             }
-            setup_window_events(&window);
 
             Ok(())
         })

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -108,7 +108,7 @@ fn toggle_window(app_handle: &tauri::AppHandle) {
     let Some(window) = app_handle.get_webview_window(consts::MAIN_WINDOW) else {
         return;
     };
-    if window.is_visible().unwrap_or(false) {
+    if commands::launcher_visible(&window) {
         #[cfg(target_os = "linux")]
         platform::linux::window_focus::notify_hidden();
         hide_launcher(&window);
@@ -120,6 +120,13 @@ fn toggle_window(app_handle: &tauri::AppHandle) {
         LAST_SHOWN_AT.store(now_ms(), Ordering::Relaxed);
         FOCUSED_SINCE_SHOWN.store(false, Ordering::Relaxed);
 
+        // A layer surface is placed and stacked by the compositor; neither is
+        // ours to ask for.
+        #[cfg(target_os = "linux")]
+        let placed_by_compositor = platform::linux::layer_shell::is_active();
+        #[cfg(not(target_os = "linux"))]
+        let placed_by_compositor = false;
+
         // Tiling WMs (i3, sway, Hyprland) ignore set_position on unmapped
         // windows - they apply their own placement on map. So we must
         // recenter AFTER show. Desktop environments (GNOME, KDE, …) work
@@ -129,12 +136,14 @@ fn toggle_window(app_handle: &tauri::AppHandle) {
         #[cfg(not(target_os = "linux"))]
         let tiling = false;
 
-        if !tiling {
-            recenter_window(&window);
+        if !placed_by_compositor {
+            if !tiling {
+                recenter_window(&window);
+            }
+            let _ = window.set_always_on_top(true);
         }
-        let _ = window.set_always_on_top(true);
         commands::show_launcher(&window);
-        if tiling {
+        if !placed_by_compositor && tiling {
             recenter_window(&window);
         }
         let _ = window.emit(EVENT_WINDOW_SHOWN, ());
@@ -148,16 +157,18 @@ fn toggle_window(app_handle: &tauri::AppHandle) {
             platform::linux::window_focus::notify_shown();
         }
 
-        let _ = window.set_focus();
+        commands::focus_launcher(&window);
     }
 }
 
 /// Center and scale a window to fit the current monitor.
 /// Called once at startup. Avoid calling on toggle - see toggle_window.
-fn center_and_scale_window(window: &tauri::WebviewWindow) {
-    let Some(monitor) = monitor_at_cursor(window) else {
-        return;
-    };
+///
+/// Returns the logical size it settled on. The layer surface needs it from
+/// here rather than reading `inner_size` back: a Wayland window the compositor
+/// has not configured yet still reports tauri.conf's default.
+fn center_and_scale_window(window: &tauri::WebviewWindow) -> Option<(i32, i32)> {
+    let monitor = monitor_at_cursor(window)?;
     let pos = monitor.position();
     let screen = monitor.size();
     let scale = monitor.scale_factor();
@@ -178,6 +189,7 @@ fn center_and_scale_window(window: &tauri::WebviewWindow) {
     let lx = pos.x as f64 / scale + (logical_screen_w - win_w as f64) / 2.0;
     let ly = pos.y as f64 / scale + (logical_screen_h - win_h as f64) / 2.0;
     let _ = window.set_position(tauri::LogicalPosition::new(lx, ly));
+    Some((win_w as i32, win_h as i32))
 }
 
 /// Find the monitor that contains the cursor. Falls back to the window's
@@ -484,25 +496,42 @@ fn apply_transparency(window: &tauri::WebviewWindow) {
 
 /// Set up window event handlers (focus input on focus, auto-hide on blur).
 fn setup_window_events(window: &tauri::WebviewWindow) {
+    // Tauri reports focus for the husk toplevel, so on the layer-shell path
+    // GTK's own signals are the only focus events left.
+    #[cfg(target_os = "linux")]
+    if platform::linux::layer_shell::is_active() {
+        let w = window.clone();
+        platform::linux::layer_shell::on_focus(move |focused| on_focus_change(&w, focused));
+        return;
+    }
+
     let w = window.clone();
-    window.on_window_event(move |event| match event {
-        tauri::WindowEvent::Focused(true) => {
-            FOCUSED_SINCE_SHOWN.store(true, Ordering::Relaxed);
-            let _ = w.eval(
-                "{ let q = document.getElementById('query'); if (q) { q.focus(); q.select(); } }",
-            );
+    window.on_window_event(move |event| {
+        if let tauri::WindowEvent::Focused(focused) = event {
+            on_focus_change(&w, *focused);
         }
-        tauri::WindowEvent::Focused(false)
-            if !PICKING_FILE.load(Ordering::Relaxed)
-                && FOCUSED_SINCE_SHOWN.load(Ordering::Relaxed)
-                && now_ms() - LAST_SHOWN_AT.load(Ordering::Relaxed) > AUTO_HIDE_GRACE_MS
-                && focus_loss_means_dismiss() =>
-        {
-            LAST_AUTO_HIDDEN_AT.store(now_ms(), Ordering::Relaxed);
-            hide_launcher(&w);
-        }
-        _ => {}
     });
+}
+
+/// Shared by both focus sources: Tauri's window event, and GTK's signals once
+/// the webview lives on a layer surface.
+fn on_focus_change(window: &tauri::WebviewWindow, focused: bool) {
+    if focused {
+        FOCUSED_SINCE_SHOWN.store(true, Ordering::Relaxed);
+        let _ = window.eval(
+            "{ let q = document.getElementById('query'); if (q) { q.focus(); q.select(); } }",
+        );
+        return;
+    }
+    if PICKING_FILE.load(Ordering::Relaxed)
+        || !FOCUSED_SINCE_SHOWN.load(Ordering::Relaxed)
+        || now_ms() - LAST_SHOWN_AT.load(Ordering::Relaxed) <= AUTO_HIDE_GRACE_MS
+        || !focus_loss_means_dismiss()
+    {
+        return;
+    }
+    LAST_AUTO_HIDDEN_AT.store(now_ms(), Ordering::Relaxed);
+    hide_launcher(window);
 }
 
 /// Whether a `Focused(false)` event should auto-hide the launcher.
@@ -539,7 +568,7 @@ fn main() {
             if let Some(window) = app.get_webview_window(consts::MAIN_WINDOW) {
                 LAST_SHOWN_AT.store(now_ms(), Ordering::Relaxed);
                 commands::show_launcher(&window);
-                let _ = window.set_focus();
+                commands::focus_launcher(&window);
             }
         }))
         .plugin(tauri_plugin_dialog::init())
@@ -610,7 +639,11 @@ fn main() {
                 let _ = window.hide();
                 let _ = window.set_background_color(Some(tauri::window::Color(0, 0, 0, 0)));
             }
-            center_and_scale_window(&window);
+            let scaled_size = center_and_scale_window(&window);
+            #[cfg(target_os = "linux")]
+            platform::linux::layer_shell::attach(&window, scaled_size);
+            #[cfg(not(target_os = "linux"))]
+            let _ = scaled_size;
             apply_transparency(&window);
             // Needs the main thread and a live window: the surface pointer
             // comes off the window handle.

--- a/apps/linows/src-tauri/src/platform/linux/layer_shell.rs
+++ b/apps/linows/src-tauri/src/platform/linux/layer_shell.rs
@@ -1,0 +1,240 @@
+//! The launcher on the wlr-layer-shell overlay layer.
+//!
+//! An xdg-toplevel cannot sit above a fullscreen window on Wayland: sway and
+//! niri paint fullscreen above every layer but `overlay`, and
+//! `set_always_on_top` has no protocol behind it. An overlay surface clears
+//! fullscreen, takes keyboard focus through `keyboard-interactivity`, and is
+//! centred by the compositor when it anchors to no edge.
+//!
+//! GTK cannot turn a mapped toplevel into a layer surface, so the webview's
+//! vbox is reparented into a window of ours, layer-initialised before it is
+//! realised. That orphans Tauri's `WebviewWindow`: `show`, `hide`,
+//! `is_visible` and `set_focus` on it no longer describe anything on screen,
+//! and `set_focus` would map the empty husk. Those callers route here instead.
+
+use gtk::glib;
+use gtk::prelude::*;
+use std::cell::RefCell;
+use std::ffi::c_void;
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Soname, resolved through the loader's search path. `LOOK_GTK_LAYER_SHELL`
+/// lets the Nix package bake in an absolute store path instead, which keeps
+/// `LD_LIBRARY_PATH` out of the environment of every app Look launches.
+const LIB: &str = "libgtk-layer-shell.so.0";
+
+/// Escape hatch back to the toplevel, for a compositor whose layer-shell
+/// implementation misbehaves.
+const ENV_DISABLE: &str = "LOOK_NO_LAYER_SHELL";
+
+const NAMESPACE: &std::ffi::CStr = c"lookapp";
+
+/// `GtkLayerShellLayer`. Only overlay clears a fullscreen window.
+const LAYER_OVERLAY: u32 = 3;
+
+/// `GtkLayerShellKeyboardMode`. On-demand, not exclusive: the protocol says a
+/// compositor "should give the surface keyboard focus on creation" in this
+/// mode, so the launcher still accepts typing the moment it appears, but the
+/// user can take the keyboard back by clicking elsewhere. Exclusive is for
+/// lock screens - it makes the session's keyboard ours until we drop it, and
+/// a click outside then reaches a window that cannot be typed into. None while
+/// hidden, so an unmapped surface holds nothing.
+const KEYBOARD_NONE: u32 = 0;
+const KEYBOARD_ON_DEMAND: u32 = 2;
+
+static ACTIVE: AtomicBool = AtomicBool::new(false);
+static VISIBLE: AtomicBool = AtomicBool::new(false);
+
+thread_local! {
+    /// GTK types are not `Send` and every touch of one belongs on the thread
+    /// running the main context, so off-thread callers marshal in.
+    static LAYER: RefCell<Option<gtk::ApplicationWindow>> = const { RefCell::new(None) };
+}
+
+struct Api {
+    /// Kept so the library outlives the function pointers taken from it.
+    _lib: libloading::Library,
+    is_supported: unsafe extern "C" fn() -> i32,
+    init_for_window: unsafe extern "C" fn(*mut c_void),
+    set_layer: unsafe extern "C" fn(*mut c_void, u32),
+    set_keyboard_mode: unsafe extern "C" fn(*mut c_void, u32),
+    set_namespace: unsafe extern "C" fn(*mut c_void, *const std::ffi::c_char),
+}
+
+/// Opened at runtime rather than linked, so a system without the library falls
+/// back to the toplevel path instead of failing to start.
+fn api() -> Option<&'static Api> {
+    static API: OnceLock<Option<Api>> = OnceLock::new();
+    API.get_or_init(|| unsafe {
+        let path = option_env!("LOOK_GTK_LAYER_SHELL").unwrap_or(LIB);
+        let lib = libloading::Library::new(path)
+            .inspect_err(|e| eprintln!("[look:layer-shell] {path} not loadable: {e}"))
+            .ok()?;
+        let is_supported = *lib.get(b"gtk_layer_is_supported\0").ok()?;
+        let init_for_window = *lib.get(b"gtk_layer_init_for_window\0").ok()?;
+        let set_layer = *lib.get(b"gtk_layer_set_layer\0").ok()?;
+        let set_keyboard_mode = *lib.get(b"gtk_layer_set_keyboard_mode\0").ok()?;
+        let set_namespace = *lib.get(b"gtk_layer_set_namespace\0").ok()?;
+        Some(Api {
+            _lib: lib,
+            is_supported,
+            init_for_window,
+            set_layer,
+            set_keyboard_mode,
+            set_namespace,
+        })
+    })
+    .as_ref()
+}
+
+/// Move the webview onto an overlay layer surface. Main thread only, and
+/// before anything shows the Tauri window. `false` leaves every caller on the
+/// toplevel path unchanged.
+pub fn attach(window: &tauri::WebviewWindow, size: Option<(i32, i32)>) -> bool {
+    if super::transparency::window_is_x11() || std::env::var_os(ENV_DISABLE).is_some() {
+        return false;
+    }
+    let Some(api) = api() else {
+        return false;
+    };
+    // False on compositors without the protocol, mutter above all.
+    if unsafe { (api.is_supported)() } == 0 {
+        eprintln!("[look:layer-shell] compositor does not advertise wlr-layer-shell");
+        return false;
+    }
+
+    let (Ok(toplevel), Ok(vbox)) = (window.gtk_window(), window.default_vbox()) else {
+        return false;
+    };
+    let Some(app) = toplevel.application() else {
+        return false;
+    };
+
+    // The husk Tauri still hands out; it must never map again.
+    let _ = window.hide();
+
+    let layer = gtk::ApplicationWindow::new(&app);
+    layer.set_decorated(false);
+    // Without this GTK paints its opaque theme background over the rounded
+    // launcher, the same reason apply_transparency exists for the toplevel.
+    layer.set_app_paintable(true);
+    if let Some(visual) = WidgetExt::screen(&layer).and_then(|screen| screen.rgba_visual()) {
+        layer.set_visual(Some(&visual));
+    }
+    // app_paintable stops GTK drawing the background, but nothing then clears
+    // the buffer: wherever the page is transparent an RGBA window shows
+    // whatever the surface already held. Proceed so the webview still draws.
+    layer.connect_draw(|_, cr| {
+        cr.set_operator(gtk::cairo::Operator::Source);
+        cr.set_source_rgba(0.0, 0.0, 0.0, 0.0);
+        let _ = cr.paint();
+        cr.set_operator(gtk::cairo::Operator::Over);
+        glib::Propagation::Proceed
+    });
+
+    toplevel.remove(&vbox);
+    layer.add(&vbox);
+
+    let ptr = layer.as_ptr() as *mut c_void;
+    unsafe {
+        (api.init_for_window)(ptr);
+        (api.set_layer)(ptr, LAYER_OVERLAY);
+        (api.set_namespace)(ptr, NAMESPACE.as_ptr());
+        (api.set_keyboard_mode)(ptr, KEYBOARD_NONE);
+    }
+
+    // Anchored nowhere, so the compositor centres it; the size is whatever the
+    // widget asks for, and there is no set_position counterpart.
+    let (width, height) = size.unwrap_or_else(|| fallback_size(window));
+    layer.set_default_size(width, height);
+    layer.set_size_request(width, height);
+
+    // Realized, not shown: the GdkWindow and its RGBA visual have to exist
+    // before the first summon, or the first frame arrives untransparent.
+    layer.realize();
+
+    LAYER.with(|cell| cell.replace(Some(layer)));
+    ACTIVE.store(true, Ordering::Relaxed);
+    eprintln!("[look:layer-shell] attached to the overlay layer");
+    true
+}
+
+/// Only for a startup that identified no monitor: `inner_size` reports
+/// tauri.conf's default until the compositor configures the window.
+fn fallback_size(window: &tauri::WebviewWindow) -> (i32, i32) {
+    let scale = window.scale_factor().unwrap_or(1.0);
+    window
+        .inner_size()
+        .map(|size| {
+            let logical = size.to_logical::<i32>(scale);
+            (logical.width, logical.height)
+        })
+        .unwrap_or_default()
+}
+
+pub fn is_active() -> bool {
+    ACTIVE.load(Ordering::Relaxed)
+}
+
+/// Whether the launcher is on screen, or `None` when the toplevel is still the
+/// real window and its own `is_visible` is authoritative.
+pub fn visible() -> Option<bool> {
+    is_active().then(|| VISIBLE.load(Ordering::Relaxed))
+}
+
+pub fn show() {
+    VISIBLE.store(true, Ordering::Relaxed);
+    on_main(|layer| {
+        set_keyboard_mode(layer, KEYBOARD_ON_DEMAND);
+        layer.show_all();
+    });
+}
+
+pub fn hide() {
+    VISIBLE.store(false, Ordering::Relaxed);
+    on_main(|layer| {
+        set_keyboard_mode(layer, KEYBOARD_NONE);
+        layer.hide();
+    });
+}
+
+fn set_keyboard_mode(layer: &gtk::ApplicationWindow, mode: u32) {
+    if let Some(api) = api() {
+        unsafe { (api.set_keyboard_mode)(layer.as_ptr() as *mut c_void, mode) }
+    }
+}
+
+/// Keyboard focus arriving and leaving, which `WindowEvent::Focused` no longer
+/// reports for a surface Tauri does not own. Main thread only.
+pub fn on_focus(handler: impl Fn(bool) + 'static) {
+    let handler = std::rc::Rc::new(handler);
+    LAYER.with(|cell| {
+        let Some(layer) = cell.borrow().clone() else {
+            return;
+        };
+        let entered = handler.clone();
+        layer.connect_focus_in_event(move |_, _| {
+            entered(true);
+            glib::Propagation::Proceed
+        });
+        layer.connect_focus_out_event(move |_, _| {
+            handler(false);
+            glib::Propagation::Proceed
+        });
+    });
+}
+
+/// The hotkey arrives on the D-Bus thread; GTK belongs to the main context.
+fn on_main(f: impl FnOnce(&gtk::ApplicationWindow) + Send + 'static) {
+    if !is_active() {
+        return;
+    }
+    glib::idle_add_once(move || {
+        LAYER.with(|cell| {
+            if let Some(layer) = cell.borrow().as_ref() {
+                f(layer);
+            }
+        });
+    });
+}

--- a/apps/linows/src-tauri/src/platform/linux/layer_shell.rs
+++ b/apps/linows/src-tauri/src/platform/linux/layer_shell.rs
@@ -33,15 +33,19 @@ const NAMESPACE: &std::ffi::CStr = c"lookapp";
 /// `GtkLayerShellLayer`. Only overlay clears a fullscreen window.
 const LAYER_OVERLAY: u32 = 3;
 
-/// `GtkLayerShellKeyboardMode`. On-demand, not exclusive: the protocol says a
-/// compositor "should give the surface keyboard focus on creation" in this
-/// mode, so the launcher still accepts typing the moment it appears, but the
-/// user can take the keyboard back by clicking elsewhere. Exclusive is for
-/// lock screens - it makes the session's keyboard ours until we drop it, and
-/// a click outside then reaches a window that cannot be typed into. None while
-/// hidden, so an unmapped surface holds nothing.
+/// `GtkLayerShellKeyboardMode`. The protocol says a compositor "should give
+/// the surface keyboard focus on creation" under on-demand, but sway reads
+/// that as click-to-focus: its `arrange_layers` only keeps the keyboard on a
+/// layer whose interactivity is exclusive, and drops any other layer's focus
+/// the moment it runs. The launcher then maps, blinks a caret, and swallows
+/// every key until the user clicks it. Exclusive is what the wlr-layer-shell
+/// launchers all use, for exactly this reason.
+///
+/// The cost is that a click outside no longer dismisses: focus never leaves,
+/// so no focus-out arrives to trigger it. Escape and running an entry still
+/// do, and both restore the mode below.
 const KEYBOARD_NONE: u32 = 0;
-const KEYBOARD_ON_DEMAND: u32 = 2;
+const KEYBOARD_EXCLUSIVE: u32 = 1;
 
 static ACTIVE: AtomicBool = AtomicBool::new(false);
 static VISIBLE: AtomicBool = AtomicBool::new(false);
@@ -135,6 +139,13 @@ pub fn attach(window: &tauri::WebviewWindow, size: Option<(i32, i32)>) -> bool {
 
     toplevel.remove(&vbox);
     layer.add(&vbox);
+    // gtk_container_remove drops the toplevel's focus widget, and the new
+    // window inherits none. The compositor still hands the layer surface the
+    // keyboard, but GtkWindow has nowhere to route a key press, so the
+    // launcher comes up unable to type into.
+    if let Some(target) = focus_target(&layer) {
+        layer.set_focus(Some(&target));
+    }
 
     let ptr = layer.as_ptr() as *mut c_void;
     unsafe {
@@ -186,23 +197,44 @@ pub fn visible() -> Option<bool> {
 pub fn show() {
     VISIBLE.store(true, Ordering::Relaxed);
     on_main(|layer| {
-        set_keyboard_mode(layer, KEYBOARD_ON_DEMAND);
+        // Before the map: sway reads the committed interactivity in its map
+        // handler, and a mode raised afterwards never reaches that path.
+        set_keyboard_mode(layer, KEYBOARD_EXCLUSIVE);
         layer.show_all();
+        // show_all marks every child visible again, which is when a widget can
+        // hold focus; re-grab here so a dismissal that unmapped the surface
+        // does not leave the next summon typing into nothing.
+        if let Some(target) = focus_target(layer) {
+            target.grab_focus();
+        }
     });
 }
 
-pub fn hide() {
-    VISIBLE.store(false, Ordering::Relaxed);
-    on_main(|layer| {
-        set_keyboard_mode(layer, KEYBOARD_NONE);
-        layer.hide();
-    });
+/// The webview, the only child that takes key events. Looked up rather than
+/// stored: the vbox is Tauri's and its contents are not ours to assume.
+fn focus_target(layer: &gtk::ApplicationWindow) -> Option<gtk::Widget> {
+    let vbox = layer.children().into_iter().next()?;
+    vbox.downcast::<gtk::Container>()
+        .ok()?
+        .children()
+        .into_iter()
+        .find(|child| child.can_focus())
 }
 
 fn set_keyboard_mode(layer: &gtk::ApplicationWindow, mode: u32) {
     if let Some(api) = api() {
         unsafe { (api.set_keyboard_mode)(layer.as_ptr() as *mut c_void, mode) }
     }
+}
+
+pub fn hide() {
+    VISIBLE.store(false, Ordering::Relaxed);
+    on_main(|layer| {
+        // Give the keyboard back before the surface goes; an exclusive layer
+        // that merely unmaps can leave the session without focus.
+        set_keyboard_mode(layer, KEYBOARD_NONE);
+        layer.hide();
+    });
 }
 
 /// Keyboard focus arriving and leaving, which `WindowEvent::Focused` no longer

--- a/apps/linows/src-tauri/src/platform/linux/mod.rs
+++ b/apps/linows/src-tauri/src/platform/linux/mod.rs
@@ -8,6 +8,7 @@ pub mod gnome_ext;
 pub mod gpu;
 pub mod icons;
 pub mod kde_focus;
+pub mod layer_shell;
 pub mod niri;
 pub mod process;
 pub mod sysinfo;

--- a/apps/linows/src-tauri/src/platform/linux/wayland_shortcut.rs
+++ b/apps/linows/src-tauri/src/platform/linux/wayland_shortcut.rs
@@ -149,8 +149,9 @@ where
         // per issue id, and a missing caller explains the dead key better than
         // the per-compositor failures that follow.
         if compositor != Compositor::Kde && dbus_caller().is_none() {
-            health::report(
+            health::report_as(
                 health::ISSUE_HOTKEY,
+                "no-dbus-tool",
                 format!(
                     "Alt+Space cannot reach Look: none of these D-Bus \
                      command-line tools are installed ({}). Install one of \
@@ -171,8 +172,9 @@ where
             Compositor::Kde => {}
             Compositor::Other => {
                 let cmd = toggle_cmd();
-                health::report(
+                health::report_as(
                     health::ISSUE_HOTKEY,
+                    "no-api",
                     format!(
                         "This compositor has no supported hotkey API, so Alt+Space \
                          is not set up. Bind a key manually to run: {cmd}"
@@ -194,8 +196,9 @@ where
                 tokio::task::spawn(async move {
                     if let Err(e) = run_kde_keybinding(move || toggle()).await {
                         let cmd = toggle_cmd();
-                        health::report(
+                        health::report_as(
                             health::ISSUE_HOTKEY,
+                            "kde-failed",
                             format!(
                                 "KDE hotkey registration failed ({e}). Bind a key \
                                  manually to run: {cmd}"
@@ -214,8 +217,9 @@ where
                 } else {
                     // Every other compositor binding toggles by calling this
                     // service, so the hotkey is dead without it.
-                    health::report(
+                    health::report_as(
                         health::ISSUE_HOTKEY,
+                        "dbus-service",
                         format!(
                             "Look's D-Bus service failed to start ({e}), so the \
                              Alt+Space binding cannot reach the app. Restart Look \
@@ -271,8 +275,9 @@ fn ensure_sway_keybinding() {
     if bound {
         eprintln!("[look] Registered Sway keybinding: Alt+Space → Look toggle");
     } else {
-        health::report(
+        health::report_as(
             health::ISSUE_HOTKEY,
+            "sway-failed",
             format!(
                 "Failed to register Alt+Space via swaymsg. Bind a key manually \
                  to run: {cmd}"
@@ -304,8 +309,9 @@ fn ensure_hyprland_keybinding() {
     if bound {
         eprintln!("[look] Registered Hyprland keybinding: Alt+Space → Look toggle");
     } else {
-        health::report(
+        health::report_as(
             health::ISSUE_HOTKEY,
+            "hypr-failed",
             format!(
                 "Failed to register Alt+Space via hyprctl. Bind a key manually \
                  to run: {cmd}"
@@ -337,6 +343,13 @@ hl.bind("ALT + space", hl.dsp.exec_cmd("{cmd}"){flags})"#
         return true;
     }
 
+    // The Lua path opens with an unbind; this one has to as well. `keyword
+    // bind` appends rather than replaces, so an ALT,space bind left by an
+    // earlier run - or by the other of bind/bindp - stays live alongside the
+    // new one and Hyprland fires both dispatchers.
+    let _ = host_command("hyprctl")
+        .args(["keyword", "unbind", "ALT,space"])
+        .output();
     let _ = host_command("hyprctl")
         .args(["keyword", "windowrulev2", "float, class:lookapp"])
         .output();
@@ -395,19 +408,84 @@ fn niri_bind_snippet() -> String {
     format!("binds {{ Alt+Space {NIRI_NO_INHIBIT} {{ spawn {argv}; }} }}")
 }
 
-/// Where niri looks for its config, in the order it does. `NIRI_CONFIG` wins
-/// when set; a `-c` given on niri's command line stays invisible to us.
-fn niri_config_paths() -> Vec<std::path::PathBuf> {
-    if let Some(path) = std::env::var_os("NIRI_CONFIG") {
-        return vec![std::path::PathBuf::from(path)];
-    }
+/// Read only when nothing above it names a config.
+const NIRI_SYSTEM_CONFIG: &str = "/etc/niri/config.kdl";
+
+/// The one config niri actually loaded. It reads a single root and never
+/// merges, so every other candidate has to stay unread: a bind sitting in a
+/// file niri ignores would otherwise pass for a working hotkey and suppress
+/// the setup notice the user needs.
+fn niri_config_root() -> std::path::PathBuf {
+    select_niri_root(
+        niri_config_flag(),
+        std::env::var_os("NIRI_CONFIG").map(std::path::PathBuf::from),
+        niri_user_config().filter(|path| path.is_file()),
+    )
+}
+
+/// niri's order: `--config` beats `NIRI_CONFIG` ("if both are set, the command
+/// line argument takes precedence"), either beats the user's file, and the
+/// system file is the last resort. `user` is `None` unless it exists, since
+/// niri falls through to the system file when it does not.
+fn select_niri_root(
+    flag: Option<std::path::PathBuf>,
+    env: Option<std::path::PathBuf>,
+    user: Option<std::path::PathBuf>,
+) -> std::path::PathBuf {
+    [flag, env]
+        .into_iter()
+        .flatten()
+        // An exported-but-empty NIRI_CONFIG names nothing; niri treats it as
+        // unset and so must we, or we scan "" and report a missing bind.
+        .find(|path| !path.as_os_str().is_empty())
+        .or(user)
+        .unwrap_or_else(|| std::path::PathBuf::from(NIRI_SYSTEM_CONFIG))
+}
+
+fn niri_user_config() -> Option<std::path::PathBuf> {
     std::env::var_os("XDG_CONFIG_HOME")
         .map(std::path::PathBuf::from)
         .or_else(|| std::env::var_os("HOME").map(|h| std::path::PathBuf::from(h).join(".config")))
         .map(|dir| dir.join("niri/config.kdl"))
-        .into_iter()
-        .chain([std::path::PathBuf::from("/etc/niri/config.kdl")])
-        .collect()
+}
+
+/// `-c`/`--config` off niri's own command line, which nothing exports. The
+/// socket path carries the compositor's pid - `niri.<display>.<pid>.sock` - so
+/// `/proc` has the argv. Silently `None` anywhere that lookup does not hold.
+fn niri_config_flag() -> Option<std::path::PathBuf> {
+    let socket = std::env::var("NIRI_SOCKET").ok()?;
+    let pid: u32 = std::path::Path::new(&socket)
+        .file_stem()?
+        .to_str()?
+        .rsplit('.')
+        .next()?
+        .parse()
+        .ok()?;
+    let cmdline = std::fs::read(format!("/proc/{pid}/cmdline")).ok()?;
+    niri_config_arg(
+        cmdline
+            .split(|byte| *byte == 0)
+            .filter(|arg| !arg.is_empty())
+            .map(String::from_utf8_lossy),
+    )
+}
+
+/// Last one wins, as clap resolves a repeated single-value argument.
+fn niri_config_arg<'a>(
+    args: impl Iterator<Item = std::borrow::Cow<'a, str>>,
+) -> Option<std::path::PathBuf> {
+    let mut args = args.skip(1);
+    let mut found = None;
+    while let Some(arg) = args.next() {
+        if let Some(path) = arg.strip_prefix("--config=") {
+            found = Some(std::path::PathBuf::from(path));
+        } else if arg == "-c" || arg == "--config" {
+            found = args
+                .next()
+                .map(|path| std::path::PathBuf::from(path.as_ref()));
+        }
+    }
+    found
 }
 
 /// Ceiling on `include` nesting, matching niri's own recursion limit.
@@ -460,16 +538,13 @@ fn resolve_niri_include(arg: &str, dir: &std::path::Path) -> Option<std::path::P
 /// callers, and for a user's own wrapper script. Included files count:
 /// splitting binds into their own `.kdl` is common, and missing one means
 /// nagging a user whose hotkey already works.
-fn niri_bind_state() -> NiriBind {
-    niri_bind_state_in(niri_config_paths())
-}
-
-fn niri_bind_state_in(roots: Vec<std::path::PathBuf>) -> NiriBind {
-    let mut pending: Vec<(std::path::PathBuf, u8)> =
-        roots.into_iter().map(|path| (path, 0)).collect();
+fn niri_bind_state_in(root: std::path::PathBuf) -> NiriBind {
+    // A queue, not a stack: niri applies includes in the order it meets them,
+    // and the header we read the opt-out off has to be the one it would use.
+    let mut pending = std::collections::VecDeque::from([(root, 0u8)]);
     let mut seen = std::collections::HashSet::new();
 
-    while let Some((path, depth)) = pending.pop() {
+    while let Some((path, depth)) = pending.pop_front() {
         if !seen.insert(path.clone()) {
             continue;
         }
@@ -513,23 +588,30 @@ fn niri_bind_inhibitable(config: &str) -> NiriBind {
 }
 
 fn report_niri_keybinding() {
-    match niri_bind_state() {
+    // Named in both notices: with `--config`, `NIRI_CONFIG` or no user file at
+    // all, the path we read is not the one the user would guess.
+    let root = niri_config_root();
+    let state = niri_bind_state_in(root.clone());
+    let root = root.display();
+    match state {
         NiriBind::Ready => {}
-        NiriBind::Inhibitable => health::report(
+        NiriBind::Inhibitable => health::report_as(
             health::ISSUE_HOTKEY,
+            "niri-inhibitable",
             format!(
                 "niri hands Alt+Space to fullscreen windows that inhibit \
                  keyboard shortcuts (games, browsers, virtual machines), so \
                  Look will not open over them. Add {NIRI_NO_INHIBIT} to the \
-                 bind in ~/.config/niri/config.kdl: {}",
+                 bind in {root}: {}",
                 niri_bind_snippet()
             ),
         ),
-        NiriBind::Missing => health::report(
+        NiriBind::Missing => health::report_as(
             health::ISSUE_HOTKEY,
+            "niri-missing",
             format!(
                 "niri has no API to register hotkeys, so Alt+Space must be bound in \
-                 ~/.config/niri/config.kdl, or any file it includes: {}",
+                 {root}, or any file it includes: {}",
                 niri_bind_snippet()
             ),
         ),
@@ -603,8 +685,9 @@ fn ensure_gnome_keybinding() {
     if ok {
         eprintln!("[look] Registered GNOME keybinding: Alt+Space → Look toggle");
     } else {
-        health::report(
+        health::report_as(
             health::ISSUE_HOTKEY,
+            "gsettings-failed",
             format!(
                 "Failed to register Alt+Space via gsettings. Bind a key manually \
                  to run: {cmd}"
@@ -771,8 +854,9 @@ where
         eprintln!("[look] Registered KDE keybinding: Alt+Space → Look toggle");
     } else {
         let cmd = toggle_cmd();
-        health::report(
+        health::report_as(
             health::ISSUE_HOTKEY,
+            "kde-rebound",
             format!(
                 "KDE assigned a different key than Alt+Space (it may be taken). \
                  Rebind it in System Settings → Shortcuts → Look, or bind a key \
@@ -929,7 +1013,8 @@ fn parse_gsettings_array(s: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::Path;
+    use std::borrow::Cow;
+    use std::path::{Path, PathBuf};
 
     #[test]
     fn gdbus_command_targets_our_service() {
@@ -1016,16 +1101,105 @@ mod tests {
         )
         .expect("binds");
 
-        assert_eq!(
-            niri_bind_state_in(vec![dir.join("config.kdl")]),
-            NiriBind::Ready
-        );
+        assert_eq!(niri_bind_state_in(dir.join("config.kdl")), NiriBind::Ready);
 
         std::fs::write(dir.join("nested/binds.kdl"), "binds { }").expect("binds");
         assert_eq!(
-            niri_bind_state_in(vec![dir.join("config.kdl")]),
+            niri_bind_state_in(dir.join("config.kdl")),
             NiriBind::Missing
         );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// An exported-but-empty NIRI_CONFIG names nothing. Reading it as a path
+    /// finds no bind and nags a user whose hotkey already works.
+    #[test]
+    fn an_empty_niri_config_env_falls_through_to_the_user_file() {
+        let user = PathBuf::from("/home/u/.config/niri/config.kdl");
+        assert_eq!(
+            select_niri_root(None, Some(PathBuf::new()), Some(user.clone())),
+            user
+        );
+    }
+
+    #[test]
+    fn the_user_file_wins_over_the_system_one_and_only_when_it_exists() {
+        let user = PathBuf::from("/home/u/.config/niri/config.kdl");
+        assert_eq!(select_niri_root(None, None, Some(user.clone())), user);
+        assert_eq!(
+            select_niri_root(None, None, None),
+            PathBuf::from(NIRI_SYSTEM_CONFIG)
+        );
+    }
+
+    /// niri: "if both are set, the command line argument takes precedence".
+    #[test]
+    fn the_command_line_config_outranks_the_env_and_the_user_file() {
+        assert_eq!(
+            select_niri_root(
+                Some(PathBuf::from("/flag.kdl")),
+                Some(PathBuf::from("/env.kdl")),
+                Some(PathBuf::from("/user.kdl")),
+            ),
+            PathBuf::from("/flag.kdl")
+        );
+        assert_eq!(
+            select_niri_root(
+                None,
+                Some(PathBuf::from("/env.kdl")),
+                Some(PathBuf::from("/user.kdl"))
+            ),
+            PathBuf::from("/env.kdl")
+        );
+    }
+
+    #[test]
+    fn the_config_flag_is_read_off_niri_argv_in_either_form() {
+        let arg = |args: &[&str]| niri_config_arg(args.iter().map(|a| Cow::from(*a)));
+        assert_eq!(arg(&["niri", "--session"]), None);
+        assert_eq!(
+            arg(&["niri", "-c", "/a.kdl"]),
+            Some(PathBuf::from("/a.kdl"))
+        );
+        assert_eq!(
+            arg(&["niri", "--config", "/a.kdl"]),
+            Some(PathBuf::from("/a.kdl"))
+        );
+        assert_eq!(
+            arg(&["niri", "--config=/a.kdl"]),
+            Some(PathBuf::from("/a.kdl"))
+        );
+        // clap resolves a repeated single-value argument to the last one.
+        assert_eq!(
+            arg(&["niri", "-c", "/a.kdl", "--config=/b.kdl"]),
+            Some(PathBuf::from("/b.kdl"))
+        );
+    }
+
+    /// The regression the selection exists for: a bind in a config niri never
+    /// loads must not pass for a working hotkey.
+    #[test]
+    fn a_bind_only_in_the_unselected_config_does_not_count() {
+        let dir = std::env::temp_dir().join("look-niri-precedence-test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let user = dir.join("user.kdl");
+        let system = dir.join("system.kdl");
+        std::fs::write(&user, "binds { }").expect("user");
+        std::fs::write(
+            &system,
+            format!("binds {{ Alt+Space {NIRI_NO_INHIBIT} {{ spawn \"{DBUS_NAME}\"; }} }}"),
+        )
+        .expect("system");
+
+        assert_eq!(
+            select_niri_root(None, None, Some(user.clone())),
+            user,
+            "the existing user file is the root"
+        );
+        assert_eq!(niri_bind_state_in(user), NiriBind::Missing);
+        assert_eq!(niri_bind_state_in(system), NiriBind::Ready);
 
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -1069,10 +1243,7 @@ mod tests {
         std::fs::write(dir.join("a.kdl"), "include \"b.kdl\"\n").expect("a");
         std::fs::write(dir.join("b.kdl"), "include \"a.kdl\"\n").expect("b");
 
-        assert_eq!(
-            niri_bind_state_in(vec![dir.join("a.kdl")]),
-            NiriBind::Missing
-        );
+        assert_eq!(niri_bind_state_in(dir.join("a.kdl")), NiriBind::Missing);
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/apps/linows/src-tauri/src/platform/linux/wayland_shortcut.rs
+++ b/apps/linows/src-tauri/src/platform/linux/wayland_shortcut.rs
@@ -416,21 +416,25 @@ const NIRI_SYSTEM_CONFIG: &str = "/etc/niri/config.kdl";
 /// file niri ignores would otherwise pass for a working hotkey and suppress
 /// the setup notice the user needs.
 fn niri_config_root() -> std::path::PathBuf {
+    let pid = niri_pid();
     select_niri_root(
-        niri_config_flag(),
+        pid.and_then(niri_config_flag),
         std::env::var_os("NIRI_CONFIG").map(std::path::PathBuf::from),
         niri_user_config().filter(|path| path.is_file()),
+        pid.and_then(niri_cwd),
     )
 }
 
 /// niri's order: `--config` beats `NIRI_CONFIG` ("if both are set, the command
 /// line argument takes precedence"), either beats the user's file, and the
 /// system file is the last resort. `user` is `None` unless it exists, since
-/// niri falls through to the system file when it does not.
+/// niri falls through to the system file when it does not. `cwd` is niri's
+/// working directory, which only the two explicit paths are resolved against.
 fn select_niri_root(
     flag: Option<std::path::PathBuf>,
     env: Option<std::path::PathBuf>,
     user: Option<std::path::PathBuf>,
+    cwd: Option<std::path::PathBuf>,
 ) -> std::path::PathBuf {
     [flag, env]
         .into_iter()
@@ -438,6 +442,12 @@ fn select_niri_root(
         // An exported-but-empty NIRI_CONFIG names nothing; niri treats it as
         // unset and so must we, or we scan "" and report a missing bind.
         .find(|path| !path.as_os_str().is_empty())
+        // A relative `--config`/`NIRI_CONFIG` is niri's own working directory,
+        // not ours; joining ours would read a different file or none at all.
+        .map(|path| match cwd {
+            Some(cwd) if path.is_relative() => cwd.join(path),
+            _ => path,
+        })
         .or(user)
         .unwrap_or_else(|| std::path::PathBuf::from(NIRI_SYSTEM_CONFIG))
 }
@@ -449,18 +459,22 @@ fn niri_user_config() -> Option<std::path::PathBuf> {
         .map(|dir| dir.join("niri/config.kdl"))
 }
 
-/// `-c`/`--config` off niri's own command line, which nothing exports. The
-/// socket path carries the compositor's pid - `niri.<display>.<pid>.sock` - so
-/// `/proc` has the argv. Silently `None` anywhere that lookup does not hold.
-fn niri_config_flag() -> Option<std::path::PathBuf> {
+/// The compositor's pid, off the socket path - `niri.<display>.<pid>.sock` -
+/// since nothing else exports it. Silently `None` anywhere that shape does not
+/// hold, which leaves every caller on its own fallback.
+fn niri_pid() -> Option<u32> {
     let socket = std::env::var("NIRI_SOCKET").ok()?;
-    let pid: u32 = std::path::Path::new(&socket)
+    std::path::Path::new(&socket)
         .file_stem()?
         .to_str()?
         .rsplit('.')
         .next()?
         .parse()
-        .ok()?;
+        .ok()
+}
+
+/// `-c`/`--config` off niri's own command line, which nothing exports.
+fn niri_config_flag(pid: u32) -> Option<std::path::PathBuf> {
     let cmdline = std::fs::read(format!("/proc/{pid}/cmdline")).ok()?;
     niri_config_arg(
         cmdline
@@ -468,6 +482,13 @@ fn niri_config_flag() -> Option<std::path::PathBuf> {
             .filter(|arg| !arg.is_empty())
             .map(String::from_utf8_lossy),
     )
+}
+
+/// Where niri resolves its relative config path from. Look is not started from
+/// the same directory - systemd units and `spawn-at-startup` both land in the
+/// home - so this cannot be assumed to be ours.
+fn niri_cwd(pid: u32) -> Option<std::path::PathBuf> {
+    std::fs::read_link(format!("/proc/{pid}/cwd")).ok()
 }
 
 /// Last one wins, as clap resolves a repeated single-value argument.
@@ -1118,7 +1139,7 @@ mod tests {
     fn an_empty_niri_config_env_falls_through_to_the_user_file() {
         let user = PathBuf::from("/home/u/.config/niri/config.kdl");
         assert_eq!(
-            select_niri_root(None, Some(PathBuf::new()), Some(user.clone())),
+            select_niri_root(None, Some(PathBuf::new()), Some(user.clone()), None),
             user
         );
     }
@@ -1126,9 +1147,9 @@ mod tests {
     #[test]
     fn the_user_file_wins_over_the_system_one_and_only_when_it_exists() {
         let user = PathBuf::from("/home/u/.config/niri/config.kdl");
-        assert_eq!(select_niri_root(None, None, Some(user.clone())), user);
+        assert_eq!(select_niri_root(None, None, Some(user.clone()), None), user);
         assert_eq!(
-            select_niri_root(None, None, None),
+            select_niri_root(None, None, None, None),
             PathBuf::from(NIRI_SYSTEM_CONFIG)
         );
     }
@@ -1141,6 +1162,7 @@ mod tests {
                 Some(PathBuf::from("/flag.kdl")),
                 Some(PathBuf::from("/env.kdl")),
                 Some(PathBuf::from("/user.kdl")),
+                None,
             ),
             PathBuf::from("/flag.kdl")
         );
@@ -1148,9 +1170,51 @@ mod tests {
             select_niri_root(
                 None,
                 Some(PathBuf::from("/env.kdl")),
-                Some(PathBuf::from("/user.kdl"))
+                Some(PathBuf::from("/user.kdl")),
+                None,
             ),
             PathBuf::from("/env.kdl")
+        );
+    }
+
+    /// niri reads a relative `--config`/`NIRI_CONFIG` from its own working
+    /// directory. Look runs from a different one, so keeping the path as given
+    /// scans the wrong file and nags about a hotkey that already works.
+    #[test]
+    fn a_relative_explicit_config_resolves_against_niris_working_directory() {
+        let cwd = PathBuf::from("/run/niri");
+        assert_eq!(
+            select_niri_root(
+                Some(PathBuf::from("niri.kdl")),
+                None,
+                None,
+                Some(cwd.clone())
+            ),
+            cwd.join("niri.kdl")
+        );
+        assert_eq!(
+            select_niri_root(
+                None,
+                Some(PathBuf::from("cfg/niri.kdl")),
+                None,
+                Some(cwd.clone())
+            ),
+            cwd.join("cfg/niri.kdl")
+        );
+        // Absolute paths and the user/system fallbacks are untouched by it.
+        assert_eq!(
+            select_niri_root(
+                Some(PathBuf::from("/flag.kdl")),
+                None,
+                None,
+                Some(cwd.clone())
+            ),
+            PathBuf::from("/flag.kdl")
+        );
+        let user = PathBuf::from("/home/u/.config/niri/config.kdl");
+        assert_eq!(
+            select_niri_root(None, None, Some(user.clone()), Some(cwd)),
+            user
         );
     }
 
@@ -1194,7 +1258,7 @@ mod tests {
         .expect("system");
 
         assert_eq!(
-            select_niri_root(None, None, Some(user.clone())),
+            select_niri_root(None, None, Some(user.clone()), None),
             user,
             "the existing user file is the root"
         );

--- a/apps/linows/src-tauri/src/platform/linux/wayland_shortcut.rs
+++ b/apps/linows/src-tauri/src/platform/linux/wayland_shortcut.rs
@@ -232,6 +232,14 @@ where
 // Sway
 // ---------------------------------------------------------------------------
 
+const SWAY_KEY: &str = "Alt+space";
+
+/// Sway drops its own bindings while the focused window holds a
+/// keyboard-shortcuts inhibitor, which fullscreen browsers, games and VMs all
+/// take; `--inhibited` exempts ours. Bind and unbind must agree on it, since
+/// sway matches bindings on flags as well as keys.
+const SWAY_BIND_FLAGS: &str = "--inhibited";
+
 fn ensure_sway_keybinding() {
     // Add window rule: float + no border
     let _ = host_command("swaymsg")
@@ -245,10 +253,17 @@ fn ensure_sway_keybinding() {
         ])
         .output();
 
+    // Drop a binding left by a Look old enough to predate SWAY_BIND_FLAGS:
+    // sway counts the flag as part of a binding's identity, so the two would
+    // coexist and fire the toggle twice.
+    let _ = host_command("swaymsg")
+        .arg(format!("unbindsym {SWAY_KEY}"))
+        .output();
+
     // Bind Alt+Space to toggle Look via D-Bus
     let cmd = toggle_cmd();
     let bound = host_command("swaymsg")
-        .arg(format!("bindsym Alt+space exec {cmd}"))
+        .arg(format!("bindsym {SWAY_BIND_FLAGS} {SWAY_KEY} exec {cmd}"))
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false);
@@ -267,7 +282,9 @@ fn ensure_sway_keybinding() {
 }
 
 fn cleanup_sway_keybinding() {
-    let _ = host_command("swaymsg").arg("unbindsym Alt+space").output();
+    let _ = host_command("swaymsg")
+        .arg(format!("unbindsym {SWAY_BIND_FLAGS} {SWAY_KEY}"))
+        .output();
     eprintln!("[look] Removed Sway keybinding for Alt+Space");
 }
 
@@ -276,36 +293,13 @@ fn cleanup_sway_keybinding() {
 // ---------------------------------------------------------------------------
 
 fn ensure_hyprland_keybinding() {
-    // Hyprland v0.55+ uses Lua config - `hyprctl eval` with hl.* API.
-    // Older versions use `hyprctl keyword bind ...` (INI-style parser).
-    //
-    // hl.bind stacks duplicates on every call (hot-reloads in dev, or
-    // sequential launches in prod), so unbind first via pcall - pcall keeps
-    // the eval succeeding even when the binding doesn't exist yet (first run).
     let cmd = toggle_cmd();
-    let lua = format!(
-        r#"pcall(hl.unbind, "ALT + space")
-hl.window_rule({{ name = "look-float", match = {{ class = "lookapp" }}, float = true }})
-hl.window_rule({{ name = "look-noborder", match = {{ class = "lookapp" }}, border_size = 0, rounding = 0, no_shadow = true }})
-hl.bind("ALT + space", hl.dsp.exec_cmd("{cmd}"))"#
-    );
 
-    let used_lua = hyprctl_ok(host_command("hyprctl").args(["eval", &lua]).output());
-
-    let bound = used_lua || {
-        // Fallback: legacy keyword syntax for older Hyprland
-        let _ = host_command("hyprctl")
-            .args(["keyword", "windowrulev2", "float, class:lookapp"])
-            .output();
-        let _ = host_command("hyprctl")
-            .args(["keyword", "windowrulev2", "noborder, class:lookapp"])
-            .output();
-        hyprctl_ok(
-            host_command("hyprctl")
-                .args(["keyword", "bind", &format!("ALT,space,exec,{cmd}")])
-                .output(),
-        )
-    };
+    // `dont_inhibit` keeps Alt+Space alive while the focused window holds a
+    // keyboard-shortcuts inhibitor, as fullscreen browsers, games and VMs do.
+    // Hyprland builds predating the flag reject the whole bind, so a plain one
+    // follows.
+    let bound = hyprland_bind(cmd, true) || hyprland_bind(cmd, false);
 
     if bound {
         eprintln!("[look] Registered Hyprland keybinding: Alt+Space → Look toggle");
@@ -318,6 +312,46 @@ hl.bind("ALT + space", hl.dsp.exec_cmd("{cmd}"))"#
             ),
         );
     }
+}
+
+/// One bind attempt over both config dialects: Hyprland v0.55+ takes Lua via
+/// `hyprctl eval` with the hl.* API, older versions the INI-style
+/// `hyprctl keyword`, where `bindp` spells `dont_inhibit`.
+///
+/// hl.bind stacks duplicates on every call (hot-reloads in dev, or sequential
+/// launches in prod), so unbind first via pcall - pcall keeps the eval
+/// succeeding even when the binding doesn't exist yet (first run).
+fn hyprland_bind(cmd: &str, dont_inhibit: bool) -> bool {
+    let flags = if dont_inhibit {
+        ", { dont_inhibit = true }"
+    } else {
+        ""
+    };
+    let lua = format!(
+        r#"pcall(hl.unbind, "ALT + space")
+hl.window_rule({{ name = "look-float", match = {{ class = "lookapp" }}, float = true }})
+hl.window_rule({{ name = "look-noborder", match = {{ class = "lookapp" }}, border_size = 0, rounding = 0, no_shadow = true }})
+hl.bind("ALT + space", hl.dsp.exec_cmd("{cmd}"){flags})"#
+    );
+    if hyprctl_ok(host_command("hyprctl").args(["eval", &lua]).output()) {
+        return true;
+    }
+
+    let _ = host_command("hyprctl")
+        .args(["keyword", "windowrulev2", "float, class:lookapp"])
+        .output();
+    let _ = host_command("hyprctl")
+        .args(["keyword", "windowrulev2", "noborder, class:lookapp"])
+        .output();
+    hyprctl_ok(
+        host_command("hyprctl")
+            .args([
+                "keyword",
+                if dont_inhibit { "bindp" } else { "bind" },
+                &format!("ALT,space,exec,{cmd}"),
+            ])
+            .output(),
+    )
 }
 
 /// hyprctl exits 0 even for some rejected commands, reporting the failure as
@@ -358,7 +392,7 @@ fn niri_bind_snippet() -> String {
         .map(|arg| format!("\"{arg}\""))
         .collect::<Vec<_>>()
         .join(" ");
-    format!("binds {{ Alt+Space {{ spawn {argv}; }} }}")
+    format!("binds {{ Alt+Space {NIRI_NO_INHIBIT} {{ spawn {argv}; }} }}")
 }
 
 /// Where niri looks for its config, in the order it does. `NIRI_CONFIG` wins
@@ -378,6 +412,21 @@ fn niri_config_paths() -> Vec<std::path::PathBuf> {
 
 /// Ceiling on `include` nesting, matching niri's own recursion limit.
 const NIRI_INCLUDE_DEPTH: u8 = 10;
+
+/// Bind property that keeps niri handling the key itself instead of passing it
+/// to a window holding a keyboard-shortcuts inhibitor.
+const NIRI_NO_INHIBIT: &str = "allow-inhibiting=false";
+
+/// What the user's config does about Look's hotkey.
+#[derive(Debug, PartialEq)]
+enum NiriBind {
+    /// No bind spawns our D-Bus call.
+    Missing,
+    /// Bound, but fullscreen windows can swallow the key.
+    Inhibitable,
+    /// Bound and exempt from inhibiting.
+    Ready,
+}
 
 /// Files an `include` node pulls in, resolved as niri resolves them: one
 /// quoted path per node, relative to the including file, `~` for `$HOME`,
@@ -406,16 +455,16 @@ fn resolve_niri_include(arg: &str, dir: &std::path::Path) -> Option<std::path::P
     })
 }
 
-/// Whether a bind already spawns something that talks to Look's D-Bus service.
-/// Matching on the bus name rather than a full command line keeps this true
-/// for any of the three callers, and for a user's own wrapper script. Included
-/// files count: splitting binds into their own `.kdl` is common, and missing
-/// one means nagging a user whose hotkey already works.
-fn niri_bind_present() -> bool {
-    niri_bind_present_in(niri_config_paths())
+/// What, if anything, the config binds to Look's D-Bus service. Matching on the
+/// bus name rather than a full command line finds the bind for any of the three
+/// callers, and for a user's own wrapper script. Included files count:
+/// splitting binds into their own `.kdl` is common, and missing one means
+/// nagging a user whose hotkey already works.
+fn niri_bind_state() -> NiriBind {
+    niri_bind_state_in(niri_config_paths())
 }
 
-fn niri_bind_present_in(roots: Vec<std::path::PathBuf>) -> bool {
+fn niri_bind_state_in(roots: Vec<std::path::PathBuf>) -> NiriBind {
     let mut pending: Vec<(std::path::PathBuf, u8)> =
         roots.into_iter().map(|path| (path, 0)).collect();
     let mut seen = std::collections::HashSet::new();
@@ -428,7 +477,7 @@ fn niri_bind_present_in(roots: Vec<std::path::PathBuf>) -> bool {
             continue;
         };
         if config.contains(DBUS_NAME) {
-            return true;
+            return niri_bind_inhibitable(&config);
         }
         if depth < NIRI_INCLUDE_DEPTH {
             let dir = path.parent().unwrap_or(std::path::Path::new(""));
@@ -439,21 +488,52 @@ fn niri_bind_present_in(roots: Vec<std::path::PathBuf>) -> bool {
             );
         }
     }
-    false
+    NiriBind::Missing
+}
+
+/// Whether the bind spawning our D-Bus call opts out of shortcut inhibiting.
+/// KDL keeps a node's properties on its opening line, so the header is the
+/// last `{` line at or above the one naming the bus - a `spawn` argv split
+/// over several lines sits below it. A header we cannot identify reports
+/// `Ready` rather than nagging about a hotkey that may well be fine.
+fn niri_bind_inhibitable(config: &str) -> NiriBind {
+    let mut header = None;
+    for line in config.lines() {
+        if line.contains('{') {
+            header = Some(line);
+        }
+        if line.contains(DBUS_NAME) {
+            break;
+        }
+    }
+    match header {
+        Some(line) if !line.contains(NIRI_NO_INHIBIT) => NiriBind::Inhibitable,
+        _ => NiriBind::Ready,
+    }
 }
 
 fn report_niri_keybinding() {
-    if niri_bind_present() {
-        return;
-    }
-    health::report(
-        health::ISSUE_HOTKEY,
-        format!(
-            "niri has no API to register hotkeys, so Alt+Space must be bound in \
-             ~/.config/niri/config.kdl, or any file it includes: {}",
-            niri_bind_snippet()
+    match niri_bind_state() {
+        NiriBind::Ready => {}
+        NiriBind::Inhibitable => health::report(
+            health::ISSUE_HOTKEY,
+            format!(
+                "niri hands Alt+Space to fullscreen windows that inhibit \
+                 keyboard shortcuts (games, browsers, virtual machines), so \
+                 Look will not open over them. Add {NIRI_NO_INHIBIT} to the \
+                 bind in ~/.config/niri/config.kdl: {}",
+                niri_bind_snippet()
+            ),
         ),
-    );
+        NiriBind::Missing => health::report(
+            health::ISSUE_HOTKEY,
+            format!(
+                "niri has no API to register hotkeys, so Alt+Space must be bound in \
+                 ~/.config/niri/config.kdl, or any file it includes: {}",
+                niri_bind_snippet()
+            ),
+        ),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -930,16 +1010,55 @@ mod tests {
         std::fs::write(dir.join("config.kdl"), "include \"nested/binds.kdl\"\n").expect("config");
         std::fs::write(
             dir.join("nested/binds.kdl"),
-            format!("binds {{ Alt+Space {{ spawn \"gdbus\" \"{DBUS_NAME}\"; }} }}"),
+            format!(
+                "binds {{ Alt+Space {NIRI_NO_INHIBIT} {{ spawn \"gdbus\" \"{DBUS_NAME}\"; }} }}"
+            ),
         )
         .expect("binds");
 
-        assert!(niri_bind_present_in(vec![dir.join("config.kdl")]));
+        assert_eq!(
+            niri_bind_state_in(vec![dir.join("config.kdl")]),
+            NiriBind::Ready
+        );
 
         std::fs::write(dir.join("nested/binds.kdl"), "binds { }").expect("binds");
-        assert!(!niri_bind_present_in(vec![dir.join("config.kdl")]));
+        assert_eq!(
+            niri_bind_state_in(vec![dir.join("config.kdl")]),
+            NiriBind::Missing
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn a_bind_without_the_opt_out_is_reported_inhibitable() {
+        assert_eq!(
+            niri_bind_inhibitable(&multiline_bind("")),
+            NiriBind::Inhibitable
+        );
+    }
+
+    #[test]
+    fn the_opt_out_on_the_bind_header_counts_for_a_multiline_spawn() {
+        assert_eq!(
+            niri_bind_inhibitable(&multiline_bind(NIRI_NO_INHIBIT)),
+            NiriBind::Ready
+        );
+    }
+
+    /// A bind whose `spawn` argv wraps, so the bus name lands well below the
+    /// header carrying the properties.
+    fn multiline_bind(props: &str) -> String {
+        [
+            "binds {".to_string(),
+            format!("    Alt+Space {props} {{"),
+            "        spawn \"dbus-send\" \\".to_string(),
+            format!("              \"--dest={DBUS_NAME}\" \\"),
+            format!("              \"{DBUS_NAME}.{TOGGLE_METHOD}\""),
+            "    }".to_string(),
+            "}".to_string(),
+        ]
+        .join("\n")
     }
 
     #[test]
@@ -950,7 +1069,10 @@ mod tests {
         std::fs::write(dir.join("a.kdl"), "include \"b.kdl\"\n").expect("a");
         std::fs::write(dir.join("b.kdl"), "include \"a.kdl\"\n").expect("b");
 
-        assert!(!niri_bind_present_in(vec![dir.join("a.kdl")]));
+        assert_eq!(
+            niri_bind_state_in(vec![dir.join("a.kdl")]),
+            NiriBind::Missing
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/apps/linows/src-tauri/src/platform/linux/wayland_shortcut.rs
+++ b/apps/linows/src-tauri/src/platform/linux/wayland_shortcut.rs
@@ -361,8 +361,12 @@ fn niri_bind_snippet() -> String {
     format!("binds {{ Alt+Space {{ spawn {argv}; }} }}")
 }
 
-/// Where niri looks for its config, in the order it does.
+/// Where niri looks for its config, in the order it does. `NIRI_CONFIG` wins
+/// when set; a `-c` given on niri's command line stays invisible to us.
 fn niri_config_paths() -> Vec<std::path::PathBuf> {
+    if let Some(path) = std::env::var_os("NIRI_CONFIG") {
+        return vec![std::path::PathBuf::from(path)];
+    }
     std::env::var_os("XDG_CONFIG_HOME")
         .map(std::path::PathBuf::from)
         .or_else(|| std::env::var_os("HOME").map(|h| std::path::PathBuf::from(h).join(".config")))
@@ -372,15 +376,70 @@ fn niri_config_paths() -> Vec<std::path::PathBuf> {
         .collect()
 }
 
+/// Ceiling on `include` nesting, matching niri's own recursion limit.
+const NIRI_INCLUDE_DEPTH: u8 = 10;
+
+/// Files an `include` node pulls in, resolved as niri resolves them: one
+/// quoted path per node, relative to the including file, `~` for `$HOME`,
+/// no globs. The path is the only quoted token on the line, so an
+/// `optional=true` property in front of it needs no parsing of its own.
+fn niri_includes(config: &str, dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+    config
+        .lines()
+        .filter_map(|line| {
+            let rest = line.trim_start().strip_prefix("include")?;
+            let (_, quoted) = rest.strip_prefix(char::is_whitespace)?.split_once('"')?;
+            resolve_niri_include(quoted.split_once('"')?.0, dir)
+        })
+        .collect()
+}
+
+fn resolve_niri_include(arg: &str, dir: &std::path::Path) -> Option<std::path::PathBuf> {
+    let path = match arg.strip_prefix("~/") {
+        Some(rest) => std::path::PathBuf::from(std::env::var_os("HOME")?).join(rest),
+        None => std::path::PathBuf::from(arg),
+    };
+    Some(if path.is_absolute() {
+        path
+    } else {
+        dir.join(path)
+    })
+}
+
 /// Whether a bind already spawns something that talks to Look's D-Bus service.
 /// Matching on the bus name rather than a full command line keeps this true
-/// for any of the three callers, and for a user's own wrapper script.
+/// for any of the three callers, and for a user's own wrapper script. Included
+/// files count: splitting binds into their own `.kdl` is common, and missing
+/// one means nagging a user whose hotkey already works.
 fn niri_bind_present() -> bool {
-    niri_config_paths().iter().any(|path| {
-        std::fs::read_to_string(path)
-            .map(|config| config.contains(DBUS_NAME))
-            .unwrap_or(false)
-    })
+    niri_bind_present_in(niri_config_paths())
+}
+
+fn niri_bind_present_in(roots: Vec<std::path::PathBuf>) -> bool {
+    let mut pending: Vec<(std::path::PathBuf, u8)> =
+        roots.into_iter().map(|path| (path, 0)).collect();
+    let mut seen = std::collections::HashSet::new();
+
+    while let Some((path, depth)) = pending.pop() {
+        if !seen.insert(path.clone()) {
+            continue;
+        }
+        let Ok(config) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        if config.contains(DBUS_NAME) {
+            return true;
+        }
+        if depth < NIRI_INCLUDE_DEPTH {
+            let dir = path.parent().unwrap_or(std::path::Path::new(""));
+            pending.extend(
+                niri_includes(&config, dir)
+                    .into_iter()
+                    .map(|path| (path, depth + 1)),
+            );
+        }
+    }
+    false
 }
 
 fn report_niri_keybinding() {
@@ -391,7 +450,7 @@ fn report_niri_keybinding() {
         health::ISSUE_HOTKEY,
         format!(
             "niri has no API to register hotkeys, so Alt+Space must be bound in \
-             ~/.config/niri/config.kdl: {}",
+             ~/.config/niri/config.kdl, or any file it includes: {}",
             niri_bind_snippet()
         ),
     );
@@ -833,5 +892,84 @@ mod tests {
             caller_invocation(CALLER_GDBUS, Path::new("/usr/bin/gdbus")),
             CALLER_GDBUS
         );
+    }
+
+    #[test]
+    fn includes_resolve_against_the_including_file() {
+        assert_eq!(
+            niri_includes("include \"binds.kdl\"", Path::new("/home/u/.config/niri")),
+            [Path::new("/home/u/.config/niri/binds.kdl")]
+        );
+    }
+
+    #[test]
+    fn absolute_includes_are_taken_as_is() {
+        assert_eq!(
+            niri_includes(
+                "  include   \"/etc/niri/binds.kdl\" // shared",
+                Path::new("/tmp")
+            ),
+            [Path::new("/etc/niri/binds.kdl")]
+        );
+    }
+
+    #[test]
+    fn tilde_includes_expand_to_home() {
+        let home = std::env::var("HOME").expect("HOME");
+        assert_eq!(
+            niri_includes("include \"~/dots/binds.kdl\"", Path::new("/tmp")),
+            [Path::new(&home).join("dots/binds.kdl")]
+        );
+    }
+
+    #[test]
+    fn a_bind_in_an_included_file_counts_as_present() {
+        let dir = std::env::temp_dir().join("look-niri-include-test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("nested")).expect("temp dir");
+        std::fs::write(dir.join("config.kdl"), "include \"nested/binds.kdl\"\n").expect("config");
+        std::fs::write(
+            dir.join("nested/binds.kdl"),
+            format!("binds {{ Alt+Space {{ spawn \"gdbus\" \"{DBUS_NAME}\"; }} }}"),
+        )
+        .expect("binds");
+
+        assert!(niri_bind_present_in(vec![dir.join("config.kdl")]));
+
+        std::fs::write(dir.join("nested/binds.kdl"), "binds { }").expect("binds");
+        assert!(!niri_bind_present_in(vec![dir.join("config.kdl")]));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn cyclic_includes_terminate() {
+        let dir = std::env::temp_dir().join("look-niri-cycle-test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        std::fs::write(dir.join("a.kdl"), "include \"b.kdl\"\n").expect("a");
+        std::fs::write(dir.join("b.kdl"), "include \"a.kdl\"\n").expect("b");
+
+        assert!(!niri_bind_present_in(vec![dir.join("a.kdl")]));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn optional_includes_are_followed_too() {
+        assert_eq!(
+            niri_includes(
+                "include optional=true \"local.kdl\"",
+                Path::new("/etc/niri")
+            ),
+            [Path::new("/etc/niri/local.kdl")]
+        );
+    }
+
+    #[test]
+    fn non_include_lines_pull_in_nothing() {
+        let config =
+            "// include \"old.kdl\"\nincludes \"x.kdl\"\nbinds { Alt+Space { spawn \"x\"; } }";
+        assert!(niri_includes(config, Path::new("/tmp")).is_empty());
     }
 }

--- a/apps/linows/src-tauri/src/process.rs
+++ b/apps/linows/src-tauri/src/process.rs
@@ -370,7 +370,7 @@ pub fn activate_running_app(
             && let Some(desktop_path) = id.strip_prefix("app:")
             && crate::commands::try_focus_existing_pub(desktop_path)
         {
-            let _ = window.hide();
+            crate::commands::hide_now(&window);
             return Ok(true);
         }
         // Fallback: try focusing by exec binary name
@@ -385,7 +385,7 @@ pub fn activate_running_app(
             .and_then(|f| f.to_str())
             .unwrap_or("");
             if !bin.is_empty() && crate::commands::try_focus_window_pub(bin) {
-                let _ = window.hide();
+                crate::commands::hide_now(&window);
                 return Ok(true);
             }
         }
@@ -401,7 +401,7 @@ pub fn activate_running_app(
                 if let Ok(h) = raw.parse::<isize>()
                     && crate::platform::windows::window_focus::focus_hwnd(h)
                 {
-                    let _ = window.hide();
+                    crate::commands::hide_now(&window);
                     return Ok(true);
                 }
                 return Ok(false);
@@ -409,7 +409,7 @@ pub fn activate_running_app(
             if let Some(path) = id.strip_prefix("app:")
                 && crate::platform::windows::window_focus::try_focus_existing(path)
             {
-                let _ = window.hide();
+                crate::commands::hide_now(&window);
                 return Ok(true);
             }
         }

--- a/apps/linows/src-tauri/src/tools.rs
+++ b/apps/linows/src-tauri/src/tools.rs
@@ -60,7 +60,7 @@ pub async fn perform_tool_action(
     // no explanation, so bring the launcher back to carry the banner.
     if outcome.is_failure() {
         crate::commands::show_launcher(&window);
-        let _ = window.set_focus();
+        crate::commands::focus_launcher(&window);
     }
     Some(outcome)
 }

--- a/apps/linows/src-tauri/tauri.conf.json
+++ b/apps/linows/src-tauri/tauri.conf.json
@@ -60,7 +60,10 @@
           "libasound2",
           "xdg-desktop-portal"
         ],
-        "section": "utils",
+        "recommends": [
+        "libgtk-layer-shell0"
+      ],
+      "section": "utils",
         "priority": "optional"
       }
     },

--- a/apps/linows/src/js/components/health.js
+++ b/apps/linows/src/js/components/health.js
@@ -18,10 +18,10 @@ function dismissedSet() {
     }
 }
 
-// Keyed on id + message: a new failure mode under the same id should
-// surface again even if an older notice was dismissed.
+// id + kind, never the message: messages carry store paths and error text
+// that churn, which would resurrect a dismissed notice.
 function issueKey(issue) {
-    return `${issue.id}:${issue.message}`;
+    return `${issue.id}:${issue.kind ?? issue.id}`;
 }
 
 function render() {

--- a/apps/linows/src/js/components/health.js
+++ b/apps/linows/src/js/components/health.js
@@ -24,8 +24,35 @@ function issueKey(issue) {
     return `${issue.id}:${issue.kind ?? issue.id}`;
 }
 
+// What issueKey produced before it dropped the message. Kept only so an
+// upgrade does not re-nag about a notice the user already dismissed.
+function legacyKey(issue) {
+    return `${issue.id}:${issue.message}`;
+}
+
+// Rewrite any legacy entry the current issues still match, so the old
+// message-keyed set drains instead of growing alongside the new one.
+function migrate(dismissed) {
+    let changed = false;
+    issues.forEach((i) => {
+        if (!dismissed.delete(legacyKey(i))) return;
+        dismissed.add(issueKey(i));
+        changed = true;
+    });
+    if (changed) persist(dismissed);
+}
+
+function persist(dismissed) {
+    try {
+        localStorage.setItem(DISMISSED_KEY, JSON.stringify([...dismissed]));
+    } catch {
+        // Best effort - worst case the notice reappears next launch.
+    }
+}
+
 function render() {
     const dismissed = dismissedSet();
+    migrate(dismissed);
     const visible = issues.filter((i) => !dismissed.has(issueKey(i)));
     if (visible.length === 0) {
         banner.showSticky(null);
@@ -37,11 +64,7 @@ function render() {
 function dismissAll() {
     const dismissed = dismissedSet();
     issues.forEach((i) => dismissed.add(issueKey(i)));
-    try {
-        localStorage.setItem(DISMISSED_KEY, JSON.stringify([...dismissed]));
-    } catch {
-        // Best effort - worst case the notice reappears next launch.
-    }
+    persist(dismissed);
 }
 
 export function init() {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added Linux Wayland layer-shell support for improved launcher positioning, visibility, focus, and fullscreen compatibility.
- Added fallback behavior when layer-shell is unavailable.
- Improved shortcut handling across Sway, Hyprland, and Niri, including reliable configuration detection.
- Added clearer health notices with distinct failure types and dismissal handling.

## Bug Fixes
- Prevented duplicate shortcut firing when rebinding.
- Improved launcher hiding, showing, focusing, and recovery behavior.
- Made health-notice dismissal more reliable when messages change.

## Documentation
- Clarified shortcut placement, customization, conflict removal, fullscreen support, and Niri configuration validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [x] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)


## Checklist

- [x] I have read and agree to the CLA (CLA.md)
- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


