### PR TITLE
feat: Default terms for Look (MacOS)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -13,12 +13,21 @@ Guide for building Look locally and contributing to the project.
 │       ├── src-tauri/            #   Rust backend (commands, config, platform, etc.)
 │       ├── src/                  #   Frontend (vanilla HTML/CSS/JS, ES modules)
 │       └── flake.nix             #   NixOS dev shell
-├── core/
-│   ├── engine/                   # Query engine, search pipeline
+├── core/                         # Shared Rust, consumed by every shell
+│   ├── ai/                       # Routing, planning, lexicon
+│   ├── answers/                  # Platform-agnostic "web answer" features
+│   ├── calc/                     # Calculator expression evaluation
+│   ├── engine/                   # Query engine, search pipeline, config
 │   ├── indexing/                 # Candidate model, source traits
+│   ├── lunar/                    # Solar-to-lunar date conversion
 │   ├── matching/                 # Fuzzy matching
+│   ├── netspeed/                 # Bandwidth measurement
+│   ├── qactions/                 # Quick Actions catalog (declarative half)
 │   ├── ranking/                  # Ranking heuristics
-│   └── storage/                  # SQLite-backed storage
+│   ├── sources/                  # User-declared source blocks
+│   ├── storage/                  # SQLite-backed storage
+│   ├── todo/                     # Todo backend
+│   └── tools/                    # Preferred tools: catalog + command composition
 ├── bridge/
 │   └── ffi/                      # Rust FFI bridge (consumed by macOS/Windows native apps)
 ├── tools/

--- a/apps/linows/src-tauri/Cargo.lock
+++ b/apps/linows/src-tauri/Cargo.lock
@@ -2476,6 +2476,7 @@ dependencies = [
  "look-ranking",
  "look-sources",
  "look-storage",
+ "look-tools",
  "objc2",
  "objc2-foundation",
  "regex",
@@ -2533,6 +2534,7 @@ name = "look-sources"
 version = "0.1.0"
 dependencies = [
  "globset",
+ "look-tools",
  "serde",
  "toml 0.9.12+spec-1.1.0",
 ]
@@ -2552,6 +2554,10 @@ dependencies = [
  "rusqlite",
  "serde",
 ]
+
+[[package]]
+name = "look-tools"
+version = "0.1.0"
 
 [[package]]
 name = "lookapp"

--- a/apps/macos/LauncherApp/LauncherLogicTests/RevealTargetLogicTests.swift
+++ b/apps/macos/LauncherApp/LauncherLogicTests/RevealTargetLogicTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+
+@testable import LauncherLogic
+
+final class RevealTargetLogicTests: XCTestCase {
+    func testAnExistingFilesystemPathIsSelectedInTheFileViewer() {
+        XCTAssertEqual(
+            RevealTargetLogic.plan(for: "/tmp/look/a.txt", exists: true),
+            .selectInFileViewer
+        )
+    }
+
+    func testAMissingFilesystemPathIsUnavailable() {
+        XCTAssertEqual(
+            RevealTargetLogic.plan(for: "/tmp/look/gone.txt", exists: false),
+            .unavailable
+        )
+    }
+
+    /// A scheme is never stat'd, so `exists` must not decide it.
+    func testAURLSchemeIsOpenedRegardlessOfTheStat() {
+        for path in ["x-apple.systempreferences:com.apple.Bluetooth", "https://example.com"] {
+            XCTAssertEqual(RevealTargetLogic.plan(for: path, exists: false), .openURL, path)
+        }
+    }
+
+    func testAnEmptyPathIsUnavailable() {
+        XCTAssertEqual(RevealTargetLogic.plan(for: "", exists: false), .unavailable)
+        XCTAssertEqual(RevealTargetLogic.plan(for: "", exists: true), .unavailable)
+    }
+}

--- a/apps/macos/LauncherApp/Package.swift
+++ b/apps/macos/LauncherApp/Package.swift
@@ -21,6 +21,7 @@ let package = Package(
                 "Support/Launcher/LauncherSearchLogic.swift",
                 "Support/Launcher/ProcessScoring.swift",
                 "Support/Launcher/DeleteTargetLogic.swift",
+                "Support/Launcher/RevealTargetLogic.swift",
                 "Support/Launcher/BridgeErrorMapping.swift",
                 "Support/Launcher/SyntheticRow.swift",
                 "Support/AI/OllamaCodec.swift",

--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -335,8 +335,17 @@ enum AppConstants {
         enum Tools {
             static let editAction = "edit"
             static let terminalAction = "terminal"
+            static let revealAction = "reveal"
             static let launchFailedBanner = "Could not start"
+            /// Shown when no `file_manager` is declared, which is the default.
+            static let systemFileManagerName = "Finder"
             static let bannerDuration: TimeInterval = 2.4
+            /// Long enough for the terminal to have made its new window, so
+            /// activating raises that one and not the window it already had.
+            static let activationSettleNanoseconds: UInt64 = 350_000_000
+            /// A terminal that was not running yet has to start first.
+            static let activationPollNanoseconds: UInt64 = 200_000_000
+            static let activationPollAttempts = 8
         }
 
         /// Rows from a user-declared block in `~/.look/sources`.

--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -330,6 +330,15 @@ enum AppConstants {
             static let shadowRadius: CGFloat = 14
         }
 
+        /// Preferred tools: Cmd+E and Cmd+T act through the tools a user named
+        /// in their config. See `specs/preferred-tools.md`.
+        enum Tools {
+            static let editAction = "edit"
+            static let terminalAction = "terminal"
+            static let launchFailedBanner = "Could not start"
+            static let bannerDuration: TimeInterval = 2.4
+        }
+
         /// Rows from a user-declared block in `~/.look/sources`.
         enum SourceBlock {
             static let idPrefix = "src:"
@@ -405,6 +414,8 @@ enum AppConstants {
             static let f: UInt16 = 3
             static let h: UInt16 = 4
             static let c: UInt16 = 8
+            static let e: UInt16 = 14
+            static let t: UInt16 = 17
             static let j: UInt16 = 38
             static let k: UInt16 = 40
             static let p: UInt16 = 35

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/AppBundleLocator.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/AppBundleLocator.swift
@@ -1,0 +1,27 @@
+import AppKit
+import Foundation
+
+/// Where `open -a Name` would find a bundle: the same roots `open` itself
+/// searches, plus a bundle-id lookup for a name that is one.
+enum AppBundleLocator {
+    private static let roots = [
+        "/Applications",
+        "/System/Applications",
+        "/System/Applications/Utilities",
+        "/Applications/Utilities",
+        NSHomeDirectory() + "/Applications",
+    ]
+
+    static func bundlePath(forAppNamed name: String) -> String? {
+        let bundleName = name.hasSuffix(".app") ? name : name + ".app"
+        for root in roots {
+            let candidate = root + "/" + bundleName
+            if FileManager.default.fileExists(atPath: candidate) {
+                return candidate
+            }
+        }
+        return NSWorkspace.shared
+            .urlForApplication(withBundleIdentifier: name)?
+            .path
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
@@ -244,6 +244,14 @@ private func look_source_block_json(_ candidateID: UnsafePointer<CChar>?, _ rowI
 nonisolated
 private func look_perform_block_json(_ blockID: UnsafePointer<CChar>?, _ rowID: UnsafePointer<CChar>?, _ rowTitle: UnsafePointer<CChar>?, _ rowPath: UnsafePointer<CChar>?, _ query: UnsafePointer<CChar>?, _ asTarget: Bool) -> UnsafeMutablePointer<CChar>?
 
+@_silgen_name("look_tool_action_json")
+nonisolated
+private func look_tool_action_json(_ action: UnsafePointer<CChar>?, _ path: UnsafePointer<CChar>?, _ isDir: Bool) -> UnsafeMutablePointer<CChar>?
+
+@_silgen_name("look_perform_tool_action_json")
+nonisolated
+private func look_perform_tool_action_json(_ action: UnsafePointer<CChar>?, _ path: UnsafePointer<CChar>?, _ isDir: Bool) -> UnsafeMutablePointer<CChar>?
+
 @_silgen_name("look_netspeed_run_json")
 nonisolated
 private func look_netspeed_run_json() -> UnsafeMutablePointer<CChar>?
@@ -1025,6 +1033,36 @@ final class EngineBridge: @unchecked Sendable {
         return try? JSONDecoder().decode(SourceBlock.self, from: data)
     }
 
+    /// What `action` would do to a row, without doing it: the tool it would
+    /// start, or why it cannot. For labels and availability.
+    nonisolated func toolAction(_ action: String, path: String, isDirectory: Bool) -> ToolAction? {
+        let ptr = action.withCString { action in
+            path.withCString { path in
+                look_tool_action_json(action, path, isDirectory)
+            }
+        }
+        return Self.decodeToolAction(ptr)
+    }
+
+    /// Runs `action` on a row. Shell actions are spawned detached inside core;
+    /// an `application` result is handed back for `NSWorkspace` to launch.
+    /// Spawns a process, so call it off the main thread.
+    nonisolated func performToolAction(_ action: String, path: String, isDirectory: Bool) -> ToolAction? {
+        let ptr = action.withCString { action in
+            path.withCString { path in
+                look_perform_tool_action_json(action, path, isDirectory)
+            }
+        }
+        return Self.decodeToolAction(ptr)
+    }
+
+    private nonisolated static func decodeToolAction(_ ptr: UnsafeMutablePointer<CChar>?) -> ToolAction? {
+        guard let ptr else { return nil }
+        defer { look_free_cstring(ptr) }
+        guard let data = String(cString: ptr).data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(ToolAction.self, from: data)
+    }
+
     /// Re-runs every `run` block and stores its rows for the next index pass.
     /// Spawns the user's commands and waits for them - call off the main thread.
     nonisolated func refreshRunBlocks() -> RunBlockRefreshOutcome {
@@ -1304,6 +1342,32 @@ nonisolated struct URLMatch: Decodable {
 
 /// A user-declared block and the steps performing it will run, so the panel can
 /// show exactly what Enter is about to do.
+/// One preferred-tool action resolved against a row. `kind` says which of the
+/// other fields are filled; see `specs/preferred-tools.md`.
+nonisolated struct ToolAction: Decodable {
+    enum Kind: String, Decodable {
+        /// Composed shell text. Only `look_tool_action_json` returns this;
+        /// performing runs it in core and reports `performed` or `failed`.
+        case shell
+        /// The native side launches `tool` with `path`.
+        case application
+        /// Core spawned it.
+        case performed
+        case failed
+        /// No tool declared, or one that cannot do this.
+        case unavailable
+    }
+
+    let kind: Kind
+    let tool: String?
+    let command: String?
+    let path: String?
+    /// Shown as-is when `kind` is `unavailable` or `failed`.
+    let reason: String?
+    /// The config key that would fix an `unavailable` action.
+    let key: String?
+}
+
 nonisolated struct SourceBlock: Decodable {
     let id: String
     let name: String

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
@@ -1351,6 +1351,8 @@ nonisolated struct ToolAction: Decodable {
         case shell
         /// The native side launches `tool` with `path`.
         case application
+        /// Nothing declared, so the platform's own handler does it.
+        case systemDefault = "system_default"
         /// Core spawned it.
         case performed
         case failed

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
@@ -43,6 +43,11 @@ final class KeyboardSelectionMonitor {
         onActionMenuRun: @escaping @MainActor () -> Void = {},
         onActionMenuClose: @escaping @MainActor () -> Void = {},
         onRevealInFinder: @escaping @MainActor () -> Void,
+        /// Cmd+E / Cmd+T act through the user's declared tools. They sit with
+        /// the other result chords, below the launchpad mnemonics, so the strip
+        /// keeps Cmd+T for the theme while a row is not selected.
+        onEditSelection: @escaping @MainActor () -> Void = {},
+        onOpenTerminalForSelection: @escaping @MainActor () -> Void = {},
         onCopySelection: @escaping @MainActor () -> Bool,
         onTogglePick: @escaping @MainActor () -> Void,
         onClearPicked: @escaping @MainActor () -> Void,
@@ -190,6 +195,20 @@ final class KeyboardSelectionMonitor {
                 && flags == [.command]
             {
                 onRevealInFinder()
+                return nil
+            }
+
+            if (event.keyCode == KeyCode.e || event.charactersIgnoringModifiers?.lowercased() == "e")
+                && flags == [.command]
+            {
+                onEditSelection()
+                return nil
+            }
+
+            if (event.keyCode == KeyCode.t || event.charactersIgnoringModifiers?.lowercased() == "t")
+                && flags == [.command]
+            {
+                onOpenTerminalForSelection()
                 return nil
             }
 

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/RevealTargetLogic.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/RevealTargetLogic.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// What revealing a path should do, decided without AppKit so it is testable.
+enum RevealTargetLogic {
+    enum Plan: Equatable {
+        case selectInFileViewer
+        case openURL
+        case unavailable
+    }
+
+    static func plan(for path: String, exists: Bool) -> Plan {
+        guard !path.isEmpty else { return .unavailable }
+        guard !DeleteTargetLogic.isURLScheme(path) else { return .openURL }
+        return exists ? .selectInFileViewer : .unavailable
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/SourceBlockIcons.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/SourceBlockIcons.swift
@@ -162,26 +162,8 @@ enum SourceBlockIcons {
         return icons
     }
 
-    /// Where `open -a Name` would find the bundle. The same roots `open` itself
-    /// searches, plus a bundle-id lookup for a step that names one.
     private static func bundlePath(forAppNamed name: String) -> String? {
-        let roots = [
-            "/Applications",
-            "/System/Applications",
-            "/System/Applications/Utilities",
-            "/Applications/Utilities",
-            NSHomeDirectory() + "/Applications",
-        ]
-        let bundleName = name.hasSuffix(".app") ? name : name + ".app"
-        for root in roots {
-            let candidate = root + "/" + bundleName
-            if FileManager.default.fileExists(atPath: candidate) {
-                return candidate
-            }
-        }
-        return NSWorkspace.shared
-            .urlForApplication(withBundleIdentifier: name)?
-            .path
+        AppBundleLocator.bundlePath(forAppNamed: name)
     }
 
     /// The first argument after `-a`, honouring quotes so a two-word app name

--- a/apps/macos/LauncherApp/look-app/Support/ShortcutCatalog.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ShortcutCatalog.swift
@@ -71,6 +71,8 @@ enum ShortcutCatalog {
             ShortcutEntry("main.moveTab", "Tab / Shift+Tab", "Move selection"),
             ShortcutEntry("main.moveArrows", "Up / Down", "Move selection"),
             ShortcutEntry("main.reveal", "Cmd+F", "Reveal selected app/file/folder in Finder"),
+            ShortcutEntry("main.edit", "Cmd+E", "Open selected file/folder in your editor (set text_editor / code_editor)"),
+            ShortcutEntry("main.terminal", "Cmd+T", "Open a terminal there (set terminal); switches theme when no row is selected"),
             ShortcutEntry("main.webSearch", "Cmd+Enter", "Search current query on Google"),
             ShortcutEntry("main.commandMode", "Cmd+/", "Enter command mode"),
             ShortcutEntry("main.commandJump", ":cmd", "Jump to a command from home (e.g. :calc 2+2, :kill chrome)", remappable: false),
@@ -84,7 +86,7 @@ enum ShortcutCatalog {
         // the shared catalog (core/qactions), fired with Cmd.
         ShortcutGroup(title: "Super actions", topic: .main, entries: [
             ShortcutEntry("super.bluetoothWifi", "Cmd+B / Cmd+W", "Toggle Bluetooth / Wi-Fi"),
-            ShortcutEntry("super.themeAwake", "Cmd+T / Cmd+K", "Switch theme / toggle Keep Awake"),
+            ShortcutEntry("super.themeAwake", "Cmd+T / Cmd+K", "Switch theme / toggle Keep Awake (empty query only; Cmd+T opens a terminal once a row is selected)"),
             ShortcutEntry("super.screensaverMic", "Cmd+S / Cmd+M", "Start screensaver / mute mic"),
             ShortcutEntry("super.playPause", "Cmd+P", "Play/pause the current track"),
             ShortcutEntry("super.power", "Cmd+R / Cmd+D", "Restart / Shut Down (press twice, Esc cancels)"),

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+ActionMenu.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+ActionMenu.swift
@@ -99,6 +99,12 @@ extension LauncherView {
             return
         }
 
+        if RowAction.isOne(descriptor.actionId) {
+            closeActionMenu()
+            activateRowAction(descriptor.actionId)
+            return
+        }
+
         closeActionMenu()
         runQuickAction(descriptor, intent: descriptor.control == .toggle ? .toggle : .run)
     }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+QuickActions.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+QuickActions.swift
@@ -83,7 +83,15 @@ extension LauncherView {
         // A block's `then` targets are actions on this row, so they join the
         // same Cmd+K menu as the compiled controls. They are declared at parse
         // time rather than build time; that is the only difference.
-        descriptors.append(contentsOf: sourceBlockTargets(for: result))
+        let blockTargets = sourceBlockTargets(for: result)
+        descriptors.append(contentsOf: blockTargets)
+
+        // Declared beats default in the panel exactly as it does when running
+        // (`specs/preferred-tools.md` §7.1): a block that named its own actions
+        // keeps them unburied, and its rows keep every chord regardless.
+        if blockTargets.isEmpty {
+            descriptors.append(contentsOf: rowActionDescriptors(for: result))
+        }
         quickActionDescriptors = descriptors
 
         // Only a *different* result invalidates what the panel is showing. Re-reading

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
@@ -268,19 +268,7 @@ extension LauncherView {
 
         switch selected.kind {
         case .app, .file, .folder:
-            if selected.path.contains(":") && !selected.path.hasPrefix("/") {
-                if let url = URL(string: selected.path) {
-                    NSWorkspace.shared.open(url)
-                } else {
-                    showBanner(
-                        AppConstants.Launcher.Finder.cannotRevealBanner,
-                        style: .info,
-                        duration: AppConstants.Launcher.Clipboard.infoBannerDuration
-                    )
-                }
-            } else {
-                NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: selected.path)])
-            }
+            revealPathInFinder(selected.path)
         case .clipboard:
             showBanner(
                 AppConstants.Launcher.Clipboard.nonFileBanner,
@@ -294,6 +282,25 @@ extension LauncherView {
             // file and is the thing the user wants to get to from here.
             revealDeclaringFile(for: selected)
         }
+    }
+
+    /// Reveals one path rather than whatever happens to be selected now. An
+    /// action resolved off the main thread must reveal the row it was resolved
+    /// for, even if the user has since moved the selection.
+    func revealPathInFinder(_ path: String) {
+        guard path.contains(":"), !path.hasPrefix("/") else {
+            NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: path)])
+            return
+        }
+        guard let url = URL(string: path) else {
+            showBanner(
+                AppConstants.Launcher.Finder.cannotRevealBanner,
+                style: .info,
+                duration: AppConstants.Launcher.Clipboard.infoBannerDuration
+            )
+            return
+        }
+        NSWorkspace.shared.open(url)
     }
 
     func togglePickForSelectedResult() {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
@@ -284,23 +284,31 @@ extension LauncherView {
         }
     }
 
-    /// Reveals one path rather than whatever happens to be selected now. An
-    /// action resolved off the main thread must reveal the row it was resolved
-    /// for, even if the user has since moved the selection.
+    /// Takes a path, not the selection: an action resolved off the main thread
+    /// must reveal the row it was resolved for.
     func revealPathInFinder(_ path: String) {
-        guard path.contains(":"), !path.hasPrefix("/") else {
+        switch RevealTargetLogic.plan(
+            for: path, exists: FileManager.default.fileExists(atPath: path)
+        ) {
+        case .selectInFileViewer:
             NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: path)])
-            return
+        case .openURL:
+            // An unhandled scheme returns false, and ignoring it is silence.
+            guard let url = URL(string: path), NSWorkspace.shared.open(url) else {
+                showCannotReveal()
+                return
+            }
+        case .unavailable:
+            showCannotReveal()
         }
-        guard let url = URL(string: path) else {
-            showBanner(
-                AppConstants.Launcher.Finder.cannotRevealBanner,
-                style: .info,
-                duration: AppConstants.Launcher.Clipboard.infoBannerDuration
-            )
-            return
-        }
-        NSWorkspace.shared.open(url)
+    }
+
+    private func showCannotReveal() {
+        showBanner(
+            AppConstants.Launcher.Finder.cannotRevealBanner,
+            style: .info,
+            duration: AppConstants.Launcher.Clipboard.infoBannerDuration
+        )
     }
 
     func togglePickForSelectedResult() {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+RowActions.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+RowActions.swift
@@ -21,23 +21,50 @@ extension LauncherView {
         }
     }
 
-    /// Which tool each action would start, so a label can name it instead of
-    /// saying "Edit" and hoping. Cheap after the first call: the tools come from
-    /// the process-wide config cache and resolving is string work.
-    private func resolvedTools(for result: LauncherResult) -> [String: ToolAction] {
-        var resolved: [String: ToolAction] = [:]
-        for action in [
-            AppConstants.Launcher.Tools.editAction,
-            AppConstants.Launcher.Tools.terminalAction,
-            AppConstants.Launcher.Tools.revealAction,
-        ] where Self.toolActionApplies(action, to: result.kind) {
-            if let outcome = EngineBridge.shared.toolAction(
-                action, path: result.path, isDirectory: result.kind == .folder
-            ) {
-                resolved[action] = outcome
-            }
+    /// One panel entry. `named` is the wording used once a tool resolves, so
+    /// "Edit" becomes "Edit in Zed" and the menu teaches what the chord opens.
+    private struct RowActionEntry {
+        let id: String
+        let plain: String
+        let named: String?
+        let chord: String
+        /// The tool action whose resolved name fills `named`, when there is one.
+        let tool: String?
+        /// Used in place of a declared tool, for an action the platform always
+        /// has an answer for.
+        let fallbackTool: String?
+
+        init(
+            id: String, plain: String, named: String? = nil, chord: String,
+            tool: String? = nil, fallbackTool: String? = nil
+        ) {
+            self.id = id
+            self.plain = plain
+            self.named = named
+            self.chord = chord
+            self.tool = tool
+            self.fallbackTool = fallbackTool
         }
-        return resolved
+    }
+
+    /// Separates a label from the chord that already performs it.
+    private static let chordGap = "  "
+
+    private static var rowActionCatalog: [RowActionEntry] {
+        [
+            RowActionEntry(id: RowAction.open, plain: "Open", chord: "⏎"),
+            RowActionEntry(
+                id: RowAction.edit, plain: "Edit", named: "Edit in", chord: "⌘E",
+                tool: AppConstants.Launcher.Tools.editAction),
+            RowActionEntry(
+                id: RowAction.terminal, plain: "Open terminal here", named: "Open in",
+                chord: "⌘T", tool: AppConstants.Launcher.Tools.terminalAction),
+            RowActionEntry(
+                id: RowAction.reveal, plain: "Reveal", named: "Reveal in", chord: "⌘F",
+                tool: AppConstants.Launcher.Tools.revealAction,
+                fallbackTool: AppConstants.Launcher.Tools.systemFileManagerName),
+            RowActionEntry(id: RowAction.copyPath, plain: "Copy path", chord: "⌘C"),
+        ]
     }
 
     func rowActionDescriptors(for result: LauncherResult) -> [QuickActionDescriptor] {
@@ -45,34 +72,16 @@ extension LauncherView {
             return []
         }
 
-        let tools = resolvedTools(for: result)
-        let applies = { Self.toolActionApplies($0, to: result.kind) }
-        var entries: [(id: String, title: String)] = [(RowAction.open, "Open  ⏎")]
+        let offered = Self.rowActionCatalog.filter { entry in
+            guard let action = entry.tool else { return true }
+            return Self.toolActionApplies(action, to: result.kind)
+        }
+        let tools = resolvedTools(for: result, entries: offered)
 
-        if applies(AppConstants.Launcher.Tools.editAction) {
-            entries.append((
-                RowAction.edit,
-                "\(title("Edit", "Edit in", tools, AppConstants.Launcher.Tools.editAction))  ⌘E"
-            ))
-        }
-        if applies(AppConstants.Launcher.Tools.terminalAction) {
-            entries.append((
-                RowAction.terminal,
-                "\(title("Open terminal here", "Open in", tools, AppConstants.Launcher.Tools.terminalAction))  ⌘T"
-            ))
-        }
-        if applies(AppConstants.Launcher.Tools.revealAction) {
-            entries.append((
-                RowAction.reveal,
-                "Reveal in \(tools[AppConstants.Launcher.Tools.revealAction]?.tool ?? AppConstants.Launcher.Tools.systemFileManagerName)  ⌘F"
-            ))
-        }
-        entries.append((RowAction.copyPath, "Copy path  ⌘C"))
-
-        return entries.map { entry in
+        return offered.map { entry in
             QuickActionDescriptor(
                 actionId: entry.id,
-                title: entry.title,
+                title: Self.label(for: entry, tools: tools),
                 control: .button,
                 onLabel: nil,
                 offLabel: nil,
@@ -81,12 +90,28 @@ extension LauncherView {
         }
     }
 
-    /// `<named> <tool>` when a tool resolved, the plain wording otherwise.
-    private func title(
-        _ plain: String, _ named: String, _ tools: [String: ToolAction], _ action: String
-    ) -> String {
-        guard let tool = tools[action]?.tool else { return plain }
-        return "\(named) \(tool)"
+    private static func label(for entry: RowActionEntry, tools: [String: ToolAction]) -> String {
+        let resolved = entry.tool.flatMap { tools[$0]?.tool } ?? entry.fallbackTool
+        let wording =
+            if let named = entry.named, let resolved { "\(named) \(resolved)" } else { entry.plain }
+        return "\(wording)\(chordGap)\(entry.chord)"
+    }
+
+    /// Which tool each offered action would start. Cheap after the first call:
+    /// the tools come from the process-wide config cache and resolving is string
+    /// work.
+    private func resolvedTools(
+        for result: LauncherResult, entries: [RowActionEntry]
+    ) -> [String: ToolAction] {
+        var resolved: [String: ToolAction] = [:]
+        for action in entries.compactMap(\.tool) {
+            if let outcome = EngineBridge.shared.toolAction(
+                action, path: result.path, isDirectory: result.kind == .folder
+            ) {
+                resolved[action] = outcome
+            }
+        }
+        return resolved
     }
 
     func activateRowAction(_ actionID: String) {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+RowActions.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+RowActions.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// The Cmd+K entries every row with a path offers. Most already worked as chords
+/// nobody could discover; the panel is where they become visible.
+///
+/// Suppressed for a row whose block declared `then` targets: the author already
+/// chose that row's vocabulary and every entry here keeps its chord anyway
+/// (`specs/preferred-tools.md` §7.1).
+extension LauncherView {
+    enum RowAction {
+        static let prefix = "rowaction:"
+
+        static let open = "\(prefix)open"
+        static let edit = "\(prefix)edit"
+        static let terminal = "\(prefix)terminal"
+        static let reveal = "\(prefix)reveal"
+        static let copyPath = "\(prefix)copypath"
+
+        static func isOne(_ actionID: String) -> Bool {
+            actionID.hasPrefix(prefix)
+        }
+    }
+
+    /// Which tool each action would start, so a label can name it instead of
+    /// saying "Edit" and hoping. Cheap after the first call: the tools come from
+    /// the process-wide config cache and resolving is string work.
+    private func resolvedTools(for result: LauncherResult) -> [String: ToolAction] {
+        var resolved: [String: ToolAction] = [:]
+        for action in [
+            AppConstants.Launcher.Tools.editAction,
+            AppConstants.Launcher.Tools.terminalAction,
+            AppConstants.Launcher.Tools.revealAction,
+        ] where Self.toolActionApplies(action, to: result.kind) {
+            if let outcome = EngineBridge.shared.toolAction(
+                action, path: result.path, isDirectory: result.kind == .folder
+            ) {
+                resolved[action] = outcome
+            }
+        }
+        return resolved
+    }
+
+    func rowActionDescriptors(for result: LauncherResult) -> [QuickActionDescriptor] {
+        guard !result.path.isEmpty, result.kind != .clipboard, result.kind != .process else {
+            return []
+        }
+
+        let tools = resolvedTools(for: result)
+        let applies = { Self.toolActionApplies($0, to: result.kind) }
+        var entries: [(id: String, title: String)] = [(RowAction.open, "Open  ⏎")]
+
+        if applies(AppConstants.Launcher.Tools.editAction) {
+            entries.append((
+                RowAction.edit,
+                "\(title("Edit", "Edit in", tools, AppConstants.Launcher.Tools.editAction))  ⌘E"
+            ))
+        }
+        if applies(AppConstants.Launcher.Tools.terminalAction) {
+            entries.append((
+                RowAction.terminal,
+                "\(title("Open terminal here", "Open in", tools, AppConstants.Launcher.Tools.terminalAction))  ⌘T"
+            ))
+        }
+        if applies(AppConstants.Launcher.Tools.revealAction) {
+            entries.append((
+                RowAction.reveal,
+                "Reveal in \(tools[AppConstants.Launcher.Tools.revealAction]?.tool ?? AppConstants.Launcher.Tools.systemFileManagerName)  ⌘F"
+            ))
+        }
+        entries.append((RowAction.copyPath, "Copy path  ⌘C"))
+
+        return entries.map { entry in
+            QuickActionDescriptor(
+                actionId: entry.id,
+                title: entry.title,
+                control: .button,
+                onLabel: nil,
+                offLabel: nil,
+                info: []
+            )
+        }
+    }
+
+    /// `<named> <tool>` when a tool resolved, the plain wording otherwise.
+    private func title(
+        _ plain: String, _ named: String, _ tools: [String: ToolAction], _ action: String
+    ) -> String {
+        guard let tool = tools[action]?.tool else { return plain }
+        return "\(named) \(tool)"
+    }
+
+    func activateRowAction(_ actionID: String) {
+        switch actionID {
+        case RowAction.open:
+            openSelectedApp()
+        case RowAction.edit:
+            editSelectedResult()
+        case RowAction.terminal:
+            openTerminalForSelectedResult()
+        case RowAction.reveal:
+            revealSelectedResult()
+        case RowAction.copyPath:
+            _ = copySelectedResultToPasteboard()
+        default:
+            break
+        }
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
@@ -230,6 +230,12 @@ extension LauncherView {
             onRevealInFinder: {
                 revealSelectedInFinder()
             },
+            onEditSelection: {
+                editSelectedResult()
+            },
+            onOpenTerminalForSelection: {
+                openTerminalForSelectedResult()
+            },
             onCopySelection: {
                 copySelectedResultToPasteboard()
             },

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Tools.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Tools.swift
@@ -6,33 +6,50 @@ import Foundation
 /// row is eligible and what to do with the result.
 extension LauncherView {
     func editSelectedResult() {
-        runToolAction(AppConstants.Launcher.Tools.editAction, requiresEditable: true)
+        runToolAction(AppConstants.Launcher.Tools.editAction)
     }
 
     func openTerminalForSelectedResult() {
-        runToolAction(AppConstants.Launcher.Tools.terminalAction, requiresEditable: false)
+        runToolAction(AppConstants.Launcher.Tools.terminalAction)
     }
 
-    /// The selected row as a path plus whether it is a directory, or nil when
-    /// the action does not apply. An app bundle counts as a file, so a terminal
-    /// opens the folder holding it rather than descending into the bundle.
-    private func toolTarget(requiresEditable: Bool) -> (path: String, isDirectory: Bool)? {
-        guard let selected = actionableSelectedResult(), !selected.path.isEmpty else { return nil }
+    /// Reveal through the declared `file_manager`, or Finder when none is set.
+    /// Core answers which, so linows gets the same rule.
+    func revealSelectedResult() {
+        guard toolTarget(for: AppConstants.Launcher.Tools.revealAction) != nil else {
+            revealSelectedInFinder()
+            return
+        }
+        runToolAction(AppConstants.Launcher.Tools.revealAction)
+    }
 
-        switch selected.kind {
-        case .folder:
-            return (selected.path, true)
-        case .file:
-            return (selected.path, false)
-        case .app:
-            return requiresEditable ? nil : (selected.path, false)
+    /// Whether `action` means anything for a row of this kind.
+    ///
+    /// Editing and opening a terminal are about a place you work in. An app is a
+    /// thing you launch, and the folder holding it is `/Applications`, which is
+    /// never "here" — so both are absent for app rows rather than quietly acting
+    /// on the wrong directory. Revealing an app is genuinely useful and stays.
+    static func toolActionApplies(_ action: String, to kind: LauncherResultKind) -> Bool {
+        switch action {
+        case AppConstants.Launcher.Tools.revealAction:
+            return kind.isFileOrFolder || kind == .app
         default:
-            return nil
+            return kind.isFileOrFolder
         }
     }
 
-    private func runToolAction(_ action: String, requiresEditable: Bool) {
-        guard let target = toolTarget(requiresEditable: requiresEditable) else { return }
+    /// The selected row as a path plus whether it is a directory, or nil when
+    /// the action does not apply to it.
+    private func toolTarget(for action: String) -> (path: String, isDirectory: Bool)? {
+        guard let selected = actionableSelectedResult(), !selected.path.isEmpty,
+            Self.toolActionApplies(action, to: selected.kind)
+        else { return nil }
+
+        return (selected.path, selected.kind == .folder)
+    }
+
+    private func runToolAction(_ action: String) {
+        guard let target = toolTarget(for: action) else { return }
         let path = target.path
         let isDirectory = target.isDirectory
 
@@ -53,8 +70,11 @@ extension LauncherView {
         switch outcome.kind {
         case .performed:
             hideLauncherWindow(restorePreviousApp: false)
+            activateTool(named: outcome.tool)
         case .application:
             launchApplication(tool: outcome.tool, path: outcome.path ?? path)
+        case .systemDefault:
+            revealSelectedInFinder()
         case .unavailable, .failed:
             showToolBanner(outcome.reason)
         case .shell:
@@ -78,6 +98,54 @@ extension LauncherView {
             completionHandler: nil
         )
         hideLauncherWindow(restorePreviousApp: false)
+    }
+
+    /// Bring the terminal forward once its new window exists.
+    ///
+    /// Nothing else will. `wezterm start` hands a window to a WezTerm that is
+    /// already running, and that process never asks to come forward; a freshly
+    /// launched app does ask, but Look is an accessory app that stays *active*
+    /// after ordering its window out, and one process's request does not
+    /// preempt the active app. Look is the only party here holding activation,
+    /// so Look is the one that can pass it on.
+    ///
+    /// Ordered deliberately: this runs while Look is still active, because a
+    /// resigned app may no longer be allowed to hand activation to another.
+    private func activateTool(named tool: String?) {
+        guard let tool, let bundle = AppBundleLocator.bundlePath(forAppNamed: tool) else {
+            NSApp.hide(nil)
+            return
+        }
+        let target = URL(fileURLWithPath: bundle).resolvingSymlinksInPath()
+
+        let ownPID = ProcessInfo.processInfo.processIdentifier
+
+        Task { @MainActor in
+            try? await Task.sleep(
+                nanoseconds: AppConstants.Launcher.Tools.activationSettleNanoseconds)
+
+            for _ in 0..<AppConstants.Launcher.Tools.activationPollAttempts {
+                if let app = NSWorkspace.shared.runningApplications.first(where: {
+                    $0.bundleURL?.resolvingSymlinksInPath() == target
+                }) {
+                    // The user may have moved on while a cold terminal started.
+                    // Same courtesy `launchApp(at:)` extends to slow apps.
+                    if let frontmost = NSWorkspace.shared.frontmostApplication,
+                        frontmost.processIdentifier != ownPID,
+                        frontmost.processIdentifier != app.processIdentifier
+                    {
+                        return
+                    }
+                    app.activate()
+                    return
+                }
+                try? await Task.sleep(
+                    nanoseconds: AppConstants.Launcher.Tools.activationPollNanoseconds)
+            }
+
+            // It never appeared, so at least stop holding focus ourselves.
+            NSApp.hide(nil)
+        }
     }
 
     private func showToolBanner(_ message: String?) {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Tools.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Tools.swift
@@ -27,7 +27,7 @@ extension LauncherView {
     ///
     /// Editing and opening a terminal are about a place you work in. An app is a
     /// thing you launch, and the folder holding it is `/Applications`, which is
-    /// never "here" — so both are absent for app rows rather than quietly acting
+    /// never "here", so both are absent for app rows rather than quietly acting
     /// on the wrong directory. Revealing an app is genuinely useful and stays.
     static func toolActionApplies(_ action: String, to kind: LauncherResultKind) -> Bool {
         switch action {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Tools.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Tools.swift
@@ -1,0 +1,91 @@
+import AppKit
+import Foundation
+
+/// Cmd+E and Cmd+T: act on the selected row through the tools the user named in
+/// their config. Composition lives in core (`look-tools`); this decides which
+/// row is eligible and what to do with the result.
+extension LauncherView {
+    func editSelectedResult() {
+        runToolAction(AppConstants.Launcher.Tools.editAction, requiresEditable: true)
+    }
+
+    func openTerminalForSelectedResult() {
+        runToolAction(AppConstants.Launcher.Tools.terminalAction, requiresEditable: false)
+    }
+
+    /// The selected row as a path plus whether it is a directory, or nil when
+    /// the action does not apply. An app bundle counts as a file, so a terminal
+    /// opens the folder holding it rather than descending into the bundle.
+    private func toolTarget(requiresEditable: Bool) -> (path: String, isDirectory: Bool)? {
+        guard let selected = actionableSelectedResult(), !selected.path.isEmpty else { return nil }
+
+        switch selected.kind {
+        case .folder:
+            return (selected.path, true)
+        case .file:
+            return (selected.path, false)
+        case .app:
+            return requiresEditable ? nil : (selected.path, false)
+        default:
+            return nil
+        }
+    }
+
+    private func runToolAction(_ action: String, requiresEditable: Bool) {
+        guard let target = toolTarget(requiresEditable: requiresEditable) else { return }
+        let path = target.path
+        let isDirectory = target.isDirectory
+
+        Task {
+            let outcome = await Task.detached(priority: .userInitiated) {
+                EngineBridge.shared.performToolAction(action, path: path, isDirectory: isDirectory)
+            }.value
+
+            await MainActor.run {
+                applyToolOutcome(outcome, path: path)
+            }
+        }
+    }
+
+    private func applyToolOutcome(_ outcome: ToolAction?, path: String) {
+        guard let outcome else { return }
+
+        switch outcome.kind {
+        case .performed:
+            hideLauncherWindow(restorePreviousApp: false)
+        case .application:
+            launchApplication(tool: outcome.tool, path: outcome.path ?? path)
+        case .unavailable, .failed:
+            showToolBanner(outcome.reason)
+        case .shell:
+            // Only the resolve-only entry point returns this; performing
+            // reports `performed` or `failed`.
+            break
+        }
+    }
+
+    private func launchApplication(tool: String?, path: String) {
+        guard let tool else { return }
+        guard let bundle = AppBundleLocator.bundlePath(forAppNamed: tool) else {
+            showToolBanner("\(AppConstants.Launcher.Tools.launchFailedBanner) \(tool)")
+            return
+        }
+
+        NSWorkspace.shared.open(
+            [URL(fileURLWithPath: path)],
+            withApplicationAt: URL(fileURLWithPath: bundle),
+            configuration: NSWorkspace.OpenConfiguration(),
+            completionHandler: nil
+        )
+        hideLauncherWindow(restorePreviousApp: false)
+    }
+
+    private func showToolBanner(_ message: String?) {
+        guard let message, !message.isEmpty else { return }
+        showBanner(
+            message,
+            style: .info,
+            duration: AppConstants.Launcher.Tools.bannerDuration
+        )
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Tools.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Tools.swift
@@ -74,7 +74,9 @@ extension LauncherView {
         case .application:
             launchApplication(tool: outcome.tool, path: outcome.path ?? path)
         case .systemDefault:
-            revealSelectedInFinder()
+            // The path this action resolved for, not the current selection: the
+            // user may have moved on while the resolve was in flight.
+            revealPathInFinder(outcome.path ?? path)
         case .unavailable, .failed:
             showToolBanner(outcome.reason)
         case .shell:

--- a/bridge/ffi/Cargo.lock
+++ b/bridge/ffi/Cargo.lock
@@ -423,6 +423,7 @@ dependencies = [
  "look-sources",
  "look-storage",
  "look-todo",
+ "look-tools",
  "notify",
  "serde",
  "serde_json",

--- a/bridge/ffi/Cargo.lock
+++ b/bridge/ffi/Cargo.lock
@@ -396,6 +396,7 @@ dependencies = [
  "look-ranking",
  "look-sources",
  "look-storage",
+ "look-tools",
  "objc2",
  "objc2-foundation",
  "regex",
@@ -475,6 +476,7 @@ name = "look-sources"
 version = "0.1.0"
 dependencies = [
  "globset",
+ "look-tools",
  "serde",
  "toml",
 ]
@@ -494,6 +496,10 @@ dependencies = [
  "rusqlite",
  "serde",
 ]
+
+[[package]]
+name = "look-tools"
+version = "0.1.0"
 
 [[package]]
 name = "memchr"

--- a/bridge/ffi/Cargo.toml
+++ b/bridge/ffi/Cargo.toml
@@ -24,6 +24,7 @@ look-qactions = { path = "../../core/qactions" }
 look-ranking = { path = "../../core/ranking" }
 look-storage = { path = "../../core/storage" }
 look-todo = { path = "../../core/todo" }
+look-tools = { path = "../../core/tools" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 notify = "8"

--- a/bridge/ffi/src/lib.rs
+++ b/bridge/ffi/src/lib.rs
@@ -291,9 +291,10 @@ pub extern "C" fn look_source_blocks_json() -> *mut c_char {
     .unwrap_or(std::ptr::null_mut())
 }
 
-/// What `action` ("edit", "terminal") does to the row at `path`, as
+/// What `action` ("edit", "terminal", "reveal") does to the row at `path`, as
 /// `{kind, tool, command, path, reason, key}` where `kind` is "shell",
-/// "application", or "unavailable". Null for an unknown action or empty path.
+/// "application", "system_default", or "unavailable". Null for an unknown
+/// action or empty path.
 ///
 /// Reads the declared tools from the cached config, so Cmd+Shift+; is all a
 /// user needs after editing them.

--- a/bridge/ffi/src/lib.rs
+++ b/bridge/ffi/src/lib.rs
@@ -16,6 +16,7 @@ mod seed_api;
 mod sources_api;
 mod state;
 mod todo_api;
+mod tools_api;
 mod translate_api;
 mod url_history_api;
 mod usage_api;
@@ -286,6 +287,48 @@ pub extern "C" fn look_source_block_json(
 pub extern "C" fn look_source_blocks_json() -> *mut c_char {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(
         sources_api::look_source_blocks_json_impl,
+    ))
+    .unwrap_or(std::ptr::null_mut())
+}
+
+/// What `action` ("edit", "terminal") does to the row at `path`, as
+/// `{kind, tool, command, path, reason, key}` where `kind` is "shell",
+/// "application", or "unavailable". Null for an unknown action or empty path.
+///
+/// Reads the declared tools from the cached config, so Cmd+Shift+; is all a
+/// user needs after editing them.
+#[unsafe(no_mangle)]
+pub extern "C" fn look_tool_action_json(
+    action: *const c_char,
+    path: *const c_char,
+    is_dir: bool,
+) -> *mut c_char {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        tools_api::look_tool_action_json_impl(action, path, is_dir)
+    }))
+    .unwrap_or(std::ptr::null_mut())
+}
+
+/// Runs `action` on the row at `path`. Shell actions are performed here,
+/// detached, and come back as `{"kind":"performed"}` or `{"kind":"failed"}`; an
+/// `application` result is handed back for the shell to launch itself.
+#[unsafe(no_mangle)]
+pub extern "C" fn look_perform_tool_action_json(
+    action: *const c_char,
+    path: *const c_char,
+    is_dir: bool,
+) -> *mut c_char {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        tools_api::look_perform_tool_action_json_impl(action, path, is_dir)
+    }))
+    .unwrap_or(std::ptr::null_mut())
+}
+
+/// Every action id `look_tool_action_json` accepts, as a JSON array.
+#[unsafe(no_mangle)]
+pub extern "C" fn look_tool_actions_json() -> *mut c_char {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(
+        tools_api::look_tool_actions_json_impl,
     ))
     .unwrap_or(std::ptr::null_mut())
 }

--- a/bridge/ffi/src/tools_api.rs
+++ b/bridge/ffi/src/tools_api.rs
@@ -13,6 +13,8 @@ use crate::state::{cstr_to_string, json_cstring_or_null};
 
 const KIND_SHELL: &str = "shell";
 const KIND_APPLICATION: &str = "application";
+/// Nothing declared, so the platform's own handler does it.
+const KIND_SYSTEM_DEFAULT: &str = "system_default";
 const KIND_UNAVAILABLE: &str = "unavailable";
 /// Core already ran it; the shell has nothing left to do.
 const KIND_PERFORMED: &str = "performed";
@@ -52,6 +54,14 @@ impl ResolvedAction {
             Ok(Launch::Application { tool, path }) => Self {
                 kind: KIND_APPLICATION,
                 tool: Some(tool),
+                command: None,
+                path: Some(path),
+                reason: None,
+                key: None,
+            },
+            Ok(Launch::SystemDefault { path }) => Self {
+                kind: KIND_SYSTEM_DEFAULT,
+                tool: None,
                 command: None,
                 path: Some(path),
                 reason: None,
@@ -193,6 +203,18 @@ mod tests {
         assert_eq!(json["tool"], "zed");
         assert_eq!(json["path"], "/tmp/look");
         assert!(json["command"].is_null());
+    }
+
+    #[test]
+    fn a_system_default_carries_only_the_path() {
+        let json = json_of(Ok(Launch::SystemDefault {
+            path: "/tmp/look".into(),
+        }));
+
+        assert_eq!(json["kind"], KIND_SYSTEM_DEFAULT);
+        assert_eq!(json["path"], "/tmp/look");
+        assert!(json["tool"].is_null());
+        assert!(json["reason"].is_null());
     }
 
     #[test]

--- a/bridge/ffi/src/tools_api.rs
+++ b/bridge/ffi/src/tools_api.rs
@@ -79,8 +79,8 @@ impl ResolvedAction {
     }
 }
 
-/// Resolves `action` ("edit", "terminal") against a row, or the JSON literal
-/// `null` when the action is unknown or the path is empty.
+/// Resolves `action` ("edit", "terminal", "reveal") against a row, or the JSON
+/// literal `null` when the action is unknown or the path is empty.
 pub(crate) fn look_tool_action_json_impl(
     action: *const c_char,
     path: *const c_char,

--- a/bridge/ffi/src/tools_api.rs
+++ b/bridge/ffi/src/tools_api.rs
@@ -1,0 +1,227 @@
+//! C-ABI wrapper over `look_tools`, so a shell can ask what one action on one
+//! row resolves to without knowing anything about terminals or editors.
+//!
+//! The tools are read from the cached config, so a reload picks up an edited
+//! `~/.look/config` with no extra call from the shell.
+
+use look_engine::config::RuntimeConfig;
+use look_tools::{Action, Launch, Target, Unavailable};
+use serde::Serialize;
+use std::os::raw::c_char;
+
+use crate::state::{cstr_to_string, json_cstring_or_null};
+
+const KIND_SHELL: &str = "shell";
+const KIND_APPLICATION: &str = "application";
+const KIND_UNAVAILABLE: &str = "unavailable";
+/// Core already ran it; the shell has nothing left to do.
+const KIND_PERFORMED: &str = "performed";
+/// Core tried and the spawn itself failed.
+const KIND_FAILED: &str = "failed";
+
+/// One action resolved against one row.
+///
+/// Flat rather than a tagged union so the shells can decode it with a plain
+/// struct: `kind` says which of the other fields are filled.
+#[derive(Serialize)]
+struct ResolvedAction {
+    kind: &'static str,
+    /// The tool that will start, for the label and the installed check.
+    tool: Option<String>,
+    /// For `shell`: the line to run through the login shell.
+    command: Option<String>,
+    /// For `application`: the path to hand the platform launcher.
+    path: Option<String>,
+    /// For `unavailable`: what to show the user.
+    reason: Option<String>,
+    /// For `unavailable`: the config key that would fix it, when one would.
+    key: Option<String>,
+}
+
+impl ResolvedAction {
+    fn of(outcome: Result<Launch, Unavailable>) -> Self {
+        match outcome {
+            Ok(Launch::Shell { tool, command }) => Self {
+                kind: KIND_SHELL,
+                tool: Some(tool),
+                command: Some(command),
+                path: None,
+                reason: None,
+                key: None,
+            },
+            Ok(Launch::Application { tool, path }) => Self {
+                kind: KIND_APPLICATION,
+                tool: Some(tool),
+                command: None,
+                path: Some(path),
+                reason: None,
+                key: None,
+            },
+            Err(unavailable) => Self {
+                kind: KIND_UNAVAILABLE,
+                tool: None,
+                command: None,
+                path: None,
+                reason: Some(unavailable.message()),
+                key: unavailable.key().map(str::to_string),
+            },
+        }
+    }
+}
+
+/// Resolves `action` ("edit", "terminal") against a row, or the JSON literal
+/// `null` when the action is unknown or the path is empty.
+pub(crate) fn look_tool_action_json_impl(
+    action: *const c_char,
+    path: *const c_char,
+    is_dir: bool,
+) -> *mut c_char {
+    let path = cstr_to_string(path);
+    let Some(action) = Action::from_id(&cstr_to_string(action)) else {
+        return json_cstring_or_null(None);
+    };
+    if path.trim().is_empty() {
+        return json_cstring_or_null(None);
+    }
+
+    let target = if is_dir {
+        Target::Folder(path)
+    } else {
+        Target::File(path)
+    };
+    let resolved = ResolvedAction::of(action.resolve(&RuntimeConfig::load_cached().tools, &target));
+
+    json_cstring_or_null(serde_json::to_string(&resolved).ok())
+}
+
+/// Resolves `action` and, when it composes to shell text, runs it detached
+/// through `look_sources::run`, which already owns process groups and login
+/// shell selection.
+///
+/// An `application` result comes back untouched: finding and starting a bundle
+/// is the native side's job (`specs/preferred-tools.md` §8).
+pub(crate) fn look_perform_tool_action_json_impl(
+    action: *const c_char,
+    path: *const c_char,
+    is_dir: bool,
+) -> *mut c_char {
+    let path = cstr_to_string(path);
+    let Some(action) = Action::from_id(&cstr_to_string(action)) else {
+        return json_cstring_or_null(None);
+    };
+    if path.trim().is_empty() {
+        return json_cstring_or_null(None);
+    }
+
+    let target = if is_dir {
+        Target::Folder(path)
+    } else {
+        Target::File(path)
+    };
+
+    let resolved = match action.resolve(&RuntimeConfig::load_cached().tools, &target) {
+        Ok(Launch::Shell { tool, command }) => performed(&tool, command),
+        other => ResolvedAction::of(other),
+    };
+
+    json_cstring_or_null(serde_json::to_string(&resolved).ok())
+}
+
+fn performed(tool: &str, command: String) -> ResolvedAction {
+    let error = look_sources::perform(&[command], None)
+        .into_iter()
+        .find_map(|outcome| outcome.error);
+
+    match error {
+        None => ResolvedAction {
+            kind: KIND_PERFORMED,
+            tool: Some(tool.to_string()),
+            command: None,
+            path: None,
+            reason: None,
+            key: None,
+        },
+        Some(reason) => ResolvedAction {
+            kind: KIND_FAILED,
+            tool: Some(tool.to_string()),
+            command: None,
+            path: None,
+            reason: Some(reason),
+            key: None,
+        },
+    }
+}
+
+/// Every action id the shells may pass, so a menu can be built without
+/// hardcoding the list twice.
+pub(crate) fn look_tool_actions_json_impl() -> *mut c_char {
+    let ids: Vec<&str> = Action::ALL.iter().map(|action| action.id()).collect();
+    json_cstring_or_null(serde_json::to_string(&ids).ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use look_tools::key;
+
+    fn json_of(outcome: Result<Launch, Unavailable>) -> serde_json::Value {
+        serde_json::to_value(ResolvedAction::of(outcome)).expect("serialize")
+    }
+
+    #[test]
+    fn a_shell_launch_carries_its_command() {
+        let json = json_of(Ok(Launch::Shell {
+            tool: "ghostty".into(),
+            command: "'ghostty' -e true".into(),
+        }));
+
+        assert_eq!(json["kind"], KIND_SHELL);
+        assert_eq!(json["tool"], "ghostty");
+        assert_eq!(json["command"], "'ghostty' -e true");
+        assert!(json["path"].is_null());
+        assert!(json["reason"].is_null());
+    }
+
+    #[test]
+    fn an_application_launch_carries_its_path_instead() {
+        let json = json_of(Ok(Launch::Application {
+            tool: "zed".into(),
+            path: "/tmp/look".into(),
+        }));
+
+        assert_eq!(json["kind"], KIND_APPLICATION);
+        assert_eq!(json["tool"], "zed");
+        assert_eq!(json["path"], "/tmp/look");
+        assert!(json["command"].is_null());
+    }
+
+    #[test]
+    fn an_unavailable_action_carries_a_reason_and_the_key_to_set() {
+        let json = json_of(Err(Unavailable::NotDeclared {
+            key: key::TEXT_EDITOR,
+        }));
+
+        assert_eq!(json["kind"], KIND_UNAVAILABLE);
+        assert_eq!(json["key"], key::TEXT_EDITOR);
+        assert!(
+            json["reason"]
+                .as_str()
+                .is_some_and(|reason| reason.contains(key::TEXT_EDITOR))
+        );
+    }
+
+    #[test]
+    fn a_reason_with_no_fix_still_explains_itself() {
+        let json = json_of(Err(Unavailable::CannotRunCommand {
+            tool: "warp".into(),
+        }));
+
+        assert_eq!(json["kind"], KIND_UNAVAILABLE);
+        assert!(json["key"].is_null());
+        assert!(
+            json["reason"]
+                .as_str()
+                .is_some_and(|reason| reason.contains("warp"))
+        );
+    }
+}

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -347,6 +347,7 @@ dependencies = [
  "look-ranking",
  "look-sources",
  "look-storage",
+ "look-tools",
  "objc2",
  "objc2-foundation",
  "regex",
@@ -404,6 +405,7 @@ name = "look-sources"
 version = "0.1.0"
 dependencies = [
  "globset",
+ "look-tools",
  "serde",
  "toml",
 ]
@@ -424,6 +426,10 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "look-tools"
+version = "0.1.0"
 
 [[package]]
 name = "memchr"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "sources",
   "storage",
   "todo",
+  "tools",
 ]
 resolver = "2"
 

--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -12,6 +12,7 @@ look-matching = { path = "../matching" }
 look-ranking = { path = "../ranking" }
 look-sources = { path = "../sources" }
 look-storage = { path = "../storage" }
+look-tools = { path = "../tools" }
 ignore = "0.4"
 regex = "1"
 serde = { version = "1", features = ["derive"] }

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -450,7 +450,8 @@ clipboard_history_limit=10\n\
 # including running a terminal editor inside your terminal. Declare nothing and\n\
 # nothing changes. Editing uses text_editor on a file and code_editor on a\n\
 # folder; declaring only one of the two covers both.\n\
-# Acted on from the row's action menu (macOS also binds Cmd+E and Cmd+T).\n\
+# Acted on from the row's action menu, and from Cmd+E / Cmd+T.\n\
+# macOS only so far: the Linux and Windows shells do not read these yet.\n\
 # text_editor=nvim\n\
 # code_editor=zed\n\
 # terminal=ghostty\n\

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -454,7 +454,6 @@ clipboard_history_limit=10\n\
 # text_editor=nvim\n\
 # code_editor=zed\n\
 # terminal=ghostty\n\
-# browser=firefox\n\
 # file_manager=finder\n\
 \n\
 # UI theme\n\
@@ -1049,13 +1048,12 @@ mod tests {
         assert!(tools.text_editor.is_none());
     }
 
-    /// The keys ship commented out: an existing config is not grown by five
-    /// lines it did not ask for, and Cmd+E names the key to set at the point of
-    /// use instead.
+    /// The keys ship commented out: an existing config is not grown by lines it
+    /// did not ask for, and Cmd+E names the key to set at the point of use.
     #[test]
     fn tool_keys_are_documented_but_not_enabled_by_default() {
         let defaults = default_config_contents();
-        for key in look_tools::key::ALL {
+        for key in ADVERTISED_TOOL_KEYS {
             assert!(
                 defaults.contains(&format!("# {key}=")),
                 "{key} should appear commented out in the generated config"
@@ -1066,6 +1064,36 @@ mod tests {
             );
         }
     }
+
+    /// `browser` parses, but no action reads it yet: Look has no URL row for it
+    /// to act on. Advertising it would make it a key a user can set and get
+    /// silence from, which is the trap `specs/preferred-tools.md` §6 calls out.
+    /// Document it here when something consumes it.
+    #[test]
+    fn unconsumed_tool_keys_are_not_advertised() {
+        // The assignment form, not the bare word: `ignored_patterns_browser=`
+        // is a different key that legitimately contains it.
+        let defaults = default_config_contents();
+        for form in ["# browser=", "\nbrowser="] {
+            assert!(
+                !defaults.contains(form),
+                "{form:?} should not be advertised"
+            );
+        }
+
+        let unadvertised: Vec<_> = look_tools::key::ALL
+            .iter()
+            .filter(|key| !ADVERTISED_TOOL_KEYS.contains(key))
+            .collect();
+        assert_eq!(unadvertised, vec![&look_tools::key::BROWSER]);
+    }
+
+    const ADVERTISED_TOOL_KEYS: &[&str] = &[
+        look_tools::key::TEXT_EDITOR,
+        look_tools::key::CODE_EDITOR,
+        look_tools::key::TERMINAL,
+        look_tools::key::FILE_MANAGER,
+    ];
 
     #[test]
     fn localized_app_names_defaults_to_false_and_loads_from_config() {

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -4,6 +4,7 @@ use crate::platform;
 use crate::platform::paths::compile_ignore_matcher;
 use crate::platform::paths::expand_with_home;
 use globset::GlobBuilder;
+use look_tools::Tools;
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::path::{Path, PathBuf};
@@ -94,6 +95,7 @@ pub struct RuntimeConfig {
     pub lazy_indexing_enabled: bool,
     pub localized_app_names: bool,
     pub search_aliases: HashMap<String, Vec<String>>,
+    pub tools: Tools,
 }
 
 impl Default for RuntimeConfig {
@@ -125,6 +127,7 @@ impl Default for RuntimeConfig {
             lazy_indexing_enabled: LAZY_INDEXING_ENABLED,
             localized_app_names: false,
             search_aliases: default_search_aliases(),
+            tools: Tools::default(),
         }
     }
 }
@@ -328,6 +331,7 @@ impl RuntimeConfig {
                         apply_alias_override(alias_key, value, &mut self.search_aliases);
                     }
                 }
+                _ if look_tools::key::ALL.contains(&key) => self.tools.set(key, value),
                 _ => {}
             }
         }
@@ -441,6 +445,17 @@ skip_dir_names=node_modules,target,build,dist,library,applications,old firefox d
 \n\
 # Clipboard history size (10-100). Out-of-range values fall back to 10.\n\
 clipboard_history_limit=10\n\
+\n\
+# Preferred tools. Name the tool, not a command: Look knows how to drive it,\n\
+# including running a terminal editor inside your terminal. Declare nothing and\n\
+# nothing changes. Cmd+E edits the selected row, Cmd+T opens a terminal there.\n\
+# Edit uses text_editor on a file and code_editor on a folder; declaring only\n\
+# one of the two covers both.\n\
+# text_editor=nvim\n\
+# code_editor=zed\n\
+# terminal=ghostty\n\
+# browser=firefox\n\
+# file_manager=finder\n\
 \n\
 # UI theme\n\
 ui_tint_red=0.08\n\
@@ -976,6 +991,80 @@ mod tests {
     #[test]
     fn default_config_contents_include_lazy_indexing_enabled() {
         assert!(default_config_contents().contains("lazy_indexing_enabled=true"));
+    }
+
+    fn config_from(contents: &str, label: &str) -> RuntimeConfig {
+        let tmp = std::env::temp_dir().join(format!(
+            "look-config-test-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time should be after epoch")
+                .as_nanos()
+        ));
+        std::fs::write(&tmp, contents).expect("write temporary config");
+
+        let mut config = RuntimeConfig::default();
+        config.apply_from_file(&tmp);
+
+        let _ = std::fs::remove_file(&tmp);
+        config
+    }
+
+    #[test]
+    fn tools_are_unset_until_declared() {
+        assert!(RuntimeConfig::default().tools.is_empty());
+        assert!(
+            config_from("file_scan_depth=4\n", "tools-absent")
+                .tools
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn every_tool_key_loads_from_config() {
+        let declared = look_tools::key::ALL
+            .iter()
+            .map(|key| format!("{key}=ghostty\n"))
+            .collect::<String>();
+
+        let tools = config_from(&declared, "tools-all").tools;
+
+        assert_eq!(tools.text_editor.as_deref(), Some("ghostty"));
+        assert_eq!(tools.code_editor.as_deref(), Some("ghostty"));
+        assert_eq!(tools.terminal.as_deref(), Some("ghostty"));
+        assert_eq!(tools.browser.as_deref(), Some("ghostty"));
+        assert_eq!(tools.file_manager.as_deref(), Some("ghostty"));
+    }
+
+    #[test]
+    fn tool_keys_survive_comments_and_whitespace() {
+        let tools = config_from(
+            "  terminal = ghostty   # my terminal\ntext_editor=\n",
+            "tools-trim",
+        )
+        .tools;
+
+        assert_eq!(tools.terminal.as_deref(), Some("ghostty"));
+        assert!(tools.text_editor.is_none());
+    }
+
+    /// The keys ship commented out: an existing config is not grown by five
+    /// lines it did not ask for, and Cmd+E names the key to set at the point of
+    /// use instead.
+    #[test]
+    fn tool_keys_are_documented_but_not_enabled_by_default() {
+        let defaults = default_config_contents();
+        for key in look_tools::key::ALL {
+            assert!(
+                defaults.contains(&format!("# {key}=")),
+                "{key} should appear commented out in the generated config"
+            );
+            assert!(
+                !defaults.contains(&format!("\n{key}=")),
+                "{key} should not be live in the generated config"
+            );
+        }
     }
 
     #[test]

--- a/core/engine/src/config.rs
+++ b/core/engine/src/config.rs
@@ -448,13 +448,13 @@ clipboard_history_limit=10\n\
 \n\
 # Preferred tools. Name the tool, not a command: Look knows how to drive it,\n\
 # including running a terminal editor inside your terminal. Declare nothing and\n\
-# nothing changes. Cmd+E edits the selected row, Cmd+T opens a terminal there.\n\
-# Edit uses text_editor on a file and code_editor on a folder; declaring only\n\
-# one of the two covers both.\n\
+# nothing changes. Editing uses text_editor on a file and code_editor on a\n\
+# folder; declaring only one of the two covers both.\n\
+# Acted on from the row's action menu (macOS also binds Cmd+E and Cmd+T).\n\
 # text_editor=nvim\n\
 # code_editor=zed\n\
 # terminal=ghostty\n\
-# file_manager=finder\n\
+# file_manager=nautilus\n\
 \n\
 # UI theme\n\
 ui_tint_red=0.08\n\

--- a/core/sources/Cargo.toml
+++ b/core/sources/Cargo.toml
@@ -8,5 +8,6 @@ version = "0.1.0"
 
 [dependencies]
 globset = "0.4.18"
+look-tools = { path = "../tools" }
 serde = { version = "1", features = ["derive"] }
 toml = "0.9"

--- a/core/sources/src/run.rs
+++ b/core/sources/src/run.rs
@@ -16,6 +16,8 @@
 
 use std::io::Read;
 use std::process::{Command, Stdio};
+
+use look_tools::shell_quote as quote;
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
@@ -119,12 +121,6 @@ fn parent_dir(path: &str) -> String {
         .parent()
         .map(|parent| parent.to_string_lossy().into_owned())
         .unwrap_or_default()
-}
-
-/// POSIX single-quoting: everything inside is literal, and an embedded quote is
-/// closed, escaped, and reopened.
-fn quote(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 /// The login shell to run a step with: the user's own where it speaks POSIX,

--- a/core/tools/Cargo.toml
+++ b/core/tools/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "look-tools"
+edition = "2024"
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+version = "0.1.0"

--- a/core/tools/src/catalog.rs
+++ b/core/tools/src/catalog.rs
@@ -159,14 +159,22 @@ pub fn surface(tool: &str) -> Surface {
     }
 }
 
+/// A declared name reduced to a catalog key. Case, a trailing `.app`, and a
+/// leading directory are things a user should not have to get right: naming a
+/// specific build (`/opt/homebrew/bin/nvim`) still means nvim.
 fn normalize(tool: &str) -> String {
-    let lowered = tool.trim().to_ascii_lowercase();
+    let trimmed = tool.trim();
+    let name = trimmed.rsplit('/').next().unwrap_or(trimmed);
+    let lowered = name.to_ascii_lowercase();
     lowered.strip_suffix(".app").unwrap_or(&lowered).to_string()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // These three police contributions to the tables, so a bad new row fails the
+    // build rather than failing quietly on someone's machine.
 
     #[test]
     fn every_entry_cites_its_source() {
@@ -211,82 +219,82 @@ mod tests {
         }
     }
 
+    /// (declared name, expected style, why this row exists).
+    ///
+    /// The fallback rows are the load-bearing ones: every terminal riding `-e`
+    /// works with no catalog entry at all, which is what keeps the table an
+    /// exceptions list. `kgx` honors it too, per its Debian man page.
     #[test]
-    fn unknown_terminal_falls_back_to_dash_e() {
-        assert_eq!(command_style("rio"), CommandStyle::Argv(DASH_E));
+    fn a_declared_name_resolves_to_its_style() {
+        const FALLBACK: CommandStyle = DEFAULT_COMMAND_STYLE;
+        const POSITIONAL_STYLE: CommandStyle = CommandStyle::Argv(POSITIONAL);
+        const DASHDASH: CommandStyle = CommandStyle::Argv(DASH_DASH);
+        const WEZ: CommandStyle = CommandStyle::Argv(WEZTERM_START);
+        const TERM_APP: CommandStyle = CommandStyle::Script(AppleScript::TerminalApp);
+        const ITERM: CommandStyle = CommandStyle::Script(AppleScript::ITerm2);
+        const NONE: CommandStyle = CommandStyle::Unsupported;
+
+        let cases: &[(&str, CommandStyle, &str)] = &[
+            ("rio", FALLBACK, "unknown rides the fallback"),
+            ("alacritty", FALLBACK, "honors -e"),
+            ("konsole", FALLBACK, "honors -e"),
+            ("xterm", FALLBACK, "honors -e"),
+            ("st", FALLBACK, "honors -e"),
+            ("urxvt", FALLBACK, "honors -e"),
+            ("kgx", FALLBACK, "honors -e"),
+            ("xfce4-terminal", FALLBACK, "honors -e"),
+            ("tilix", FALLBACK, "honors -e"),
+            ("terminator", FALLBACK, "honors -e"),
+            ("kitty", POSITIONAL_STYLE, "positional, no -e exists"),
+            ("foot", POSITIONAL_STYLE, "trailing args are the command"),
+            ("wezterm", WEZ, "runs through its start subcommand"),
+            ("gnome-terminal", DASHDASH, "-e is deprecated upstream"),
+            ("ptyxis", DASHDASH, "-- is the supported spelling"),
+            ("Terminal.app", TERM_APP, "an app, not a CLI"),
+            ("apple terminal", TERM_APP, "alias of the same row"),
+            ("iterm", ITERM, "an app, not a CLI"),
+            ("iTerm2", ITERM, "alias of the same row"),
+            ("Warp", NONE, "cannot be told to run a command"),
+            ("hyper", NONE, "cannot be told to run a command"),
+            ("KITTY", POSITIONAL_STYLE, "case is normalized"),
+            ("  WezTerm.app  ", WEZ, "whitespace and .app are normalized"),
+            (
+                "/opt/homebrew/bin/kitty",
+                POSITIONAL_STYLE,
+                "a leading path is normalized",
+            ),
+        ];
+
+        for (declared, want, why) in cases {
+            assert_eq!(command_style(declared), *want, "{declared:?} ({why})");
+        }
+    }
+
+    #[test]
+    fn a_terminal_riding_the_fallback_has_no_row() {
         assert!(entry("rio").is_none());
+        assert!(entry("alacritty").is_none());
+        assert!(entry("kitty").is_some());
     }
 
+    /// Every GUI editor rides the fallback, including ones that did not exist
+    /// when this was written: a new editor ships and Look supports it without a
+    /// release. `emacs` is deliberately GUI, since `emacs <path>` starts the GUI
+    /// build and wanting `emacs -nw` is declaring a command, not a tool.
     #[test]
-    fn convention_followers_need_no_entry() {
-        for terminal in [
-            "ghostty",
-            "alacritty",
-            "konsole",
-            "xterm",
-            "st",
-            "urxvt",
-            // kgx honors -e: https://manpages.debian.org/testing/gnome-console/kgx.1.en.html
-            "kgx",
-            "xfce4-terminal",
-            "tilix",
-            "terminator",
-        ] {
-            assert_eq!(
-                command_style(terminal),
-                DEFAULT_COMMAND_STYLE,
-                "{terminal} should ride the fallback rather than carry an entry"
-            );
-        }
-    }
-
-    #[test]
-    fn deviating_terminals_are_stored() {
-        assert_eq!(command_style("kitty"), CommandStyle::Argv(POSITIONAL));
-        assert_eq!(command_style("foot"), CommandStyle::Argv(POSITIONAL));
-        assert_eq!(command_style("wezterm"), CommandStyle::Argv(WEZTERM_START));
-        assert_eq!(
-            command_style("gnome-terminal"),
-            CommandStyle::Argv(DASH_DASH)
-        );
-        assert_eq!(command_style("ptyxis"), CommandStyle::Argv(DASH_DASH));
-    }
-
-    #[test]
-    fn macos_apps_use_applescript() {
-        assert_eq!(
-            command_style("Terminal.app"),
-            CommandStyle::Script(AppleScript::TerminalApp)
-        );
-        assert_eq!(
-            command_style("iTerm2"),
-            CommandStyle::Script(AppleScript::ITerm2)
-        );
-        assert_eq!(AppleScript::ITerm2.app_name(), "iTerm");
-    }
-
-    #[test]
-    fn terminals_without_command_support_are_named() {
-        assert_eq!(command_style("Warp"), CommandStyle::Unsupported);
-        assert_eq!(command_style("hyper"), CommandStyle::Unsupported);
-    }
-
-    #[test]
-    fn an_alias_reaches_the_same_row() {
-        assert_eq!(command_style("iterm"), command_style("iterm2"));
-        assert_eq!(command_style("terminal"), command_style("apple terminal"));
-    }
-
-    #[test]
-    fn tty_editors_are_known() {
-        for editor in ["vim", "nvim", "Helix", "hx", "kak", "nano", "micro"] {
-            assert_eq!(surface(editor), Surface::Tty, "{editor} needs a terminal");
-        }
-    }
-
-    #[test]
-    fn gui_editors_need_no_entry() {
-        for editor in [
+    fn a_tool_is_tty_only_when_the_catalog_says_so() {
+        let tty = [
+            "vim",
+            "nvim",
+            "Helix",
+            "hx",
+            "kak",
+            "nano",
+            "micro",
+            "/opt/homebrew/bin/nvim",
+            "/opt/my tools/nvim",
+        ];
+        let gui = [
             "zed",
             "vscode",
             "code",
@@ -297,21 +305,19 @@ mod tests {
             "textmate",
             "emacs",
             "something-nobody-has-shipped-yet",
-        ] {
-            assert_eq!(
-                surface(editor),
-                Surface::Gui,
-                "{editor} draws its own window"
-            );
+        ];
+
+        for tool in tty {
+            assert_eq!(surface(tool), Surface::Tty, "{tool:?} needs a terminal");
+        }
+        for tool in gui {
+            assert_eq!(surface(tool), Surface::Gui, "{tool:?} draws its own window");
         }
     }
 
     #[test]
-    fn names_normalize_on_case_and_app_suffix() {
-        assert_eq!(command_style("KITTY"), CommandStyle::Argv(POSITIONAL));
-        assert_eq!(
-            command_style("  WezTerm.app  "),
-            CommandStyle::Argv(WEZTERM_START)
-        );
+    fn an_applescript_dialect_knows_its_app_name() {
+        assert_eq!(AppleScript::TerminalApp.app_name(), "Terminal");
+        assert_eq!(AppleScript::ITerm2.app_name(), "iTerm");
     }
 }

--- a/core/tools/src/catalog.rs
+++ b/core/tools/src/catalog.rs
@@ -46,6 +46,11 @@ pub struct Terminal {
     /// Every name selecting this row, already normalized.
     pub names: &'static [&'static str],
     pub style: CommandStyle,
+    /// A single-instance macOS `.app` that has to be started through
+    /// `open -na <app> --args`. Running its CLI directly works only while the
+    /// app is not already up; afterwards the process exits without ever making
+    /// a window, which reads as the key doing nothing.
+    pub macos_app: Option<&'static str>,
     /// Where `style` was verified.
     pub source: &'static str,
     /// Why the row exists.
@@ -54,50 +59,66 @@ pub struct Terminal {
 
 pub const TERMINALS: &[Terminal] = &[
     Terminal {
+        names: &["ghostty"],
+        style: CommandStyle::Argv(DASH_E),
+        macos_app: Some("Ghostty"),
+        source: "https://github.com/ghostty-org/ghostty/discussions/9221",
+        note: "honors -e, but on macOS it is single-instance: running the CLI while the \
+               app is already up exits without ever making a window",
+    },
+    Terminal {
         names: &["kitty"],
         style: CommandStyle::Argv(POSITIONAL),
+        macos_app: None,
         source: "https://sw.kovidgoyal.net/kitty/invocation/",
         note: "\"kitty [options] [program-to-run ...]\": positional, no -e exists",
     },
     Terminal {
         names: &["foot"],
         style: CommandStyle::Argv(POSITIONAL),
+        macos_app: None,
         source: "https://man.archlinux.org/man/foot.1.en",
         note: "\"All trailing (non-option) arguments are treated as a command\"",
     },
     Terminal {
         names: &["wezterm"],
         style: CommandStyle::Argv(WEZTERM_START),
+        macos_app: None,
         source: "https://wezterm.org/cli/start.html",
         note: "\"wezterm start [OPTIONS] [PROG]...\", e.g. `wezterm start -- bash -l`",
     },
     Terminal {
         names: &["gnome-terminal"],
         style: CommandStyle::Argv(DASH_DASH),
+        macos_app: None,
         source: "https://bugs.launchpad.net/ubuntu/+source/gnome-terminal/+bug/1726380",
         note: "-e is deprecated upstream and warns; -- is the supported spelling",
     },
     Terminal {
         names: &["ptyxis"],
         style: CommandStyle::Argv(DASH_DASH),
+        macos_app: None,
         source: "https://man.archlinux.org/man/ptyxis.1.en",
         note: "\"In general, you should use -- instead of\" --execute",
     },
     Terminal {
         names: &["terminal", "apple terminal"],
         style: CommandStyle::Script(AppleScript::TerminalApp),
+        macos_app: None,
         source: "https://support.apple.com/guide/terminal/welcome/mac",
         note: "an application rather than a CLI",
     },
     Terminal {
         names: &["iterm", "iterm2"],
         style: CommandStyle::Script(AppleScript::ITerm2),
+        macos_app: None,
         source: "https://iterm2.com/documentation-scripting.html",
         note: "an application rather than a CLI; its AppleScript name is still iTerm",
     },
     Terminal {
         names: &["warp", "hyper"],
         style: CommandStyle::Unsupported,
+        macos_app: None,
         source: "https://docs.warp.dev/",
         note: "neither documents a way to open a window running a given command",
     },

--- a/core/tools/src/catalog.rs
+++ b/core/tools/src/catalog.rs
@@ -1,0 +1,296 @@
+//! What Look knows about the tools a user can name.
+//!
+//! An exceptions list, not an inventory (`specs/preferred-tools.md` §4). `-e` is
+//! the xterm convention and the fallback, and a working directory is composed
+//! into the command, so only deviating tools need a row.
+//!
+//! To add a tool, append to [`TERMINALS`] or [`TTY_TOOLS`]. Nothing else reads
+//! anything but these tables. Cite the tool's own docs in `source`, and store
+//! names lowercased without `.app`; tests enforce both.
+
+/// How a terminal accepts the command it should run.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CommandStyle {
+    /// Argv inserted between the terminal and the command.
+    Argv(&'static [&'static str]),
+    Script(AppleScript),
+    /// Known to offer no way to run a command, so the user is told why.
+    Unsupported,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AppleScript {
+    TerminalApp,
+    ITerm2,
+}
+
+impl AppleScript {
+    pub fn app_name(self) -> &'static str {
+        match self {
+            AppleScript::TerminalApp => "Terminal",
+            AppleScript::ITerm2 => "iTerm",
+        }
+    }
+}
+
+const DASH_E: &[&str] = &["-e"];
+const POSITIONAL: &[&str] = &[];
+const DASH_DASH: &[&str] = &["--"];
+const WEZTERM_START: &[&str] = &["start", "--"];
+
+pub const DEFAULT_COMMAND_STYLE: CommandStyle = CommandStyle::Argv(DASH_E);
+
+/// One terminal that deviates from `-e`.
+#[derive(Clone, Copy, Debug)]
+pub struct Terminal {
+    /// Every name selecting this row, already normalized.
+    pub names: &'static [&'static str],
+    pub style: CommandStyle,
+    /// Where `style` was verified.
+    pub source: &'static str,
+    /// Why the row exists.
+    pub note: &'static str,
+}
+
+pub const TERMINALS: &[Terminal] = &[
+    Terminal {
+        names: &["kitty"],
+        style: CommandStyle::Argv(POSITIONAL),
+        source: "https://sw.kovidgoyal.net/kitty/invocation/",
+        note: "\"kitty [options] [program-to-run ...]\": positional, no -e exists",
+    },
+    Terminal {
+        names: &["foot"],
+        style: CommandStyle::Argv(POSITIONAL),
+        source: "https://man.archlinux.org/man/foot.1.en",
+        note: "\"All trailing (non-option) arguments are treated as a command\"",
+    },
+    Terminal {
+        names: &["wezterm"],
+        style: CommandStyle::Argv(WEZTERM_START),
+        source: "https://wezterm.org/cli/start.html",
+        note: "\"wezterm start [OPTIONS] [PROG]...\", e.g. `wezterm start -- bash -l`",
+    },
+    Terminal {
+        names: &["gnome-terminal"],
+        style: CommandStyle::Argv(DASH_DASH),
+        source: "https://bugs.launchpad.net/ubuntu/+source/gnome-terminal/+bug/1726380",
+        note: "-e is deprecated upstream and warns; -- is the supported spelling",
+    },
+    Terminal {
+        names: &["ptyxis"],
+        style: CommandStyle::Argv(DASH_DASH),
+        source: "https://man.archlinux.org/man/ptyxis.1.en",
+        note: "\"In general, you should use -- instead of\" --execute",
+    },
+    Terminal {
+        names: &["terminal", "apple terminal"],
+        style: CommandStyle::Script(AppleScript::TerminalApp),
+        source: "https://support.apple.com/guide/terminal/welcome/mac",
+        note: "an application rather than a CLI",
+    },
+    Terminal {
+        names: &["iterm", "iterm2"],
+        style: CommandStyle::Script(AppleScript::ITerm2),
+        source: "https://iterm2.com/documentation-scripting.html",
+        note: "an application rather than a CLI; its AppleScript name is still iTerm",
+    },
+    Terminal {
+        names: &["warp", "hyper"],
+        style: CommandStyle::Unsupported,
+        source: "https://docs.warp.dev/",
+        note: "neither documents a way to open a window running a given command",
+    },
+];
+
+pub fn command_style(terminal: &str) -> CommandStyle {
+    entry(terminal)
+        .map(|found| found.style)
+        .unwrap_or(DEFAULT_COMMAND_STYLE)
+}
+
+/// The row for `terminal`, or `None` when it rides the fallback.
+pub fn entry(terminal: &str) -> Option<&'static Terminal> {
+    let name = normalize(terminal);
+    TERMINALS
+        .iter()
+        .find(|candidate| candidate.names.contains(&name.as_str()))
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Surface {
+    Gui,
+    Tty,
+}
+
+/// Editors needing a terminal. `emacs` is absent on purpose: `emacs <path>`
+/// starts the GUI build, and wanting `emacs -nw` is declaring a command rather
+/// than a tool, which is what a source block is for.
+pub const TTY_TOOLS: &[&str] = &[
+    "vi", "vim", "nvim", "neovim", "hx", "helix", "kak", "kakoune", "nano", "micro", "pico", "ed",
+];
+
+pub fn surface(tool: &str) -> Surface {
+    if TTY_TOOLS.contains(&normalize(tool).as_str()) {
+        Surface::Tty
+    } else {
+        Surface::Gui
+    }
+}
+
+fn normalize(tool: &str) -> String {
+    let lowered = tool.trim().to_ascii_lowercase();
+    lowered.strip_suffix(".app").unwrap_or(&lowered).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_entry_cites_its_source() {
+        for terminal in TERMINALS {
+            assert!(
+                terminal.source.starts_with("https://"),
+                "{:?} must cite the page its flag was read from",
+                terminal.names
+            );
+            assert!(
+                !terminal.note.is_empty(),
+                "{:?} must say why it needs an entry",
+                terminal.names
+            );
+        }
+    }
+
+    #[test]
+    fn names_are_stored_normalized() {
+        let stored = TERMINALS
+            .iter()
+            .flat_map(|terminal| terminal.names.iter())
+            .chain(TTY_TOOLS.iter());
+        for name in stored {
+            assert_eq!(
+                &normalize(name),
+                name,
+                "{name:?} is stored in a form lookup can never match"
+            );
+        }
+    }
+
+    #[test]
+    fn no_name_is_claimed_twice() {
+        let mut seen: Vec<&str> = Vec::new();
+        for name in TERMINALS.iter().flat_map(|terminal| terminal.names.iter()) {
+            assert!(
+                !seen.contains(name),
+                "{name:?} appears twice, so one of the rows is unreachable"
+            );
+            seen.push(name);
+        }
+    }
+
+    #[test]
+    fn unknown_terminal_falls_back_to_dash_e() {
+        assert_eq!(command_style("rio"), CommandStyle::Argv(DASH_E));
+        assert!(entry("rio").is_none());
+    }
+
+    #[test]
+    fn convention_followers_need_no_entry() {
+        for terminal in [
+            "ghostty",
+            "alacritty",
+            "konsole",
+            "xterm",
+            "st",
+            "urxvt",
+            // kgx honors -e: https://manpages.debian.org/testing/gnome-console/kgx.1.en.html
+            "kgx",
+            "xfce4-terminal",
+            "tilix",
+            "terminator",
+        ] {
+            assert_eq!(
+                command_style(terminal),
+                DEFAULT_COMMAND_STYLE,
+                "{terminal} should ride the fallback rather than carry an entry"
+            );
+        }
+    }
+
+    #[test]
+    fn deviating_terminals_are_stored() {
+        assert_eq!(command_style("kitty"), CommandStyle::Argv(POSITIONAL));
+        assert_eq!(command_style("foot"), CommandStyle::Argv(POSITIONAL));
+        assert_eq!(command_style("wezterm"), CommandStyle::Argv(WEZTERM_START));
+        assert_eq!(
+            command_style("gnome-terminal"),
+            CommandStyle::Argv(DASH_DASH)
+        );
+        assert_eq!(command_style("ptyxis"), CommandStyle::Argv(DASH_DASH));
+    }
+
+    #[test]
+    fn macos_apps_use_applescript() {
+        assert_eq!(
+            command_style("Terminal.app"),
+            CommandStyle::Script(AppleScript::TerminalApp)
+        );
+        assert_eq!(
+            command_style("iTerm2"),
+            CommandStyle::Script(AppleScript::ITerm2)
+        );
+        assert_eq!(AppleScript::ITerm2.app_name(), "iTerm");
+    }
+
+    #[test]
+    fn terminals_without_command_support_are_named() {
+        assert_eq!(command_style("Warp"), CommandStyle::Unsupported);
+        assert_eq!(command_style("hyper"), CommandStyle::Unsupported);
+    }
+
+    #[test]
+    fn an_alias_reaches_the_same_row() {
+        assert_eq!(command_style("iterm"), command_style("iterm2"));
+        assert_eq!(command_style("terminal"), command_style("apple terminal"));
+    }
+
+    #[test]
+    fn tty_editors_are_known() {
+        for editor in ["vim", "nvim", "Helix", "hx", "kak", "nano", "micro"] {
+            assert_eq!(surface(editor), Surface::Tty, "{editor} needs a terminal");
+        }
+    }
+
+    #[test]
+    fn gui_editors_need_no_entry() {
+        for editor in [
+            "zed",
+            "vscode",
+            "code",
+            "cursor",
+            "windsurf",
+            "sublime",
+            "xcode",
+            "textmate",
+            "emacs",
+            "something-nobody-has-shipped-yet",
+        ] {
+            assert_eq!(
+                surface(editor),
+                Surface::Gui,
+                "{editor} draws its own window"
+            );
+        }
+    }
+
+    #[test]
+    fn names_normalize_on_case_and_app_suffix() {
+        assert_eq!(command_style("KITTY"), CommandStyle::Argv(POSITIONAL));
+        assert_eq!(
+            command_style("  WezTerm.app  "),
+            CommandStyle::Argv(WEZTERM_START)
+        );
+    }
+}

--- a/core/tools/src/compose.rs
+++ b/core/tools/src/compose.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 
-use crate::catalog::{AppleScript, CommandStyle, Surface, command_style, surface};
+use crate::catalog::{AppleScript, CommandStyle, Surface, command_style, entry, surface};
 use crate::quote::{applescript_quote, shell_quote};
 use crate::{Tools, key};
 
@@ -13,6 +13,15 @@ const LOGIN_COMMAND_FLAGS: &str = "-lc";
 const INTERACTIVE_TAIL: &str = "exec \"$SHELL\" -l";
 const OSASCRIPT: &str = "osascript";
 const OSASCRIPT_EXPRESSION: &str = "-e";
+/// `-n` is what makes this work at all: plain `open -a` only focuses an app that
+/// is already running and drops the arguments.
+const MACOS_OPEN: &str = "open -na";
+const MACOS_OPEN_ARGS: &str = "--args";
+
+#[cfg(target_os = "macos")]
+const IS_MACOS: bool = true;
+#[cfg(not(target_os = "macos"))]
+const IS_MACOS: bool = false;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Target {
@@ -70,6 +79,64 @@ pub enum Unavailable {
     TerminalRequired { tool: String, key: &'static str },
     CannotRunCommand { tool: String },
     UnsupportedPlatform,
+}
+
+impl Unavailable {
+    /// Shown as-is, so both shells word it the same way.
+    pub fn message(&self) -> String {
+        match self {
+            Unavailable::NotDeclared { key } => format!("Set {key} in your Look config"),
+            Unavailable::TerminalRequired { tool, key } => {
+                format!("{tool} runs in a terminal; set {key} in your Look config")
+            }
+            Unavailable::CannotRunCommand { tool } => {
+                format!("{tool} cannot be told to run a command")
+            }
+            Unavailable::UnsupportedPlatform => {
+                "This platform has no POSIX shell to run actions through".to_string()
+            }
+        }
+    }
+
+    /// The config key that would fix this, when one would.
+    pub fn key(&self) -> Option<&'static str> {
+        match self {
+            Unavailable::NotDeclared { key } | Unavailable::TerminalRequired { key, .. } => {
+                Some(key)
+            }
+            Unavailable::CannotRunCommand { .. } | Unavailable::UnsupportedPlatform => None,
+        }
+    }
+}
+
+/// What Look can do to a row through a declared tool. Ids are shared so every
+/// shell names the same action the same way.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Action {
+    Edit,
+    TerminalHere,
+}
+
+impl Action {
+    pub const ALL: &'static [Action] = &[Action::Edit, Action::TerminalHere];
+
+    pub const fn id(self) -> &'static str {
+        match self {
+            Action::Edit => "edit",
+            Action::TerminalHere => "terminal",
+        }
+    }
+
+    pub fn from_id(id: &str) -> Option<Self> {
+        Self::ALL.iter().copied().find(|action| action.id() == id)
+    }
+
+    pub fn resolve(self, tools: &Tools, target: &Target) -> Result<Launch, Unavailable> {
+        match self {
+            Action::Edit => edit(tools, target),
+            Action::TerminalHere => terminal_here(tools, target),
+        }
+    }
 }
 
 /// Composition emits POSIX shell text down to its quoting, so a platform without
@@ -133,7 +200,10 @@ fn in_terminal(tools: &Tools, inner: &str, requester: &str) -> Result<Launch, Un
         })?;
 
     let command = match command_style(terminal) {
-        CommandStyle::Argv(prefix) => argv_command(terminal, prefix, inner),
+        CommandStyle::Argv(prefix) => match macos_app(terminal) {
+            Some(app) => open_command(app, prefix, inner),
+            None => argv_command(terminal, prefix, inner),
+        },
         CommandStyle::Script(dialect) => applescript_command(dialect, inner),
         CommandStyle::Unsupported => {
             return Err(Unavailable::CannotRunCommand {
@@ -151,12 +221,34 @@ fn in_terminal(tools: &Tools, inner: &str, requester: &str) -> Result<Launch, Un
 /// `<terminal> <prefix...> "$SHELL" -lc '<inner>'`. The inner login shell is what
 /// makes `nvim` and Homebrew resolve from a window-server-launched app.
 fn argv_command(terminal: &str, prefix: &[&str], inner: &str) -> String {
-    let mut parts = vec![shell_quote(terminal)];
+    command_line(&shell_quote(terminal), prefix, inner)
+}
+
+/// The same argv, handed to a single-instance macOS app through `open -na`.
+fn open_command(app: &str, prefix: &[&str], inner: &str) -> String {
+    command_line(
+        &format!("{MACOS_OPEN} {} {MACOS_OPEN_ARGS}", shell_quote(app)),
+        prefix,
+        inner,
+    )
+}
+
+fn command_line(launcher: &str, prefix: &[&str], inner: &str) -> String {
+    let mut parts = vec![launcher.to_string()];
     parts.extend(prefix.iter().map(|argument| (*argument).to_string()));
     parts.push(SHELL_VAR.to_string());
     parts.push(LOGIN_COMMAND_FLAGS.to_string());
     parts.push(shell_quote(inner));
     parts.join(" ")
+}
+
+/// The app name to hand `open -na`, when this terminal needs it and we are on
+/// the platform where that matters.
+fn macos_app(terminal: &str) -> Option<&'static str> {
+    if !IS_MACOS {
+        return None;
+    }
+    entry(terminal).and_then(|found| found.macos_app)
 }
 
 /// The second expression raises the window, which neither dialect does itself.
@@ -261,17 +353,52 @@ mod tests {
 
     #[test]
     fn a_tty_editor_is_hosted_by_the_declared_terminal() {
-        let declared = tools(Some("nvim"), None, Some("ghostty"));
+        let declared = tools(Some("nvim"), None, Some("alacritty"));
         let Ok(Launch::Shell { tool, command }) =
             edit(&declared, &Target::File("/tmp/a.txt".into()))
         else {
             panic!("expected a shell launch");
         };
-        assert_eq!(tool, "ghostty");
+        assert_eq!(tool, "alacritty");
         assert_eq!(
             command,
-            "'ghostty' -e \"$SHELL\" -lc 'nvim '\\''/tmp/a.txt'\\'''"
+            "'alacritty' -e \"$SHELL\" -lc 'nvim '\\''/tmp/a.txt'\\'''"
         );
+    }
+
+    /// Ghostty is single-instance on macOS: invoking its CLI while the app is
+    /// already up exits without ever making a window, so the key looks dead.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn a_single_instance_mac_app_goes_through_open() {
+        let declared = tools(None, None, Some("ghostty"));
+        let Ok(Launch::Shell { tool, command }) =
+            terminal_here(&declared, &Target::Folder("/tmp".into()))
+        else {
+            panic!("expected a shell launch");
+        };
+
+        assert_eq!(tool, "ghostty");
+        assert!(
+            command.starts_with("open -na 'Ghostty' --args -e \"$SHELL\" -lc "),
+            "got: {command}"
+        );
+    }
+
+    /// Only the terminals that need it: adding `open -na` everywhere would spawn
+    /// a second instance of terminals that are perfectly happy without one.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn terminals_without_the_override_still_launch_directly() {
+        for terminal in ["alacritty", "kitty", "wezterm"] {
+            let declared = tools(None, None, Some(terminal));
+            let Ok(Launch::Shell { command, .. }) =
+                terminal_here(&declared, &Target::Folder("/tmp".into()))
+            else {
+                panic!("expected a shell launch");
+            };
+            assert!(!command.starts_with("open"), "{terminal} got: {command}");
+        }
     }
 
     #[test]
@@ -381,6 +508,51 @@ mod tests {
                 key: key::TEXT_EDITOR
             })
         );
+    }
+
+    #[test]
+    fn action_ids_round_trip_and_reject_the_unknown() {
+        for action in Action::ALL {
+            assert_eq!(Action::from_id(action.id()), Some(*action));
+        }
+        assert_eq!(Action::from_id("frobnicate"), None);
+    }
+
+    #[test]
+    fn resolve_dispatches_to_the_same_result_as_the_direct_call() {
+        let declared = tools(None, Some("zed"), Some("ghostty"));
+        let target = Target::Folder("/tmp/look".into());
+
+        assert_eq!(
+            Action::Edit.resolve(&declared, &target),
+            edit(&declared, &target)
+        );
+        assert_eq!(
+            Action::TerminalHere.resolve(&declared, &target),
+            terminal_here(&declared, &target)
+        );
+    }
+
+    #[test]
+    fn a_reason_names_the_key_that_would_fix_it() {
+        let missing = Unavailable::NotDeclared {
+            key: key::TEXT_EDITOR,
+        };
+        assert_eq!(missing.key(), Some(key::TEXT_EDITOR));
+        assert!(missing.message().contains(key::TEXT_EDITOR));
+
+        let hosted = Unavailable::TerminalRequired {
+            tool: "nvim".into(),
+            key: key::TERMINAL,
+        };
+        assert_eq!(hosted.key(), Some(key::TERMINAL));
+        assert!(hosted.message().contains("nvim"));
+
+        let unsupported = Unavailable::CannotRunCommand {
+            tool: "warp".into(),
+        };
+        assert_eq!(unsupported.key(), None);
+        assert!(unsupported.message().contains("warp"));
     }
 
     #[test]

--- a/core/tools/src/compose.rs
+++ b/core/tools/src/compose.rs
@@ -1,0 +1,391 @@
+//! Turning an action plus an object into one thing the shell can launch.
+
+use std::path::Path;
+
+use crate::catalog::{AppleScript, CommandStyle, Surface, command_style, surface};
+use crate::quote::{applescript_quote, shell_quote};
+use crate::{Tools, key};
+
+/// Expanded by the inner shell, not by whatever spawned the launcher.
+const SHELL_VAR: &str = "\"$SHELL\"";
+const LOGIN_COMMAND_FLAGS: &str = "-lc";
+/// Replaces the wrapper so closing the shell closes the window once, not twice.
+const INTERACTIVE_TAIL: &str = "exec \"$SHELL\" -l";
+const OSASCRIPT: &str = "osascript";
+const OSASCRIPT_EXPRESSION: &str = "-e";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Target {
+    File(String),
+    Folder(String),
+}
+
+impl Target {
+    pub fn path(&self) -> &str {
+        match self {
+            Target::File(path) | Target::Folder(path) => path,
+        }
+    }
+
+    /// A folder is its own directory, a file's is its parent. Lexical: core
+    /// never touches the filesystem to answer this.
+    pub fn dir(&self) -> String {
+        match self {
+            Target::Folder(path) => path.clone(),
+            Target::File(path) => Path::new(path)
+                .parent()
+                .map(|parent| parent.to_string_lossy().into_owned())
+                .unwrap_or_default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Launch {
+    Shell {
+        tool: String,
+        command: String,
+    },
+    /// For the platform's application launcher (`open -a`), since a GUI app may
+    /// ship no CLI and only the native side can find a bundle.
+    Application {
+        tool: String,
+        path: String,
+    },
+}
+
+impl Launch {
+    pub fn tool(&self) -> &str {
+        match self {
+            Launch::Shell { tool, .. } | Launch::Application { tool, .. } => tool,
+        }
+    }
+}
+
+/// Every variant names something the user can act on: an action that is merely
+/// absent reads as the feature being broken.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Unavailable {
+    NotDeclared { key: &'static str },
+    TerminalRequired { tool: String, key: &'static str },
+    CannotRunCommand { tool: String },
+    UnsupportedPlatform,
+}
+
+/// Composition emits POSIX shell text down to its quoting, so a platform without
+/// a POSIX shell is refused rather than handed text `cmd` would mangle.
+#[cfg(unix)]
+const POSIX_SHELL_AVAILABLE: bool = true;
+#[cfg(not(unix))]
+const POSIX_SHELL_AVAILABLE: bool = false;
+
+/// `text_editor` for a file, `code_editor` for a folder; declaring one covers
+/// both.
+pub fn edit(tools: &Tools, target: &Target) -> Result<Launch, Unavailable> {
+    let (preferred, fallback, missing) = match target {
+        Target::File(_) => (&tools.text_editor, &tools.code_editor, key::TEXT_EDITOR),
+        Target::Folder(_) => (&tools.code_editor, &tools.text_editor, key::CODE_EDITOR),
+    };
+
+    let editor = preferred
+        .as_deref()
+        .or(fallback.as_deref())
+        .filter(|name| !name.trim().is_empty())
+        .ok_or(Unavailable::NotDeclared { key: missing })?;
+
+    match surface(editor) {
+        Surface::Gui => Ok(Launch::Application {
+            tool: editor.to_string(),
+            path: target.path().to_string(),
+        }),
+        Surface::Tty => {
+            let inner = format!("{} {}", editor, shell_quote(target.path()));
+            in_terminal(tools, &inner, editor)
+        }
+    }
+}
+
+pub fn terminal_here(tools: &Tools, target: &Target) -> Result<Launch, Unavailable> {
+    let inner = format!("cd {} && {INTERACTIVE_TAIL}", shell_quote(&target.dir()));
+    in_terminal(tools, &inner, "")
+}
+
+/// `requester` is the TTY tool needing a host, or empty when the terminal is the
+/// point of the action.
+fn in_terminal(tools: &Tools, inner: &str, requester: &str) -> Result<Launch, Unavailable> {
+    if !POSIX_SHELL_AVAILABLE {
+        return Err(Unavailable::UnsupportedPlatform);
+    }
+
+    let terminal = tools
+        .terminal
+        .as_deref()
+        .filter(|name| !name.trim().is_empty())
+        .ok_or_else(|| {
+            if requester.is_empty() {
+                Unavailable::NotDeclared { key: key::TERMINAL }
+            } else {
+                Unavailable::TerminalRequired {
+                    tool: requester.to_string(),
+                    key: key::TERMINAL,
+                }
+            }
+        })?;
+
+    let command = match command_style(terminal) {
+        CommandStyle::Argv(prefix) => argv_command(terminal, prefix, inner),
+        CommandStyle::Script(dialect) => applescript_command(dialect, inner),
+        CommandStyle::Unsupported => {
+            return Err(Unavailable::CannotRunCommand {
+                tool: terminal.to_string(),
+            });
+        }
+    };
+
+    Ok(Launch::Shell {
+        tool: terminal.to_string(),
+        command,
+    })
+}
+
+/// `<terminal> <prefix...> "$SHELL" -lc '<inner>'`. The inner login shell is what
+/// makes `nvim` and Homebrew resolve from a window-server-launched app.
+fn argv_command(terminal: &str, prefix: &[&str], inner: &str) -> String {
+    let mut parts = vec![shell_quote(terminal)];
+    parts.extend(prefix.iter().map(|argument| (*argument).to_string()));
+    parts.push(SHELL_VAR.to_string());
+    parts.push(LOGIN_COMMAND_FLAGS.to_string());
+    parts.push(shell_quote(inner));
+    parts.join(" ")
+}
+
+/// The second expression raises the window, which neither dialect does itself.
+fn applescript_command(dialect: AppleScript, inner: &str) -> String {
+    let app = dialect.app_name();
+    let run = match dialect {
+        AppleScript::TerminalApp => format!(
+            "tell application {} to do script {}",
+            applescript_quote(app),
+            applescript_quote(inner)
+        ),
+        AppleScript::ITerm2 => format!(
+            "tell application {} to create window with default profile command {}",
+            applescript_quote(app),
+            applescript_quote(inner)
+        ),
+    };
+    let activate = format!("tell application {} to activate", applescript_quote(app));
+    format!(
+        "{OSASCRIPT} {OSASCRIPT_EXPRESSION} {} {OSASCRIPT_EXPRESSION} {}",
+        shell_quote(&run),
+        shell_quote(&activate)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tools(text: Option<&str>, code: Option<&str>, terminal: Option<&str>) -> Tools {
+        Tools {
+            text_editor: text.map(str::to_string),
+            code_editor: code.map(str::to_string),
+            terminal: terminal.map(str::to_string),
+            ..Tools::default()
+        }
+    }
+
+    #[test]
+    fn nothing_declared_names_the_key_to_set() {
+        let empty = Tools::default();
+        assert_eq!(
+            edit(&empty, &Target::File("/tmp/a.txt".into())),
+            Err(Unavailable::NotDeclared {
+                key: key::TEXT_EDITOR
+            })
+        );
+        assert_eq!(
+            edit(&empty, &Target::Folder("/tmp".into())),
+            Err(Unavailable::NotDeclared {
+                key: key::CODE_EDITOR
+            })
+        );
+        assert_eq!(
+            terminal_here(&empty, &Target::Folder("/tmp".into())),
+            Err(Unavailable::NotDeclared { key: key::TERMINAL })
+        );
+    }
+
+    #[test]
+    fn a_gui_editor_goes_to_the_application_launcher() {
+        let declared = tools(None, Some("zed"), None);
+        assert_eq!(
+            edit(&declared, &Target::Folder("/tmp/look".into())),
+            Ok(Launch::Application {
+                tool: "zed".into(),
+                path: "/tmp/look".into()
+            })
+        );
+    }
+
+    #[test]
+    fn one_editor_declared_serves_both_row_kinds() {
+        let only_code = tools(None, Some("zed"), None);
+        assert_eq!(
+            edit(&only_code, &Target::File("/tmp/a.txt".into()))
+                .unwrap()
+                .tool(),
+            "zed"
+        );
+
+        let only_text = tools(Some("zed"), None, None);
+        assert_eq!(
+            edit(&only_text, &Target::Folder("/tmp".into()))
+                .unwrap()
+                .tool(),
+            "zed"
+        );
+    }
+
+    #[test]
+    fn a_tty_editor_without_a_terminal_says_which_key_is_missing() {
+        let declared = tools(Some("nvim"), None, None);
+        assert_eq!(
+            edit(&declared, &Target::File("/tmp/a.txt".into())),
+            Err(Unavailable::TerminalRequired {
+                tool: "nvim".into(),
+                key: key::TERMINAL
+            })
+        );
+    }
+
+    #[test]
+    fn a_tty_editor_is_hosted_by_the_declared_terminal() {
+        let declared = tools(Some("nvim"), None, Some("ghostty"));
+        let Ok(Launch::Shell { tool, command }) =
+            edit(&declared, &Target::File("/tmp/a.txt".into()))
+        else {
+            panic!("expected a shell launch");
+        };
+        assert_eq!(tool, "ghostty");
+        assert_eq!(
+            command,
+            "'ghostty' -e \"$SHELL\" -lc 'nvim '\\''/tmp/a.txt'\\'''"
+        );
+    }
+
+    #[test]
+    fn kitty_takes_the_command_positionally() {
+        let declared = tools(None, None, Some("kitty"));
+        let Ok(Launch::Shell { command, .. }) =
+            terminal_here(&declared, &Target::Folder("/tmp".into()))
+        else {
+            panic!("expected a shell launch");
+        };
+        assert!(
+            !command.contains(" -e "),
+            "kitty has no -e flag, got: {command}"
+        );
+        assert!(
+            command.starts_with("'kitty' \"$SHELL\" -lc "),
+            "got: {command}"
+        );
+    }
+
+    #[test]
+    fn wezterm_goes_through_its_start_subcommand() {
+        let declared = tools(None, None, Some("wezterm"));
+        let Ok(Launch::Shell { command, .. }) =
+            terminal_here(&declared, &Target::Folder("/tmp".into()))
+        else {
+            panic!("expected a shell launch");
+        };
+        assert!(
+            command.starts_with("'wezterm' start -- \"$SHELL\" -lc "),
+            "got: {command}"
+        );
+    }
+
+    #[test]
+    fn a_terminal_on_a_file_row_opens_its_parent() {
+        let declared = tools(None, None, Some("ghostty"));
+        let Ok(Launch::Shell { command, .. }) =
+            terminal_here(&declared, &Target::File("/tmp/look/a.txt".into()))
+        else {
+            panic!("expected a shell launch");
+        };
+        assert!(command.contains("/tmp/look"), "got: {command}");
+        assert!(!command.contains("a.txt"), "got: {command}");
+    }
+
+    #[test]
+    fn a_directory_with_spaces_stays_one_argument() {
+        let declared = tools(None, None, Some("ghostty"));
+        let Ok(Launch::Shell { command, .. }) =
+            terminal_here(&declared, &Target::Folder("/tmp/my project".into()))
+        else {
+            panic!("expected a shell launch");
+        };
+        assert!(
+            command.contains("cd '\\''/tmp/my project'\\''"),
+            "got: {command}"
+        );
+    }
+
+    #[test]
+    fn terminal_app_is_driven_through_osascript() {
+        let declared = tools(None, None, Some("Terminal.app"));
+        let Ok(Launch::Shell { tool, command }) =
+            terminal_here(&declared, &Target::Folder("/tmp".into()))
+        else {
+            panic!("expected a shell launch");
+        };
+        assert_eq!(tool, "Terminal.app");
+        assert!(command.starts_with("osascript -e "), "got: {command}");
+        assert!(command.contains("do script"), "got: {command}");
+        assert!(command.contains("to activate"), "got: {command}");
+    }
+
+    #[test]
+    fn iterm_creates_a_window_with_the_command() {
+        let declared = tools(None, None, Some("iterm"));
+        let Ok(Launch::Shell { command, .. }) =
+            terminal_here(&declared, &Target::Folder("/tmp".into()))
+        else {
+            panic!("expected a shell launch");
+        };
+        assert!(
+            command.contains("create window with default profile command"),
+            "got: {command}"
+        );
+        assert!(command.contains(r#"application "iTerm""#), "got: {command}");
+    }
+
+    #[test]
+    fn a_terminal_that_cannot_run_commands_says_so() {
+        let declared = tools(None, None, Some("warp"));
+        assert_eq!(
+            terminal_here(&declared, &Target::Folder("/tmp".into())),
+            Err(Unavailable::CannotRunCommand {
+                tool: "warp".into()
+            })
+        );
+    }
+
+    #[test]
+    fn a_blank_declaration_reads_as_undeclared() {
+        let blank = tools(Some("   "), None, None);
+        assert_eq!(
+            edit(&blank, &Target::File("/tmp/a.txt".into())),
+            Err(Unavailable::NotDeclared {
+                key: key::TEXT_EDITOR
+            })
+        );
+    }
+
+    #[test]
+    fn a_folder_is_its_own_directory() {
+        assert_eq!(Target::Folder("/tmp/look".into()).dir(), "/tmp/look");
+        assert_eq!(Target::File("/tmp/look/a.txt".into()).dir(), "/tmp/look");
+    }
+}

--- a/core/tools/src/compose.rs
+++ b/core/tools/src/compose.rs
@@ -61,12 +61,18 @@ pub enum Launch {
         tool: String,
         path: String,
     },
+    /// No tool declared, so the platform's own handler does it. This is today's
+    /// behavior, and the reason declaring nothing changes nothing.
+    SystemDefault {
+        path: String,
+    },
 }
 
 impl Launch {
-    pub fn tool(&self) -> &str {
+    pub fn tool(&self) -> Option<&str> {
         match self {
-            Launch::Shell { tool, .. } | Launch::Application { tool, .. } => tool,
+            Launch::Shell { tool, .. } | Launch::Application { tool, .. } => Some(tool),
+            Launch::SystemDefault { .. } => None,
         }
     }
 }
@@ -115,15 +121,17 @@ impl Unavailable {
 pub enum Action {
     Edit,
     TerminalHere,
+    Reveal,
 }
 
 impl Action {
-    pub const ALL: &'static [Action] = &[Action::Edit, Action::TerminalHere];
+    pub const ALL: &'static [Action] = &[Action::Edit, Action::TerminalHere, Action::Reveal];
 
     pub const fn id(self) -> &'static str {
         match self {
             Action::Edit => "edit",
             Action::TerminalHere => "terminal",
+            Action::Reveal => "reveal",
         }
     }
 
@@ -135,7 +143,27 @@ impl Action {
         match self {
             Action::Edit => edit(tools, target),
             Action::TerminalHere => terminal_here(tools, target),
+            Action::Reveal => Ok(reveal(tools, target)),
         }
+    }
+}
+
+/// Show the target in a file manager. Undeclared means the platform's own, which
+/// is what the launcher does today, so this never fails.
+pub fn reveal(tools: &Tools, target: &Target) -> Launch {
+    let path = target.path().to_string();
+    match tools
+        .file_manager
+        .as_deref()
+        .filter(|name| !name.trim().is_empty())
+    {
+        // A custom manager is opened at the containing folder: only the
+        // platform's own can select the file inside it.
+        Some(manager) => Launch::Application {
+            tool: manager.to_string(),
+            path: target.dir(),
+        },
+        None => Launch::SystemDefault { path },
     }
 }
 
@@ -327,7 +355,7 @@ mod tests {
             edit(&only_code, &Target::File("/tmp/a.txt".into()))
                 .unwrap()
                 .tool(),
-            "zed"
+            Some("zed")
         );
 
         let only_text = tools(Some("zed"), None, None);
@@ -335,7 +363,7 @@ mod tests {
             edit(&only_text, &Target::Folder("/tmp".into()))
                 .unwrap()
                 .tool(),
-            "zed"
+            Some("zed")
         );
     }
 
@@ -553,6 +581,33 @@ mod tests {
         };
         assert_eq!(unsupported.key(), None);
         assert!(unsupported.message().contains("warp"));
+    }
+
+    #[test]
+    fn reveal_falls_back_to_the_platform_when_nothing_is_declared() {
+        assert_eq!(
+            reveal(&Tools::default(), &Target::File("/tmp/a.txt".into())),
+            Launch::SystemDefault {
+                path: "/tmp/a.txt".into()
+            }
+        );
+    }
+
+    /// Only the platform's own manager can select a file inside its folder, so a
+    /// declared one is opened at the containing directory instead.
+    #[test]
+    fn a_declared_file_manager_opens_the_containing_folder() {
+        let declared = Tools {
+            file_manager: Some("nautilus".into()),
+            ..Tools::default()
+        };
+        assert_eq!(
+            reveal(&declared, &Target::File("/tmp/look/a.txt".into())),
+            Launch::Application {
+                tool: "nautilus".into(),
+                path: "/tmp/look".into()
+            }
+        );
     }
 
     #[test]

--- a/core/tools/src/compose.rs
+++ b/core/tools/src/compose.rs
@@ -13,6 +13,8 @@ const LOGIN_COMMAND_FLAGS: &str = "-lc";
 const INTERACTIVE_TAIL: &str = "exec \"$SHELL\" -l";
 const OSASCRIPT: &str = "osascript";
 const OSASCRIPT_EXPRESSION: &str = "-e";
+/// Where a path with no directory of its own lives.
+const CURRENT_DIR: &str = ".";
 /// `-n` is what makes this work at all: plain `open -a` only focuses an app that
 /// is already running and drops the arguments.
 const MACOS_OPEN: &str = "open -na";
@@ -41,10 +43,13 @@ impl Target {
     pub fn dir(&self) -> String {
         match self {
             Target::Folder(path) => path.clone(),
+            // A bare filename has an empty parent and a root path has none.
+            // Either would compose `cd ''`, which fails in the new window.
             Target::File(path) => Path::new(path)
                 .parent()
                 .map(|parent| parent.to_string_lossy().into_owned())
-                .unwrap_or_default(),
+                .filter(|parent| !parent.is_empty())
+                .unwrap_or_else(|| CURRENT_DIR.to_string()),
         }
     }
 }
@@ -152,11 +157,7 @@ impl Action {
 /// is what the launcher does today, so this never fails.
 pub fn reveal(tools: &Tools, target: &Target) -> Launch {
     let path = target.path().to_string();
-    match tools
-        .file_manager
-        .as_deref()
-        .filter(|name| !name.trim().is_empty())
-    {
+    match declared(&tools.file_manager) {
         // A custom manager is opened at the containing folder: only the
         // platform's own can select the file inside it.
         Some(manager) => Launch::Application {
@@ -182,10 +183,10 @@ pub fn edit(tools: &Tools, target: &Target) -> Result<Launch, Unavailable> {
         Target::Folder(_) => (&tools.code_editor, &tools.text_editor, key::CODE_EDITOR),
     };
 
-    let editor = preferred
-        .as_deref()
-        .or(fallback.as_deref())
-        .filter(|name| !name.trim().is_empty())
+    // Filtered before the choice, not after: a blank preferred key must fall
+    // through to the other editor rather than swallow it.
+    let editor = declared(preferred)
+        .or_else(|| declared(fallback))
         .ok_or(Unavailable::NotDeclared { key: missing })?;
 
     match surface(editor) {
@@ -194,10 +195,20 @@ pub fn edit(tools: &Tools, target: &Target) -> Result<Launch, Unavailable> {
             path: target.path().to_string(),
         }),
         Surface::Tty => {
-            let inner = format!("{} {}", editor, shell_quote(target.path()));
+            // Quoted like the path: a tool declared as `/opt/my tools/nvim` is
+            // one word. A tool is a name, never a command with its own args.
+            let inner = format!("{} {}", shell_quote(editor), shell_quote(target.path()));
             in_terminal(tools, &inner, editor)
         }
     }
+}
+
+/// A declared name, trimmed, or `None` when the key is absent or blank.
+fn declared(value: &Option<String>) -> Option<&str> {
+    value
+        .as_deref()
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
 }
 
 pub fn terminal_here(tools: &Tools, target: &Target) -> Result<Launch, Unavailable> {
@@ -212,20 +223,16 @@ fn in_terminal(tools: &Tools, inner: &str, requester: &str) -> Result<Launch, Un
         return Err(Unavailable::UnsupportedPlatform);
     }
 
-    let terminal = tools
-        .terminal
-        .as_deref()
-        .filter(|name| !name.trim().is_empty())
-        .ok_or_else(|| {
-            if requester.is_empty() {
-                Unavailable::NotDeclared { key: key::TERMINAL }
-            } else {
-                Unavailable::TerminalRequired {
-                    tool: requester.to_string(),
-                    key: key::TERMINAL,
-                }
+    let terminal = declared(&tools.terminal).ok_or_else(|| {
+        if requester.is_empty() {
+            Unavailable::NotDeclared { key: key::TERMINAL }
+        } else {
+            Unavailable::TerminalRequired {
+                tool: requester.to_string(),
+                key: key::TERMINAL,
             }
-        })?;
+        }
+    })?;
 
     let command = match command_style(terminal) {
         CommandStyle::Argv(prefix) => match macos_app(terminal) {
@@ -315,32 +322,140 @@ mod tests {
         }
     }
 
+    /// Only a POSIX platform composes shell text, so every caller is gated.
+    #[cfg(unix)]
+    fn shell_command(outcome: Result<Launch, Unavailable>) -> String {
+        match outcome {
+            Ok(Launch::Shell { command, .. }) => command,
+            other => panic!("expected a shell launch, got {other:?}"),
+        }
+    }
+
+    fn file() -> Target {
+        Target::File("/tmp/a.txt".into())
+    }
+
+    fn folder() -> Target {
+        Target::Folder("/tmp".into())
+    }
+
     #[test]
     fn nothing_declared_names_the_key_to_set() {
-        let empty = Tools::default();
+        let none = Tools::default();
         assert_eq!(
-            edit(&empty, &Target::File("/tmp/a.txt".into())),
+            edit(&none, &file()),
             Err(Unavailable::NotDeclared {
                 key: key::TEXT_EDITOR
             })
         );
         assert_eq!(
-            edit(&empty, &Target::Folder("/tmp".into())),
+            edit(&none, &folder()),
             Err(Unavailable::NotDeclared {
                 key: key::CODE_EDITOR
             })
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_terminal_with_nothing_declared_names_the_terminal_key() {
         assert_eq!(
-            terminal_here(&empty, &Target::Folder("/tmp".into())),
+            terminal_here(&Tools::default(), &folder()),
             Err(Unavailable::NotDeclared { key: key::TERMINAL })
         );
     }
 
+    /// Composition emits POSIX shell text down to its quoting, so a platform
+    /// without a POSIX shell is refused outright rather than handed something
+    /// `cmd` would mangle. Windows needs its own composition path, not a few
+    /// catalog rows.
+    #[cfg(not(unix))]
+    #[test]
+    fn a_platform_without_a_posix_shell_is_refused() {
+        assert_eq!(
+            terminal_here(&tools(None, None, Some("wt")), &folder()),
+            Err(Unavailable::UnsupportedPlatform)
+        );
+        assert_eq!(
+            edit(&tools(Some("nvim"), None, Some("wt")), &file()),
+            Err(Unavailable::UnsupportedPlatform)
+        );
+    }
+
+    #[test]
+    fn edit_prefers_the_editor_for_the_row_kind() {
+        let both = tools(Some("zed"), Some("cursor"), None);
+        assert_eq!(edit(&both, &file()).unwrap().tool(), Some("zed"));
+        assert_eq!(edit(&both, &folder()).unwrap().tool(), Some("cursor"));
+    }
+
+    #[test]
+    fn one_editor_declared_serves_both_row_kinds() {
+        assert_eq!(
+            edit(&tools(None, Some("zed"), None), &file())
+                .unwrap()
+                .tool(),
+            Some("zed")
+        );
+        assert_eq!(
+            edit(&tools(Some("zed"), None, None), &folder())
+                .unwrap()
+                .tool(),
+            Some("zed")
+        );
+    }
+
+    /// `Option::or` would keep the blank and never consult the fallback, so a
+    /// usable editor would be reported as undeclared.
+    #[test]
+    fn a_blank_key_falls_through_to_the_other_editor() {
+        assert_eq!(
+            edit(&tools(Some("   "), Some("zed"), None), &file())
+                .unwrap()
+                .tool(),
+            Some("zed")
+        );
+        assert_eq!(
+            edit(&tools(Some("zed"), Some(""), None), &folder())
+                .unwrap()
+                .tool(),
+            Some("zed")
+        );
+        assert_eq!(
+            edit(&tools(Some("   "), None, None), &file()),
+            Err(Unavailable::NotDeclared {
+                key: key::TEXT_EDITOR
+            })
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_tty_editor_needs_a_terminal_and_then_runs_inside_it() {
+        assert_eq!(
+            edit(&tools(Some("nvim"), None, None), &file()),
+            Err(Unavailable::TerminalRequired {
+                tool: "nvim".into(),
+                key: key::TERMINAL
+            })
+        );
+        assert_eq!(
+            edit(&tools(Some("nvim"), None, Some("alacritty")), &file())
+                .unwrap()
+                .tool(),
+            Some("alacritty")
+        );
+    }
+
+    /// A GUI editor is handed to the platform launcher with the path, since only
+    /// native code can find and start a bundle.
     #[test]
     fn a_gui_editor_goes_to_the_application_launcher() {
-        let declared = tools(None, Some("zed"), None);
         assert_eq!(
-            edit(&declared, &Target::Folder("/tmp/look".into())),
+            edit(
+                &tools(None, Some("zed"), None),
+                &Target::Folder("/tmp/look".into())
+            ),
             Ok(Launch::Application {
                 tool: "zed".into(),
                 path: "/tmp/look".into()
@@ -348,192 +463,211 @@ mod tests {
         );
     }
 
+    /// (terminal, command prefix, must contain, must not contain).
+    ///
+    /// The prefixes are the contract with the catalog, so a changed flag fails
+    /// here rather than at a keypress. Ghostty is absent: its expected output
+    /// differs by platform, so it has its own test below.
+    #[cfg(unix)]
     #[test]
-    fn one_editor_declared_serves_both_row_kinds() {
-        let only_code = tools(None, Some("zed"), None);
-        assert_eq!(
-            edit(&only_code, &Target::File("/tmp/a.txt".into()))
-                .unwrap()
-                .tool(),
-            Some("zed")
-        );
+    fn each_terminal_is_handed_the_command_its_own_way() {
+        let cases: &[(&str, &str, &[&str], &[&str])] = &[
+            ("alacritty", "'alacritty' -e \"$SHELL\" -lc ", &[], &[]),
+            ("kitty", "'kitty' \"$SHELL\" -lc ", &[], &[" -e "]),
+            ("wezterm", "'wezterm' start -- \"$SHELL\" -lc ", &[], &[]),
+            (
+                "gnome-terminal",
+                "'gnome-terminal' -- \"$SHELL\" -lc ",
+                &[],
+                &[],
+            ),
+            ("ptyxis", "'ptyxis' -- \"$SHELL\" -lc ", &[], &[]),
+            (
+                "Terminal.app",
+                "osascript -e ",
+                &["do script", "to activate"],
+                &[],
+            ),
+            (
+                "iterm",
+                "osascript -e ",
+                &[
+                    "create window with default profile command",
+                    r#"application "iTerm""#,
+                ],
+                &[],
+            ),
+        ];
 
-        let only_text = tools(Some("zed"), None, None);
-        assert_eq!(
-            edit(&only_text, &Target::Folder("/tmp".into()))
-                .unwrap()
-                .tool(),
-            Some("zed")
-        );
-    }
-
-    #[test]
-    fn a_tty_editor_without_a_terminal_says_which_key_is_missing() {
-        let declared = tools(Some("nvim"), None, None);
-        assert_eq!(
-            edit(&declared, &Target::File("/tmp/a.txt".into())),
-            Err(Unavailable::TerminalRequired {
-                tool: "nvim".into(),
-                key: key::TERMINAL
-            })
-        );
-    }
-
-    #[test]
-    fn a_tty_editor_is_hosted_by_the_declared_terminal() {
-        let declared = tools(Some("nvim"), None, Some("alacritty"));
-        let Ok(Launch::Shell { tool, command }) =
-            edit(&declared, &Target::File("/tmp/a.txt".into()))
-        else {
-            panic!("expected a shell launch");
-        };
-        assert_eq!(tool, "alacritty");
-        assert_eq!(
-            command,
-            "'alacritty' -e \"$SHELL\" -lc 'nvim '\\''/tmp/a.txt'\\'''"
-        );
-    }
-
-    /// Ghostty is single-instance on macOS: invoking its CLI while the app is
-    /// already up exits without ever making a window, so the key looks dead.
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn a_single_instance_mac_app_goes_through_open() {
-        let declared = tools(None, None, Some("ghostty"));
-        let Ok(Launch::Shell { tool, command }) =
-            terminal_here(&declared, &Target::Folder("/tmp".into()))
-        else {
-            panic!("expected a shell launch");
-        };
-
-        assert_eq!(tool, "ghostty");
-        assert!(
-            command.starts_with("open -na 'Ghostty' --args -e \"$SHELL\" -lc "),
-            "got: {command}"
-        );
-    }
-
-    /// Only the terminals that need it: adding `open -na` everywhere would spawn
-    /// a second instance of terminals that are perfectly happy without one.
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn terminals_without_the_override_still_launch_directly() {
-        for terminal in ["alacritty", "kitty", "wezterm"] {
-            let declared = tools(None, None, Some(terminal));
-            let Ok(Launch::Shell { command, .. }) =
-                terminal_here(&declared, &Target::Folder("/tmp".into()))
-            else {
-                panic!("expected a shell launch");
-            };
-            assert!(!command.starts_with("open"), "{terminal} got: {command}");
+        for (terminal, prefix, present, absent) in cases {
+            let command =
+                shell_command(terminal_here(&tools(None, None, Some(terminal)), &folder()));
+            assert!(command.starts_with(prefix), "{terminal}: got {command}");
+            for needle in *present {
+                assert!(
+                    command.contains(needle),
+                    "{terminal}: missing {needle:?} in {command}"
+                );
+            }
+            for needle in *absent {
+                assert!(
+                    !command.contains(needle),
+                    "{terminal}: unexpected {needle:?} in {command}"
+                );
+            }
         }
     }
 
+    /// An empty `cd ''` fails inside the new window, so every target has to
+    /// resolve to a directory something can change into.
     #[test]
-    fn kitty_takes_the_command_positionally() {
-        let declared = tools(None, None, Some("kitty"));
-        let Ok(Launch::Shell { command, .. }) =
-            terminal_here(&declared, &Target::Folder("/tmp".into()))
-        else {
-            panic!("expected a shell launch");
+    fn every_target_resolves_to_a_usable_directory() {
+        let cases = [
+            (Target::Folder("/tmp/look".into()), "/tmp/look"),
+            (Target::File("/tmp/look/a.txt".into()), "/tmp/look"),
+            (Target::File("a.txt".into()), CURRENT_DIR),
+            (Target::File("/".into()), CURRENT_DIR),
+        ];
+
+        for (target, expected) in cases {
+            assert_eq!(target.dir(), expected, "{target:?}");
+        }
+    }
+
+    /// (label, file_manager, target, expected). Only the platform's own manager
+    /// can select a file inside its folder, so a declared one is opened at the
+    /// containing directory instead.
+    #[test]
+    fn reveal_uses_the_declared_manager_or_the_platform() {
+        let platform = |path: &str| Launch::SystemDefault { path: path.into() };
+        let app = |path: &str| Launch::Application {
+            tool: "nautilus".into(),
+            path: path.into(),
         };
-        assert!(
-            !command.contains(" -e "),
-            "kitty has no -e flag, got: {command}"
-        );
-        assert!(
-            command.starts_with("'kitty' \"$SHELL\" -lc "),
-            "got: {command}"
+        let cases: &[(&str, Option<&str>, Target, Launch)] = &[
+            ("nothing declared", None, file(), platform("/tmp/a.txt")),
+            (
+                "a blank declaration",
+                Some("  "),
+                file(),
+                platform("/tmp/a.txt"),
+            ),
+            (
+                "a file opens its folder",
+                Some("nautilus"),
+                Target::File("/tmp/look/a.txt".into()),
+                app("/tmp/look"),
+            ),
+            (
+                "a folder is its own",
+                Some("nautilus"),
+                Target::Folder("/tmp/look".into()),
+                app("/tmp/look"),
+            ),
+        ];
+
+        for (label, manager, target, expected) in cases {
+            let declared = Tools {
+                file_manager: manager.map(str::to_string),
+                ..Tools::default()
+            };
+            assert_eq!(&reveal(&declared, target), expected, "{label}");
+        }
+    }
+
+    /// (reason, key that would fix it, what the message must name).
+    #[test]
+    fn a_reason_names_what_would_fix_it() {
+        let cases: &[(Unavailable, Option<&str>, &str)] = &[
+            (
+                Unavailable::NotDeclared {
+                    key: key::TEXT_EDITOR,
+                },
+                Some(key::TEXT_EDITOR),
+                key::TEXT_EDITOR,
+            ),
+            (
+                Unavailable::TerminalRequired {
+                    tool: "nvim".into(),
+                    key: key::TERMINAL,
+                },
+                Some(key::TERMINAL),
+                "nvim",
+            ),
+            (
+                Unavailable::CannotRunCommand {
+                    tool: "warp".into(),
+                },
+                None,
+                "warp",
+            ),
+            (Unavailable::UnsupportedPlatform, None, "POSIX"),
+        ];
+
+        for (reason, expected_key, mentions) in cases {
+            assert_eq!(reason.key(), *expected_key, "{reason:?}");
+            let message = reason.message();
+            assert!(
+                message.contains(mentions),
+                "{reason:?} should name {mentions:?}: {message}"
+            );
+        }
+    }
+
+    /// The exact composition, kept as a golden string: the nesting of a quoted
+    /// command inside a quoted command is what breaks first when this changes.
+    #[cfg(unix)]
+    #[test]
+    fn a_hosted_editor_composes_exactly() {
+        let declared = tools(Some("nvim"), None, Some("alacritty"));
+        assert_eq!(
+            shell_command(edit(&declared, &file())),
+            "'alacritty' -e \"$SHELL\" -lc ''\\''nvim'\\'' '\\''/tmp/a.txt'\\'''"
         );
     }
 
+    /// A tool is a name, so one living under a path with a space stays one word.
+    #[cfg(unix)]
     #[test]
-    fn wezterm_goes_through_its_start_subcommand() {
-        let declared = tools(None, None, Some("wezterm"));
-        let Ok(Launch::Shell { command, .. }) =
-            terminal_here(&declared, &Target::Folder("/tmp".into()))
-        else {
-            panic!("expected a shell launch");
-        };
-        assert!(
-            command.starts_with("'wezterm' start -- \"$SHELL\" -lc "),
-            "got: {command}"
-        );
+    fn an_editor_path_with_a_space_stays_one_word() {
+        let declared = tools(Some("/opt/my tools/nvim"), None, Some("alacritty"));
+        let command = shell_command(edit(&declared, &file()));
+
+        assert!(command.contains("/opt/my tools/nvim"), "got: {command}");
+        assert!(!command.contains("tools/nvim '"), "got: {command}");
     }
 
-    #[test]
-    fn a_terminal_on_a_file_row_opens_its_parent() {
-        let declared = tools(None, None, Some("ghostty"));
-        let Ok(Launch::Shell { command, .. }) =
-            terminal_here(&declared, &Target::File("/tmp/look/a.txt".into()))
-        else {
-            panic!("expected a shell launch");
-        };
-        assert!(command.contains("/tmp/look"), "got: {command}");
-        assert!(!command.contains("a.txt"), "got: {command}");
-    }
-
+    #[cfg(unix)]
     #[test]
     fn a_directory_with_spaces_stays_one_argument() {
-        let declared = tools(None, None, Some("ghostty"));
-        let Ok(Launch::Shell { command, .. }) =
-            terminal_here(&declared, &Target::Folder("/tmp/my project".into()))
-        else {
-            panic!("expected a shell launch");
-        };
+        let declared = tools(None, None, Some("alacritty"));
+        let target = Target::Folder("/tmp/my project".into());
+        let command = shell_command(terminal_here(&declared, &target));
+
         assert!(
             command.contains("cd '\\''/tmp/my project'\\''"),
             "got: {command}"
         );
     }
 
+    #[cfg(unix)]
     #[test]
-    fn terminal_app_is_driven_through_osascript() {
-        let declared = tools(None, None, Some("Terminal.app"));
-        let Ok(Launch::Shell { tool, command }) =
-            terminal_here(&declared, &Target::Folder("/tmp".into()))
-        else {
-            panic!("expected a shell launch");
-        };
-        assert_eq!(tool, "Terminal.app");
-        assert!(command.starts_with("osascript -e "), "got: {command}");
-        assert!(command.contains("do script"), "got: {command}");
-        assert!(command.contains("to activate"), "got: {command}");
+    fn a_terminal_on_a_file_row_opens_its_parent() {
+        let declared = tools(None, None, Some("alacritty"));
+        let target = Target::File("/tmp/look/a.txt".into());
+        let command = shell_command(terminal_here(&declared, &target));
+
+        assert!(command.contains("/tmp/look"), "got: {command}");
+        assert!(!command.contains("a.txt"), "got: {command}");
     }
 
-    #[test]
-    fn iterm_creates_a_window_with_the_command() {
-        let declared = tools(None, None, Some("iterm"));
-        let Ok(Launch::Shell { command, .. }) =
-            terminal_here(&declared, &Target::Folder("/tmp".into()))
-        else {
-            panic!("expected a shell launch");
-        };
-        assert!(
-            command.contains("create window with default profile command"),
-            "got: {command}"
-        );
-        assert!(command.contains(r#"application "iTerm""#), "got: {command}");
-    }
-
+    #[cfg(unix)]
     #[test]
     fn a_terminal_that_cannot_run_commands_says_so() {
-        let declared = tools(None, None, Some("warp"));
         assert_eq!(
-            terminal_here(&declared, &Target::Folder("/tmp".into())),
+            terminal_here(&tools(None, None, Some("warp")), &folder()),
             Err(Unavailable::CannotRunCommand {
                 tool: "warp".into()
-            })
-        );
-    }
-
-    #[test]
-    fn a_blank_declaration_reads_as_undeclared() {
-        let blank = tools(Some("   "), None, None);
-        assert_eq!(
-            edit(&blank, &Target::File("/tmp/a.txt".into())),
-            Err(Unavailable::NotDeclared {
-                key: key::TEXT_EDITOR
             })
         );
     }
@@ -548,7 +682,7 @@ mod tests {
 
     #[test]
     fn resolve_dispatches_to_the_same_result_as_the_direct_call() {
-        let declared = tools(None, Some("zed"), Some("ghostty"));
+        let declared = tools(None, Some("zed"), Some("alacritty"));
         let target = Target::Folder("/tmp/look".into());
 
         assert_eq!(
@@ -559,60 +693,32 @@ mod tests {
             Action::TerminalHere.resolve(&declared, &target),
             terminal_here(&declared, &target)
         );
-    }
-
-    #[test]
-    fn a_reason_names_the_key_that_would_fix_it() {
-        let missing = Unavailable::NotDeclared {
-            key: key::TEXT_EDITOR,
-        };
-        assert_eq!(missing.key(), Some(key::TEXT_EDITOR));
-        assert!(missing.message().contains(key::TEXT_EDITOR));
-
-        let hosted = Unavailable::TerminalRequired {
-            tool: "nvim".into(),
-            key: key::TERMINAL,
-        };
-        assert_eq!(hosted.key(), Some(key::TERMINAL));
-        assert!(hosted.message().contains("nvim"));
-
-        let unsupported = Unavailable::CannotRunCommand {
-            tool: "warp".into(),
-        };
-        assert_eq!(unsupported.key(), None);
-        assert!(unsupported.message().contains("warp"));
-    }
-
-    #[test]
-    fn reveal_falls_back_to_the_platform_when_nothing_is_declared() {
         assert_eq!(
-            reveal(&Tools::default(), &Target::File("/tmp/a.txt".into())),
-            Launch::SystemDefault {
-                path: "/tmp/a.txt".into()
-            }
+            Action::Reveal.resolve(&declared, &target),
+            Ok(reveal(&declared, &target))
         );
     }
 
-    /// Only the platform's own manager can select a file inside its folder, so a
-    /// declared one is opened at the containing directory instead.
+    /// Ghostty is single-instance on macOS: invoking its CLI while the app is
+    /// already up exits without ever making a window, so the key looks dead.
+    /// Only the terminals that need it get this, or every other terminal would
+    /// spawn a redundant second instance.
+    #[cfg(target_os = "macos")]
     #[test]
-    fn a_declared_file_manager_opens_the_containing_folder() {
-        let declared = Tools {
-            file_manager: Some("nautilus".into()),
-            ..Tools::default()
-        };
-        assert_eq!(
-            reveal(&declared, &Target::File("/tmp/look/a.txt".into())),
-            Launch::Application {
-                tool: "nautilus".into(),
-                path: "/tmp/look".into()
-            }
+    fn only_a_single_instance_mac_app_goes_through_open() {
+        let ghostty = shell_command(terminal_here(
+            &tools(None, None, Some("ghostty")),
+            &folder(),
+        ));
+        assert!(
+            ghostty.starts_with("open -na 'Ghostty' --args -e \"$SHELL\" -lc "),
+            "got: {ghostty}"
         );
-    }
 
-    #[test]
-    fn a_folder_is_its_own_directory() {
-        assert_eq!(Target::Folder("/tmp/look".into()).dir(), "/tmp/look");
-        assert_eq!(Target::File("/tmp/look/a.txt".into()).dir(), "/tmp/look");
+        for terminal in ["alacritty", "kitty", "wezterm"] {
+            let command =
+                shell_command(terminal_here(&tools(None, None, Some(terminal)), &folder()));
+            assert!(!command.starts_with("open"), "{terminal} got: {command}");
+        }
     }
 }

--- a/core/tools/src/lib.rs
+++ b/core/tools/src/lib.rs
@@ -13,7 +13,7 @@ pub use catalog::{
     AppleScript, CommandStyle, DEFAULT_COMMAND_STYLE, Surface, TERMINALS, TTY_TOOLS, Terminal,
     command_style, entry, surface,
 };
-pub use compose::{Action, Launch, Target, Unavailable, edit, terminal_here};
+pub use compose::{Action, Launch, Target, Unavailable, edit, reveal, terminal_here};
 pub use quote::{applescript_quote, shell_quote};
 
 /// The tool keys read from `~/.look/config`, as constants so the config parser,

--- a/core/tools/src/lib.rs
+++ b/core/tools/src/lib.rs
@@ -13,7 +13,7 @@ pub use catalog::{
     AppleScript, CommandStyle, DEFAULT_COMMAND_STYLE, Surface, TERMINALS, TTY_TOOLS, Terminal,
     command_style, entry, surface,
 };
-pub use compose::{Launch, Target, Unavailable, edit, terminal_here};
+pub use compose::{Action, Launch, Target, Unavailable, edit, terminal_here};
 pub use quote::{applescript_quote, shell_quote};
 
 /// The tool keys read from `~/.look/config`, as constants so the config parser,

--- a/core/tools/src/lib.rs
+++ b/core/tools/src/lib.rs
@@ -1,0 +1,113 @@
+//! Preferred tools: how to drive the tools a user named, and how an action plus
+//! an object become one thing the platform can launch.
+//!
+//! The user declares nouns in `~/.look/config` (`terminal = ghostty`); this
+//! crate owns the verbs. Nothing here reads a command string out of config, by
+//! design: that is what a source block is for. See `specs/preferred-tools.md`.
+
+mod catalog;
+mod compose;
+mod quote;
+
+pub use catalog::{
+    AppleScript, CommandStyle, DEFAULT_COMMAND_STYLE, Surface, TERMINALS, TTY_TOOLS, Terminal,
+    command_style, entry, surface,
+};
+pub use compose::{Launch, Target, Unavailable, edit, terminal_here};
+pub use quote::{applescript_quote, shell_quote};
+
+/// The tool keys read from `~/.look/config`, as constants so the config parser,
+/// the catalog, and the "which key to set" message cannot drift apart.
+pub mod key {
+    pub const TEXT_EDITOR: &str = "text_editor";
+    pub const CODE_EDITOR: &str = "code_editor";
+    pub const TERMINAL: &str = "terminal";
+    pub const BROWSER: &str = "browser";
+    pub const FILE_MANAGER: &str = "file_manager";
+
+    pub const ALL: &[&str] = &[TEXT_EDITOR, CODE_EDITOR, TERMINAL, BROWSER, FILE_MANAGER];
+}
+
+/// All-`None` means the app behaves exactly as it does without this feature.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Tools {
+    pub text_editor: Option<String>,
+    pub code_editor: Option<String>,
+    pub terminal: Option<String>,
+    pub browser: Option<String>,
+    pub file_manager: Option<String>,
+}
+
+impl Tools {
+    pub fn is_empty(&self) -> bool {
+        self.text_editor.is_none()
+            && self.code_editor.is_none()
+            && self.terminal.is_none()
+            && self.browser.is_none()
+            && self.file_manager.is_none()
+    }
+
+    /// Unknown keys are ignored so a config written for a newer version loads.
+    pub fn set(&mut self, key_name: &str, value: &str) {
+        let value = value.trim();
+        let slot = match key_name.trim() {
+            key::TEXT_EDITOR => &mut self.text_editor,
+            key::CODE_EDITOR => &mut self.code_editor,
+            key::TERMINAL => &mut self.terminal,
+            key::BROWSER => &mut self.browser,
+            key::FILE_MANAGER => &mut self.file_manager,
+            _ => return,
+        };
+        *slot = if value.is_empty() {
+            None
+        } else {
+            Some(value.to_string())
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_empty() {
+        assert!(Tools::default().is_empty());
+    }
+
+    #[test]
+    fn set_records_known_keys_and_ignores_the_rest() {
+        let mut tools = Tools::default();
+        tools.set(key::TERMINAL, "ghostty");
+        tools.set("verb_edit", "nvim {path}");
+
+        assert_eq!(tools.terminal.as_deref(), Some("ghostty"));
+        assert!(tools.text_editor.is_none());
+        assert!(!tools.is_empty());
+    }
+
+    #[test]
+    fn an_empty_value_clears_rather_than_declaring_nothing() {
+        let mut tools = Tools::default();
+        tools.set(key::TERMINAL, "  ");
+        assert!(tools.is_empty());
+    }
+
+    #[test]
+    fn every_key_is_settable() {
+        let mut tools = Tools::default();
+        for name in key::ALL {
+            tools.set(name, "x");
+        }
+        assert_eq!(
+            tools,
+            Tools {
+                text_editor: Some("x".into()),
+                code_editor: Some("x".into()),
+                terminal: Some("x".into()),
+                browser: Some("x".into()),
+                file_manager: Some("x".into()),
+            }
+        );
+    }
+}

--- a/core/tools/src/quote.rs
+++ b/core/tools/src/quote.rs
@@ -1,0 +1,72 @@
+//! Quoting for the two languages a composed action passes through.
+
+/// POSIX single-quoting: close, escape, reopen.
+pub fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+pub fn applescript_quote(value: &str) -> String {
+    // Backslash first, or the quotes escaped next would have theirs doubled.
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    const HOSTILE: &[&str] = &[
+        "plain",
+        "/tmp/my project",
+        "it's",
+        "; rm -rf ~",
+        "$(whoami)",
+        "`id`",
+        "a\"b",
+        "back\\slash",
+        "new\nline",
+        "* ? [glob]",
+        "'",
+        "''",
+    ];
+
+    #[cfg(unix)]
+    fn echoed_through_sh(script: &str) -> String {
+        let output = std::process::Command::new("/bin/sh")
+            .arg("-c")
+            .arg(script)
+            .output()
+            .expect("running /bin/sh");
+        assert!(
+            output.status.success(),
+            "shell rejected: {script}\nstderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout).expect("utf8 stdout")
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_real_shell_reads_back_exactly_what_was_quoted() {
+        for value in HOSTILE {
+            let script = format!("printf '%s' {}", shell_quote(value));
+            assert_eq!(&echoed_through_sh(&script), value, "quoting {value:?}");
+        }
+    }
+
+    /// Hosting a TTY editor quotes an already-quoted command.
+    #[cfg(unix)]
+    #[test]
+    fn nesting_survives_two_rounds() {
+        for value in HOSTILE {
+            let inner = format!("printf '%s' {}", shell_quote(value));
+            let outer = format!("/bin/sh -c {}", shell_quote(&inner));
+            assert_eq!(&echoed_through_sh(&outer), value, "nesting {value:?}");
+        }
+    }
+
+    #[test]
+    fn applescript_escapes_backslash_before_quote() {
+        assert_eq!(applescript_quote(r#"a\"b"#), r#""a\\\"b""#);
+    }
+}


### PR DESCRIPTION
## Summary

- Default terms live in .look/config (new config file)
  - text_editor = nvim
  - terminal    = wezterm
  - code_editor = nvim
...
- Object based actions panel: 
  - Edit
  - Copy path
  - Reveal
  - ...
- Docs update and Testcases added

- TODO: Linows ver

## Why

#387 

## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [x] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

<img width="826" height="393" alt="image" src="https://github.com/user-attachments/assets/a5c71b7c-e16f-452f-94ef-8ae42f114411" />

## Checklist

- [x] I have read and agree to the CLA (CLA.md)
- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added configurable preferred tools for editing, opening terminals, and revealing items in Finder.
- Added row actions for opening, editing, terminal access, revealing, and copying paths.
- Added Cmd+E and Cmd+T shortcuts for selected results.
- Added platform-aware resolution for applications, terminals, editors, and file managers.

## Bug Fixes
- Improved quick-action selection, fallback behavior, path handling, and reveal target handling.
- Added clearer feedback when configured tools cannot be launched.

## Documentation
- Expanded repository layout documentation to include shared modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->