### PR TITLE
fix: App blur effect on MacOS

### DIFF
--- a/apps/linows/src-tauri/src/config.rs
+++ b/apps/linows/src-tauri/src/config.rs
@@ -136,7 +136,7 @@ fn default_config_contents() -> String {
          \n\
          # Home-screen inner gap in px (0-24). 0 keeps the classic framed panel;\n\
          # above 0 the home screen splits into floating tiles separated by this gap.\n\
-         inner_gap=0\n\
+         inner_gap=7\n\
          \n\
          # Web answers - inline answer card for question-like queries. Set false to\n\
          # disable all network answer features and run fully offline.\n\

--- a/apps/macos/LauncherApp/look-app/Components/ThemedBackdrop.swift
+++ b/apps/macos/LauncherApp/look-app/Components/ThemedBackdrop.swift
@@ -10,6 +10,9 @@ struct ThemedBackdrop: View {
     @ObservedObject var themeStore: ThemeStore
     /// Thins the blur only, for the settings overlay.
     var blurOpacityMultiplier: Double = 1
+    /// The window backdrop frosts the desktop. A tile inside the window must
+    /// not: it would sample past the panel it sits on and cut a hole through it.
+    var blendingMode: NSVisualEffectView.BlendingMode = .withinWindow
     /// Corner the glass is cut to. Callers clip this view, but glass draws its
     /// own specular edge and needs the corner up front or it lands outside the
     /// clip. Ignored by the blur path.
@@ -17,6 +20,21 @@ struct ThemedBackdrop: View {
 
     private var tintOpacity: Double {
         clamped(themeStore.settings.tintOpacity * themeStore.settings.blurMaterial.tintOpacityScale)
+    }
+
+    /// Behind-window blur is composited by the window server, and it can only do
+    /// that while the layer is drawn straight through. Any opacity below 1 sends
+    /// SwiftUI down an offscreen pass, and the material collapses to a flat
+    /// translucent wash with nothing blurred behind it. So the window backdrop
+    /// renders at full strength and `Blur Style` is what varies the frost;
+    /// in-window tiles have no backdrop to lose and keep the sliders.
+    private var blurLayerOpacity: Double {
+        guard blendingMode != .behindWindow else { return 1 }
+        return clamped(
+            themeStore.settings.blurOpacity
+                * themeStore.settings.blurMaterial.blurOpacityScale
+                * blurOpacityMultiplier
+        )
     }
 
     var body: some View {
@@ -40,15 +58,10 @@ struct ThemedBackdrop: View {
             } else {
                 VisualEffectBlur(
                     material: themeStore.settings.blurMaterial.material,
+                    blendingMode: blendingMode,
                     appearance: themeStore.themeAppearance()
                 )
-                .opacity(
-                    clamped(
-                        themeStore.settings.blurOpacity
-                            * themeStore.settings.blurMaterial.blurOpacityScale
-                            * blurOpacityMultiplier
-                    )
-                )
+                .opacity(blurLayerOpacity)
 
                 Color(
                     .sRGB,

--- a/apps/macos/LauncherApp/look-app/Components/ThemedBackdrop.swift
+++ b/apps/macos/LauncherApp/look-app/Components/ThemedBackdrop.swift
@@ -1,40 +1,49 @@
 import AppKit
 import SwiftUI
 
-/// Blur plus tint at the opacities set in Settings. Shared by the window backdrop
-/// and every floating tile so both sliders reach all of them.
+/// Frost plus tint at the opacities set in Settings. Shared by the window
+/// backdrop and every floating tile so the sliders reach all of them.
 ///
-/// On Liquid Glass the glass carries the tint itself and no wash is drawn over
-/// it. See `GlassEffectBackdrop`.
+/// On macOS 26 the frost is Liquid Glass for every theme, with the slider
+/// riding the glass tint; earlier systems fall back to a light material under
+/// a scrim. Slider at 0 draws no frost at all.
 struct ThemedBackdrop: View {
     @ObservedObject var themeStore: ThemeStore
-    /// Thins the blur only, for the settings overlay.
+    /// Thins the frost only, for the settings overlay.
     var blurOpacityMultiplier: Double = 1
-    /// The window backdrop frosts the desktop. A tile inside the window must
-    /// not: it would sample past the panel it sits on and cut a hole through it.
+    /// Fallback path only. The window backdrop frosts the desktop; a tile
+    /// inside the window must not, or it samples past the panel it sits on.
     var blendingMode: NSVisualEffectView.BlendingMode = .withinWindow
     /// Corner the glass is cut to. Callers clip this view, but glass draws its
     /// own specular edge and needs the corner up front or it lands outside the
-    /// clip. Ignored by the blur path.
+    /// clip. Ignored by the fallback path.
     var cornerRadius: CGFloat = 0
+
+    /// The heaviest darkness a full slider adds over the base frost.
+    private static let maxFrostScrim = 0.7
+    /// Below this no frost is drawn: the fallback material cannot fade (it
+    /// loses its blur below full alpha), so 0 means off on both paths.
+    private static let frostCutoff = 0.01
 
     private var tintOpacity: Double {
         clamped(themeStore.settings.tintOpacity * themeStore.settings.blurMaterial.tintOpacityScale)
     }
 
-    /// Behind-window blur is composited by the window server, and it can only do
-    /// that while the layer is drawn straight through. Any opacity below 1 sends
-    /// SwiftUI down an offscreen pass, and the material collapses to a flat
-    /// translucent wash with nothing blurred behind it. So the window backdrop
-    /// renders at full strength and `Blur Style` is what varies the frost;
-    /// in-window tiles have no backdrop to lose and keep the sliders.
-    private var blurLayerOpacity: Double {
-        guard blendingMode != .behindWindow else { return 1 }
-        return clamped(
+    private var frostWeight: Double {
+        clamped(
             themeStore.settings.blurOpacity
                 * themeStore.settings.blurMaterial.blurOpacityScale
                 * blurOpacityMultiplier
         )
+    }
+
+    private var showsFrost: Bool {
+        frostWeight > Self.frostCutoff
+    }
+
+    /// Squared so the low end ramps gently while the range stays visible.
+    private var frostScrimOpacity: Double {
+        frostWeight * frostWeight * Self.maxFrostScrim
     }
 
     var body: some View {
@@ -49,29 +58,65 @@ struct ThemedBackdrop: View {
     private var backdrop: some View {
         ZStack {
             if themeStore.settings.blurMaterial == .liquidGlass, #available(macOS 26.0, *) {
-                // No blur substrate: frost in front of the refraction flattens it.
                 GlassEffectBackdrop(
                     cornerRadius: cornerRadius,
                     tint: tintColor,
                     appearance: themeStore.themeAppearance())
                     .opacity(clamped(blurOpacityMultiplier))
+            } else if #available(macOS 26.0, *) {
+                if showsFrost {
+                    GlassEffectBackdrop(
+                        cornerRadius: cornerRadius,
+                        tint: frostGlassTint,
+                        appearance: themeStore.themeAppearance())
+                } else {
+                    themeTintWash
+                }
             } else {
-                VisualEffectBlur(
-                    material: themeStore.settings.blurMaterial.material,
-                    blendingMode: blendingMode,
-                    appearance: themeStore.themeAppearance()
-                )
-                .opacity(blurLayerOpacity)
+                if showsFrost {
+                    VisualEffectBlur(
+                        material: .underWindowBackground,
+                        blendingMode: blendingMode,
+                        appearance: themeStore.themeAppearance()
+                    )
 
-                Color(
-                    .sRGB,
-                    red: themeStore.settings.tintRed,
-                    green: themeStore.settings.tintGreen,
-                    blue: themeStore.settings.tintBlue,
-                    opacity: tintOpacity
-                )
+                    themeStore.scrimColor(opacity: frostScrimOpacity)
+                }
+
+                themeTintWash
             }
         }
+    }
+
+    private var themeTintWash: Color {
+        Color(
+            .sRGB,
+            red: themeStore.settings.tintRed,
+            green: themeStore.settings.tintGreen,
+            blue: themeStore.settings.tintBlue,
+            opacity: tintOpacity
+        )
+    }
+
+    /// Theme tint composited under the slider's darkness, as the single colour
+    /// the glass accepts: a wash layered over glass would cancel the
+    /// refraction, so the two merge here instead.
+    private var frostGlassTint: NSColor? {
+        let scrim = frostScrimOpacity
+        let tint = tintOpacity
+        let outAlpha = scrim + tint * (1 - scrim)
+        guard outAlpha > 0.001 else { return nil }
+
+        let scrimChannel = themeStore.themeAppearance() == .dark ? 0.0 : 1.0
+        func blend(_ themeChannel: Double) -> Double {
+            (scrimChannel * scrim + themeChannel * tint * (1 - scrim)) / outAlpha
+        }
+        return NSColor(
+            srgbRed: blend(themeStore.settings.tintRed),
+            green: blend(themeStore.settings.tintGreen),
+            blue: blend(themeStore.settings.tintBlue),
+            alpha: outAlpha
+        )
     }
 
     /// nil at zero opacity, so the glass stays untinted rather than

--- a/apps/macos/LauncherApp/look-app/Components/VisualEffectBlur.swift
+++ b/apps/macos/LauncherApp/look-app/Components/VisualEffectBlur.swift
@@ -3,13 +3,18 @@ import SwiftUI
 
 struct VisualEffectBlur: NSViewRepresentable {
     var material: NSVisualEffectView.Material
+    /// What the material samples. `.behindWindow` frosts the desktop, which is
+    /// the look the material is for; `.withinWindow` samples the window's own
+    /// backing, so with nothing behind it renders as a flat wash whose only
+    /// adjustable property is alpha.
+    var blendingMode: NSVisualEffectView.BlendingMode = .withinWindow
     /// Pinned per theme: materials otherwise follow the system light/dark setting.
     var appearance: ThemeAppearance = .dark
 
     func makeNSView(context: Context) -> NSVisualEffectView {
         let view = NSVisualEffectView()
         view.material = material
-        view.blendingMode = .withinWindow
+        view.blendingMode = blendingMode
         view.state = .active
         view.appearance = NSAppearance(named: appearance.nsAppearanceName)
         return view
@@ -21,6 +26,9 @@ struct VisualEffectBlur: NSViewRepresentable {
         // hasn't actually changed.
         if nsView.material != material {
             nsView.material = material
+        }
+        if nsView.blendingMode != blendingMode {
+            nsView.blendingMode = blendingMode
         }
         if nsView.appearance?.name != appearance.nsAppearanceName {
             nsView.appearance = NSAppearance(named: appearance.nsAppearanceName)

--- a/apps/macos/LauncherApp/look-app/Components/VisualEffectBlur.swift
+++ b/apps/macos/LauncherApp/look-app/Components/VisualEffectBlur.swift
@@ -10,7 +10,6 @@ struct VisualEffectBlur: NSViewRepresentable {
     var blendingMode: NSVisualEffectView.BlendingMode = .withinWindow
     /// Pinned per theme: materials otherwise follow the system light/dark setting.
     var appearance: ThemeAppearance = .dark
-
     func makeNSView(context: Context) -> NSVisualEffectView {
         let view = NSVisualEffectView()
         view.material = material

--- a/apps/macos/LauncherApp/look-app/Models/ThemeSettings.swift
+++ b/apps/macos/LauncherApp/look-app/Models/ThemeSettings.swift
@@ -236,7 +236,7 @@ struct ThemeSettings: Codable, Equatable {
     /// `0` keeps the classic flat layout with hairline dividers; any value > 0 turns
     /// each pane into its own rounded card separated by empty space. Persisted in
     /// `~/.look.config` under `inner_gap`.
-    var innerGap: Double = 0
+    var innerGap: Double = 7
 
     /// Whether Apple Intelligence / AI-assisted features are enabled. Defaults to
     /// on; users can opt out via Settings → Appearance. Persisted in

--- a/apps/macos/LauncherApp/look-app/Support/AppUIState.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppUIState.swift
@@ -8,29 +8,12 @@ final class AppUIState: ObservableObject {
     static let shared = AppUIState()
 
     @Published var showsThemeSettings = false
-    @Published var settingsBlurMultiplier: Double {
-        didSet {
-            UserDefaults.standard.set(settingsBlurMultiplier, forKey: Self.settingsBlurMultiplierKey)
-        }
-    }
 
     // Remembered command id of the last command-mode panel the user
     // visited *during this launch*. Re-entering command mode (Cmd+/)
     // resumes there instead of jumping back to /calc. Intentionally
     // not persisted - each fresh launch should start at /calc.
     @Published var lastCommandID: String?
-
-    private static let settingsBlurMultiplierKey = "look.ui.settingsBlurMultiplier"
-
-    init() {
-        if let stored = UserDefaults.standard.object(forKey: Self.settingsBlurMultiplierKey) as? Double,
-            stored > 0
-        {
-            settingsBlurMultiplier = min(max(stored, 0.4), 1.0)
-        } else {
-            settingsBlurMultiplier = 0.5
-        }
-    }
 }
 
 extension Notification.Name {

--- a/apps/macos/LauncherApp/look-app/Support/QuickActions/QuickActionModels.swift
+++ b/apps/macos/LauncherApp/look-app/Support/QuickActions/QuickActionModels.swift
@@ -35,6 +35,8 @@ struct QuickActionDescriptor: Decodable, Equatable, Identifiable {
     /// action silently. The descriptor is what gets activated, so the guard
     /// travels with it.
     var confirm: String? = nil
+    /// Chord that already runs this, shown right-aligned in the menu.
+    var shortcut: String? = nil
 
     var id: String { actionId }
 }

--- a/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
@@ -866,7 +866,7 @@ ui_border_opacity=0.12
 running_apps_placement=right
 
 # Inner gap (points, 0-24) between the three home panes; 0 = classic flat layout
-inner_gap=0
+inner_gap=7
 
 # Apple Intelligence / AI features. ai_provider: appleIntelligence | ollama
 ai_enabled=true

--- a/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
@@ -407,11 +407,11 @@ final class ThemeStore: ObservableObject {
 
     /// Value for `ui_theme`. Recorded only while the values still match the
     /// preset, since reading applies it over the individual keys. Empty = Custom.
+    /// The theme the user chose, kept even once they tune values away from it.
+    /// Dropping it on divergence left `activeAppearanceStyle()` nil, so one
+    /// slider silently re-derived the whole palette. Only Custom clears it.
     private func savedThemeName() -> String {
-        guard let style = detectBuiltinTheme(for: settings).style, style.matches(settings) else {
-            return ""
-        }
-        return style.themeName
+        settings.themeName
     }
 
     private func applyThemeOverridesFromConfigFile() {
@@ -426,6 +426,14 @@ final class ThemeStore: ObservableObject {
         excludedFolderPaths = []
         fileScanRoots = defaultFileScanRoots()
         extraFileScanRoots = []
+
+        // Base, not override: the ui_* keys below win. Applied last, it threw
+        // away tuned values on every load. Accepted cost: a hand-written
+        // `ui_theme` no longer beats ui_* keys already in the file.
+        if let themeValue = ConfigFileLines.keyValues(raw)["ui_theme"],
+           let preset = BuiltinThemePreset.preset(forThemeName: themeValue) {
+            applyBuiltinTheme(preset)
+        }
 
         for line in raw.split(whereSeparator: \ .isNewline) {
             let stripped = ConfigFileLines.stripComment(String(line)).trimmingCharacters(in: .whitespacesAndNewlines)
@@ -604,14 +612,6 @@ final class ThemeStore: ObservableObject {
             default:
                 continue
             }
-        }
-
-        // Applied last, overriding the individual ui_* keys: every config file
-        // carries a full set of them, so the other order would ignore a
-        // hand-written `ui_theme=kindle`. See savedThemeName.
-        if let themeValue = ConfigFileLines.keyValues(raw)["ui_theme"],
-           let preset = BuiltinThemePreset.preset(forThemeName: themeValue) {
-            applyBuiltinTheme(preset)
         }
 
         // Keeps the Settings picker in step when the config file is what changed.

--- a/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
@@ -405,8 +405,6 @@ final class ThemeStore: ObservableObject {
         UserDefaults.standard.set(data, forKey: defaultsKey)
     }
 
-    /// Value for `ui_theme`. Recorded only while the values still match the
-    /// preset, since reading applies it over the individual keys. Empty = Custom.
     /// The theme the user chose, kept even once they tune values away from it.
     /// Dropping it on divergence left `activeAppearanceStyle()` nil, so one
     /// slider silently re-derived the whole palette. Only Custom clears it.
@@ -842,7 +840,8 @@ skip_dir_names=node_modules,target,build,dist,library,applications,old firefox d
 # UI theme
 # Preset: catppuccin, tokyoNight, rosePine, gruvbox, dracula, kanagawa, kindle,
 # liquid (liquid needs macOS 26; it falls back to the classic surface below that).
-# A preset overrides every ui_* value below. Leave it empty to use them as written.
+# A preset supplies base values; the ui_* keys below override it. The name stays
+# recorded as you tune, until you pick Custom. Empty = only the keys below.
 ui_theme=
 ui_tint_red=0.08
 ui_tint_green=0.10

--- a/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ThemeStore.swift
@@ -74,7 +74,6 @@ final class ThemeStore: ObservableObject {
     struct ConfigReloadResult {
         let loadedTheme: String
         let warnings: [String]
-        let settingsBlurMultiplier: Double?
     }
 
     func reloadFromConfig() -> ConfigReloadResult {
@@ -159,8 +158,7 @@ final class ThemeStore: ObservableObject {
         _ = applyLaunchAtLoginSetting()
 
         let resultTheme = detectBuiltinTheme(for: settings)
-        let loadedBlurMultiplier = settings.settingsBlurMultiplier
-        return ConfigReloadResult(loadedTheme: resultTheme.title, warnings: warnings, settingsBlurMultiplier: loadedBlurMultiplier)
+        return ConfigReloadResult(loadedTheme: resultTheme.title, warnings: warnings)
     }
 
     func saveCurrentConfigToFile() -> Bool {

--- a/apps/macos/LauncherApp/look-app/Themes/BuiltinThemeStyle.swift
+++ b/apps/macos/LauncherApp/look-app/Themes/BuiltinThemeStyle.swift
@@ -159,7 +159,12 @@ init(
         settings.tintOpacity = tintOpacity
         settings.blurMaterial = blurMaterial
         settings.blurOpacity = blurOpacity
-        settings.fontName = fontName ?? ThemeSettings.default.fontName
+        // Only a preset that names a font imposes one. Liquid passes nil, and
+        // forcing the default there reset the user's typeface every load, since
+        // `matches` now keeps `ui_theme` in the config across a font change.
+        if let fontName {
+            settings.fontName = fontName
+        }
         settings.fontRed = fontRed
         settings.fontGreen = fontGreen
         settings.fontBlue = fontBlue
@@ -171,9 +176,14 @@ init(
         settings.themeName = self.themeName
     }
 
+    /// Deliberately ignores `fontName`. A preset still SETS one when applied
+    /// (see `apply`), but the typeface is not what makes a theme that theme:
+    /// picking a different font would otherwise drop Liquid Glass to Custom and
+    /// take `ui_theme` out of the config with it. Font *size* has never been
+    /// compared here, so this only makes the two agree. Text colour stays in,
+    /// since that is part of the look.
     func matches(_ settings: ThemeSettings, tolerance: Double = 0.01) -> Bool {
-        settings.fontName == (fontName ?? ThemeSettings.default.fontName)
-            && abs(settings.tintRed - tintRed) <= tolerance
+        abs(settings.tintRed - tintRed) <= tolerance
             && abs(settings.tintGreen - tintGreen) <= tolerance
             && abs(settings.tintBlue - tintBlue) <= tolerance
             && abs(settings.tintOpacity - tintOpacity) <= tolerance

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/AIAnswerCardView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/AIAnswerCardView.swift
@@ -5,6 +5,10 @@ import SwiftUI
 /// block per source (Calculator / DuckDuckGo / Wikipedia), each appearing as it
 /// resolves, and falls back to a streaming on-device answer when none hit.
 struct AIAnswerCardView: View {
+    /// How much themed floor sits under the card, so a light page behind the
+    /// window cannot bleed through into the answer text.
+    private static let legibilityFloorOpacity = 0.55
+
     @ObservedObject var controller: AIAnswerController
     @ObservedObject var themeStore: ThemeStore
 
@@ -37,8 +41,17 @@ struct AIAnswerCardView: View {
         .padding(12)
         .frame(maxWidth: .infinity, alignment: .topLeading)
         .background(
+            // A themed floor under the fill. The panel behind this card blurs
+            // the desktop, so over a light page the card had nothing to stand
+            // against and its own text washed out (issue #398). The fill alone
+            // is 0.30, which is a tint, not a substrate.
             RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .fill(themeStore.controlFillColor())
+                .fill(themeStore.commandModeBackgroundColor())
+                .opacity(Self.legibilityFloorOpacity)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .fill(themeStore.controlFillColor())
+                )
         )
         .overlay(
             RoundedRectangle(cornerRadius: 10, style: .continuous)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ActionMenuView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ActionMenuView.swift
@@ -17,17 +17,26 @@ struct ActionMenuView: View {
 
     private typealias Layout = AppConstants.Launcher.ActionMenu
 
+    @State private var contentHeight: CGFloat = 0
+
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView(.vertical, showsIndicators: false) {
-                LazyVStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: 2) {
                     ForEach(Array(descriptors.enumerated()), id: \.element.id) { pair in
                         row(pair.element, isFocused: pair.offset == focusedIndex)
                             .id(pair.offset)
                     }
                 }
+                .background(
+                    GeometryReader { geo in
+                        Color.clear
+                            .onAppear { contentHeight = geo.size.height }
+                            .onChange(of: geo.size.height) { _, new in contentHeight = new }
+                    }
+                )
             }
-            .frame(height: menuHeight)
+            .frame(height: min(contentHeight, Layout.maxHeight))
             .onChange(of: focusedIndex) { _, index in
                 withAnimation(Motion.Selection.glide) { proxy.scrollTo(index) }
             }
@@ -35,13 +44,6 @@ struct ActionMenuView: View {
         .padding(4)
         .background(menuBackground)
         .overlay(menuBorder)
-    }
-
-    /// Tall enough for its rows, never taller than the cap.
-    private var menuHeight: CGFloat {
-        let rows = CGFloat(descriptors.count)
-        let rowHeight = CGFloat(themeStore.settings.fontSize - 1) + Layout.rowVerticalPadding * 2 + 6
-        return min(rows * rowHeight + max(0, rows - 1) * 2, Layout.maxHeight)
     }
 
     private var menuBackground: some View {
@@ -69,6 +71,11 @@ struct ActionMenuView: View {
                 .foregroundStyle(themeStore.fontColor())
                 .lineLimit(1)
             Spacer(minLength: 8)
+            if let shortcut = descriptor.shortcut {
+                Text(shortcut)
+                    .font(themeStore.uiFont(size: hintSize, weight: .regular))
+                    .foregroundStyle(themeStore.mutedTextColor())
+            }
             if isFocused {
                 Text(Layout.runHint)
                     .font(themeStore.uiFont(size: hintSize, weight: .semibold))

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
@@ -580,13 +580,14 @@ private let launchpadAlertBorderOpacity = 0.3
 func frostedTile(
     themeStore: ThemeStore,
     cornerRadius: CGFloat? = nil,
+    blendingMode: NSVisualEffectView.BlendingMode = .withinWindow,
     tint: Color? = nil,
     tintOpacity: Double = 0
 ) -> some View {
     let radius = cornerRadius
         ?? themeStore.surfaceCornerRadius(AppConstants.Launcher.Launchpad.cornerRadius)
     return ZStack {
-        ThemedBackdrop(themeStore: themeStore, cornerRadius: radius)
+        ThemedBackdrop(themeStore: themeStore, blendingMode: blendingMode, cornerRadius: radius)
         themeStore.controlFillColor()
         if let tint {
             tint.opacity(tintOpacity)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
@@ -580,7 +580,10 @@ private let launchpadAlertBorderOpacity = 0.3
 func frostedTile(
     themeStore: ThemeStore,
     cornerRadius: CGFloat? = nil,
-    blendingMode: NSVisualEffectView.BlendingMode = .withinWindow,
+    /// Floating surfaces sit straight on the desktop with no window backdrop
+    /// behind them, so they have to sample it directly. `.withinWindow` would
+    /// find nothing there and render a flat wash instead of a blur.
+    blendingMode: NSVisualEffectView.BlendingMode = .behindWindow,
     tint: Color? = nil,
     tintOpacity: Double = 0
 ) -> some View {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/EmptyStateLaunchpadView.swift
@@ -577,8 +577,14 @@ private let launchpadAlertBorderOpacity = 0.3
 /// The frosted surface every launchpad tile sits on: the same backdrop +
 /// control-fill stack as `LauncherView.tileBackground(floats:)`. An optional tint
 /// (accent for on-state toggles, caution for a confirming/muted action) layers on top.
-func frostedTile(themeStore: ThemeStore, tint: Color? = nil, tintOpacity: Double = 0) -> some View {
-    let radius = themeStore.surfaceCornerRadius(AppConstants.Launcher.Launchpad.cornerRadius)
+func frostedTile(
+    themeStore: ThemeStore,
+    cornerRadius: CGFloat? = nil,
+    tint: Color? = nil,
+    tintOpacity: Double = 0
+) -> some View {
+    let radius = cornerRadius
+        ?? themeStore.surfaceCornerRadius(AppConstants.Launcher.Launchpad.cornerRadius)
     return ZStack {
         ThemedBackdrop(themeStore: themeStore, cornerRadius: radius)
         themeStore.controlFillColor()

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Background.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Background.swift
@@ -24,16 +24,22 @@ extension LauncherView {
             // NSVisualEffectView to sample anything → no halo.
             commandModeBackdrop
         } else {
+            ThemedBackdrop(
+                themeStore: themeStore,
+                blurOpacityMultiplier: appUIState.showsThemeSettings
+                    ? themeStore.settings.settingsBlurMultiplier : 1.0,
+                blendingMode: .behindWindow
+            )
+
+            // Above the backdrop, not below it: the blur samples what is behind
+            // the WINDOW, so anything drawn under it is simply covered. The
+            // image keeps its own blur and opacity, and a partly transparent
+            // one still shows the frosted desktop through.
             if let image = themeStore.backgroundImage {
                 backgroundImageView(image: image)
                     .blur(radius: themeStore.settings.backgroundImageBlur)
                     .opacity(themeStore.settings.backgroundImageOpacity)
             }
-
-            ThemedBackdrop(
-                themeStore: themeStore,
-                blurOpacityMultiplier: appUIState.showsThemeSettings ? appUIState.settingsBlurMultiplier : 1.0
-            )
         }
     }
 

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+RowActions.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+RowActions.swift
@@ -47,9 +47,6 @@ extension LauncherView {
         }
     }
 
-    /// Separates a label from the chord that already performs it.
-    private static let chordGap = "  "
-
     private static var rowActionCatalog: [RowActionEntry] {
         [
             RowActionEntry(id: RowAction.open, plain: "Open", chord: "⏎"),
@@ -85,16 +82,16 @@ extension LauncherView {
                 control: .button,
                 onLabel: nil,
                 offLabel: nil,
-                info: []
+                info: [],
+                shortcut: entry.chord
             )
         }
     }
 
     private static func label(for entry: RowActionEntry, tools: [String: ToolAction]) -> String {
         let resolved = entry.tool.flatMap { tools[$0]?.tool } ?? entry.fallbackTool
-        let wording =
-            if let named = entry.named, let resolved { "\(named) \(resolved)" } else { entry.plain }
-        return "\(wording)\(chordGap)\(entry.chord)"
+        guard let named = entry.named, let resolved else { return entry.plain }
+        return "\(named) \(resolved)"
     }
 
     /// Which tool each offered action would start. Cheap after the first call:

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Search.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Search.swift
@@ -380,11 +380,6 @@ extension LauncherView {
         SourceBlockCatalog.invalidate()
         refreshRunBlocksInBackground()
 
-        // Sync settings blur multiplier to AppUIState
-        if let blurMultiplier = result.settingsBlurMultiplier {
-            appUIState.settingsBlurMultiplier = blurMultiplier
-        }
-
         var message = successMessage
         var style: BannerStyle = successStyle
         var duration: Double = successDuration

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -171,10 +171,15 @@ struct LauncherView: View {
     static let panelCoordinateSpace = "launcherPanel"
 
     static let floatingTileScrimOpacity = 0.30
+
+    /// How much themed floor sits under the search bar's frost. The bar renders
+    /// its material lighter than the launchpad pills do from the same
+    /// `frostedTile`, so this bounds how bright it can get over a white page.
+    /// 0 = pure glass and it goes white; 1 = opaque and the blur is lost.
+    static let searchBarSubstrateOpacity = 0.55
     /// Legibility floor for surfaces that float on the bare desktop while the
     /// material is Liquid Glass. Tune here: too low and light theme text
     /// disappears over a white window, too high and the refraction is lost.
-    static let glassLegibilityScrimOpacity = 0.22
     /// Resting corner for a tile that floats free of its neighbours, and for the
     /// seated variant that reads as part of one box. Both are scaled by the
     /// active theme surface (Liquid rounds harder) at each use.
@@ -2227,33 +2232,33 @@ struct LauncherView: View {
     /// so the tiles read as separate windows onto one image. Otherwise it takes the
     /// themed backdrop, at the same blur and tint opacities as the window.
     @ViewBuilder
-    private func tileBackground(cornerRadius: CGFloat, floats: Bool) -> some View {
-        if floats {
+    private func tileBackground(
+        cornerRadius: CGFloat, floats: Bool, substrate: Bool = false
+    ) -> some View {
+        if floats, let image = themeStore.backgroundImage {
             ZStack {
-                if let image = themeStore.backgroundImage {
-                    croppedBackgroundImage(image)
-                    // Only the opaque image needs a scrim; the blur path is
-                    // covered by the tint.
-                    themeStore.scrimColor(opacity: Self.floatingTileScrimOpacity)
-                } else {
-                    ThemedBackdrop(themeStore: themeStore, cornerRadius: cornerRadius)
-                    // Liquid Glass is transparent to the desktop, and a floating
-                    // surface sits over content we do not control. The launchpad
-                    // tiles get away with it because the panel backs them; this
-                    // bar does not, so over a white window the theme's own light
-                    // text lands on near-white. A scrim guarantees the substrate
-                    // the glass cannot: enough to read against, well under the
-                    // weight that would cancel the refraction.
-                    if themeStore.settings.blurMaterial.rendersGlass {
-                        themeStore.scrimColor(opacity: Self.glassLegibilityScrimOpacity)
-                    }
-                }
+                croppedBackgroundImage(image)
+                // Only the opaque image needs a scrim; the blur path is
+                // covered by the tint.
+                themeStore.scrimColor(opacity: Self.floatingTileScrimOpacity)
                 themeStore.controlFillColor()
             }
             .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
         } else {
-            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                .fill(themeStore.controlFillColor())
+            ZStack {
+                // Only the search bar asks for this. Its material renders
+                // lighter than the launchpad pills do from the same
+                // `frostedTile`, so a themed floor bounds how bright it can get
+                // over a white page. The panes are large and densely filled, so
+                // the same floor only flattens them.
+                if substrate {
+                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                        .fill(themeStore.commandModeBackgroundColor())
+                        .opacity(Self.searchBarSubstrateOpacity)
+                }
+
+                frostedTile(themeStore: themeStore, cornerRadius: cornerRadius)
+            }
         }
     }
 
@@ -2301,7 +2306,8 @@ struct LauncherView: View {
                     cornerRadius: themeStore.surfaceCornerRadius(
                         floats ? Self.floatingTileCornerRadius : Self.seatedTileCornerRadius
                     ),
-                    floats: floats
+                    floats: floats,
+                    substrate: true
                 )
             }
             .overlay {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -172,10 +172,8 @@ struct LauncherView: View {
 
     static let floatingTileScrimOpacity = 0.30
 
-    /// How much themed floor sits under the search bar's frost. The bar renders
-    /// its material lighter than the launchpad pills do from the same
-    /// `frostedTile`, so this bounds how bright it can get over a white page.
-    /// 0 = pure glass and it goes white; 1 = opaque and the blur is lost.
+    /// 0 = pure glass, and the bar goes white over a light page; 1 = opaque,
+    /// and the blur is lost.
     static let searchBarSubstrateOpacity = 0.55
     /// Legibility floor for surfaces that float on the bare desktop while the
     /// material is Liquid Glass. Tune here: too low and light theme text
@@ -837,7 +835,9 @@ struct LauncherView: View {
         // floating strip that grows the window. The launcher is always a single
         // fixed-size panel regardless of the running-apps toggle.
         borderedPanel(windowCornerRadius: windowCornerRadius, contentSpacing: contentSpacing, contentPadding: contentPadding)
-        .rootReveal(token: appearanceRevealToken)
+        // No `.rootReveal`: its opacity rasterized the panel on every show, and
+        // the bar's backdrop must draw straight through. The spawnReveal
+        // cascade still animates the open.
         .ignoresSafeArea()
         .onAppear {
             refreshSearchResults()
@@ -2246,18 +2246,22 @@ struct LauncherView: View {
             .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
         } else {
             ZStack {
-                // Only the search bar asks for this. Its material renders
-                // lighter than the launchpad pills do from the same
-                // `frostedTile`, so a themed floor bounds how bright it can get
-                // over a white page. The panes are large and densely filled, so
-                // the same floor only flattens them.
+                // Bounds how bright the bar can get over a white page. The
+                // panes are dense enough that the same floor only flattens them.
                 if substrate {
                     RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
                         .fill(themeStore.commandModeBackgroundColor())
                         .opacity(Self.searchBarSubstrateOpacity)
                 }
 
-                frostedTile(themeStore: themeStore, cornerRadius: cornerRadius)
+                // Window-server composited. The bar hosts an
+                // `NSViewRepresentable`, and a `.withinWindow` material beside
+                // one flips brightness whenever the layer is re-composited.
+                frostedTile(
+                    themeStore: themeStore,
+                    cornerRadius: cornerRadius,
+                    blendingMode: substrate ? .behindWindow : .withinWindow
+                )
             }
         }
     }
@@ -2301,13 +2305,17 @@ struct LauncherView: View {
         // (e.g. typing the first character out of the empty-rest state at gap 0).
         let floats = barFloatsFree
         return content()
+            // Wraps the content, not the chrome: the reveal leaves an opacity
+            // in the tree, which would rasterize the backdrop below.
+            .spawnReveal(index: Self.searchBarRevealIndex, token: appearanceRevealToken, scales: false)
             .background {
                 tileBackground(
                     cornerRadius: themeStore.surfaceCornerRadius(
                         floats ? Self.floatingTileCornerRadius : Self.seatedTileCornerRadius
                     ),
                     floats: floats,
-                    substrate: true
+                    // Seated, the panel's backdrop already backs the bar.
+                    substrate: floats
                 )
             }
             .overlay {
@@ -2317,9 +2325,6 @@ struct LauncherView: View {
             }
             .shadow(color: floats ? .black.opacity(0.25) : .clear,
                     radius: floats ? 7 : 0, x: 0, y: floats ? 3 : 0)
-            // Leads the cascade: the bar lands first, then the launchpad tiles.
-            // No scale, so the search field's text stays crisp (see spawnReveal).
-            .spawnReveal(index: Self.searchBarRevealIndex, token: appearanceRevealToken, scales: false)
     }
 
     /// Wraps a single-panel home state (translation, clipboard/recent empty) in a

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -2260,7 +2260,8 @@ struct LauncherView: View {
                 frostedTile(
                     themeStore: themeStore,
                     cornerRadius: cornerRadius,
-                    blendingMode: substrate ? .behindWindow : .withinWindow
+                    // Seated is the only case with a window backdrop behind it.
+                    blendingMode: floats ? .behindWindow : .withinWindow
                 )
             }
         }

--- a/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Appearance.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Appearance.swift
@@ -63,14 +63,9 @@ extension ThemeSettingsView {
                 LabeledSlider(title: "Blur Opacity", value: $settings.blurOpacity, range: 0...1)
                     .disabled(settings.blurMaterial.rendersGlass)
                     .opacity(settings.blurMaterial.rendersGlass ? AppConstants.ThemeUI.disabledControlOpacity : 1)
-                    .help("Thins the frost on floating tiles. The window itself is set by Blur Style: its blur is composited by the window server, and thinning it would flatten it.")
 
-                // Only the glass backdrop can be thinned. Behind the window the
-                // multiplier is ignored, so the control would be writable and
-                // do nothing. See `ThemedBackdrop.blurLayerOpacity`.
                 LabeledSlider(title: "Settings Blur", value: $settings.settingsBlurMultiplier, range: 0.4...1)
-                    .disabled(!settings.blurMaterial.rendersGlass)
-                    .opacity(settings.blurMaterial.rendersGlass ? 1 : AppConstants.ThemeUI.disabledControlOpacity)
+                    .help("How much the backdrop thins while Settings is open.")
 
                 HStack(spacing: 10) {
                     Text("Blur Style")

--- a/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Appearance.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Appearance.swift
@@ -64,7 +64,7 @@ extension ThemeSettingsView {
                 LabeledSlider(title: "Blur Opacity", value: $settings.blurOpacity, range: 0...1)
                     .disabled(settings.blurMaterial.rendersGlass)
                     .opacity(settings.blurMaterial.rendersGlass ? AppConstants.ThemeUI.disabledControlOpacity : 1)
-                LabeledSlider(title: "Settings Blur", value: $appUIState.settingsBlurMultiplier, range: 0.4...1)
+                LabeledSlider(title: "Settings Blur", value: $settings.settingsBlurMultiplier, range: 0.4...1)
 
                 HStack(spacing: 10) {
                     Text("Blur Style")

--- a/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Appearance.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Settings/ThemeSettingsView+Appearance.swift
@@ -59,12 +59,18 @@ extension ThemeSettingsView {
 
                 sectionHeader("Blur")
 
-                // Glass has no blur to thin, so `ThemedBackdrop` ignores this.
                 // Disabled rather than hidden, to keep the value visible.
                 LabeledSlider(title: "Blur Opacity", value: $settings.blurOpacity, range: 0...1)
                     .disabled(settings.blurMaterial.rendersGlass)
                     .opacity(settings.blurMaterial.rendersGlass ? AppConstants.ThemeUI.disabledControlOpacity : 1)
+                    .help("Thins the frost on floating tiles. The window itself is set by Blur Style: its blur is composited by the window server, and thinning it would flatten it.")
+
+                // Only the glass backdrop can be thinned. Behind the window the
+                // multiplier is ignored, so the control would be writable and
+                // do nothing. See `ThemedBackdrop.blurLayerOpacity`.
                 LabeledSlider(title: "Settings Blur", value: $settings.settingsBlurMultiplier, range: 0.4...1)
+                    .disabled(!settings.blurMaterial.rendersGlass)
+                    .opacity(settings.blurMaterial.rendersGlass ? 1 : AppConstants.ThemeUI.disabledControlOpacity)
 
                 HStack(spacing: 10) {
                     Text("Blur Style")


### PR DESCRIPTION
## Summary

- Fix bugs
  - Setting blur auto reset to 50 when hitting save config button
  - Blur effect gone due to new feature: liquid glass. Causes: 
  Behind-window blur is composited by the window server, which can only do that while the layer draws straight through. Any **SwiftUI** opacity below 1 forces an **offscreen** render pass, and the material collapses to a flat translucent wash with nothing blurred behind it.

- Right align hint shortkeys for actions panel
- Default inner gap to 7
  
## Why

- #396 , #399 
- #398 is also expected to be resolved in this PR. (confirmed on dev PCs)


## Testing

- `apps/linows`
  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)


## Checklist

- [x] I have read and agree to the CLA (CLA.md)
- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added macOS 26 Liquid Glass support across themed backdrops.
- Added configurable backdrop blending modes and improved search-bar and tile layering.
- Action menus now display available keyboard shortcuts and size more naturally.

## Improvements
- Background images appear above themed backdrops.
- Improved AI answer card readability.
- Theme presets better preserve customized typefaces and names.
- Increased the default pane gap for improved visual separation.
- Simplified Settings Blur guidance and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->