### PR TITLE
fix: adjust settings tab index mapping to match UI order

### DIFF
--- a/apps/linows/src/js/screens/settings.js
+++ b/apps/linows/src/js/screens/settings.js
@@ -21,7 +21,7 @@ let activeTab = 'appearance';
 let onExit = null;
 let onConfigReloadFn = null;
 
-const TABS = ['appearance', 'shortcuts', 'advanced'];
+const TABS = ['appearance', 'advanced', 'shortcuts'];
 
 // Sentinel the Font field falls back to: "let the theme decide", not a family.
 const DEFAULT_FONT_NAME = 'system-ui';


### PR DESCRIPTION
## Summary

- Tab and Shift+Tab key navigation in Settings is reversed. Pressing Tab moves focus to the previous item instead of the next item and The opposite is Shift+tab.

## Why

- Closes: #395 

## Changes

- adjust order setting index tab

## Testing

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)


https://github.com/user-attachments/assets/cd059f9b-ccb2-48d4-afe1-9e24a6a2398f




## Risks / Notes

- N/A

## Checklist

- [x] I have read and agree to the CLA (CLA.md)
- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Reordered the Settings tabs so **Advanced** appears before **Shortcuts**.
  - Updated keyboard navigation to follow the new tab order.
  - Improved configuration reset, saving, and reloading to ensure changes are refreshed correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->