### PR TITLE
feat: user defined source with drilldown actions, bug fixes, ...

### DIFF
--- a/apps/linows/src-tauri/Cargo.lock
+++ b/apps/linows/src-tauri/Cargo.lock
@@ -2536,6 +2536,7 @@ dependencies = [
  "globset",
  "look-tools",
  "serde",
+ "serde_json",
  "toml 0.9.12+spec-1.1.0",
 ]
 

--- a/apps/macos/LauncherApp/LauncherLogicTests/SourceLevelStackTests.swift
+++ b/apps/macos/LauncherApp/LauncherLogicTests/SourceLevelStackTests.swift
@@ -76,6 +76,45 @@ final class SourceLevelStackTests: XCTestCase {
         XCTAssertEqual([SourceLevelParent]().ancestorsJSON, "[]")
     }
 
+    // ── A request only lands in the state that asked for it ─────────────
+
+    func testHidingTheLauncherInvalidatesARequestForTheFirstLevel() {
+        // The stack is empty while the first level's command runs, so a clear
+        // that only bumped when it had frames would let the result through.
+        var stack = SourceLevelStack()
+        let inFlight = stack.beginRequest()
+
+        stack.clear()
+
+        XCTAssertNotEqual(inFlight, stack.epoch)
+    }
+
+    func testASecondRequestInvalidatesTheFirst() {
+        var stack = SourceLevelStack()
+        let first = stack.beginRequest()
+        let second = stack.beginRequest()
+
+        XCTAssertNotEqual(first, stack.epoch)
+        XCTAssertEqual(second, stack.epoch, "the newest request is the live one")
+    }
+
+    func testARequestThatNothingInterruptedStillHoldsItsEpoch() {
+        var stack = SourceLevelStack()
+        let inFlight = stack.beginRequest()
+
+        XCTAssertEqual(inFlight, stack.epoch)
+    }
+
+    func testLeavingALevelInvalidatesWhatWasStartedInIt() {
+        var stack = SourceLevelStack()
+        stack.push(frame(block: "Browse", parent: "look"))
+        let inFlight = stack.beginRequest()
+
+        _ = stack.pop()
+
+        XCTAssertNotEqual(inFlight, stack.epoch)
+    }
+
     // ── Escape restores rather than re-searching ────────────────────────
 
     func testPoppingHandsBackWhatTheLevelWasOpenedFrom() {

--- a/apps/macos/LauncherApp/LauncherLogicTests/SourceLevelStackTests.swift
+++ b/apps/macos/LauncherApp/LauncherLogicTests/SourceLevelStackTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import LauncherLogic
+
+/// The drill-down stack (`specs/user-sources.md` §2.10). Pure navigation state,
+/// so it is testable without a launcher: what the query bar says, what the core
+/// is told about ancestors, and what Escape puts back.
+final class SourceLevelStackTests: XCTestCase {
+    private func row(_ id: String) -> SourceLevelRow {
+        SourceLevelRow(candidateId: "src:child:\(id)", id: id, title: id, subtitle: "", path: nil)
+    }
+
+    private func frame(
+        block: String, parent: String, path: String = "", query: String = "",
+        selection: String? = nil
+    ) -> SourceLevelFrame {
+        SourceLevelFrame(
+            blockName: block,
+            parentRowID: parent,
+            parentTitle: parent,
+            parentPath: path,
+            rows: [row("one")],
+            restoredQuery: query,
+            restoredSelectionID: selection
+        )
+    }
+
+    // ── The breadcrumb says where you are AND what you are looking at ────
+
+    func testBreadcrumbEndsWithTheBlockNotTheRowYouCameFrom() {
+        // "look" alone cannot tell Changed files from Branches: the row you
+        // came from does not say which of its targets you picked.
+        var stack = SourceLevelStack()
+        stack.push(frame(block: "Changed files", parent: "look"))
+        XCTAssertEqual(stack.breadcrumb, ["look", "Changed files"])
+    }
+
+    func testBreadcrumbWalksEveryLevelInOrder() {
+        var stack = SourceLevelStack()
+        stack.push(frame(block: "Browse", parent: "look"))
+        stack.push(frame(block: "Browse", parent: "apps"))
+        XCTAssertEqual(stack.breadcrumb, ["look", "apps", "Browse"])
+    }
+
+    func testAnEmptyStackHasNoBreadcrumbAndIsNotActive() {
+        let stack = SourceLevelStack()
+        XCTAssertTrue(stack.breadcrumb.isEmpty)
+        XCTAssertFalse(stack.isActive)
+    }
+
+    // ── Ancestors reach the core nearest-first, which is what {parent.*} means ──
+
+    func testAncestorsAreNearestFirst() {
+        var stack = SourceLevelStack()
+        stack.push(frame(block: "Browse", parent: "look", path: "/dev/look"))
+        stack.push(frame(block: "Browse", parent: "apps", path: "/dev/look/apps"))
+
+        let ancestors = stack.ancestorsOfCurrentRows
+        // {parent.path} is the level directly above these rows, and each
+        // further `parent.` steps one further out.
+        XCTAssertEqual(ancestors.map(\.id), ["apps", "look"])
+        XCTAssertEqual(ancestors.first?.path, "/dev/look/apps")
+    }
+
+    func testAncestorsEncodeAsTheCoreReadsThem() throws {
+        var stack = SourceLevelStack()
+        stack.push(frame(block: "Scripts", parent: "animate", path: "/dev/animate"))
+
+        let json = stack.ancestorsOfCurrentRows.ancestorsJSON
+        let decoded = try JSONSerialization.jsonObject(with: Data(json.utf8))
+        let ancestors = try XCTUnwrap(decoded as? [[String: String]])
+        XCTAssertEqual(ancestors.count, 1)
+        XCTAssertEqual(ancestors.first?["path"], "/dev/animate")
+    }
+
+    func testNoLevelsMeansAnEmptyPayloadRatherThanAnEmptyString() {
+        // The core parses this as JSON, so "no ancestors" has to be a list.
+        XCTAssertEqual([SourceLevelParent]().ancestorsJSON, "[]")
+    }
+
+    // ── Escape restores rather than re-searching ────────────────────────
+
+    func testPoppingHandsBackWhatTheLevelWasOpenedFrom() {
+        var stack = SourceLevelStack()
+        stack.push(frame(block: "Branches", parent: "look", query: "loo", selection: "src:projects:look"))
+
+        let left = stack.pop()
+        XCTAssertEqual(left?.restoredQuery, "loo")
+        XCTAssertEqual(left?.restoredSelectionID, "src:projects:look")
+        XCTAssertFalse(stack.isActive)
+        XCTAssertNil(stack.pop())
+    }
+}

--- a/apps/macos/LauncherApp/LauncherLogicTests/SourceLevelStackTests.swift
+++ b/apps/macos/LauncherApp/LauncherLogicTests/SourceLevelStackTests.swift
@@ -1,9 +1,8 @@
 import XCTest
 @testable import LauncherLogic
 
-/// The drill-down stack (`specs/user-sources.md` §2.10). Pure navigation state,
-/// so it is testable without a launcher: what the query bar says, what the core
-/// is told about ancestors, and what Escape puts back.
+/// The drill-down stack: what the query bar says, what the core is told about
+/// ancestors, and what Escape puts back.
 final class SourceLevelStackTests: XCTestCase {
     private func row(_ id: String) -> SourceLevelRow {
         SourceLevelRow(candidateId: "src:child:\(id)", id: id, title: id, subtitle: "", path: nil)

--- a/apps/macos/LauncherApp/Package.swift
+++ b/apps/macos/LauncherApp/Package.swift
@@ -38,6 +38,8 @@ let package = Package(
                 "Support/Actions/MentionAttachments.swift",
                 "Support/SingleInstanceLock.swift",
                 "Models/LauncherResult.swift",
+                "Models/SourceLevel.swift",
+                "Support/Launcher/SourceLevelStack.swift",
             ]
         ),
         .testTarget(

--- a/apps/macos/LauncherApp/look-app/Models/LauncherResult.swift
+++ b/apps/macos/LauncherApp/look-app/Models/LauncherResult.swift
@@ -52,9 +52,8 @@ struct LauncherResult: Identifiable {
 }
 
 extension LauncherResult {
-    /// A row a user-declared block produced (`specs/user-sources.md`). One
-    /// definition: the prefix was spelled out in three views, which is how a
-    /// namespace check drifts.
+    /// A row a user-declared block produced. One definition: the prefix was
+    /// spelled out in three views, which is how a namespace check drifts.
     var isSourceRow: Bool {
         id.hasPrefix(AppConstants.Launcher.SourceBlock.idPrefix)
     }

--- a/apps/macos/LauncherApp/look-app/Models/LauncherResult.swift
+++ b/apps/macos/LauncherApp/look-app/Models/LauncherResult.swift
@@ -50,3 +50,12 @@ struct LauncherResult: Identifiable {
     var linkKindLabel: String? = nil
     var linkDetail: String? = nil
 }
+
+extension LauncherResult {
+    /// A row a user-declared block produced (`specs/user-sources.md`). One
+    /// definition: the prefix was spelled out in three views, which is how a
+    /// namespace check drifts.
+    var isSourceRow: Bool {
+        id.hasPrefix(AppConstants.Launcher.SourceBlock.idPrefix)
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Models/SourceLevel.swift
+++ b/apps/macos/LauncherApp/look-app/Models/SourceLevel.swift
@@ -25,3 +25,30 @@ nonisolated struct SourceLevelRow: Decodable, Identifiable {
     let subtitle: String
     let path: String?
 }
+
+/// The row a tool action acts on. One value because the four always travel
+/// together, and because a block's `edit` / `terminal` / `reveal` expands
+/// against the row exactly like its `open` does (`specs/preferred-tools.md` §6).
+nonisolated struct ToolActionRow {
+    let candidateID: String
+    let title: String
+    let path: String
+    /// The levels it was reached through, for `{parent.*}`. Empty outside a
+    /// drill-down.
+    var ancestorsJSON: String = "[]"
+
+    func withCStrings<T>(
+        _ body: (UnsafePointer<CChar>?, UnsafePointer<CChar>?, UnsafePointer<CChar>?,
+            UnsafePointer<CChar>?) -> T
+    ) -> T {
+        candidateID.withCString { candidate in
+            title.withCString { title in
+                path.withCString { path in
+                    ancestorsJSON.withCString { ancestors in
+                        body(candidate, title, path, ancestors)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Models/SourceLevel.swift
+++ b/apps/macos/LauncherApp/look-app/Models/SourceLevel.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// One level of a drill-down: the rows a block produced against the row it was
+/// opened from (`specs/user-sources.md` §2.10).
+nonisolated struct SourceLevel: Decodable {
+    /// The parent row's own id, decoded by the core so the shell never has to
+    /// take a candidate id apart itself.
+    let parentRowId: String
+    let rows: [SourceLevelRow]
+    /// The row cap dropped rows, so the list is not all there is.
+    let truncated: Bool
+    /// Why the level could not be produced. Non-nil means do not descend.
+    let error: String?
+}
+
+/// A row inside a level. `candidateId` already encodes the levels it was reached
+/// through, so usage ranks per ancestor path and two parents never share a row's
+/// history.
+nonisolated struct SourceLevelRow: Decodable, Identifiable {
+    let candidateId: String
+    let id: String
+    let title: String
+    /// Already resolved against the block name by the core, so a level row and
+    /// an indexed one read the same.
+    let subtitle: String
+    let path: String?
+}

--- a/apps/macos/LauncherApp/look-app/Models/SourceLevel.swift
+++ b/apps/macos/LauncherApp/look-app/Models/SourceLevel.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// One level of a drill-down: the rows a block produced against the row it was
-/// opened from (`specs/user-sources.md` §2.10).
+/// opened from.
 nonisolated struct SourceLevel: Decodable {
     /// The parent row's own id, decoded by the core so the shell never has to
     /// take a candidate id apart itself.
@@ -13,28 +13,25 @@ nonisolated struct SourceLevel: Decodable {
     let error: String?
 }
 
-/// A row inside a level. `candidateId` already encodes the levels it was reached
-/// through, so usage ranks per ancestor path and two parents never share a row's
-/// history.
+/// A row inside a level. `candidateId` encodes the levels it came through, so
+/// two parents never share a row.
 nonisolated struct SourceLevelRow: Decodable, Identifiable {
     let candidateId: String
     let id: String
     let title: String
-    /// Already resolved against the block name by the core, so a level row and
-    /// an indexed one read the same.
+    /// Resolved against the block name by the core.
     let subtitle: String
     let path: String?
 }
 
-/// The row a tool action acts on. One value because the four always travel
-/// together, and because a block's `edit` / `terminal` / `reveal` expands
-/// against the row exactly like its `open` does (`specs/preferred-tools.md` §6).
+/// The row a tool action acts on: one value because the four always travel
+/// together, and a block's `edit` / `terminal` / `reveal` expands against the
+/// row exactly like its `open` does.
 nonisolated struct ToolActionRow {
     let candidateID: String
     let title: String
     let path: String
-    /// The levels it was reached through, for `{parent.*}`. Empty outside a
-    /// drill-down.
+    /// The levels it came through, for `{parent.*}`. Empty outside a level.
     var ancestorsJSON: String = "[]"
 
     func withCStrings<T>(

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
@@ -230,19 +230,23 @@ private func look_refresh_run_blocks_json() -> UnsafeMutablePointer<CChar>?
 
 @_silgen_name("look_source_preview_json")
 nonisolated
-private func look_source_preview_json(_ candidateID: UnsafePointer<CChar>?, _ rowID: UnsafePointer<CChar>?, _ rowTitle: UnsafePointer<CChar>?, _ rowPath: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
+private func look_source_preview_json(_ candidateID: UnsafePointer<CChar>?, _ rowID: UnsafePointer<CChar>?, _ rowTitle: UnsafePointer<CChar>?, _ rowPath: UnsafePointer<CChar>?, _ ancestorsJSON: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
 
 @_silgen_name("look_source_blocks_json")
 nonisolated
 private func look_source_blocks_json() -> UnsafeMutablePointer<CChar>?
 
+@_silgen_name("look_source_rows_json")
+nonisolated
+private func look_source_rows_json(_ blockID: UnsafePointer<CChar>?, _ parentCandidateID: UnsafePointer<CChar>?, _ parentTitle: UnsafePointer<CChar>?, _ parentPath: UnsafePointer<CChar>?, _ query: UnsafePointer<CChar>?, _ ancestorsJSON: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
+
 @_silgen_name("look_source_block_json")
 nonisolated
-private func look_source_block_json(_ candidateID: UnsafePointer<CChar>?, _ rowID: UnsafePointer<CChar>?, _ rowTitle: UnsafePointer<CChar>?, _ rowPath: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
+private func look_source_block_json(_ candidateID: UnsafePointer<CChar>?, _ rowID: UnsafePointer<CChar>?, _ rowTitle: UnsafePointer<CChar>?, _ rowPath: UnsafePointer<CChar>?, _ ancestorsJSON: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
 
 @_silgen_name("look_perform_block_json")
 nonisolated
-private func look_perform_block_json(_ blockID: UnsafePointer<CChar>?, _ rowID: UnsafePointer<CChar>?, _ rowTitle: UnsafePointer<CChar>?, _ rowPath: UnsafePointer<CChar>?, _ query: UnsafePointer<CChar>?, _ asTarget: Bool) -> UnsafeMutablePointer<CChar>?
+private func look_perform_block_json(_ blockID: UnsafePointer<CChar>?, _ rowID: UnsafePointer<CChar>?, _ rowTitle: UnsafePointer<CChar>?, _ rowPath: UnsafePointer<CChar>?, _ query: UnsafePointer<CChar>?, _ ancestorsJSON: UnsafePointer<CChar>?, _ asTarget: Bool) -> UnsafeMutablePointer<CChar>?
 
 @_silgen_name("look_tool_action_json")
 nonisolated
@@ -1016,13 +1020,16 @@ final class EngineBridge: @unchecked Sendable {
     /// The user-declared block a row belongs to, with the exact steps Enter will
     /// perform. Reads the sources directory, so call it off the main thread.
     nonisolated func sourceBlock(
-        candidateID: String, rowID: String = "", rowTitle: String = "", rowPath: String = ""
+        candidateID: String, rowID: String = "", rowTitle: String = "", rowPath: String = "",
+        ancestorsJSON: String = "[]"
     ) -> SourceBlock? {
         let ptr = candidateID.withCString { candidate in
             rowID.withCString { id in
                 rowTitle.withCString { title in
                     rowPath.withCString { path in
-                        look_source_block_json(candidate, id, title, path)
+                        ancestorsJSON.withCString { ancestors in
+                            look_source_block_json(candidate, id, title, path, ancestors)
+                        }
                     }
                 }
             }
@@ -1031,6 +1038,35 @@ final class EngineBridge: @unchecked Sendable {
         defer { look_free_cstring(ptr) }
         guard let data = String(cString: ptr).data(using: .utf8) else { return nil }
         return try? JSONDecoder().decode(SourceBlock.self, from: data)
+    }
+
+    /// The rows of `blockID`, produced against the row a level is being opened
+    /// from. Runs the block's command, so call it off the main thread.
+    ///
+    /// `error` non-nil means do not descend: an empty level and a broken command
+    /// look the same on screen, so neither is entered silently.
+    nonisolated func sourceRows(
+        blockID: String, parentCandidateID: String, parentTitle: String, parentPath: String,
+        query: String, ancestorsJSON: String = "[]"
+    ) -> SourceLevel? {
+        let ptr = blockID.withCString { block in
+            parentCandidateID.withCString { parent in
+                parentTitle.withCString { title in
+                    parentPath.withCString { path in
+                        query.withCString { query in
+                            ancestorsJSON.withCString { ancestors in
+                                look_source_rows_json(
+                                    block, parent, title, path, query, ancestors)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        guard let ptr else { return nil }
+        defer { look_free_cstring(ptr) }
+        guard let data = String(cString: ptr).data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(SourceLevel.self, from: data)
     }
 
     /// What `action` would do to a row, without doing it: the tool it would
@@ -1081,13 +1117,16 @@ final class EngineBridge: @unchecked Sendable {
     /// A block's declared `preview`, run against the selected row. Nil when the
     /// block declares none. Runs a command - call off the main thread.
     nonisolated func sourcePreview(
-        candidateID: String, rowID: String, rowTitle: String, rowPath: String
+        candidateID: String, rowID: String, rowTitle: String, rowPath: String,
+        ancestorsJSON: String = "[]"
     ) -> SourcePreview? {
         let ptr = candidateID.withCString { candidate in
             rowID.withCString { id in
                 rowTitle.withCString { title in
                     rowPath.withCString { path in
-                        look_source_preview_json(candidate, id, title, path)
+                        ancestorsJSON.withCString { ancestors in
+                            look_source_preview_json(candidate, id, title, path, ancestors)
+                        }
                     }
                 }
             }
@@ -1118,6 +1157,7 @@ final class EngineBridge: @unchecked Sendable {
         rowTitle: String = "",
         rowPath: String = "",
         query: String = "",
+        ancestorsJSON: String = "[]",
         asTarget: Bool = false
     ) -> PerformBlockOutcome {
         let ptr = blockID.withCString { block in
@@ -1125,7 +1165,10 @@ final class EngineBridge: @unchecked Sendable {
                 rowTitle.withCString { title in
                     rowPath.withCString { path in
                         query.withCString { query in
-                            look_perform_block_json(block, id, title, path, query, asTarget)
+                            ancestorsJSON.withCString { ancestors in
+                                look_perform_block_json(
+                                    block, id, title, path, query, ancestors, asTarget)
+                            }
                         }
                     }
                 }
@@ -1389,6 +1432,31 @@ nonisolated struct SourceBlockTarget: Decodable, Identifiable {
     let performs: Bool
     /// Already expanded against the row, so it names what will actually happen.
     let confirm: String?
+}
+
+/// One level of a drill-down: the rows a block produced against the row it was
+/// opened from (`specs/user-sources.md` §2.10).
+nonisolated struct SourceLevel: Decodable {
+    /// The parent row's own id, decoded by the core so the shell never has to
+    /// take a candidate id apart itself.
+    let parentRowId: String
+    let rows: [SourceLevelRow]
+    /// The row cap dropped rows, so the list is not all there is.
+    let truncated: Bool
+    /// Why the level could not be produced. Non-nil means do not descend.
+    let error: String?
+}
+
+/// A row inside a level. `candidateId` already encodes the levels it was reached
+/// through, so usage ranks per ancestor path and two parents never share a row's
+/// history.
+nonisolated struct SourceLevelRow: Decodable, Identifiable {
+    let candidateId: String
+    let id: String
+    let title: String
+    let subtitle: String?
+    let group: String?
+    let path: String?
 }
 
 /// A declared block as the row layer needs it: what to call it and what icon it

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
@@ -1040,11 +1040,9 @@ final class EngineBridge: @unchecked Sendable {
         return try? JSONDecoder().decode(SourceBlock.self, from: data)
     }
 
-    /// The rows of `blockID`, produced against the row a level is being opened
-    /// from. Runs the block's command, so call it off the main thread.
-    ///
-    /// `error` non-nil means do not descend: an empty level and a broken command
-    /// look the same on screen, so neither is entered silently.
+    /// The rows of `blockID`, produced against the row a level is opening from.
+    /// Runs the block's command, so call it off the main thread. `error`
+    /// non-nil means do not descend.
     nonisolated func sourceRows(
         blockID: String, parentCandidateID: String, parentTitle: String, parentPath: String,
         query: String, ancestorsJSON: String = "[]"
@@ -1392,7 +1390,7 @@ nonisolated struct URLMatch: Decodable {
 /// A user-declared block and the steps performing it will run, so the panel can
 /// show exactly what Enter is about to do.
 /// One preferred-tool action resolved against a row. `kind` says which of the
-/// other fields are filled; see `specs/preferred-tools.md`.
+/// other fields are filled.
 nonisolated struct ToolAction: Decodable {
     enum Kind: String, Decodable {
         /// Composed shell text. Only `look_tool_action_json` returns this;
@@ -1417,8 +1415,8 @@ nonisolated struct ToolAction: Decodable {
     let reason: String?
     /// The config key that would fix an `unavailable` action.
     let key: String?
-    /// A block declared this action for its own rows, so `tool` names the block
-    /// rather than a tool: "Open in Projects" is not a label worth showing.
+    /// A block declared this action for its own rows, so `tool` names the
+    /// block: "Open in Projects" is not a label worth showing.
     let fromBlock: Bool
 }
 

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
@@ -250,11 +250,11 @@ private func look_perform_block_json(_ blockID: UnsafePointer<CChar>?, _ rowID: 
 
 @_silgen_name("look_tool_action_json")
 nonisolated
-private func look_tool_action_json(_ action: UnsafePointer<CChar>?, _ path: UnsafePointer<CChar>?, _ isDir: Bool) -> UnsafeMutablePointer<CChar>?
+private func look_tool_action_json(_ action: UnsafePointer<CChar>?, _ candidateID: UnsafePointer<CChar>?, _ rowTitle: UnsafePointer<CChar>?, _ path: UnsafePointer<CChar>?, _ isDir: Bool, _ ancestorsJSON: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
 
 @_silgen_name("look_perform_tool_action_json")
 nonisolated
-private func look_perform_tool_action_json(_ action: UnsafePointer<CChar>?, _ path: UnsafePointer<CChar>?, _ isDir: Bool) -> UnsafeMutablePointer<CChar>?
+private func look_perform_tool_action_json(_ action: UnsafePointer<CChar>?, _ candidateID: UnsafePointer<CChar>?, _ rowTitle: UnsafePointer<CChar>?, _ path: UnsafePointer<CChar>?, _ isDir: Bool, _ ancestorsJSON: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
 
 @_silgen_name("look_netspeed_run_json")
 nonisolated
@@ -1071,10 +1071,12 @@ final class EngineBridge: @unchecked Sendable {
 
     /// What `action` would do to a row, without doing it: the tool it would
     /// start, or why it cannot. For labels and availability.
-    nonisolated func toolAction(_ action: String, path: String, isDirectory: Bool) -> ToolAction? {
-        let ptr = action.withCString { action in
-            path.withCString { path in
-                look_tool_action_json(action, path, isDirectory)
+    nonisolated func toolAction(
+        _ action: String, row: ToolActionRow, isDirectory: Bool
+    ) -> ToolAction? {
+        let ptr = row.withCStrings { candidate, title, path, ancestors in
+            action.withCString { action in
+                look_tool_action_json(action, candidate, title, path, isDirectory, ancestors)
             }
         }
         return Self.decodeToolAction(ptr)
@@ -1083,10 +1085,12 @@ final class EngineBridge: @unchecked Sendable {
     /// Runs `action` on a row. Shell actions are spawned detached inside core;
     /// an `application` result is handed back for `NSWorkspace` to launch.
     /// Spawns a process, so call it off the main thread.
-    nonisolated func performToolAction(_ action: String, path: String, isDirectory: Bool) -> ToolAction? {
-        let ptr = action.withCString { action in
-            path.withCString { path in
-                look_perform_tool_action_json(action, path, isDirectory)
+    nonisolated func performToolAction(
+        _ action: String, row: ToolActionRow, isDirectory: Bool
+    ) -> ToolAction? {
+        let ptr = row.withCStrings { candidate, title, path, ancestors in
+            action.withCString { action in
+                look_perform_tool_action_json(action, candidate, title, path, isDirectory, ancestors)
             }
         }
         return Self.decodeToolAction(ptr)
@@ -1413,6 +1417,9 @@ nonisolated struct ToolAction: Decodable {
     let reason: String?
     /// The config key that would fix an `unavailable` action.
     let key: String?
+    /// A block declared this action for its own rows, so `tool` names the block
+    /// rather than a tool: "Open in Projects" is not a label worth showing.
+    let fromBlock: Bool
 }
 
 nonisolated struct SourceBlock: Decodable {

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
@@ -1179,7 +1179,8 @@ final class EngineBridge: @unchecked Sendable {
         // caller keys on that, so the two must not share a value.
         guard let ptr else {
             return PerformBlockOutcome(
-                performed: 0, errors: ["the core did not answer"], producesRows: false)
+                performed: 0, errors: ["the core did not answer"], producesRows: false,
+                opensPath: false)
         }
         defer { look_free_cstring(ptr) }
         // The core sends snake_case, so `produces_rows` only reaches
@@ -1190,7 +1191,8 @@ final class EngineBridge: @unchecked Sendable {
               let outcome = try? decoder.decode(PerformBlockOutcome.self, from: data)
         else {
             return PerformBlockOutcome(
-                performed: 0, errors: ["the core's answer could not be read"], producesRows: false)
+                performed: 0, errors: ["the core's answer could not be read"],
+                producesRows: false, opensPath: false)
         }
         return outcome
     }
@@ -1434,31 +1436,6 @@ nonisolated struct SourceBlockTarget: Decodable, Identifiable {
     let confirm: String?
 }
 
-/// One level of a drill-down: the rows a block produced against the row it was
-/// opened from (`specs/user-sources.md` §2.10).
-nonisolated struct SourceLevel: Decodable {
-    /// The parent row's own id, decoded by the core so the shell never has to
-    /// take a candidate id apart itself.
-    let parentRowId: String
-    let rows: [SourceLevelRow]
-    /// The row cap dropped rows, so the list is not all there is.
-    let truncated: Bool
-    /// Why the level could not be produced. Non-nil means do not descend.
-    let error: String?
-}
-
-/// A row inside a level. `candidateId` already encodes the levels it was reached
-/// through, so usage ranks per ancestor path and two parents never share a row's
-/// history.
-nonisolated struct SourceLevelRow: Decodable, Identifiable {
-    let candidateId: String
-    let id: String
-    let title: String
-    let subtitle: String?
-    let group: String?
-    let path: String?
-}
-
 /// A declared block as the row layer needs it: what to call it and what icon it
 /// asked for. Cached per launcher open so rendering a row never touches disk.
 nonisolated struct SourceBlockSummary: Decodable {
@@ -1487,6 +1464,9 @@ nonisolated struct PerformBlockOutcome: Decodable {
     /// The target lists rows to pick from rather than steps to run. An explicit
     /// flag, because "nothing performed" is also what a failure looks like.
     let producesRows: Bool
+    /// Nothing declared and the row has a path, so it opens like any file. The
+    /// core decides this, not the row's kind.
+    let opensPath: Bool
 }
 
 /// Wire shape of a `url_history` row (see url-history spec), decoded with

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
@@ -58,6 +58,8 @@ final class KeyboardSelectionMonitor {
         onSelectCommandByIndex: @escaping @MainActor (Int) -> Void,
         onActivateRunningApp: @escaping @MainActor (Int) -> Bool = { _ in false },
         onActivateSession: @escaping @MainActor (Int) -> Bool = { _ in false },
+        /// Escape inside a drill-down goes back one level. True means it did.
+        onPopLevel: (@MainActor () -> Bool)? = nil,
         onEscapeHome: (@MainActor () -> Bool)? = nil,
         onConfirmKill: (@MainActor () -> Void)? = nil,
         onCancelKill: (@MainActor () -> Void)? = nil,
@@ -443,6 +445,13 @@ final class KeyboardSelectionMonitor {
 
                 if actionConfirmationActive() {
                     onCancelAction?()
+                    return nil
+                }
+
+                // Inside a drill-down, Escape goes back one level rather than
+                // closing the launcher: the way out of a list is the way you
+                // came into it.
+                if onPopLevel?() == true {
                     return nil
                 }
 

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/SourceLevelStack.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/SourceLevelStack.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// The drill-down stack: the levels a user has descended into from a block row
+/// (`specs/user-sources.md` §2.10).
+///
+/// One value type rather than another handful of `@State` booleans on
+/// `LauncherView`. A level stack IS navigation state, and the mode flags beside
+/// it (`isCommandMode`, `isAIMode`, `isActionMenuOpen`) grew into a pile exactly
+/// by being added one at a time.
+struct SourceLevelStack {
+    private(set) var frames: [SourceLevelFrame] = []
+
+    var isActive: Bool { !frames.isEmpty }
+    var current: SourceLevelFrame? { frames.last }
+    var depth: Int { frames.count }
+
+    /// What the query bar shows: the rows walked through, then WHAT is being
+    /// listed. "look › Changed files", not "look", because the row you came
+    /// from does not say which of its targets you picked.
+    var breadcrumb: [String] {
+        guard let current else { return [] }
+        return frames.map(\.parentTitle) + [current.blockName]
+    }
+
+    /// The ancestors of the rows IN the current level, nearest first, as the
+    /// core expects them for `{parent.*}`.
+    var ancestorsOfCurrentRows: [SourceLevelParent] {
+        frames.reversed().map {
+            SourceLevelParent(id: $0.parentRowID, title: $0.parentTitle, path: $0.parentPath)
+        }
+    }
+
+    /// The ancestors of the row a level was OPENED from, which is one step out
+    /// of the above: descending again passes these plus that row.
+    var ancestorsOfCurrentParent: [SourceLevelParent] {
+        Array(ancestorsOfCurrentRows.dropFirst())
+    }
+
+    mutating func push(_ frame: SourceLevelFrame) {
+        frames.append(frame)
+    }
+
+    /// Pops one level and hands back what the launcher was showing before it,
+    /// so Escape restores rather than re-searches.
+    mutating func pop() -> SourceLevelFrame? {
+        frames.popLast()
+    }
+
+    mutating func clear() {
+        frames.removeAll()
+    }
+}
+
+/// One level: the block that produced it, the row it was opened from, and what
+/// to put back on Escape.
+struct SourceLevelFrame {
+    let blockID: String
+    let blockName: String
+    /// The row's OWN id, which is what `{parent.id}` expands to, not its
+    /// namespaced candidate id.
+    let parentRowID: String
+    let parentCandidateID: String
+    let parentTitle: String
+    let parentPath: String
+    let rows: [SourceLevelRow]
+    let truncated: Bool
+    /// The query and selection the level was opened from, restored on Escape.
+    let restoredQuery: String
+    let restoredSelectionID: String?
+}
+
+/// An ancestor as the core reads it (`ParentRow`). `nonisolated`, like the
+/// bridge's own payloads: encoding one is pure work that any context may do.
+nonisolated struct SourceLevelParent: Encodable {
+    let id: String
+    let title: String
+    let path: String
+}
+
+nonisolated extension Array where Element == SourceLevelParent {
+    /// The payload every source call takes. An empty array rather than an empty
+    /// string, so the core never has to guess what "no ancestors" looked like.
+    var ancestorsJSON: String {
+        guard let data = try? JSONEncoder().encode(self),
+            let json = String(data: data, encoding: .utf8)
+        else { return "[]" }
+        return json
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/SourceLevelStack.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/SourceLevelStack.swift
@@ -12,7 +12,6 @@ struct SourceLevelStack {
 
     var isActive: Bool { !frames.isEmpty }
     var current: SourceLevelFrame? { frames.last }
-    var depth: Int { frames.count }
 
     /// What the query bar shows: the rows walked through, then WHAT is being
     /// listed. "look › Changed files", not "look", because the row you came
@@ -28,12 +27,6 @@ struct SourceLevelStack {
         frames.reversed().map {
             SourceLevelParent(id: $0.parentRowID, title: $0.parentTitle, path: $0.parentPath)
         }
-    }
-
-    /// The ancestors of the row a level was OPENED from, which is one step out
-    /// of the above: descending again passes these plus that row.
-    var ancestorsOfCurrentParent: [SourceLevelParent] {
-        Array(ancestorsOfCurrentRows.dropFirst())
     }
 
     mutating func push(_ frame: SourceLevelFrame) {
@@ -54,16 +47,13 @@ struct SourceLevelStack {
 /// One level: the block that produced it, the row it was opened from, and what
 /// to put back on Escape.
 struct SourceLevelFrame {
-    let blockID: String
     let blockName: String
     /// The row's OWN id, which is what `{parent.id}` expands to, not its
     /// namespaced candidate id.
     let parentRowID: String
-    let parentCandidateID: String
     let parentTitle: String
     let parentPath: String
     let rows: [SourceLevelRow]
-    let truncated: Bool
     /// The query and selection the level was opened from, restored on Escape.
     let restoredQuery: String
     let restoredSelectionID: String?

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/SourceLevelStack.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/SourceLevelStack.swift
@@ -1,28 +1,24 @@
 import Foundation
 
-/// The drill-down stack: the levels a user has descended into from a block row
-/// (`specs/user-sources.md` §2.10).
+/// The levels a user has descended into from a block row.
 ///
-/// One value type rather than another handful of `@State` booleans on
-/// `LauncherView`. A level stack IS navigation state, and the mode flags beside
-/// it (`isCommandMode`, `isAIMode`, `isActionMenuOpen`) grew into a pile exactly
-/// by being added one at a time.
+/// One value type rather than another handful of `@State` booleans: a level
+/// stack IS navigation state, and the mode flags beside it grew into a pile by
+/// being added one at a time.
 struct SourceLevelStack {
     private(set) var frames: [SourceLevelFrame] = []
 
     var isActive: Bool { !frames.isEmpty }
     var current: SourceLevelFrame? { frames.last }
 
-    /// What the query bar shows: the rows walked through, then WHAT is being
-    /// listed. "look › Changed files", not "look", because the row you came
-    /// from does not say which of its targets you picked.
+    /// "look › Changed files", not "look": the row you came from does not say
+    /// which of its targets you picked.
     var breadcrumb: [String] {
         guard let current else { return [] }
         return frames.map(\.parentTitle) + [current.blockName]
     }
 
-    /// The ancestors of the rows IN the current level, nearest first, as the
-    /// core expects them for `{parent.*}`.
+    /// Ancestors of the rows IN this level, nearest first, for `{parent.*}`.
     var ancestorsOfCurrentRows: [SourceLevelParent] {
         frames.reversed().map {
             SourceLevelParent(id: $0.parentRowID, title: $0.parentTitle, path: $0.parentPath)
@@ -33,8 +29,8 @@ struct SourceLevelStack {
         frames.append(frame)
     }
 
-    /// Pops one level and hands back what the launcher was showing before it,
-    /// so Escape restores rather than re-searches.
+    /// Hands back what the launcher was showing before it, so Escape restores
+    /// rather than re-searches.
     mutating func pop() -> SourceLevelFrame? {
         frames.popLast()
     }
@@ -44,12 +40,11 @@ struct SourceLevelStack {
     }
 }
 
-/// One level: the block that produced it, the row it was opened from, and what
-/// to put back on Escape.
+/// The block that produced a level, the row it opened from, and what Escape
+/// puts back.
 struct SourceLevelFrame {
     let blockName: String
-    /// The row's OWN id, which is what `{parent.id}` expands to, not its
-    /// namespaced candidate id.
+    /// The row's OWN id, what `{parent.id}` expands to.
     let parentRowID: String
     let parentTitle: String
     let parentPath: String
@@ -59,8 +54,8 @@ struct SourceLevelFrame {
     let restoredSelectionID: String?
 }
 
-/// An ancestor as the core reads it (`ParentRow`). `nonisolated`, like the
-/// bridge's own payloads: encoding one is pure work that any context may do.
+/// An ancestor as the core reads it. `nonisolated` like the bridge's other
+/// payloads: encoding one is pure work any context may do.
 nonisolated struct SourceLevelParent: Encodable {
     let id: String
     let title: String
@@ -68,8 +63,7 @@ nonisolated struct SourceLevelParent: Encodable {
 }
 
 nonisolated extension Array where Element == SourceLevelParent {
-    /// The payload every source call takes. An empty array rather than an empty
-    /// string, so the core never has to guess what "no ancestors" looked like.
+    /// An empty array rather than an empty string: the core parses it as JSON.
     var ancestorsJSON: String {
         guard let data = try? JSONEncoder().encode(self),
             let json = String(data: data, encoding: .utf8)

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/SourceLevelStack.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/SourceLevelStack.swift
@@ -7,6 +7,9 @@ import Foundation
 /// being added one at a time.
 struct SourceLevelStack {
     private(set) var frames: [SourceLevelFrame] = []
+    /// Bumped by every request and every change, so a target still running
+    /// after the launcher is hidden, or after another starts, answers stale.
+    private(set) var epoch: UInt64 = 0
 
     var isActive: Bool { !frames.isEmpty }
     var current: SourceLevelFrame? { frames.last }
@@ -25,17 +28,27 @@ struct SourceLevelStack {
         }
     }
 
+    /// The epoch a request must still hold when it answers.
+    mutating func beginRequest() -> UInt64 {
+        epoch &+= 1
+        return epoch
+    }
+
     mutating func push(_ frame: SourceLevelFrame) {
         frames.append(frame)
+        epoch &+= 1
     }
 
     /// Hands back what the launcher was showing before it, so Escape restores
     /// rather than re-searches.
     mutating func pop() -> SourceLevelFrame? {
-        frames.popLast()
+        epoch &+= 1
+        return frames.popLast()
     }
 
     mutating func clear() {
+        // Bumped even with no frames: a first-level request is in flight then.
+        epoch &+= 1
         frames.removeAll()
     }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/AICodeBlockView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/AICodeBlockView.swift
@@ -8,6 +8,11 @@ struct AICodeBlockView: View {
     let code: String
     let language: String?
     let themeStore: ThemeStore
+    /// When set, the block never wraps: it is at most this many lines tall and
+    /// scrolls in both directions instead, so one long command cannot push the
+    /// rest of a panel off the screen. An AI answer leaves it nil and wraps like
+    /// the prose around it.
+    var maxVisibleLines: Int? = nil
 
 
     /// Fence tags that don't match the extensions `SyntaxHighlighter` keys on.
@@ -24,13 +29,50 @@ struct AICodeBlockView: View {
         return AttributedString(SyntaxHighlighter.highlight(code, path: "snippet.\(ext)"))
     }
 
+    private var codeText: some View {
+        Text(highlighted)
+            .font(.system(size: CGFloat(themeStore.settings.fontSize - 2), design: .monospaced))
+            .foregroundStyle(themeStore.fontColor())
+            .textSelection(.enabled)
+    }
+
+    /// One line of the block's own font, measured rather than guessed: the size
+    /// follows the user's font-size setting.
+    private var lineHeight: CGFloat {
+        let font = NSFont.monospacedSystemFont(
+            ofSize: CGFloat(themeStore.settings.fontSize - 2), weight: .regular)
+        return ceil(font.ascender - font.descender + font.leading)
+    }
+
+    /// As tall as the code needs, capped. Sized to the content rather than
+    /// pinned to the cap, so a one-line command does not sit in a two-line box.
+    private var scrollHeight: CGFloat {
+        let lines = max(1, code.split(separator: "\n", omittingEmptySubsequences: false).count)
+        return lineHeight * CGFloat(min(lines, maxVisibleLines ?? lines))
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if maxVisibleLines != nil {
+            ScrollView([.horizontal, .vertical]) {
+                // Never wrapped: a long command reads better scrolled than
+                // folded into six lines, and the panel keeps its shape.
+                codeText.fixedSize()
+            }
+            // No bars: they would sit on top of the code in a box this small,
+            // and the content already looks scrollable when it is cut off.
+            .scrollIndicators(.hidden)
+            .frame(height: scrollHeight)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            codeText
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
     var body: some View {
         ZStack(alignment: .topTrailing) {
-            Text(highlighted)
-                .font(.system(size: CGFloat(themeStore.settings.fontSize - 2), design: .monospaced))
-                .foregroundStyle(themeStore.fontColor())
-                .textSelection(.enabled)
-                .frame(maxWidth: .infinity, alignment: .leading)
+            content
                 .padding(8)
                 .padding(.trailing, 22)  // room for the copy button
                 // Scaled with the panel material: a flat darkening plate at full

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
@@ -165,8 +165,15 @@ struct LauncherRowView: View {
             return kindLabel
         }
         if result.kind == .action {
-            // "Action • 3 steps": there is no path, and the step count says this
-            // will do several things before the user commits to it.
+            // A row that named a path is a real filesystem object, so it says
+            // where it is, like every other such row. Without one there is
+            // nothing to point at: "Action • 3 steps" says instead that pressing
+            // this will do several things.
+            if !result.path.isEmpty {
+                return [result.subtitle, pathInfo]
+                    .compactMap { $0 }
+                    .joined(separator: "  •  ")
+            }
             return [kindLabel, result.subtitle]
                 .compactMap { $0 }
                 .joined(separator: "  •  ")

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
@@ -32,6 +32,19 @@ struct LauncherRowView: View {
         SyntheticRow.classify(resultID: result.id)
     }
 
+    /// Whether the row IS the file it names, rather than something that merely
+    /// lives there. A `[changed]` row is `EngineBridge.swift` at that path; a
+    /// branch row is `main`, whose path is the repo every other branch shares,
+    /// and giving it that folder's icon says "folder" about a branch.
+    ///
+    /// The title matching the last path component is what tells them apart. A
+    /// block that knows better says so with its own `icon`, which still wins.
+    private var rowIsItsPath: Bool {
+        guard !result.path.isEmpty else { return false }
+        return (result.path as NSString).lastPathComponent
+            .caseInsensitiveCompare(result.title) == .orderedSame
+    }
+
     /// Cached: this runs inside `body`, and a fresh `NSImage` per redraw makes
     /// every icon in the list flicker. See `RowIconCache`.
     private var rowIcon: NSImage {
@@ -92,7 +105,7 @@ struct LauncherRowView: View {
             ) {
                 return declared
             }
-            if !result.path.isEmpty {
+            if rowIsItsPath {
                 return RowIconCache.icon(forFile: result.path)
             }
             return RowIconCache.image(key: "symbol:bolt") {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
@@ -32,11 +32,6 @@ struct LauncherRowView: View {
         SyntheticRow.classify(resultID: result.id)
     }
 
-    /// A row a user-declared block produced (`specs/user-sources.md`).
-    private var isSourceRow: Bool {
-        result.id.hasPrefix(AppConstants.Launcher.SourceBlock.idPrefix)
-    }
-
     /// Cached: this runs inside `body`, and a fresh `NSImage` per redraw makes
     /// every icon in the list flicker. See `RowIconCache`.
     private var rowIcon: NSImage {
@@ -86,14 +81,19 @@ struct LauncherRowView: View {
             }
         }
 
-        // A declared block has no file to take an icon from, and must not look
-        // like one: Enter performs steps rather than opening anything. What the
-        // block declared wins; the bolt is the fallback.
+        // What the block declared wins: the author chose it for these rows.
+        // Then the file, when the row names one - a row with a path IS that
+        // file (`format = "json"`), and a list of them should not be a column
+        // of identical bolts. The bolt is left for rows with nothing on disk,
+        // where it says the honest thing: Enter performs steps.
         if result.kind == .action {
             if let declared = SourceBlockIcons.declaredIcon(
                 SourceBlockCatalog.icon(forCandidateID: result.id)
             ) {
                 return declared
+            }
+            if !result.path.isEmpty {
+                return RowIconCache.icon(forFile: result.path)
             }
             return RowIconCache.image(key: "symbol:bolt") {
                 NSImage(systemSymbolName: "bolt.fill", accessibilityDescription: nil)
@@ -181,7 +181,7 @@ struct LauncherRowView: View {
         // A row a user's block produced says WHICH block, not "Folder". The kind
         // is already on the icon, and where the row came from is the thing the
         // list cannot otherwise tell you.
-        if isSourceRow, let block = result.subtitle {
+        if result.isSourceRow, let block = result.subtitle {
             return "\(block)  •  \(pathInfo)"
         }
         return "\(kindLabel)  •  \(pathInfo)"

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
@@ -15,8 +15,7 @@ struct SearchInputBar: View {
     var showsBackground: Bool = true
     /// Changes each time the launcher opens, replaying the spawn cascade.
     var revealToken: UInt64 = 0
-    /// Where a drill-down is: shown as a leading chip, because a list that has
-    /// replaced the index has to say what it is (`specs/user-sources.md` §2.10).
+    /// Where a drill-down is, shown as a leading chip.
     var breadcrumb: String?
     let onSubmit: () -> Void
     let onExitCommandMode: () -> Void

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
@@ -15,6 +15,9 @@ struct SearchInputBar: View {
     var showsBackground: Bool = true
     /// Changes each time the launcher opens, replaying the spawn cascade.
     var revealToken: UInt64 = 0
+    /// Where a drill-down is: shown as a leading chip, because a list that has
+    /// replaced the index has to say what it is (`specs/user-sources.md` §2.10).
+    var breadcrumb: String?
     let onSubmit: () -> Void
     let onExitCommandMode: () -> Void
 
@@ -29,6 +32,9 @@ struct SearchInputBar: View {
     private var showsBetaBadge: Bool { isAIMode && !isCommandMode }
 
     private var placeholderText: String {
+        if breadcrumb != nil {
+            return "Filter, or Esc to go back"
+        }
         if isCommandMode {
             return activeCommand?.placeholder ?? AppConstants.Launcher.commandModePlaceholder
         }
@@ -40,12 +46,29 @@ struct SearchInputBar: View {
 
     var body: some View {
         HStack(spacing: 8) {
-            Image(systemName: isCommandMode ? "terminal" : (isAIMode ? "sparkles" : "magnifyingglass"))
-                .foregroundStyle(
-                    isCommandMode || isAIMode
-                        ? themeStore.accentColor() : themeStore.secondaryTextColor())
-                .contentTransition(.symbolEffect(.replace))
-                .symbolEffect(.bounce, value: revealToken)
+            Image(
+                systemName: breadcrumb != nil
+                    ? "chevron.right"
+                    : (isCommandMode ? "terminal" : (isAIMode ? "sparkles" : "magnifyingglass"))
+            )
+            .foregroundStyle(
+                isCommandMode || isAIMode || breadcrumb != nil
+                    ? themeStore.accentColor() : themeStore.secondaryTextColor()
+            )
+            .contentTransition(.symbolEffect(.replace))
+            .symbolEffect(.bounce, value: revealToken)
+
+            if let breadcrumb {
+                Text(breadcrumb)
+                    .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1)))
+                    .foregroundStyle(themeStore.fontColor())
+                    .lineLimit(1)
+                    .truncationMode(.head)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background(themeStore.liftColor(opacity: 0.14), in: Capsule())
+                    .accessibilityLabel("Inside \(breadcrumb)")
+            }
             SmoothCaretTextField(
                 text: $text,
                 // Empty: the placeholder is drawn as the overlay below instead,

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Levels.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Levels.swift
@@ -25,7 +25,7 @@ extension LauncherView {
                     id: row.candidateId,
                     kind: .action,
                     title: row.title,
-                    subtitle: row.subtitle ?? row.group ?? level.blockName,
+                    subtitle: row.subtitle,
                     path: row.path ?? "",
                     // The producer's order, kept: a script list is written in an
                     // order its author chose, and nothing here knows better yet.
@@ -72,14 +72,11 @@ extension LauncherView {
 
                 levelStack.push(
                     SourceLevelFrame(
-                        blockID: blockID,
                         blockName: title,
                         parentRowID: level.parentRowId,
-                        parentCandidateID: parent.candidateID,
                         parentTitle: parent.title,
                         parentPath: parent.path,
                         rows: level.rows,
-                        truncated: level.truncated,
                         restoredQuery: openedFrom.query,
                         restoredSelectionID: openedFrom.selection
                     )
@@ -127,8 +124,6 @@ enum LevelFilter {
         let needle = query.lowercased()
         if row.title.lowercased().contains(needle) { return true }
         if row.id.lowercased().contains(needle) { return true }
-        if let subtitle = row.subtitle, subtitle.lowercased().contains(needle) { return true }
-        if let group = row.group, group.lowercased().contains(needle) { return true }
-        return false
+        return row.subtitle.lowercased().contains(needle)
     }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Levels.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Levels.swift
@@ -30,16 +30,18 @@ extension LauncherView {
             }
     }
 
-    /// Opens `blockID` as a level below the selected row.
-    func descendIntoBlock(blockID: String, title: String) {
-        guard let selected = actionableSelectedResult() else { return }
-
-        // On the main actor: the stack is main-actor state, a String is not.
-        let ancestorsJSON = levelStack.ancestorsOfCurrentRows.ancestorsJSON
-        let parent = (
-            candidateID: selected.id, title: selected.title, path: selected.path
-        )
-        let openedFrom = (query: query, selection: selectedResultID)
+    /// Opens `blockID` as a level below `parent`.
+    ///
+    /// The parent is passed in rather than read from the selection: the target
+    /// that led here already ran a detached call, and the user may have moved
+    /// on since it started.
+    func descendIntoBlock(
+        blockID: String, title: String, parent: LevelParentRow, ancestorsJSON: String
+    ) {
+        let openedFrom = (query: parent.openedFromQuery, selection: parent.openedFromSelection)
+        // A level opened after the stack was cleared is a level from a launcher
+        // the user has already closed.
+        let epoch = levelEpoch
 
         Task {
             let level = await Task.detached(priority: .userInitiated) {
@@ -54,6 +56,7 @@ extension LauncherView {
             }.value
 
             await MainActor.run {
+                guard epoch == levelEpoch else { return }
                 guard let level else {
                     showBanner("\(title): the core did not answer", style: .error, duration: 3.0)
                     return
@@ -93,12 +96,22 @@ extension LauncherView {
     @discardableResult
     func popLevel() -> Bool {
         guard let left = levelStack.pop() else { return false }
+        levelEpoch &+= 1
+        // Setting the query runs the change handler, which seeds the selection
+        // from the first row. The restore has to survive that, so it is left
+        // pending for whichever pass has the rows.
+        pendingSelectionRestore = left.restoredSelectionID.map {
+            PendingSelection(id: $0, query: left.restoredQuery)
+        }
         query = left.restoredQuery
         selectedResultID = left.restoredSelectionID
         return true
     }
 
     func clearLevels() {
+        guard levelStack.isActive || pendingSelectionRestore != nil else { return }
+        levelEpoch &+= 1
+        pendingSelectionRestore = nil
         levelStack.clear()
     }
 
@@ -106,6 +119,23 @@ extension LauncherView {
     var selectedRowAncestorsJSON: String {
         levelStack.ancestorsOfCurrentRows.ancestorsJSON
     }
+}
+
+/// The row a level is opened from, captured when the target was picked.
+struct LevelParentRow {
+    let candidateID: String
+    let title: String
+    let path: String
+    let openedFromQuery: String
+    let openedFromSelection: String?
+}
+
+/// A selection to put back once the rows it names are on screen.
+struct PendingSelection {
+    let id: String
+    /// What the query was when it was captured: typing anything else means the
+    /// user moved on and the restore is stale.
+    let query: String
 }
 
 /// Not the engine's scorer: these rows are a list the user is looking at, and

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Levels.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Levels.swift
@@ -30,18 +30,14 @@ extension LauncherView {
             }
     }
 
-    /// Opens `blockID` as a level below `parent`.
-    ///
-    /// The parent is passed in rather than read from the selection: the target
-    /// that led here already ran a detached call, and the user may have moved
-    /// on since it started.
+    /// Opens `blockID` as a level below `parent`, which is passed in rather
+    /// than read from the selection: the target that led here ran detached, and
+    /// the user may have moved on.
     func descendIntoBlock(
-        blockID: String, title: String, parent: LevelParentRow, ancestorsJSON: String
+        blockID: String, title: String, parent: LevelParentRow, ancestorsJSON: String,
+        epoch: UInt64
     ) {
         let openedFrom = (query: parent.openedFromQuery, selection: parent.openedFromSelection)
-        // A level opened after the stack was cleared is a level from a launcher
-        // the user has already closed.
-        let epoch = levelEpoch
 
         Task {
             let level = await Task.detached(priority: .userInitiated) {
@@ -56,7 +52,7 @@ extension LauncherView {
             }.value
 
             await MainActor.run {
-                guard epoch == levelEpoch else { return }
+                guard epoch == levelStack.epoch else { return }
                 guard let level else {
                     showBanner("\(title): the core did not answer", style: .error, duration: 3.0)
                     return
@@ -96,10 +92,8 @@ extension LauncherView {
     @discardableResult
     func popLevel() -> Bool {
         guard let left = levelStack.pop() else { return false }
-        levelEpoch &+= 1
-        // Setting the query runs the change handler, which seeds the selection
-        // from the first row. The restore has to survive that, so it is left
-        // pending for whichever pass has the rows.
+        // Setting the query seeds the selection from the first row, so the
+        // restore waits for whichever pass has the rows.
         pendingSelectionRestore = left.restoredSelectionID.map {
             PendingSelection(id: $0, query: left.restoredQuery)
         }
@@ -109,8 +103,6 @@ extension LauncherView {
     }
 
     func clearLevels() {
-        guard levelStack.isActive || pendingSelectionRestore != nil else { return }
-        levelEpoch &+= 1
         pendingSelectionRestore = nil
         levelStack.clear()
     }
@@ -121,7 +113,7 @@ extension LauncherView {
     }
 }
 
-/// The row a level is opened from, captured when the target was picked.
+/// The row a level is opened from, as it was when the target was picked.
 struct LevelParentRow {
     let candidateID: String
     let title: String
@@ -133,8 +125,7 @@ struct LevelParentRow {
 /// A selection to put back once the rows it names are on screen.
 struct PendingSelection {
     let id: String
-    /// What the query was when it was captured: typing anything else means the
-    /// user moved on and the restore is stale.
+    /// The query it was captured under: anything else means the user moved on.
     let query: String
 }
 

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Levels.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Levels.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+/// Descending into a `then` target that lists rather than performs
+/// (`specs/user-sources.md` §2.10).
+///
+/// A level takes the result list over: its rows are produced live against the
+/// row it was opened from, filtered here rather than by the engine, since they
+/// are not in the index and never will be.
+extension LauncherView {
+    var isInLevel: Bool { levelStack.isActive }
+
+    /// The current level's rows, filtered by what is typed at this level.
+    ///
+    /// `.action` whatever the row carries: Enter at a level runs the block's
+    /// verbs, and a path only says where the tool chords act.
+    var levelResults: [LauncherResult] {
+        guard let level = levelStack.current else { return [] }
+        let typed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return level.rows
+            .filter { LevelFilter.matches(typed, row: $0) }
+            .enumerated()
+            .map { position, row in
+                LauncherResult(
+                    id: row.candidateId,
+                    kind: .action,
+                    title: row.title,
+                    subtitle: row.subtitle ?? row.group ?? level.blockName,
+                    path: row.path ?? "",
+                    // The producer's order, kept: a script list is written in an
+                    // order its author chose, and nothing here knows better yet.
+                    score: level.rows.count - position
+                )
+            }
+    }
+
+    /// Opens `blockID` as a level below the selected row.
+    func descendIntoBlock(blockID: String, title: String) {
+        guard let selected = actionableSelectedResult() else { return }
+
+        // Resolved here, on the main actor, rather than inside the detached task
+        // below: the stack is main-actor state and a String crosses freely.
+        let ancestorsJSON = levelStack.ancestorsOfCurrentRows.ancestorsJSON
+        let parent = (
+            candidateID: selected.id, title: selected.title, path: selected.path
+        )
+        let openedFrom = (query: query, selection: selectedResultID)
+
+        Task {
+            let level = await Task.detached(priority: .userInitiated) {
+                EngineBridge.shared.sourceRows(
+                    blockID: blockID,
+                    parentCandidateID: parent.candidateID,
+                    parentTitle: parent.title,
+                    parentPath: parent.path,
+                    query: openedFrom.query,
+                    ancestorsJSON: ancestorsJSON
+                )
+            }.value
+
+            await MainActor.run {
+                guard let level else {
+                    showBanner("\(title): the core did not answer", style: .error, duration: 3.0)
+                    return
+                }
+                if let error = level.error {
+                    // Not descending is the point: an empty level and a broken
+                    // command look identical once you are inside one.
+                    showBanner("\(title): \(error)", style: .error, duration: 4.0)
+                    return
+                }
+
+                levelStack.push(
+                    SourceLevelFrame(
+                        blockID: blockID,
+                        blockName: title,
+                        parentRowID: level.parentRowId,
+                        parentCandidateID: parent.candidateID,
+                        parentTitle: parent.title,
+                        parentPath: parent.path,
+                        rows: level.rows,
+                        truncated: level.truncated,
+                        restoredQuery: openedFrom.query,
+                        restoredSelectionID: openedFrom.selection
+                    )
+                )
+                // A level starts unfiltered: narrowing it is the first thing
+                // anyone does, and the query that got here means nothing now.
+                query = ""
+                setInitialSelection()
+                if level.truncated {
+                    showBanner(
+                        "\(title): showing the first \(level.rows.count)",
+                        style: .info, duration: 2.0)
+                }
+            }
+        }
+    }
+
+    /// Escape: back one level, with the query and selection it was opened from.
+    /// Returns whether a level was there to leave.
+    @discardableResult
+    func popLevel() -> Bool {
+        guard let left = levelStack.pop() else { return false }
+        query = left.restoredQuery
+        selectedResultID = left.restoredSelectionID
+        return true
+    }
+
+    func clearLevels() {
+        levelStack.clear()
+    }
+
+    /// The ancestors of the row currently selected, for the core's `{parent.*}`.
+    /// Empty outside a level, which is what every non-drilled row has.
+    var selectedRowAncestorsJSON: String {
+        levelStack.ancestorsOfCurrentRows.ancestorsJSON
+    }
+}
+
+/// Matching inside a level. Deliberately not the engine's scorer: these rows are
+/// not candidates, they are a list the user is looking at, and the useful thing
+/// is to narrow it without reordering what the block's author wrote.
+enum LevelFilter {
+    static func matches(_ query: String, row: SourceLevelRow) -> Bool {
+        guard !query.isEmpty else { return true }
+        let needle = query.lowercased()
+        if row.title.lowercased().contains(needle) { return true }
+        if row.id.lowercased().contains(needle) { return true }
+        if let subtitle = row.subtitle, subtitle.lowercased().contains(needle) { return true }
+        if let group = row.group, group.lowercased().contains(needle) { return true }
+        return false
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Levels.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Levels.swift
@@ -1,18 +1,15 @@
 import Foundation
 
-/// Descending into a `then` target that lists rather than performs
-/// (`specs/user-sources.md` §2.10).
+/// Descending into a `then` target that lists rather than performs.
 ///
 /// A level takes the result list over: its rows are produced live against the
-/// row it was opened from, filtered here rather than by the engine, since they
-/// are not in the index and never will be.
+/// row it opened from, and filtered here, since they are not in the index.
 extension LauncherView {
     var isInLevel: Bool { levelStack.isActive }
 
-    /// The current level's rows, filtered by what is typed at this level.
-    ///
-    /// `.action` whatever the row carries: Enter at a level runs the block's
-    /// verbs, and a path only says where the tool chords act.
+    /// Filtered by what is typed at this level. `.action` whatever the row
+    /// carries: Enter runs the block's verbs, and a path only says where the
+    /// chords act.
     var levelResults: [LauncherResult] {
         guard let level = levelStack.current else { return [] }
         let typed = query.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -27,8 +24,7 @@ extension LauncherView {
                     title: row.title,
                     subtitle: row.subtitle,
                     path: row.path ?? "",
-                    // The producer's order, kept: a script list is written in an
-                    // order its author chose, and nothing here knows better yet.
+                    // The producer's order, kept: its author knows the domain.
                     score: level.rows.count - position
                 )
             }
@@ -38,8 +34,7 @@ extension LauncherView {
     func descendIntoBlock(blockID: String, title: String) {
         guard let selected = actionableSelectedResult() else { return }
 
-        // Resolved here, on the main actor, rather than inside the detached task
-        // below: the stack is main-actor state and a String crosses freely.
+        // On the main actor: the stack is main-actor state, a String is not.
         let ancestorsJSON = levelStack.ancestorsOfCurrentRows.ancestorsJSON
         let parent = (
             candidateID: selected.id, title: selected.title, path: selected.path
@@ -64,8 +59,8 @@ extension LauncherView {
                     return
                 }
                 if let error = level.error {
-                    // Not descending is the point: an empty level and a broken
-                    // command look identical once you are inside one.
+                    // An empty level and a broken command look identical once
+                    // you are inside one, so neither is entered.
                     showBanner("\(title): \(error)", style: .error, duration: 4.0)
                     return
                 }
@@ -81,8 +76,7 @@ extension LauncherView {
                         restoredSelectionID: openedFrom.selection
                     )
                 )
-                // A level starts unfiltered: narrowing it is the first thing
-                // anyone does, and the query that got here means nothing now.
+                // The query that got here means nothing now.
                 query = ""
                 setInitialSelection()
                 if level.truncated {
@@ -94,8 +88,8 @@ extension LauncherView {
         }
     }
 
-    /// Escape: back one level, with the query and selection it was opened from.
-    /// Returns whether a level was there to leave.
+    /// Back one level, with the query and selection it opened from. Returns
+    /// whether there was a level to leave.
     @discardableResult
     func popLevel() -> Bool {
         guard let left = levelStack.pop() else { return false }
@@ -108,16 +102,14 @@ extension LauncherView {
         levelStack.clear()
     }
 
-    /// The ancestors of the row currently selected, for the core's `{parent.*}`.
-    /// Empty outside a level, which is what every non-drilled row has.
+    /// Ancestors of the selected row, for `{parent.*}`. Empty outside a level.
     var selectedRowAncestorsJSON: String {
         levelStack.ancestorsOfCurrentRows.ancestorsJSON
     }
 }
 
-/// Matching inside a level. Deliberately not the engine's scorer: these rows are
-/// not candidates, they are a list the user is looking at, and the useful thing
-/// is to narrow it without reordering what the block's author wrote.
+/// Not the engine's scorer: these rows are a list the user is looking at, and
+/// narrowing it must not reorder what the block's author wrote.
 enum LevelFilter {
     static func matches(_ query: String, row: SourceLevelRow) -> Bool {
         guard !query.isEmpty else { return true }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
@@ -66,11 +66,23 @@ extension LauncherView {
             hideLauncherWindow(restorePreviousApp: false)
         case .file:
             guard ensureTargetExists(selected) else { return }
+            // A row a block produced answers to its block first: what Enter does
+            // is what the block says, whatever kind the row ended up with. The
+            // staleness check stays above it, since a row pointing at a deleted
+            // file is worth reporting either way.
+            if selected.isSourceRow {
+                performSourceBlock(selected)
+                return
+            }
             openTargetAsync(selected.path)
             recordOpen(selected, action: "open_file")
             hideLauncherWindow(restorePreviousApp: false)
         case .folder:
             guard ensureTargetExists(selected) else { return }
+            if selected.isSourceRow {
+                performSourceBlock(selected)
+                return
+            }
             openTargetAsync(selected.path)
             // Quick-folder entries are ephemeral filesystem suggestions, not
             // ranked candidates - they aren't in the usage index.
@@ -187,6 +199,10 @@ extension LauncherView {
 
     /// Performs a declared block's steps. Usage is recorded on intent, like an
     /// open, so a routine you run every morning ranks like one.
+    ///
+    /// One rule for Enter: the block's `open` when it declares one, else the
+    /// row's own path. Which producer made the row does not enter into it, and
+    /// the core is what answers, so both shells get the same behaviour.
     private func performSourceBlock(_ selected: LauncherResult) {
         // Resolve BEFORE recording usage or hiding: an unparseable id would
         // otherwise rank the row up, close the window, and do nothing, with no
@@ -215,6 +231,10 @@ extension LauncherView {
                 )
             }.value
             await MainActor.run {
+                if outcome.opensPath {
+                    openTargetAsync(row.path)
+                    return
+                }
                 guard let failure = outcome.errors.first else { return }
                 // Steps are detached, so this only fires when one could not be
                 // started at all. A step's own exit code is its business.

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
@@ -200,6 +200,9 @@ extension LauncherView {
 
         let name = selected.title
         let row = (id: selected.id, title: selected.title, path: selected.path, query: query)
+        // Inside a level the row's ancestors are what `{parent.*}` names, and
+        // without them a command would act on nothing.
+        let ancestors = selectedRowAncestorsJSON
         Task {
             let outcome = await Task.detached(priority: .userInitiated) {
                 EngineBridge.shared.performBlock(
@@ -207,7 +210,8 @@ extension LauncherView {
                     rowID: row.id,
                     rowTitle: row.title,
                     rowPath: row.path,
-                    query: row.query
+                    query: row.query,
+                    ancestorsJSON: ancestors
                 )
             }.value
             await MainActor.run {
@@ -278,9 +282,14 @@ extension LauncherView {
         case .process:
             showBanner("Processes can't be revealed in Finder", style: .info, duration: 1.2)
         case .action:
-            // No file of its own, but the declaration that created it is a real
-            // file and is the thing the user wants to get to from here.
-            revealDeclaringFile(for: selected)
+            // A block's row may name a path of its own (`format = "json"`), and
+            // then it is an ordinary filesystem object that reveals like one.
+            // Only a row without one falls back to the declaration that made it.
+            if selected.path.isEmpty {
+                revealDeclaringFile(for: selected)
+            } else {
+                revealPathInFinder(selected.path)
+            }
         }
     }
 

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+RowActions.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+RowActions.swift
@@ -4,8 +4,7 @@ import Foundation
 /// nobody could discover; the panel is where they become visible.
 ///
 /// Suppressed for a row whose block declared `then` targets: the author already
-/// chose that row's vocabulary and every entry here keeps its chord anyway
-/// (`specs/preferred-tools.md` §7.1).
+/// chose that row's vocabulary, and every entry here keeps its chord anyway.
 extension LauncherView {
     enum RowAction {
         static let prefix = "rowaction:"
@@ -89,9 +88,8 @@ extension LauncherView {
     }
 
     private static func label(for entry: RowActionEntry, tools: [String: ToolAction]) -> String {
-        // A block that took this chord names itself, not a tool, so the plain
-        // wording stands: what happens is the block's business and its steps
-        // are already on screen in the panel.
+        // A block names itself, not a tool, and its steps are already on
+        // screen in the panel.
         if let action = entry.tool, tools[action]?.fromBlock == true {
             return entry.plain
         }
@@ -101,9 +99,8 @@ extension LauncherView {
     }
 
     /// Which tool each offered action would start, or which block took the
-    /// chord over for these rows (`specs/preferred-tools.md` §6). The tools come
-    /// from the process-wide config cache; a block row also reads its
-    /// declaration, which is the same read the panel already does per selection.
+    /// chord for these rows. Tools come from the process-wide config cache; a
+    /// block row also reads its declaration, like the panel already does.
     private func resolvedTools(
         for result: LauncherResult, entries: [RowActionEntry]
     ) -> [String: ToolAction] {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+RowActions.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+RowActions.swift
@@ -108,7 +108,7 @@ extension LauncherView {
         var resolved: [String: ToolAction] = [:]
         for action in entries.compactMap(\.tool) {
             if let outcome = EngineBridge.shared.toolAction(
-                action, row: row, isDirectory: result.kind == .folder
+                action, row: row, isDirectory: pathIsDirectory(result)
             ) {
                 resolved[action] = outcome
             }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+RowActions.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+RowActions.swift
@@ -89,21 +89,29 @@ extension LauncherView {
     }
 
     private static func label(for entry: RowActionEntry, tools: [String: ToolAction]) -> String {
+        // A block that took this chord names itself, not a tool, so the plain
+        // wording stands: what happens is the block's business and its steps
+        // are already on screen in the panel.
+        if let action = entry.tool, tools[action]?.fromBlock == true {
+            return entry.plain
+        }
         let resolved = entry.tool.flatMap { tools[$0]?.tool } ?? entry.fallbackTool
         guard let named = entry.named, let resolved else { return entry.plain }
         return "\(named) \(resolved)"
     }
 
-    /// Which tool each offered action would start. Cheap after the first call:
-    /// the tools come from the process-wide config cache and resolving is string
-    /// work.
+    /// Which tool each offered action would start, or which block took the
+    /// chord over for these rows (`specs/preferred-tools.md` §6). The tools come
+    /// from the process-wide config cache; a block row also reads its
+    /// declaration, which is the same read the panel already does per selection.
     private func resolvedTools(
         for result: LauncherResult, entries: [RowActionEntry]
     ) -> [String: ToolAction] {
+        let row = toolActionRow(for: result)
         var resolved: [String: ToolAction] = [:]
         for action in entries.compactMap(\.tool) {
             if let outcome = EngineBridge.shared.toolAction(
-                action, path: result.path, isDirectory: result.kind == .folder
+                action, row: row, isDirectory: result.kind == .folder
             ) {
                 resolved[action] = outcome
             }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
@@ -13,7 +13,18 @@ extension LauncherView {
             // No rows on screen. A seeded selection here is one the user cannot
             // see, and Enter / Cmd+D / Cmd+Shift+H would still act on it.
             selectedResultID = nil
+        } else if let restore = pendingSelectionRestore, restore.query == query {
+            // Leaving a level puts back what was selected before it. The rows
+            // may not be there yet on the first pass (a parent level's search
+            // is async), so the restore waits rather than being spent.
+            if displayedResults.contains(where: { $0.id == restore.id }) {
+                selectedResultID = restore.id
+                pendingSelectionRestore = nil
+            } else {
+                selectedResultID = displayedResults.first?.id
+            }
         } else {
+            pendingSelectionRestore = nil
             selectedResultID = displayedResults.first?.id
         }
     }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
@@ -273,6 +273,9 @@ extension LauncherView {
             onActivateSession: { [self] index in
                 openSessionAt(index)
             },
+            onPopLevel: { [self] in
+                popLevel()
+            },
             onEscapeHome: { [self] in
                 // Esc closes the file popup first and leaves the typed text
                 // alone, so dismissing a suggestion never costs the message.

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Selection.swift
@@ -14,9 +14,8 @@ extension LauncherView {
             // see, and Enter / Cmd+D / Cmd+Shift+H would still act on it.
             selectedResultID = nil
         } else if let restore = pendingSelectionRestore, restore.query == query {
-            // Leaving a level puts back what was selected before it. The rows
-            // may not be there yet on the first pass (a parent level's search
-            // is async), so the restore waits rather than being spent.
+            // Leaving a level puts back what was selected before it. A parent
+            // level's search is async, so the restore waits for its rows.
             if displayedResults.contains(where: { $0.id == restore.id }) {
                 selectedResultID = restore.id
                 pendingSelectionRestore = nil

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+SourceBlocks.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+SourceBlocks.swift
@@ -26,7 +26,7 @@ extension LauncherView {
     /// selection change, and an async load that appends later would make the
     /// action list grow under the user's cursor.
     func sourceBlockTargets(for result: LauncherResult) -> [QuickActionDescriptor] {
-        guard result.id.hasPrefix(AppConstants.Launcher.SourceBlock.idPrefix) else { return [] }
+        guard result.isSourceRow else { return [] }
 
         return SourceBlockCatalog.targets(for: result).map { target in
             QuickActionDescriptor(

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+SourceBlocks.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+SourceBlocks.swift
@@ -48,6 +48,9 @@ extension LauncherView {
 
         let row = (id: selected.id, title: selected.title, path: selected.path, query: query)
         let ancestors = selectedRowAncestorsJSON
+        // Claimed before the block runs: the user can hide the launcher or
+        // start another target while it does.
+        let epoch = levelStack.beginRequest()
         let parent = LevelParentRow(
             candidateID: selected.id,
             title: selected.title,
@@ -69,6 +72,7 @@ extension LauncherView {
             }.value
 
             await MainActor.run {
+                guard epoch == levelStack.epoch else { return }
                 if let failure = outcome.errors.first {
                     showBanner("\(title): \(failure)", style: .error, duration: 4.0)
                     return
@@ -77,7 +81,8 @@ extension LauncherView {
                     // Not a failure and nothing was performed: the target lists,
                     // so it is a level to descend into.
                     descendIntoBlock(
-                        blockID: blockID, title: title, parent: parent, ancestorsJSON: ancestors)
+                        blockID: blockID, title: title, parent: parent, ancestorsJSON: ancestors,
+                        epoch: epoch)
                     return
                 }
                 hideLauncherWindow(restorePreviousApp: false)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+SourceBlocks.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+SourceBlocks.swift
@@ -48,6 +48,13 @@ extension LauncherView {
 
         let row = (id: selected.id, title: selected.title, path: selected.path, query: query)
         let ancestors = selectedRowAncestorsJSON
+        let parent = LevelParentRow(
+            candidateID: selected.id,
+            title: selected.title,
+            path: selected.path,
+            openedFromQuery: query,
+            openedFromSelection: selectedResultID
+        )
         Task {
             let outcome = await Task.detached(priority: .userInitiated) {
                 EngineBridge.shared.performBlock(
@@ -69,7 +76,8 @@ extension LauncherView {
                 if outcome.producesRows {
                     // Not a failure and nothing was performed: the target lists,
                     // so it is a level to descend into.
-                    descendIntoBlock(blockID: blockID, title: title)
+                    descendIntoBlock(
+                        blockID: blockID, title: title, parent: parent, ancestorsJSON: ancestors)
                     return
                 }
                 hideLauncherWindow(restorePreviousApp: false)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+SourceBlocks.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+SourceBlocks.swift
@@ -47,6 +47,7 @@ extension LauncherView {
         guard let selected = actionableSelectedResult() else { return }
 
         let row = (id: selected.id, title: selected.title, path: selected.path, query: query)
+        let ancestors = selectedRowAncestorsJSON
         Task {
             let outcome = await Task.detached(priority: .userInitiated) {
                 EngineBridge.shared.performBlock(
@@ -55,6 +56,7 @@ extension LauncherView {
                     rowTitle: row.title,
                     rowPath: row.path,
                     query: row.query,
+                    ancestorsJSON: ancestors,
                     asTarget: true
                 )
             }.value
@@ -65,10 +67,9 @@ extension LauncherView {
                     return
                 }
                 if outcome.producesRows {
-                    // Descending needs the level stack, which does not exist
-                    // yet. Said plainly rather than inferred from a zero count,
-                    // which is also what a failure looks like.
-                    showBanner("\(title) produces rows; drill-down is not built yet", style: .info, duration: 2.4)
+                    // Not a failure and nothing was performed: the target lists,
+                    // so it is a level to descend into.
+                    descendIntoBlock(blockID: blockID, title: title)
                     return
                 }
                 hideLauncherWindow(restorePreviousApp: false)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Tools.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Tools.swift
@@ -29,12 +29,17 @@ extension LauncherView {
     /// thing you launch, and the folder holding it is `/Applications`, which is
     /// never "here", so both are absent for app rows rather than quietly acting
     /// on the wrong directory. Revealing an app is genuinely useful and stays.
+    ///
+    /// An action row qualifies too, because a block's row can name a `path`
+    /// (`format = "json"`) and is then a real filesystem object. Both callers
+    /// already require a non-empty path, so the ones that name none never reach
+    /// here.
     static func toolActionApplies(_ action: String, to kind: LauncherResultKind) -> Bool {
         switch action {
         case AppConstants.Launcher.Tools.revealAction:
-            return kind.isFileOrFolder || kind == .app
+            return kind.isFileOrFolder || kind == .app || kind == .action
         default:
-            return kind.isFileOrFolder
+            return kind.isFileOrFolder || kind == .action
         }
     }
 
@@ -45,7 +50,21 @@ extension LauncherView {
             Self.toolActionApplies(action, to: selected.kind)
         else { return nil }
 
-        return (selected.path, selected.kind == .folder)
+        return (selected.path, pathIsDirectory(selected))
+    }
+
+    /// A file row and a folder row say which they are; a block's row does not,
+    /// so its path is checked. Editing resolves to a different tool for each and
+    /// a terminal opens in a different place, so guessing is not an option.
+    private func pathIsDirectory(_ result: LauncherResult) -> Bool {
+        if result.kind != .action {
+            return result.kind == .folder
+        }
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: result.path, isDirectory: &isDir) else {
+            return false
+        }
+        return isDir.boolValue
     }
 
     private func runToolAction(_ action: String) {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Tools.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Tools.swift
@@ -43,14 +43,26 @@ extension LauncherView {
         }
     }
 
-    /// The selected row as a path plus whether it is a directory, or nil when
-    /// the action does not apply to it.
-    private func toolTarget(for action: String) -> (path: String, isDirectory: Bool)? {
+    /// The selected row as a tool target, or nil when the action does not apply
+    /// to it.
+    private func toolTarget(for action: String) -> (row: ToolActionRow, isDirectory: Bool)? {
         guard let selected = actionableSelectedResult(), !selected.path.isEmpty,
             Self.toolActionApplies(action, to: selected.kind)
         else { return nil }
 
-        return (selected.path, pathIsDirectory(selected))
+        return (toolActionRow(for: selected), pathIsDirectory(selected))
+    }
+
+    /// A row as the core needs it for a tool action: its id so a block can
+    /// override the chord, its title and ancestors so that override expands
+    /// like any other command the block declares.
+    func toolActionRow(for result: LauncherResult) -> ToolActionRow {
+        ToolActionRow(
+            candidateID: result.id,
+            title: result.title,
+            path: result.path,
+            ancestorsJSON: selectedRowAncestorsJSON
+        )
     }
 
     /// A file row and a folder row say which they are; a block's row does not,
@@ -69,16 +81,16 @@ extension LauncherView {
 
     private func runToolAction(_ action: String) {
         guard let target = toolTarget(for: action) else { return }
-        let path = target.path
+        let row = target.row
         let isDirectory = target.isDirectory
 
         Task {
             let outcome = await Task.detached(priority: .userInitiated) {
-                EngineBridge.shared.performToolAction(action, path: path, isDirectory: isDirectory)
+                EngineBridge.shared.performToolAction(action, row: row, isDirectory: isDirectory)
             }.value
 
             await MainActor.run {
-                applyToolOutcome(outcome, path: path)
+                applyToolOutcome(outcome, path: row.path)
             }
         }
     }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Tools.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Tools.swift
@@ -68,7 +68,7 @@ extension LauncherView {
     /// A file row and a folder row say which they are; a block's row does not,
     /// so its path is checked. Editing resolves to a different tool for each and
     /// a terminal opens in a different place, so guessing is not an option.
-    private func pathIsDirectory(_ result: LauncherResult) -> Bool {
+    func pathIsDirectory(_ result: LauncherResult) -> Bool {
         if result.kind != .action {
             return result.kind == .folder
         }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+WindowControl.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+WindowControl.swift
@@ -199,6 +199,10 @@ extension LauncherView {
         // Don't leave a stale Empty Trash confirmation to reappear on next show.
         pendingEmptyTrashCount = nil
         pendingHideAppResult = nil
+        // Levels do not survive a hide (§2.10). Their rows were produced live
+        // from a row that may not even exist by the next open, and coming back
+        // to a list with no visible way in would be worse than starting fresh.
+        clearLevels()
         // The AI session intentionally survives hide/recall (Cmd+Space away and
         // back must not lose the conversation). Only Esc ends and archives it.
         let wasVisible = window.isVisible

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -117,9 +117,6 @@ struct LauncherView: View {
     /// flags: a level stack IS navigation state, and the mode booleans above
     /// grew into a pile by being added one at a time.
     @State var levelStack = SourceLevelStack()
-    /// Bumped whenever the stack changes, so a level whose command is still
-    /// running cannot push its rows into a launcher that has moved on.
-    @State var levelEpoch: UInt64 = 0
     /// A selection to restore once its rows are on screen (see `popLevel`).
     @State var pendingSelectionRestore: PendingSelection?
     /// `@`-mention state for the AI input. `mentionHighlight` starts at -1 so

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -113,9 +113,9 @@ struct LauncherView: View {
     @State var pendingQuickActions: Set<String> = []
     @State var quickActionTask: Task<Void, Never>?
     @State var selectedResultID: String?
-    /// Where the user has drilled to (`specs/user-sources.md` §2.10). One value
-    /// rather than another set of flags: a level stack IS navigation state, and
-    /// the mode booleans above grew into a pile by being added one at a time.
+    /// Where the user has drilled to. One value rather than another set of
+    /// flags: a level stack IS navigation state, and the mode booleans above
+    /// grew into a pile by being added one at a time.
     @State var levelStack = SourceLevelStack()
     /// `@`-mention state for the AI input. `mentionHighlight` starts at -1 so
     /// Enter still SENDS: the popup is passive until Tab reaches into it (same
@@ -503,8 +503,7 @@ struct LauncherView: View {
     // LauncherView+URLResults.swift.
 
     var displayedResults: [LauncherResult] {
-        // A level owns the list outright: its rows are not in the index, so
-        // nothing else here can produce them.
+        // A level owns the list: its rows are not in the index.
         if isInLevel { return levelResults }
         if isPrefixSuggestionQuery { return prefixSuggestionResults }
         if isCommandSuggestionQuery { return commandSuggestionResults }
@@ -618,8 +617,7 @@ struct LauncherView: View {
             return ["Y confirm", "N cancel", "Esc back"]
         }
 
-        // Inside a level the way out is the thing to say: the list came from a
-        // row, and nothing else on screen explains that.
+        // Inside a level the way out is the thing to say.
         if isInLevel {
             return [enterHint, "⌘K actions", "Esc back"]
         }
@@ -706,8 +704,8 @@ struct LauncherView: View {
         return "Enter run"
     }
 
-    /// Where the user is, when they are inside a level. Shown in the query bar,
-    /// because a list that replaced the index has to say what it is.
+    /// Shown in the query bar: a list that replaced the index has to say what
+    /// it is.
     var levelBreadcrumb: String? {
         guard isInLevel else { return nil }
         return levelStack.breadcrumb.joined(separator: "  ›  ")
@@ -2211,8 +2209,8 @@ struct LauncherView: View {
     /// the results columns and the hint bar below it. Applies in both modes (gap
     /// or no gap), so an empty launcher is always just the top bar.
     var hidesResultsForEmptyQuery: Bool {
-        // Never inside a level: it always has rows, and an empty query there
-        // means "unfiltered", not "nothing asked for" (§2.10).
+        // Never inside a level: an empty query there means "unfiltered", not
+        // "nothing asked for".
         isQueryEmpty && isLauncherIdle && !isInLevel
     }
 

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -117,6 +117,11 @@ struct LauncherView: View {
     /// flags: a level stack IS navigation state, and the mode booleans above
     /// grew into a pile by being added one at a time.
     @State var levelStack = SourceLevelStack()
+    /// Bumped whenever the stack changes, so a level whose command is still
+    /// running cannot push its rows into a launcher that has moved on.
+    @State var levelEpoch: UInt64 = 0
+    /// A selection to restore once its rows are on screen (see `popLevel`).
+    @State var pendingSelectionRestore: PendingSelection?
     /// `@`-mention state for the AI input. `mentionHighlight` starts at -1 so
     /// Enter still SENDS: the popup is passive until Tab reaches into it (same
     /// shape as the conversation list's -1).

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -113,6 +113,10 @@ struct LauncherView: View {
     @State var pendingQuickActions: Set<String> = []
     @State var quickActionTask: Task<Void, Never>?
     @State var selectedResultID: String?
+    /// Where the user has drilled to (`specs/user-sources.md` §2.10). One value
+    /// rather than another set of flags: a level stack IS navigation state, and
+    /// the mode booleans above grew into a pile by being added one at a time.
+    @State var levelStack = SourceLevelStack()
     /// `@`-mention state for the AI input. `mentionHighlight` starts at -1 so
     /// Enter still SENDS: the popup is passive until Tab reaches into it (same
     /// shape as the conversation list's -1).
@@ -499,6 +503,9 @@ struct LauncherView: View {
     // LauncherView+URLResults.swift.
 
     var displayedResults: [LauncherResult] {
+        // A level owns the list outright: its rows are not in the index, so
+        // nothing else here can produce them.
+        if isInLevel { return levelResults }
         if isPrefixSuggestionQuery { return prefixSuggestionResults }
         if isCommandSuggestionQuery { return commandSuggestionResults }
         if isClipboardQuery { return clipboardResults }
@@ -558,7 +565,7 @@ struct LauncherView: View {
     /// the disjunction out by hand, and they had already drifted apart. A new
     /// mode belongs HERE, not in each caller.
     var usesOwnResultPanel: Bool {
-        isClipboardQuery || isPrefixSuggestionQuery || isCommandSuggestionQuery
+        isInLevel || isClipboardQuery || isPrefixSuggestionQuery || isCommandSuggestionQuery
             || isTranslationQuery || isProcessQuery
     }
 
@@ -609,6 +616,12 @@ struct LauncherView: View {
 
         if isHideAppConfirmationVisible {
             return ["Y confirm", "N cancel", "Esc back"]
+        }
+
+        // Inside a level the way out is the thing to say: the list came from a
+        // row, and nothing else on screen explains that.
+        if isInLevel {
+            return [enterHint, "⌘K actions", "Esc back"]
         }
 
         if isCommandMode {
@@ -691,6 +704,13 @@ struct LauncherView: View {
               selected.kind == .action
         else { return "Enter open" }
         return "Enter run"
+    }
+
+    /// Where the user is, when they are inside a level. Shown in the query bar,
+    /// because a list that replaced the index has to say what it is.
+    var levelBreadcrumb: String? {
+        guard isInLevel else { return nil }
+        return levelStack.breadcrumb.joined(separator: "  ›  ")
     }
 
     /// True when the launcher is on its default/home screen (the state
@@ -1213,6 +1233,7 @@ struct LauncherView: View {
             isAIMode: isAIMode,
             showsBackground: showsBackground,
             revealToken: appearanceRevealToken,
+            breadcrumb: levelBreadcrumb,
             onSubmit: handleSubmit,
             onExitCommandMode: exitCommandMode
         )
@@ -2045,6 +2066,7 @@ struct LauncherView: View {
                 // Info + actions panel: the preview plus any Quick Actions.
                 ResultPreviewView(
                     result: selectedResult,
+                    rowAncestorsJSON: selectedRowAncestorsJSON,
                     quickActions: quickActionDescriptors,
                     quickActionStates: quickActionStates,
                     quickActionInfo: quickActionInfo,
@@ -2189,7 +2211,9 @@ struct LauncherView: View {
     /// the results columns and the hint bar below it. Applies in both modes (gap
     /// or no gap), so an empty launcher is always just the top bar.
     var hidesResultsForEmptyQuery: Bool {
-        isQueryEmpty && isLauncherIdle
+        // Never inside a level: it always has rows, and an empty query there
+        // means "unfiltered", not "nothing asked for" (§2.10).
+        isQueryEmpty && isLauncherIdle && !isInLevel
     }
 
     /// True whenever the panel has no backdrop box and its content floats freely

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
@@ -5,6 +5,9 @@ import UniformTypeIdentifiers
 struct ResultPreviewView: View {
     @EnvironmentObject private var themeStore: ThemeStore
     let result: LauncherResult
+    /// The levels this row was reached through, for a `preview` that names
+    /// `{parent.*}`. Empty for every row that is not inside a drill-down.
+    var rowAncestorsJSON: String = "[]"
     /// Quick Actions for this result, rendered beneath the header (info + actions
     /// panel). Empty for results with no actions.
     var quickActions: [QuickActionDescriptor] = []
@@ -565,15 +568,22 @@ struct ResultPreviewView: View {
             if let file = blockFile {
                 Divider().overlay(themeStore.secondaryTextColor().opacity(0.2))
                 InfoRow(label: "Declared in", value: (file as NSString).abbreviatingWithTildeInPath)
-                hintRow(key: "⌘F", text: "Reveal that file")
+                // A row that names its own path reveals that, like every other
+                // row with one, so the chord belongs to the declaration only
+                // when the row has nothing of its own to point at.
+                if result.path.isEmpty {
+                    hintRow(key: "⌘F", text: "Reveal that file")
+                }
             }
         }
         .padding(16)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .task(id: result.id) {
             let candidateID = result.id
+            let ancestors = rowAncestorsJSON
             let block = await Task.detached(priority: .userInitiated) {
-                EngineBridge.shared.sourceBlock(candidateID: candidateID)
+                EngineBridge.shared.sourceBlock(
+                    candidateID: candidateID, ancestorsJSON: ancestors)
             }.value
             // The detached read outlives a cancelled task, so a late answer must
             // not populate the panel of a row the user has already left.
@@ -590,7 +600,8 @@ struct ResultPreviewView: View {
                     candidateID: candidateID,
                     rowID: row.id,
                     rowTitle: row.title,
-                    rowPath: row.path
+                    rowPath: row.path,
+                    ancestorsJSON: ancestors
                 )
             }.value
             if Task.isCancelled { return }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
@@ -3,6 +3,13 @@ import SwiftUI
 import UniformTypeIdentifiers
 
 struct ResultPreviewView: View {
+    private enum Layout {
+        /// How much of a block's steps the panel shows before scrolling. Two,
+        /// because the steps are context for the row, not the subject of the
+        /// panel, and one long command should not push the preview off screen.
+        static let visibleStepLines = 2
+    }
+
     @EnvironmentObject private var themeStore: ThemeStore
     let result: LauncherResult
     /// The levels this row was reached through, for a `preview` that names
@@ -554,7 +561,8 @@ struct ResultPreviewView: View {
                         AICodeBlockView(
                             code: blockSteps.joined(separator: "\n"),
                             language: "sh",
-                            themeStore: themeStore
+                            themeStore: themeStore,
+                            maxVisibleLines: Layout.visibleStepLines
                         )
                     }
                     if let preview = blockPreview {

--- a/bridge/ffi/Cargo.lock
+++ b/bridge/ffi/Cargo.lock
@@ -479,6 +479,7 @@ dependencies = [
  "globset",
  "look-tools",
  "serde",
+ "serde_json",
  "toml",
 ]
 

--- a/bridge/ffi/src/lib.rs
+++ b/bridge/ffi/src/lib.rs
@@ -289,11 +289,10 @@ pub extern "C" fn look_source_block_json(
     .unwrap_or(std::ptr::null_mut())
 }
 
-/// The rows of `block_id` produced against the selected row, for descending into
-/// a `then` target that lists rather than performs (`specs/user-sources.md`
-/// §2.10). Returns `{rows, truncated, error}`, where each row carries the
-/// `candidateId` that encodes the levels it was reached through, so usage ranks
-/// per ancestor path.
+/// The rows of `block_id` produced against the selected row, for descending
+/// into a `then` target that lists rather than performs. Returns
+/// `{rows, truncated, error}`; each row's `candidateId` encodes the levels it
+/// came through, so two parents never share a row.
 ///
 /// Runs the block live on every call. An error means do not descend.
 #[unsafe(no_mangle)]
@@ -335,10 +334,9 @@ pub extern "C" fn look_source_blocks_json() -> *mut c_char {
 /// Reads the declared tools from the cached config, so Cmd+Shift+; is all a
 /// user needs after editing them.
 ///
-/// `candidate_id` is the row's, so a block that declares `edit` / `terminal` /
-/// `reveal` wins for its own rows (`specs/preferred-tools.md` §6). Pass the row
-/// title and its ancestors too: a block's verb expands like every other command
-/// it declares, `{parent.*}` included.
+/// A block that declares `edit` / `terminal` / `reveal` wins for its own rows,
+/// so pass the row's id, title and ancestors: its verb expands like every other
+/// command it declares.
 #[unsafe(no_mangle)]
 pub extern "C" fn look_tool_action_json(
     action: *const c_char,

--- a/bridge/ffi/src/lib.rs
+++ b/bridge/ffi/src/lib.rs
@@ -334,14 +334,29 @@ pub extern "C" fn look_source_blocks_json() -> *mut c_char {
 ///
 /// Reads the declared tools from the cached config, so Cmd+Shift+; is all a
 /// user needs after editing them.
+///
+/// `candidate_id` is the row's, so a block that declares `edit` / `terminal` /
+/// `reveal` wins for its own rows (`specs/preferred-tools.md` §6). Pass the row
+/// title and its ancestors too: a block's verb expands like every other command
+/// it declares, `{parent.*}` included.
 #[unsafe(no_mangle)]
 pub extern "C" fn look_tool_action_json(
     action: *const c_char,
+    candidate_id: *const c_char,
+    row_title: *const c_char,
     path: *const c_char,
     is_dir: bool,
+    ancestors_json: *const c_char,
 ) -> *mut c_char {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        tools_api::look_tool_action_json_impl(action, path, is_dir)
+        tools_api::look_tool_action_json_impl(
+            action,
+            candidate_id,
+            row_title,
+            path,
+            is_dir,
+            ancestors_json,
+        )
     }))
     .unwrap_or(std::ptr::null_mut())
 }
@@ -352,11 +367,21 @@ pub extern "C" fn look_tool_action_json(
 #[unsafe(no_mangle)]
 pub extern "C" fn look_perform_tool_action_json(
     action: *const c_char,
+    candidate_id: *const c_char,
+    row_title: *const c_char,
     path: *const c_char,
     is_dir: bool,
+    ancestors_json: *const c_char,
 ) -> *mut c_char {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        tools_api::look_perform_tool_action_json_impl(action, path, is_dir)
+        tools_api::look_perform_tool_action_json_impl(
+            action,
+            candidate_id,
+            row_title,
+            path,
+            is_dir,
+            ancestors_json,
+        )
     }))
     .unwrap_or(std::ptr::null_mut())
 }

--- a/bridge/ffi/src/lib.rs
+++ b/bridge/ffi/src/lib.rs
@@ -275,9 +275,45 @@ pub extern "C" fn look_source_block_json(
     row_id: *const c_char,
     row_title: *const c_char,
     row_path: *const c_char,
+    ancestors_json: *const c_char,
 ) -> *mut c_char {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        sources_api::look_source_block_json_impl(candidate_id, row_id, row_title, row_path)
+        sources_api::look_source_block_json_impl(
+            candidate_id,
+            row_id,
+            row_title,
+            row_path,
+            ancestors_json,
+        )
+    }))
+    .unwrap_or(std::ptr::null_mut())
+}
+
+/// The rows of `block_id` produced against the selected row, for descending into
+/// a `then` target that lists rather than performs (`specs/user-sources.md`
+/// §2.10). Returns `{rows, truncated, error}`, where each row carries the
+/// `candidateId` that encodes the levels it was reached through, so usage ranks
+/// per ancestor path.
+///
+/// Runs the block live on every call. An error means do not descend.
+#[unsafe(no_mangle)]
+pub extern "C" fn look_source_rows_json(
+    block_id: *const c_char,
+    parent_candidate_id: *const c_char,
+    parent_title: *const c_char,
+    parent_path: *const c_char,
+    query: *const c_char,
+    ancestors_json: *const c_char,
+) -> *mut c_char {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        sources_api::look_source_rows_json_impl(
+            block_id,
+            parent_candidate_id,
+            parent_title,
+            parent_path,
+            query,
+            ancestors_json,
+        )
     }))
     .unwrap_or(std::ptr::null_mut())
 }
@@ -363,9 +399,16 @@ pub extern "C" fn look_source_preview_json(
     row_id: *const c_char,
     row_title: *const c_char,
     row_path: *const c_char,
+    ancestors_json: *const c_char,
 ) -> *mut c_char {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        sources_api::look_source_preview_json_impl(candidate_id, row_id, row_title, row_path)
+        sources_api::look_source_preview_json_impl(
+            candidate_id,
+            row_id,
+            row_title,
+            row_path,
+            ancestors_json,
+        )
     }))
     .unwrap_or(std::ptr::null_mut())
 }
@@ -379,11 +422,18 @@ pub extern "C" fn look_perform_block_json(
     row_title: *const c_char,
     row_path: *const c_char,
     query: *const c_char,
+    ancestors_json: *const c_char,
     as_target: bool,
 ) -> *mut c_char {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         sources_api::look_perform_block_json_impl(
-            block_id, row_id, row_title, row_path, query, as_target,
+            block_id,
+            row_id,
+            row_title,
+            row_path,
+            query,
+            ancestors_json,
+            as_target,
         )
     }))
     .unwrap_or(std::ptr::null_mut())

--- a/bridge/ffi/src/sources_api.rs
+++ b/bridge/ffi/src/sources_api.rs
@@ -227,10 +227,9 @@ pub(crate) fn look_refresh_run_blocks_json_impl() -> *mut c_char {
             continue;
         };
 
-        // A block whose command names a row placeholder only means something
-        // against a selection: it is a level, run live when the user descends
-        // (§2.10). Running it here would execute `jq ... {path}/package.json`
-        // literally and report a failure the user cannot act on.
+        // A block whose command names a row placeholder is a level, run live
+        // when the user descends. Running it here would execute
+        // `jq ... {path}/package.json` literally and report a useless failure.
         if block.needs_row() {
             continue;
         }
@@ -263,39 +262,34 @@ pub(crate) fn look_refresh_run_blocks_json_impl() -> *mut c_char {
     )
 }
 
-/// How deep a stack of levels may go (`specs/user-sources.md` §2.10). Bounds
-/// both the id and the stack, and a launcher six levels deep has stopped being
-/// a launcher.
+/// How deep a stack of levels may go. A launcher six levels deep has stopped
+/// being a launcher.
 const MAX_LEVEL_DEPTH: usize = 5;
 
-/// One row of a level, ready to render and to rank: its candidate id already
-/// carries the ancestors it was reached through.
+/// One row of a level: its candidate id carries the ancestors it came through.
 #[derive(Serialize)]
 struct LevelRow {
     #[serde(rename = "candidateId")]
     candidate_id: String,
     id: String,
     title: String,
-    /// Already resolved against the block name, by the same rule the index
-    /// uses, so neither shell has to know it.
+    /// Resolved against the block name by the same rule the index uses.
     subtitle: String,
     path: Option<String>,
 }
 
 #[derive(Serialize, Default)]
 struct Level {
-    /// The parent's OWN id, as the core decoded it. Handed back so the shell can
-    /// name the ancestor in later calls without keeping a second decoder for the
-    /// id format (§2.10).
+    /// The parent's OWN id, decoded here so the shell needs no second decoder
+    /// for the id format.
     #[serde(rename = "parentRowId")]
     parent_row_id: String,
     rows: Vec<LevelRow>,
     /// The row cap dropped rows, so the caller can say so rather than implying
     /// the level is all there is.
     truncated: bool,
-    /// Set when the level could not be produced. The caller must not descend:
-    /// an empty level and a broken command look identical on screen, so neither
-    /// is silently entered.
+    /// Set when the level could not be produced, and the caller must not
+    /// descend: an empty level and a broken command look identical on screen.
     error: Option<String>,
 }
 
@@ -309,13 +303,10 @@ fn level_error(message: impl Into<String>) -> *mut c_char {
     )
 }
 
-/// The rows of `block_id` produced against the selected row, for descending into
-/// it (`specs/user-sources.md` §2.10).
+/// The rows of `block_id` produced against the selected row, for descending.
 ///
 /// Live on every call, never cached: `~/.look/cache/rows/<block>` is keyed by
-/// block alone, and a level's rows depend on the row it was launched from. The
-/// user has already picked that row, so one command is a wait they asked for and
-/// a stale level is worse.
+/// block alone, and a level's rows depend on the row it opened from.
 pub(crate) fn look_source_rows_json_impl(
     block_id: *const c_char,
     parent_candidate_id: *const c_char,
@@ -326,9 +317,8 @@ pub(crate) fn look_source_rows_json_impl(
 ) -> *mut c_char {
     let block_id = cstr_to_string(block_id);
     let parent_candidate_id = cstr_to_string(parent_candidate_id);
-    // Built here rather than through `row_context`, which takes C pointers: the
-    // parent id is already an owned Rust string and handing its bytes back as a
-    // C string would read past the end of it.
+    // Not through `row_context`: the parent id is already an owned Rust string,
+    // and handing its bytes back as a C string would read past the end.
     let row = RowContext {
         id: CandidateIdKind::source_row_id_of(&parent_candidate_id).to_string(),
         title: cstr_to_string(parent_title),

--- a/bridge/ffi/src/sources_api.rs
+++ b/bridge/ffi/src/sources_api.rs
@@ -494,7 +494,7 @@ fn row_context(
 /// their titles and paths too, and only the shell still holds those. Anything
 /// unparseable is no ancestors, which reads as empty rather than as a literal
 /// placeholder reaching a shell.
-fn parents_from(ancestors_json: *const c_char) -> Vec<ParentRow> {
+pub(crate) fn parents_from(ancestors_json: *const c_char) -> Vec<ParentRow> {
     let raw = cstr_to_string(ancestors_json);
     if raw.trim().is_empty() {
         return Vec::new();
@@ -536,7 +536,7 @@ fn opens_path() -> *mut c_char {
     })
 }
 
-fn find_block(block_id: &str) -> Option<Block> {
+pub(crate) fn find_block(block_id: &str) -> Option<Block> {
     let home = home_dir()?;
     load_dir(&sources_dir(&home))
         .blocks
@@ -746,6 +746,66 @@ mod tests {
         let stuck = perform("pathless", "");
         assert_eq!(stuck["opens_path"], false, "{stuck}");
         assert!(stuck["errors"][0].as_str().unwrap().contains("open"));
+    }
+
+    fn tool_action(
+        action: &str,
+        candidate: &str,
+        title: &str,
+        path: &str,
+        ancestors: &str,
+    ) -> serde_json::Value {
+        let action = CString::new(action).unwrap();
+        let candidate = CString::new(candidate).unwrap();
+        let title = CString::new(title).unwrap();
+        let path = CString::new(path).unwrap();
+        let ancestors = CString::new(ancestors).unwrap();
+        let ptr = crate::tools_api::look_tool_action_json_impl(
+            action.as_ptr(),
+            candidate.as_ptr(),
+            title.as_ptr(),
+            path.as_ptr(),
+            true,
+            ancestors.as_ptr(),
+        );
+        let raw = unsafe { CStr::from_ptr(ptr) }
+            .to_string_lossy()
+            .into_owned();
+        crate::state::free_json_allocation(ptr);
+        serde_json::from_str(&raw).expect("resolved action json")
+    }
+
+    #[test]
+    fn a_blocks_verb_takes_the_chord_for_its_own_rows_only() {
+        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
+        let _fixture = Fixture::new(
+            "chords",
+            "[projects]\ndir = \"/tmp\"\nterminal = \"tmux new -As {title} -c {parent.path}\"\n",
+        );
+
+        // The block's own row: its verb wins, expanded like any other command
+        // it declares, ancestors included.
+        let mine = tool_action(
+            "terminal",
+            "src:projects:/tmp/look",
+            "look",
+            "/tmp/look",
+            r#"[{"id":"dev","title":"dev","path":"/dev"}]"#,
+        );
+        assert_eq!(mine["kind"], "shell", "{mine}");
+        assert_eq!(mine["command"], "tmux new -As 'look' -c '/dev'");
+        assert_eq!(mine["tool"], "projects", "the block is what decided");
+
+        // A chord it did not declare is untouched, so a block cannot quietly
+        // take over keys it never mentioned.
+        assert_ne!(
+            tool_action("edit", "src:projects:/tmp/look", "look", "/tmp/look", "[]")["tool"],
+            serde_json::json!("projects")
+        );
+
+        // An ordinary file row never sees the block at all.
+        let theirs = tool_action("terminal", "file:/tmp/other", "other", "/tmp/other", "[]");
+        assert_ne!(theirs["tool"], serde_json::json!("projects"), "{theirs}");
     }
 
     #[test]

--- a/bridge/ffi/src/sources_api.rs
+++ b/bridge/ffi/src/sources_api.rs
@@ -51,7 +51,7 @@ struct BlockSummary {
     icon: Option<String>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Default)]
 struct PerformOutcome {
     performed: usize,
     errors: Vec<String>,
@@ -59,6 +59,11 @@ struct PerformOutcome {
     /// caller should descend into it. An explicit signal, because "nothing was
     /// performed" is also what a failure looks like.
     produces_rows: bool,
+    /// The block declares no `open` and the row names a path, so the row IS the
+    /// thing: the shell opens it the way it opens any file. One rule for Enter,
+    /// decided here rather than from the row's kind, which says which producer
+    /// made it and nothing the user chose.
+    opens_path: bool,
 }
 
 /// `{id, name, steps, file, then}` for the block a candidate id belongs to, or
@@ -170,6 +175,9 @@ pub(crate) fn look_perform_block_json_impl(
         _ if as_target => return produces_rows(),
         _ => match block.verbs.open.as_deref() {
             Some(command) => vec![command.to_string()],
+            // A row that names a path needs no verb to be openable, which is
+            // what makes `dir` blocks work without declaring one.
+            None if !row.path.is_empty() => return opens_path(),
             None => {
                 return outcome(
                     0,
@@ -268,12 +276,13 @@ struct LevelRow {
     candidate_id: String,
     id: String,
     title: String,
-    subtitle: Option<String>,
-    group: Option<String>,
+    /// Already resolved against the block name, by the same rule the index
+    /// uses, so neither shell has to know it.
+    subtitle: String,
     path: Option<String>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Default)]
 struct Level {
     /// The parent's OWN id, as the core decoded it. Handed back so the shell can
     /// name the ancestor in later calls without keeping a second decoder for the
@@ -293,10 +302,8 @@ struct Level {
 fn level_error(message: impl Into<String>) -> *mut c_char {
     json_cstring_or_null(
         serde_json::to_string(&Level {
-            parent_row_id: String::new(),
-            rows: Vec::new(),
-            truncated: false,
             error: Some(message.into()),
+            ..Default::default()
         })
         .ok(),
     )
@@ -396,10 +403,9 @@ pub(crate) fn look_source_rows_json_impl(
         .into_iter()
         .map(|row| LevelRow {
             candidate_id: CandidateIdKind::source_row_candidate_id(&block.id, &ancestors, &row.id),
+            subtitle: row.display_subtitle(&block.name).to_string(),
             id: row.id,
             title: row.title,
-            subtitle: row.subtitle,
-            group: row.group,
             path: row.path.map(|path| {
                 look_sources::expand_home(&path, &home)
                     .to_string_lossy()
@@ -503,26 +509,31 @@ fn steps_of(block: &Block) -> Vec<String> {
     }
 }
 
+fn respond(outcome: PerformOutcome) -> *mut c_char {
+    json_cstring_or_null(serde_json::to_string(&outcome).ok())
+}
+
 fn outcome(performed: usize, errors: Vec<String>) -> *mut c_char {
-    json_cstring_or_null(
-        serde_json::to_string(&PerformOutcome {
-            performed,
-            errors,
-            produces_rows: false,
-        })
-        .ok(),
-    )
+    respond(PerformOutcome {
+        performed,
+        errors,
+        ..Default::default()
+    })
 }
 
 fn produces_rows() -> *mut c_char {
-    json_cstring_or_null(
-        serde_json::to_string(&PerformOutcome {
-            performed: 0,
-            errors: Vec::new(),
-            produces_rows: true,
-        })
-        .ok(),
-    )
+    respond(PerformOutcome {
+        produces_rows: true,
+        ..Default::default()
+    })
+}
+
+/// Nothing declared, but the row has somewhere to point.
+fn opens_path() -> *mut c_char {
+    respond(PerformOutcome {
+        opens_path: true,
+        ..Default::default()
+    })
 }
 
 fn find_block(block_id: &str) -> Option<Block> {
@@ -686,6 +697,55 @@ mod tests {
         // Inside a producer the parent IS the row, so `{parent.*}` is the level
         // above that one.
         assert_eq!(level["rows"][0]["id"], "the grandparent", "{level}");
+    }
+
+    fn perform(block: &str, row_path: &str) -> serde_json::Value {
+        let block = CString::new(block).unwrap();
+        let id = CString::new("src:probe:row").unwrap();
+        let title = CString::new("row").unwrap();
+        let path = CString::new(row_path).unwrap();
+        let query = CString::new("").unwrap();
+        let ancestors = CString::new("[]").unwrap();
+        let ptr = look_perform_block_json_impl(
+            block.as_ptr(),
+            id.as_ptr(),
+            title.as_ptr(),
+            path.as_ptr(),
+            query.as_ptr(),
+            ancestors.as_ptr(),
+            false,
+        );
+        let raw = unsafe { CStr::from_ptr(ptr) }
+            .to_string_lossy()
+            .into_owned();
+        crate::state::free_json_allocation(ptr);
+        serde_json::from_str(&raw).expect("outcome json")
+    }
+
+    #[test]
+    fn enter_runs_the_declared_open_whatever_producer_made_the_row() {
+        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
+        let _fixture = Fixture::new(
+            "enter",
+            "[declared]\ndir = \"/tmp\"\nopen = \"true\"\n             [bare]\ndir = \"/tmp\"\n             [pathless]\nfile = \"/tmp/rows.txt\"\n",
+        );
+
+        // Declared: run it. This is the case a `dir` block could not reach
+        // before, so `open` on one was a key that did nothing.
+        let ran = perform("declared", "/tmp");
+        assert_eq!(ran["performed"], 1, "{ran}");
+        assert_eq!(ran["opens_path"], false);
+
+        // Nothing declared but the row has a path: the row IS the thing.
+        let opens = perform("bare", "/tmp");
+        assert_eq!(opens["opens_path"], true, "{opens}");
+        assert_eq!(opens["errors"].as_array().unwrap().len(), 0);
+
+        // Nothing declared and nowhere to point: the only case left that is an
+        // error the user can act on.
+        let stuck = perform("pathless", "");
+        assert_eq!(stuck["opens_path"], false, "{stuck}");
+        assert!(stuck["errors"][0].as_str().unwrap().contains("open"));
     }
 
     #[test]

--- a/bridge/ffi/src/sources_api.rs
+++ b/bridge/ffi/src/sources_api.rs
@@ -9,7 +9,7 @@
 use std::path::PathBuf;
 
 use look_indexing::CandidateIdKind;
-use look_sources::{Block, Producer, RowContext, load_dir, sources_dir};
+use look_sources::{Block, ParentRow, Producer, RowContext, load_dir, sources_dir};
 use serde::Serialize;
 use std::os::raw::c_char;
 use std::time::Duration;
@@ -68,9 +68,10 @@ pub(crate) fn look_source_block_json_impl(
     row_id: *const c_char,
     row_title: *const c_char,
     row_path: *const c_char,
+    ancestors_json: *const c_char,
 ) -> *mut c_char {
     let candidate_id = cstr_to_string(candidate_id);
-    let row = row_context(row_id, row_title, row_path, "");
+    let row = row_context(row_id, row_title, row_path, "", ancestors_json);
     let Some(block_id) = CandidateIdKind::source_id_of(&candidate_id) else {
         return json_cstring_or_null(None);
     };
@@ -146,10 +147,17 @@ pub(crate) fn look_perform_block_json_impl(
     row_title: *const c_char,
     row_path: *const c_char,
     query: *const c_char,
+    ancestors_json: *const c_char,
     as_target: bool,
 ) -> *mut c_char {
     let block_id = cstr_to_string(block_id);
-    let row = row_context(row_id, row_title, row_path, &cstr_to_string(query));
+    let row = row_context(
+        row_id,
+        row_title,
+        row_path,
+        &cstr_to_string(query),
+        ancestors_json,
+    );
 
     let Some(block) = find_block(&block_id) else {
         return outcome(0, vec!["that block no longer exists".into()]);
@@ -205,11 +213,19 @@ pub(crate) fn look_refresh_run_blocks_json_impl() -> *mut c_char {
             command,
             cwd,
             timeout,
-            ..
+            format,
         } = &block.producer
         else {
             continue;
         };
+
+        // A block whose command names a row placeholder only means something
+        // against a selection: it is a level, run live when the user descends
+        // (§2.10). Running it here would execute `jq ... {path}/package.json`
+        // literally and report a failure the user cannot act on.
+        if block.needs_row() {
+            continue;
+        }
 
         if !block.enabled {
             look_engine::index::clear_run_rows(&block.id);
@@ -222,7 +238,7 @@ pub(crate) fn look_refresh_run_blocks_json_impl() -> *mut c_char {
             timeout.unwrap_or(DEFAULT_CAPTURE_TIMEOUT),
             MAX_CAPTURE_BYTES,
         )
-        .and_then(|output| look_engine::index::store_run_rows(&block.id, &output));
+        .and_then(|output| look_engine::index::store_run_rows(&block.id, &output, *format));
 
         match outcome {
             Ok(rows) => refreshed += rows,
@@ -239,6 +255,170 @@ pub(crate) fn look_refresh_run_blocks_json_impl() -> *mut c_char {
     )
 }
 
+/// How deep a stack of levels may go (`specs/user-sources.md` §2.10). Bounds
+/// both the id and the stack, and a launcher six levels deep has stopped being
+/// a launcher.
+const MAX_LEVEL_DEPTH: usize = 5;
+
+/// One row of a level, ready to render and to rank: its candidate id already
+/// carries the ancestors it was reached through.
+#[derive(Serialize)]
+struct LevelRow {
+    #[serde(rename = "candidateId")]
+    candidate_id: String,
+    id: String,
+    title: String,
+    subtitle: Option<String>,
+    group: Option<String>,
+    path: Option<String>,
+}
+
+#[derive(Serialize)]
+struct Level {
+    /// The parent's OWN id, as the core decoded it. Handed back so the shell can
+    /// name the ancestor in later calls without keeping a second decoder for the
+    /// id format (§2.10).
+    #[serde(rename = "parentRowId")]
+    parent_row_id: String,
+    rows: Vec<LevelRow>,
+    /// The row cap dropped rows, so the caller can say so rather than implying
+    /// the level is all there is.
+    truncated: bool,
+    /// Set when the level could not be produced. The caller must not descend:
+    /// an empty level and a broken command look identical on screen, so neither
+    /// is silently entered.
+    error: Option<String>,
+}
+
+fn level_error(message: impl Into<String>) -> *mut c_char {
+    json_cstring_or_null(
+        serde_json::to_string(&Level {
+            parent_row_id: String::new(),
+            rows: Vec::new(),
+            truncated: false,
+            error: Some(message.into()),
+        })
+        .ok(),
+    )
+}
+
+/// The rows of `block_id` produced against the selected row, for descending into
+/// it (`specs/user-sources.md` §2.10).
+///
+/// Live on every call, never cached: `~/.look/cache/rows/<block>` is keyed by
+/// block alone, and a level's rows depend on the row it was launched from. The
+/// user has already picked that row, so one command is a wait they asked for and
+/// a stale level is worse.
+pub(crate) fn look_source_rows_json_impl(
+    block_id: *const c_char,
+    parent_candidate_id: *const c_char,
+    parent_title: *const c_char,
+    parent_path: *const c_char,
+    query: *const c_char,
+    ancestors_json: *const c_char,
+) -> *mut c_char {
+    let block_id = cstr_to_string(block_id);
+    let parent_candidate_id = cstr_to_string(parent_candidate_id);
+    // Built here rather than through `row_context`, which takes C pointers: the
+    // parent id is already an owned Rust string and handing its bytes back as a
+    // C string would read past the end of it.
+    let row = RowContext {
+        id: CandidateIdKind::source_row_id_of(&parent_candidate_id).to_string(),
+        title: cstr_to_string(parent_title),
+        path: cstr_to_string(parent_path),
+        query: cstr_to_string(query),
+        // The parent's own ancestors: inside this call the parent IS the row, so
+        // a producer saying `{parent.path}` means the grandparent.
+        parents: parents_from(ancestors_json),
+    };
+
+    let Some(home) = home_dir() else {
+        return level_error("no home directory");
+    };
+    let Some(block) = find_block(&block_id) else {
+        return level_error("that block no longer exists");
+    };
+    if !block.enabled {
+        return level_error(format!("[{}] is turned off", block.id));
+    }
+
+    // The chain the child's rows will carry: everything the parent was reached
+    // through, then the parent itself.
+    let Some(parent_block) = CandidateIdKind::source_id_of(&parent_candidate_id) else {
+        return level_error("that row does not belong to a block");
+    };
+    let mut ancestors = CandidateIdKind::source_ancestors_of(&parent_candidate_id);
+    ancestors.push((parent_block.to_string(), row.id.clone()));
+    if ancestors.len() > MAX_LEVEL_DEPTH {
+        return level_error(format!("{MAX_LEVEL_DEPTH} levels is as deep as this goes"));
+    }
+
+    let collected = match &block.producer {
+        Producer::Run {
+            command,
+            cwd,
+            timeout,
+            format,
+        } => {
+            let command = look_sources::expand(command, &row);
+            let cwd = cwd
+                .as_deref()
+                .map(|cwd| look_sources::expand_path(cwd, &row));
+            match look_sources::capture(
+                &command,
+                cwd.as_deref(),
+                timeout.unwrap_or(DEFAULT_CAPTURE_TIMEOUT),
+                MAX_CAPTURE_BYTES,
+            )
+            .and_then(|output| {
+                look_sources::parse_rows(&output, look_sources::MAX_ROWS_PER_SOURCE, *format)
+            }) {
+                Ok((rows, truncated)) => look_sources::Collected {
+                    rows,
+                    truncated,
+                    unreadable: Vec::new(),
+                },
+                Err(message) => return level_error(message),
+            }
+        }
+        _ => match look_sources::collect_for_row(&block, &home, &row) {
+            Ok(collected) => collected,
+            Err(err) => return level_error(err.to_string()),
+        },
+    };
+
+    if collected.rows.is_empty() {
+        return level_error(format!("[{}] produced no rows", block.id));
+    }
+
+    let rows: Vec<LevelRow> = collected
+        .rows
+        .into_iter()
+        .map(|row| LevelRow {
+            candidate_id: CandidateIdKind::source_row_candidate_id(&block.id, &ancestors, &row.id),
+            id: row.id,
+            title: row.title,
+            subtitle: row.subtitle,
+            group: row.group,
+            path: row.path.map(|path| {
+                look_sources::expand_home(&path, &home)
+                    .to_string_lossy()
+                    .into_owned()
+            }),
+        })
+        .collect();
+
+    json_cstring_or_null(
+        serde_json::to_string(&Level {
+            parent_row_id: row.id.clone(),
+            rows,
+            truncated: collected.truncated,
+            error: None,
+        })
+        .ok(),
+    )
+}
+
 /// Runs a block's declared `preview` against the selected row and returns its
 /// output as `{rows, error}`-shaped text, or `null` when it declares none.
 pub(crate) fn look_source_preview_json_impl(
@@ -246,6 +426,7 @@ pub(crate) fn look_source_preview_json_impl(
     row_id: *const c_char,
     row_title: *const c_char,
     row_path: *const c_char,
+    ancestors_json: *const c_char,
 ) -> *mut c_char {
     let candidate_id = cstr_to_string(candidate_id);
     let Some(block_id) = CandidateIdKind::source_id_of(&candidate_id) else {
@@ -258,11 +439,11 @@ pub(crate) fn look_source_preview_json_impl(
         return json_cstring_or_null(None);
     };
 
-    let row = row_context(row_id, row_title, row_path, "");
+    let row = row_context(row_id, row_title, row_path, "", ancestors_json);
     let command = look_sources::expand(preview, &row);
     let text = look_sources::capture(
         &command,
-        Some(&row.path),
+        Some(&row.working_dir()),
         DEFAULT_CAPTURE_TIMEOUT,
         MAX_CAPTURE_BYTES,
     );
@@ -288,6 +469,7 @@ fn row_context(
     row_title: *const c_char,
     row_path: *const c_char,
     query: &str,
+    ancestors_json: *const c_char,
 ) -> RowContext {
     let candidate_id = cstr_to_string(row_id);
     RowContext {
@@ -295,7 +477,23 @@ fn row_context(
         title: cstr_to_string(row_title),
         path: cstr_to_string(row_path),
         query: query.to_string(),
+        parents: parents_from(ancestors_json),
     }
+}
+
+/// The rows a drilled row was reached through, for `{parent.*}`: nearest first,
+/// as `[{id, title, path}]`.
+///
+/// The candidate id already carries the ancestor ids, but a placeholder can name
+/// their titles and paths too, and only the shell still holds those. Anything
+/// unparseable is no ancestors, which reads as empty rather than as a literal
+/// placeholder reaching a shell.
+fn parents_from(ancestors_json: *const c_char) -> Vec<ParentRow> {
+    let raw = cstr_to_string(ancestors_json);
+    if raw.trim().is_empty() {
+        return Vec::new();
+    }
+    serde_json::from_str::<Vec<ParentRow>>(&raw).unwrap_or_default()
 }
 
 fn steps_of(block: &Block) -> Vec<String> {
@@ -354,4 +552,176 @@ fn home_dir() -> Option<PathBuf> {
         .ok()
         .filter(|value| !value.trim().is_empty())
         .map(PathBuf::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::{CStr, CString};
+
+    /// The sources directory is process-wide state, so these run one at a time.
+    static GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct Fixture {
+        dir: PathBuf,
+    }
+
+    impl Fixture {
+        fn new(label: &str, declarations: &str) -> Self {
+            let dir =
+                std::env::temp_dir().join(format!("look-ffi-level-{label}-{}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).expect("fixture dir");
+            std::fs::write(dir.join("blocks.toml"), declarations).expect("fixture file");
+            unsafe { std::env::set_var(look_sources::SOURCES_DIR_ENV, &dir) };
+            Self { dir }
+        }
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            unsafe { std::env::remove_var(look_sources::SOURCES_DIR_ENV) };
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+
+    fn descend(block: &str, parent_id: &str, parent_path: &str) -> serde_json::Value {
+        let block = CString::new(block).unwrap();
+        let parent = CString::new(parent_id).unwrap();
+        let title = CString::new("parent").unwrap();
+        let path = CString::new(parent_path).unwrap();
+        let query = CString::new("").unwrap();
+        let ancestors = CString::new("[]").unwrap();
+        let ptr = look_source_rows_json_impl(
+            block.as_ptr(),
+            parent.as_ptr(),
+            title.as_ptr(),
+            path.as_ptr(),
+            query.as_ptr(),
+            ancestors.as_ptr(),
+        );
+        let raw = unsafe { CStr::from_ptr(ptr) }
+            .to_string_lossy()
+            .into_owned();
+        crate::state::free_json_allocation(ptr);
+        serde_json::from_str(&raw).expect("level json")
+    }
+
+    #[test]
+    fn a_level_carries_the_ancestors_its_rows_were_reached_through() {
+        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
+        let _fixture = Fixture::new(
+            "rows",
+            "[child]\nrun = \"printf 'one\\ttitle one\\ntwo\\n'\"\n",
+        );
+
+        let level = descend("child", "src:parent:alpha", "/tmp");
+        assert!(level["error"].is_null(), "{level}");
+        let rows = level["rows"].as_array().unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0]["candidateId"], "src:child:|parent/alpha|one");
+        assert_eq!(rows[0]["title"], "title one");
+
+        // The same block under another parent is a different id, which is what
+        // keeps usage ranking from bleeding between levels.
+        let other = descend("child", "src:parent:beta", "/tmp");
+        assert_eq!(
+            other["rows"][0]["candidateId"],
+            "src:child:|parent/beta|one"
+        );
+    }
+
+    #[test]
+    fn a_producer_expands_against_the_row_the_level_opened_from() {
+        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
+        let _fixture = Fixture::new("expand", "[child]\nrun = \"basename {path}\"\n");
+
+        let level = descend("child", "src:parent:alpha", "/tmp/some project");
+        assert!(level["error"].is_null(), "{level}");
+        // Quoted on substitution, so a space in the path stays one argument.
+        assert_eq!(level["rows"][0]["id"], "some project");
+    }
+
+    #[test]
+    fn nothing_to_descend_into_is_an_error_rather_than_an_empty_level() {
+        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
+        let _fixture = Fixture::new(
+            "empty",
+            "[child]\nrun = \"true\"\n[off]\nrun = \"echo x\"\nenabled = false\n",
+        );
+
+        assert!(descend("child", "src:parent:alpha", "/tmp")["error"].is_string());
+        assert!(descend("off", "src:parent:alpha", "/tmp")["error"].is_string());
+        assert!(descend("missing", "src:parent:alpha", "/tmp")["error"].is_string());
+        // A row that belongs to no block cannot be a parent.
+        assert!(descend("child", "app:safari", "/tmp")["error"].is_string());
+    }
+
+    #[test]
+    fn an_ancestors_payload_reaches_the_producer_as_parent_placeholders() {
+        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
+        let _fixture = Fixture::new("parents", "[child]\nrun = \"echo {parent.title}\"\n");
+
+        let block = CString::new("child").unwrap();
+        let parent = CString::new("src:mid:row").unwrap();
+        let title = CString::new("mid").unwrap();
+        let path = CString::new("/tmp").unwrap();
+        let query = CString::new("").unwrap();
+        let ancestors =
+            CString::new(r#"[{"id":"outer","title":"the grandparent","path":"/tmp"}]"#).unwrap();
+        let ptr = look_source_rows_json_impl(
+            block.as_ptr(),
+            parent.as_ptr(),
+            title.as_ptr(),
+            path.as_ptr(),
+            query.as_ptr(),
+            ancestors.as_ptr(),
+        );
+        let raw = unsafe { CStr::from_ptr(ptr) }
+            .to_string_lossy()
+            .into_owned();
+        crate::state::free_json_allocation(ptr);
+        let level: serde_json::Value = serde_json::from_str(&raw).unwrap();
+
+        // Inside a producer the parent IS the row, so `{parent.*}` is the level
+        // above that one.
+        assert_eq!(level["rows"][0]["id"], "the grandparent", "{level}");
+    }
+
+    #[test]
+    fn a_refresh_leaves_the_levels_alone() {
+        // A level's command is written for a selected row. Refresh has none, so
+        // running it would hand the shell a literal `{path}` and report an
+        // error against a block that is working exactly as declared.
+        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
+        let _fixture = Fixture::new(
+            "refresh",
+            "[level]\nrun = \"jq . {path}/package.json\"\n[flat]\nrun = \"echo one\"\n",
+        );
+
+        let ptr = look_refresh_run_blocks_json_impl();
+        let raw = unsafe { CStr::from_ptr(ptr) }
+            .to_string_lossy()
+            .into_owned();
+        crate::state::free_json_allocation(ptr);
+        let outcome: serde_json::Value = serde_json::from_str(&raw).unwrap();
+
+        assert_eq!(outcome["errors"].as_array().unwrap().len(), 0, "{outcome}");
+        assert_eq!(outcome["refreshed"], 1, "only the flat block has rows");
+        look_engine::index::clear_run_rows("flat");
+    }
+
+    #[test]
+    fn the_stack_stops_at_the_declared_depth() {
+        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
+        let _fixture = Fixture::new("depth", "[child]\nrun = \"echo x\"\n");
+
+        let chain = (0..MAX_LEVEL_DEPTH)
+            .map(|i| format!("b{i}/r{i}"))
+            .collect::<Vec<_>>()
+            .join(";");
+        let deep = format!("src:parent:|{chain}|row");
+        let level = descend("child", &deep, "/tmp");
+        assert!(level["error"].as_str().unwrap().contains("deep"), "{level}");
+    }
 }

--- a/bridge/ffi/src/sources_api.rs
+++ b/bridge/ffi/src/sources_api.rs
@@ -577,6 +577,15 @@ mod tests {
             unsafe { std::env::set_var(look_sources::SOURCES_DIR_ENV, &dir) };
             Self { dir }
         }
+
+        /// Rows for a `file` block to read.
+        fn rows(&self, name: &str, contents: &str) {
+            let path = self.dir.join(name);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).expect("rows dir");
+            }
+            std::fs::write(&path, contents).expect("rows file");
+        }
     }
 
     impl Drop for Fixture {
@@ -611,12 +620,13 @@ mod tests {
     #[test]
     fn a_level_carries_the_ancestors_its_rows_were_reached_through() {
         let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
-        let _fixture = Fixture::new(
-            "rows",
-            "[child]\nrun = \"printf 'one\\ttitle one\\ntwo\\n'\"\n",
-        );
+        // A `file` producer: ids and ancestors are not shell behaviour, and
+        // `run` refuses off unix.
+        let fixture = Fixture::new("rows", "[child]\nfile = \"{path}/rows.txt\"\n");
+        fixture.rows("rows.txt", "one\ttitle one\ntwo\n");
+        let root = fixture.dir.to_string_lossy().into_owned();
 
-        let level = descend("child", "src:parent:alpha", "/tmp");
+        let level = descend("child", "src:parent:alpha", &root);
         assert!(level["error"].is_null(), "{level}");
         let rows = level["rows"].as_array().unwrap();
         assert_eq!(rows.len(), 2);
@@ -625,7 +635,7 @@ mod tests {
 
         // The same block under another parent is a different id, which is what
         // keeps usage ranking from bleeding between levels.
-        let other = descend("child", "src:parent:beta", "/tmp");
+        let other = descend("child", "src:parent:beta", &root);
         assert_eq!(
             other["rows"][0]["candidateId"],
             "src:child:|parent/beta|one"
@@ -635,41 +645,61 @@ mod tests {
     #[test]
     fn a_producer_expands_against_the_row_the_level_opened_from() {
         let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
-        let _fixture = Fixture::new("expand", "[child]\nrun = \"basename {path}\"\n");
+        let fixture = Fixture::new("expand", "[child]\nfile = \"{path}/rows.txt\"\n");
+        // A space in the name: the level is empty unless `{path}` was
+        // substituted and left unquoted.
+        fixture.rows("some project/rows.txt", "one\n");
+        let inside = fixture.dir.join("some project");
 
-        let level = descend("child", "src:parent:alpha", "/tmp/some project");
+        let level = descend("child", "src:parent:alpha", &inside.to_string_lossy());
         assert!(level["error"].is_null(), "{level}");
-        // Quoted on substitution, so a space in the path stays one argument.
-        assert_eq!(level["rows"][0]["id"], "some project");
+        assert_eq!(level["rows"][0]["id"], "one");
     }
 
     #[test]
     fn nothing_to_descend_into_is_an_error_rather_than_an_empty_level() {
         let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
-        let _fixture = Fixture::new(
+        let fixture = Fixture::new(
             "empty",
-            "[child]\nrun = \"true\"\n[off]\nrun = \"echo x\"\nenabled = false\n",
+            "[child]\nfile = \"{path}/rows.txt\"\n[off]\nfile = \"{path}/rows.txt\"\nenabled = false\n",
         );
+        // Produced nothing, rather than failed to run: a `run` block would
+        // pass this off unix by reporting the missing shell.
+        fixture.rows("rows.txt", "\n");
+        let root = fixture.dir.to_string_lossy().into_owned();
 
-        assert!(descend("child", "src:parent:alpha", "/tmp")["error"].is_string());
-        assert!(descend("off", "src:parent:alpha", "/tmp")["error"].is_string());
-        assert!(descend("missing", "src:parent:alpha", "/tmp")["error"].is_string());
+        let empty = descend("child", "src:parent:alpha", &root);
+        assert!(
+            empty["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("no rows"),
+            "{empty}"
+        );
+        assert!(descend("off", "src:parent:alpha", &root)["error"].is_string());
+        assert!(descend("missing", "src:parent:alpha", &root)["error"].is_string());
         // A row that belongs to no block cannot be a parent.
-        assert!(descend("child", "app:safari", "/tmp")["error"].is_string());
+        assert!(descend("child", "app:safari", &root)["error"].is_string());
     }
 
     #[test]
     fn an_ancestors_payload_reaches_the_producer_as_parent_placeholders() {
         let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
-        let _fixture = Fixture::new("parents", "[child]\nrun = \"echo {parent.title}\"\n");
+        let fixture = Fixture::new(
+            "parents",
+            "[child]\nfile = \"{path}/{parent.title}/rows.txt\"\n",
+        );
+        // The grandparent's title names the folder, so an empty level means
+        // `{parent.title}` never reached the producer.
+        fixture.rows("outer-title/rows.txt", "found\n");
 
         let block = CString::new("child").unwrap();
         let parent = CString::new("src:mid:row").unwrap();
         let title = CString::new("mid").unwrap();
-        let path = CString::new("/tmp").unwrap();
+        let path = CString::new(fixture.dir.to_string_lossy().as_ref()).unwrap();
         let query = CString::new("").unwrap();
         let ancestors =
-            CString::new(r#"[{"id":"outer","title":"the grandparent","path":"/tmp"}]"#).unwrap();
+            CString::new(r#"[{"id":"outer","title":"outer-title","path":"/tmp"}]"#).unwrap();
         let ptr = look_source_rows_json_impl(
             block.as_ptr(),
             parent.as_ptr(),
@@ -686,7 +716,7 @@ mod tests {
 
         // Inside a producer the parent IS the row, so `{parent.*}` is the level
         // above that one.
-        assert_eq!(level["rows"][0]["id"], "the grandparent", "{level}");
+        assert_eq!(level["rows"][0]["id"], "found", "{level}");
     }
 
     fn perform(block: &str, row_path: &str) -> serde_json::Value {
@@ -723,8 +753,10 @@ mod tests {
         // Declared: run it. This is the case a `dir` block could not reach
         // before, so `open` on one was a key that did nothing.
         let ran = perform("declared", "/tmp");
+        assert_eq!(ran["opens_path"], false, "{ran}");
+        // The spawn is the platform's business: `run` refuses off unix.
+        #[cfg(unix)]
         assert_eq!(ran["performed"], 1, "{ran}");
-        assert_eq!(ran["opens_path"], false);
 
         // Nothing declared but the row has a path: the row IS the thing.
         let opens = perform("bare", "/tmp");
@@ -798,6 +830,8 @@ mod tests {
         assert_ne!(theirs["tool"], serde_json::json!("projects"), "{theirs}");
     }
 
+    /// Refresh runs a `run` block's command, which `run` refuses off unix.
+    #[cfg(unix)]
     #[test]
     fn a_refresh_leaves_the_levels_alone() {
         // A level's command is written for a selected row. Refresh has none, so

--- a/bridge/ffi/src/tools_api.rs
+++ b/bridge/ffi/src/tools_api.rs
@@ -27,7 +27,14 @@ pub(crate) fn look_tool_action_json_impl(
     is_dir: bool,
     ancestors_json: *const c_char,
 ) -> *mut c_char {
-    let request = Request::read(action, candidate_id, row_title, path, is_dir, ancestors_json);
+    let request = Request::read(
+        action,
+        candidate_id,
+        row_title,
+        path,
+        is_dir,
+        ancestors_json,
+    );
 
     json_cstring_or_null(
         request
@@ -52,7 +59,14 @@ pub(crate) fn look_perform_tool_action_json_impl(
     is_dir: bool,
     ancestors_json: *const c_char,
 ) -> *mut c_char {
-    let request = Request::read(action, candidate_id, row_title, path, is_dir, ancestors_json);
+    let request = Request::read(
+        action,
+        candidate_id,
+        row_title,
+        path,
+        is_dir,
+        ancestors_json,
+    );
 
     let resolved = request.resolve().map(|outcome| {
         let resolved = match outcome {

--- a/bridge/ffi/src/tools_api.rs
+++ b/bridge/ffi/src/tools_api.rs
@@ -9,21 +9,30 @@
 //! `~/.look/config` with no extra call from the shell.
 
 use look_engine::config::RuntimeConfig;
+use look_indexing::CandidateIdKind;
+use look_sources::{Block, RowContext};
 use look_tools::{Action, Launch, Resolved};
 use std::os::raw::c_char;
 
+use crate::sources_api::{find_block, parents_from};
 use crate::state::{cstr_to_string, json_cstring_or_null};
 
 /// Resolves `action` ("edit", "terminal", "reveal") against a row, or the JSON
 /// literal `null` when the action is unknown or the path is empty.
 pub(crate) fn look_tool_action_json_impl(
     action: *const c_char,
+    candidate_id: *const c_char,
+    row_title: *const c_char,
     path: *const c_char,
     is_dir: bool,
+    ancestors_json: *const c_char,
 ) -> *mut c_char {
+    let request = Request::read(action, candidate_id, row_title, path, is_dir, ancestors_json);
+
     json_cstring_or_null(
-        resolve(action, path, is_dir)
-            .map(Resolved::from)
+        request
+            .resolve()
+            .map(|outcome| request.mark(Resolved::from(outcome)))
             .as_ref()
             .and_then(json),
     )
@@ -34,39 +43,97 @@ pub(crate) fn look_tool_action_json_impl(
 /// shell selection.
 ///
 /// An `application` result comes back untouched: finding and starting a bundle
-/// is the native side's job (`specs/preferred-tools.md` §8).
+/// is the native side's job.
 pub(crate) fn look_perform_tool_action_json_impl(
     action: *const c_char,
+    candidate_id: *const c_char,
+    row_title: *const c_char,
     path: *const c_char,
     is_dir: bool,
+    ancestors_json: *const c_char,
 ) -> *mut c_char {
-    let resolved = resolve(action, path, is_dir).map(|outcome| match outcome {
-        Ok(Launch::Shell { tool, command }) => performed(&tool, command),
-        other => Resolved::from(other),
+    let request = Request::read(action, candidate_id, row_title, path, is_dir, ancestors_json);
+
+    let resolved = request.resolve().map(|outcome| {
+        let resolved = match outcome {
+            Ok(Launch::Shell { tool, command }) => performed(&tool, command, &request.row),
+            other => Resolved::from(other),
+        };
+        request.mark(resolved)
     });
 
     json_cstring_or_null(resolved.as_ref().and_then(json))
 }
 
-fn resolve(
-    action: *const c_char,
-    path: *const c_char,
+/// One action against one row, read once and shared by resolve and perform so
+/// they cannot answer differently for the same press.
+struct Request {
+    action: String,
+    /// The block that produced the row, when one did. Its `edit` / `terminal` /
+    /// `reveal` wins for its own rows.
+    block: Option<Block>,
+    row: RowContext,
+    path: String,
     is_dir: bool,
-) -> Option<Result<Launch, look_tools::Unavailable>> {
-    look_tools::resolve(
-        &cstr_to_string(action),
-        &cstr_to_string(path),
-        is_dir,
-        &RuntimeConfig::tools_cached(),
-    )
+}
+
+impl Request {
+    fn read(
+        action: *const c_char,
+        candidate_id: *const c_char,
+        row_title: *const c_char,
+        path: *const c_char,
+        is_dir: bool,
+        ancestors_json: *const c_char,
+    ) -> Self {
+        let candidate_id = cstr_to_string(candidate_id);
+        let path = cstr_to_string(path);
+        // An ordinary file never pays for reading the sources directory.
+        let block = CandidateIdKind::source_id_of(&candidate_id).and_then(find_block);
+
+        Self {
+            action: cstr_to_string(action),
+            block,
+            row: RowContext {
+                id: CandidateIdKind::source_row_id_of(&candidate_id).to_string(),
+                title: cstr_to_string(row_title),
+                path: path.clone(),
+                // A chord carries no query: `{query}` is what the user typed to
+                // reach a row, and Cmd+E is not that.
+                query: String::new(),
+                parents: parents_from(ancestors_json),
+            },
+            path,
+            is_dir,
+        }
+    }
+
+    fn resolve(&self) -> Option<Result<Launch, look_tools::Unavailable>> {
+        look_sources::resolve_for_row(
+            &self.action,
+            &self.path,
+            self.is_dir,
+            &RuntimeConfig::tools_cached(),
+            self.block.as_ref(),
+            &self.row,
+        )
+    }
+
+    /// Says whether the block took this chord, which is what the label needs.
+    fn mark(&self, mut resolved: Resolved) -> Resolved {
+        resolved.from_block = look_sources::block_declares(self.block.as_ref(), &self.action);
+        resolved
+    }
 }
 
 fn json(resolved: &Resolved) -> Option<String> {
     serde_json::to_string(resolved).ok()
 }
 
-fn performed(tool: &str, command: String) -> Resolved {
-    let error = look_sources::perform(&[command], None)
+/// With the row, like every other command a block declares: same working
+/// directory, same `LOOK_*` environment.
+fn performed(tool: &str, command: String, row: &RowContext) -> Resolved {
+    let error = look_sources::perform(&[command], Some(row))
         .into_iter()
         .find_map(|outcome| outcome.error);
 

--- a/bridge/ffi/src/usage_api.rs
+++ b/bridge/ffi/src/usage_api.rs
@@ -106,6 +106,13 @@ fn validate_and_record_usage(
         return Err(UsageRecordError::InvalidUsageAction);
     }
 
+    // A drilled row is never written to `candidates`, which the `usage_events`
+    // foreign key requires, so there is nothing to record. Reporting a failure
+    // would show a storage error for behaving as designed.
+    if !CandidateIdKind::source_ancestors_of(trimmed_id).is_empty() {
+        return Ok(());
+    }
+
     let Ok(store) = SqliteStore::open(default_db_path()) else {
         return Err(UsageRecordError::StorageOpenFailed);
     };
@@ -130,4 +137,26 @@ fn validate_and_record_usage(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    /// Not in `candidates`, so the insert would hit the foreign key and the
+    /// shell would show a storage error for pressing Enter in a level.
+    #[test]
+    fn a_drilled_row_records_nothing_and_reports_no_failure() {
+        let id = CString::new("src:scripts:|projects/animate|build").unwrap();
+        let action = CString::new(UsageAction::EXECUTE).unwrap();
+        assert!(look_record_usage_impl(id.as_ptr(), action.as_ptr()));
+    }
+
+    #[test]
+    fn an_id_that_belongs_to_nothing_is_still_refused() {
+        let id = CString::new("not-a-candidate-id").unwrap();
+        let action = CString::new(UsageAction::EXECUTE).unwrap();
+        assert!(!look_record_usage_impl(id.as_ptr(), action.as_ptr()));
+    }
 }

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -407,6 +407,7 @@ dependencies = [
  "globset",
  "look-tools",
  "serde",
+ "serde_json",
  "toml",
 ]
 

--- a/core/engine/src/index/run_cache.rs
+++ b/core/engine/src/index/run_cache.rs
@@ -12,7 +12,7 @@
 use std::fs;
 use std::path::PathBuf;
 
-use look_sources::{SourceRow, parse_lines};
+use look_sources::{RowFormat, SourceRow, parse_rows};
 
 /// Where a block's rows are kept between refreshes.
 const CACHE_DIR_NAME: &str = ".look/cache/rows";
@@ -33,14 +33,18 @@ fn cache_path(block_id: &str) -> Option<PathBuf> {
 }
 
 /// The rows `block_id` last produced, or empty when it has never run.
-pub(super) fn read(block_id: &str) -> Vec<SourceRow> {
+///
+/// The cache holds the command's raw stdout, so reading it back needs the same
+/// format the block declared when it was written.
+pub(super) fn read(block_id: &str, format: RowFormat) -> Vec<SourceRow> {
     let Some(path) = cache_path(block_id) else {
         return Vec::new();
     };
     let Ok(contents) = fs::read(&path) else {
         return Vec::new();
     };
-    let (rows, _) = parse_lines(&String::from_utf8_lossy(&contents), MAX_CACHED_ROWS);
+    let (rows, _) = parse_rows(&String::from_utf8_lossy(&contents), MAX_CACHED_ROWS, format)
+        .unwrap_or_default();
     rows
 }
 
@@ -50,8 +54,8 @@ pub(super) fn read(block_id: &str) -> Vec<SourceRow> {
 /// broken (network down, tool missing, wrong directory) than genuinely empty,
 /// and keeping the last good rows costs nothing while clearing them loses the
 /// user's ranking.
-pub fn write(block_id: &str, output: &str) -> Result<usize, String> {
-    let (rows, _) = parse_lines(output, MAX_CACHED_ROWS);
+pub fn write(block_id: &str, output: &str, format: RowFormat) -> Result<usize, String> {
+    let (rows, _) = parse_rows(output, MAX_CACHED_ROWS, format)?;
     if rows.is_empty() {
         return Err("produced no rows; keeping the previous ones".into());
     }
@@ -87,7 +91,14 @@ mod tests {
     fn empty_output_keeps_the_previous_rows() {
         // A command returning nothing is usually broken, not empty, and the ids
         // it produced carry the user's usage history.
-        assert!(write("probe", "").is_err());
-        assert!(write("probe", "   \n\n").is_err());
+        assert!(write("probe", "", RowFormat::Lines).is_err());
+        assert!(write("probe", "   \n\n", RowFormat::Lines).is_err());
+    }
+
+    #[test]
+    fn output_that_is_not_the_declared_format_keeps_the_previous_rows() {
+        // Same reasoning: a script whose JSON broke must not take the rows, and
+        // the ranking they carry, down with it.
+        assert!(write("probe", "look\tLook", RowFormat::Json).is_err());
     }
 }

--- a/core/engine/src/index/sources.rs
+++ b/core/engine/src/index/sources.rs
@@ -272,8 +272,7 @@ mod tests {
 
         row.path = Some("~/dev/look".into());
         let candidate = row_candidate(&block, &row, home);
-        // Built the same way the code builds it: a separator is the platform's
-        // business, and hardcoding `/` fails on Windows for a correct answer.
+        // Built like the code builds it: the separator is the platform's.
         let expanded = home.join("dev/look");
         assert_eq!(candidate.path.as_ref(), expanded.to_string_lossy());
         // Still an action row: a block's verbs are what Enter performs, and a

--- a/core/engine/src/index/sources.rs
+++ b/core/engine/src/index/sources.rs
@@ -16,7 +16,9 @@ use std::sync::mpsc::SyncSender;
 use std::time::UNIX_EPOCH;
 
 use look_indexing::{Candidate, CandidateIdKind, CandidateKind};
-use look_sources::{Block, Producer, SourceRow, collect, load_dir, sources_dir};
+use look_sources::{
+    Block, Producer, RowFormat, SourceRow, collect, expand_home, load_dir, sources_dir,
+};
 
 use crate::index::run_cache;
 
@@ -65,7 +67,7 @@ pub(super) fn discover_user_sources(tx: SyncSender<Candidate>) {
             // A `run` block needs a process, and spawning one per index pass
             // would put arbitrary user commands on the indexing thread. The
             // shell runs it and hands the rows back (see `run_cache`).
-            Producer::Run { .. } => emit_cached_rows(block, &tx),
+            Producer::Run { format, .. } => emit_cached_rows(block, *format, home, &tx),
         }
     }
 }
@@ -73,7 +75,7 @@ pub(super) fn discover_user_sources(tx: SyncSender<Candidate>) {
 /// A bundle is one row, and Enter performs its steps. The step count is the
 /// honest subtitle: it says this will do several things before you press it.
 fn bundle_candidate(block: &Block, steps: usize) -> Candidate {
-    let id = format!("{}{}", CandidateIdKind::source_row_prefix(&block.id), "");
+    let id = CandidateIdKind::source_row_candidate_id(&block.id, &[], "");
     let mut candidate = Candidate::new(&id, CandidateKind::Action, &block.name, "");
     let plural = if steps == 1 { "" } else { "s" };
     candidate.subtitle = Some(format!("{steps} {BUNDLE_STEP_LABEL}{plural}").into());
@@ -128,40 +130,44 @@ fn emit_rows(block: &Block, home: &Path, tx: &SyncSender<Candidate>) {
             block.id
         );
     }
-    send_rows(block, &collected.rows, tx);
+    send_rows(block, &collected.rows, home, tx);
 }
 
 /// A `run` block's rows come from the last refresh the shell performed. No cache
 /// means the block has not been run yet, which is silent: a first launcher open
 /// should not look like a broken source.
-fn emit_cached_rows(block: &Block, tx: &SyncSender<Candidate>) {
-    let rows = run_cache::read(&block.id);
-    send_rows(block, &rows, tx);
+fn emit_cached_rows(block: &Block, format: RowFormat, home: &Path, tx: &SyncSender<Candidate>) {
+    let rows = run_cache::read(&block.id, format);
+    send_rows(block, &rows, home, tx);
 }
 
-fn send_rows(block: &Block, rows: &[SourceRow], tx: &SyncSender<Candidate>) {
+fn send_rows(block: &Block, rows: &[SourceRow], home: &Path, tx: &SyncSender<Candidate>) {
     for row in rows {
-        if tx.send(row_candidate(block, row)).is_err() {
+        if tx.send(row_candidate(block, row, home)).is_err() {
             return;
         }
     }
 }
 
-fn row_candidate(block: &Block, row: &SourceRow) -> Candidate {
-    let id = format!(
-        "{}{}",
-        CandidateIdKind::source_row_prefix(&block.id),
-        row.id
+fn row_candidate(block: &Block, row: &SourceRow, home: &Path) -> Candidate {
+    let id = CandidateIdKind::source_row_candidate_id(&block.id, &[], &row.id);
+    // A row's path comes from a script, which writes `~` as readily as a user
+    // does, and the verbs and the tool chords both act on it directly.
+    let path = row
+        .path
+        .as_deref()
+        .map(|path| expand_home(path, home).to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let mut candidate = Candidate::new(&id, CandidateKind::Action, &row.title, &path);
+    // What the row declared, then its group, then the block: the most specific
+    // thing the row can say about itself, falling back to where it came from.
+    candidate.subtitle = Some(
+        row.subtitle
+            .as_deref()
+            .or(row.group.as_deref())
+            .unwrap_or(block.name.as_str())
+            .into(),
     );
-    let mut candidate = Candidate::new(
-        &id,
-        CandidateKind::Action,
-        &row.title,
-        row.path.as_deref().unwrap_or_default(),
-    );
-    // The group when the row named one, else the block: either way the row says
-    // where it came from, and typing that word lists the block.
-    candidate.subtitle = Some(row.group.as_deref().unwrap_or(block.name.as_str()).into());
     candidate
 }
 
@@ -172,7 +178,7 @@ fn dir_candidate(block: &Block, row_id: &str, title: &str, path: &str) -> Candid
         _ => CandidateKind::File,
     };
 
-    let id = format!("{}{row_id}", CandidateIdKind::source_row_prefix(&block.id));
+    let id = CandidateIdKind::source_row_candidate_id(&block.id, &[], row_id);
     let mut candidate = Candidate::new(&id, kind, title, path);
     // The block's name, not the generic kind word the file walker uses, so the
     // row says where it came from and typing that name lists the whole block.
@@ -238,6 +244,46 @@ mod tests {
             bundle_candidate(&block, 1).subtitle.as_deref(),
             Some("1 step")
         );
+    }
+
+    #[test]
+    fn a_row_says_what_it_declared_before_its_group_or_its_block() {
+        let block = block_of("[repos]\nname = \"Repos\"\nrun = \"repos\"\n");
+        let home = Path::new("/home/u");
+
+        let mut row = SourceRow::new("look", "Look");
+        assert_eq!(
+            row_candidate(&block, &row, home).subtitle.as_deref(),
+            Some("Repos")
+        );
+
+        row.group = Some("This week".into());
+        assert_eq!(
+            row_candidate(&block, &row, home).subtitle.as_deref(),
+            Some("This week")
+        );
+
+        row.subtitle = Some("3 uncommitted".into());
+        assert_eq!(
+            row_candidate(&block, &row, home).subtitle.as_deref(),
+            Some("3 uncommitted")
+        );
+    }
+
+    #[test]
+    fn a_row_path_is_usable_whether_or_not_the_script_expanded_it() {
+        let block = block_of("[repos]\nname = \"Repos\"\nrun = \"repos\"\n");
+        let home = Path::new("/home/u");
+
+        let mut row = SourceRow::new("look", "Look");
+        assert_eq!(row_candidate(&block, &row, home).path.as_ref(), "");
+
+        row.path = Some("~/dev/look".into());
+        let candidate = row_candidate(&block, &row, home);
+        assert_eq!(candidate.path.as_ref(), "/home/u/dev/look");
+        // Still an action row: a block's verbs are what Enter performs, and a
+        // path only adds where the tool chords act.
+        assert_eq!(candidate.kind, CandidateKind::Action);
     }
 
     #[test]

--- a/core/engine/src/index/sources.rs
+++ b/core/engine/src/index/sources.rs
@@ -272,7 +272,10 @@ mod tests {
 
         row.path = Some("~/dev/look".into());
         let candidate = row_candidate(&block, &row, home);
-        assert_eq!(candidate.path.as_ref(), "/home/u/dev/look");
+        // Built the same way the code builds it: a separator is the platform's
+        // business, and hardcoding `/` fails on Windows for a correct answer.
+        let expanded = home.join("dev/look");
+        assert_eq!(candidate.path.as_ref(), expanded.to_string_lossy());
         // Still an action row: a block's verbs are what Enter performs, and a
         // path only adds where the tool chords act.
         assert_eq!(candidate.kind, CandidateKind::Action);

--- a/core/engine/src/index/sources.rs
+++ b/core/engine/src/index/sources.rs
@@ -159,12 +159,10 @@ fn row_candidate(block: &Block, row: &SourceRow, home: &Path) -> Candidate {
         .map(|path| expand_home(path, home).to_string_lossy().into_owned())
         .unwrap_or_default();
     let mut candidate = Candidate::new(&id, CandidateKind::Action, &row.title, &path);
-    // What the row declared, then its group, then the block: the most specific
-    // thing the row can say about itself, falling back to where it came from.
+    // What the row said about itself, else where it came from.
     candidate.subtitle = Some(
         row.subtitle
             .as_deref()
-            .or(row.group.as_deref())
             .unwrap_or(block.name.as_str())
             .into(),
     );
@@ -247,7 +245,7 @@ mod tests {
     }
 
     #[test]
-    fn a_row_says_what_it_declared_before_its_group_or_its_block() {
+    fn a_row_says_what_it_declared_before_its_block() {
         let block = block_of("[repos]\nname = \"Repos\"\nrun = \"repos\"\n");
         let home = Path::new("/home/u");
 
@@ -255,12 +253,6 @@ mod tests {
         assert_eq!(
             row_candidate(&block, &row, home).subtitle.as_deref(),
             Some("Repos")
-        );
-
-        row.group = Some("This week".into());
-        assert_eq!(
-            row_candidate(&block, &row, home).subtitle.as_deref(),
-            Some("This week")
         );
 
         row.subtitle = Some("3 uncommitted".into());

--- a/core/engine/src/index/sources.rs
+++ b/core/engine/src/index/sources.rs
@@ -151,8 +151,8 @@ fn send_rows(block: &Block, rows: &[SourceRow], home: &Path, tx: &SyncSender<Can
 
 fn row_candidate(block: &Block, row: &SourceRow, home: &Path) -> Candidate {
     let id = CandidateIdKind::source_row_candidate_id(&block.id, &[], &row.id);
-    // A row's path comes from a script, which writes `~` as readily as a user
-    // does, and the verbs and the tool chords both act on it directly.
+    // A script writes `~` as readily as a user does, and the verbs and chords
+    // act on this path directly.
     let path = row
         .path
         .as_deref()

--- a/core/engine/src/lib.rs
+++ b/core/engine/src/lib.rs
@@ -337,7 +337,7 @@ impl QueryEngine {
         // sweep the matching prefixes or the deleted row lingers forever
         // (only an `ALL` refresh would otherwise catch it).
         // Prune by the `seen` set rather than the old "indexed_at < run_started"
-        // sweep: the change-detecting upsert (see specs/indexing-scale.md) no
+        // sweep: the change-detecting upsert no
         // longer bumps indexed_at on unchanged rows, so only "not seen this scan"
         // reliably means "gone". delete_unseen_candidates keeps the indexed_at<run
         // guard to preserve i64::MAX pinned rows. `seen` is already collected above

--- a/core/engine/src/lib.rs
+++ b/core/engine/src/lib.rs
@@ -62,6 +62,10 @@ struct IndexedCandidate {
     title_search: String,
     subtitle_search: Option<String>,
     path_search: String,
+    /// Matched but never shown. A source row is found by the block that made it,
+    /// and the block's words cannot live in the subtitle, which the row may
+    /// have declared for itself.
+    keywords_search: Option<String>,
 }
 
 #[derive(Default)]
@@ -82,13 +86,20 @@ impl QueryEngine {
     }
 
     pub fn new_with_config(candidates: Vec<Candidate>, config: &RuntimeConfig) -> Self {
-        // Build an in-memory search index up front (hot path reads only).
-        let candidates = candidates.into_iter().map(IndexedCandidate::new).collect();
         let declared = index::declared_blocks();
+        let block_names: HashMap<&str, &str> = declared
+            .iter()
+            .map(|block| (block.id.as_str(), block.name.as_str()))
+            .collect();
+        // Build an in-memory search index up front (hot path reads only).
+        let candidates = candidates
+            .into_iter()
+            .map(|candidate| IndexedCandidate::new(candidate, &block_names))
+            .collect();
         let mut search_aliases = config.search_aliases.clone();
-        // A block's `aliases` are extra words that should find its rows. Its
-        // rows carry the block name as their subtitle, so pointing the alias at
-        // that name reuses the existing alias matcher unchanged.
+        // A block's `aliases` are extra words that should find its rows. They
+        // point at the block name, which every one of its rows carries in its
+        // search keywords.
         for block in &declared {
             for alias in &block.aliases {
                 let key = normalize_for_search(alias);
@@ -102,14 +113,16 @@ impl QueryEngine {
             }
         }
 
+        let source_biases = declared
+            .iter()
+            .filter(|block| block.bias != 0)
+            .map(|block| (block.id.clone(), block.bias))
+            .collect();
+
         Self {
             candidates,
             search_aliases,
-            source_biases: declared
-                .into_iter()
-                .filter(|block| block.bias != 0)
-                .map(|block| (block.id, block.bias))
-                .collect(),
+            source_biases,
         }
     }
 
@@ -363,7 +376,7 @@ impl QueryEngine {
 }
 
 impl IndexedCandidate {
-    fn new(candidate: Candidate) -> Self {
+    fn new(candidate: Candidate, block_names: &HashMap<&str, &str>) -> Self {
         // Normalize once; reuse for fuzzy/contains/path scoring.
         let title_search = normalize_for_search(&candidate.title);
         let subtitle_search = candidate
@@ -371,11 +384,20 @@ impl IndexedCandidate {
             .as_ref()
             .map(|subtitle| normalize_for_search(subtitle));
         let path_search = normalize_for_search(&candidate.path);
+        // Both the name the user reads and the id they wrote in the file: either
+        // is what they will type to reach the block's rows.
+        let keywords_search = CandidateIdKind::source_id_of(&candidate.id).map(|block_id| {
+            match block_names.get(block_id) {
+                Some(name) => normalize_for_search(&format!("{name} {block_id}")),
+                None => normalize_for_search(block_id),
+            }
+        });
         Self {
             candidate,
             title_search,
             subtitle_search,
             path_search,
+            keywords_search,
         }
     }
 }

--- a/core/engine/src/search.rs
+++ b/core/engine/src/search.rs
@@ -353,6 +353,13 @@ impl QueryEngine {
                 .map(|value| value / 2);
             let contains_score =
                 contains_match_score(normalized_query, &candidate.title_search, subtitle_search);
+            // Scored like a subtitle, and for the same reason: it says where the
+            // row came from, not what the row is.
+            let keywords_score = candidate
+                .keywords_search
+                .as_deref()
+                .and_then(|keywords| fuzzy_score_prepared(&prepared_query, keywords))
+                .map(|value| value / 2);
             let path_score = if has_path_hint {
                 path_match_score(normalized_query, &candidate.path_search)
             } else {
@@ -364,11 +371,20 @@ impl QueryEngine {
                 subtitle_search
             };
             let alias_score = alias_terms.and_then(|terms| {
-                if candidate.candidate.kind != CandidateKind::App {
-                    return None;
+                if candidate.candidate.kind == CandidateKind::App {
+                    // Alias boosts are app-only to avoid distorting file/folder
+                    // ranking.
+                    return Self::alias_match_score(
+                        terms,
+                        &candidate.title_search,
+                        alias_subtitle_search,
+                    );
                 }
-                // Alias boosts are app-only to avoid distorting file/folder ranking.
-                Self::alias_match_score(terms, &candidate.title_search, alias_subtitle_search)
+                // Except for a block's own rows, which is what a declared
+                // `aliases` names. It reaches them through their keywords, so no
+                // file's text is involved and no file's ranking moves.
+                let keywords = candidate.keywords_search.as_deref()?;
+                Self::alias_match_score(terms, keywords, None)
             });
 
             let base = [
@@ -377,6 +393,7 @@ impl QueryEngine {
                 contains_score,
                 path_score,
                 alias_score,
+                keywords_score,
             ]
             .into_iter()
             .flatten()
@@ -576,6 +593,24 @@ mod tests {
             ids.contains(&"folder:/u/dev/other".to_string()),
             "a different path is untouched: {ids:?}"
         );
+    }
+
+    #[test]
+    fn a_row_that_declares_its_own_subtitle_is_still_found_by_its_block() {
+        // The block name used to reach its rows only because it sat in their
+        // subtitle. A row declaring one (`format = "json"`) would otherwise
+        // become unreachable by the word the user typed to build it.
+        let mut declared = Candidate::new("src:branches:main", CandidateKind::Action, "main", "");
+        declared.subtitle = Some("3 months ago, someone".into());
+
+        let engine = QueryEngine::new(vec![declared]);
+        let ids: Vec<String> = engine
+            .search_scored("branches", 10)
+            .into_iter()
+            .map(|(candidate, _)| candidate.id.to_string())
+            .collect();
+
+        assert_eq!(ids, ["src:branches:main"]);
     }
 
     #[test]

--- a/core/indexing/src/lib.rs
+++ b/core/indexing/src/lib.rs
@@ -66,8 +66,10 @@ impl CandidateIdKind {
             .map(|(source, _)| source)
     }
 
-    /// The id-prefix that scoped pruning uses for one source's rows.
-    pub fn source_row_prefix(source_id: &str) -> String {
+    /// The namespace one block's rows share. Private: ids are built by
+    /// `source_row_candidate_id` and read by the three functions above, and a
+    /// caller assembling one by hand is how the two drift.
+    fn source_row_prefix(source_id: &str) -> String {
         format!("{}{source_id}:", Self::PREFIX_SOURCE)
     }
 

--- a/core/indexing/src/lib.rs
+++ b/core/indexing/src/lib.rs
@@ -74,14 +74,131 @@ impl CandidateIdKind {
     /// The ROW's own id inside a source row id (`src:<source>:<row>`), which is
     /// what a user's command expects `{id}` to be. Anything not namespaced is
     /// returned as-is, so a caller can pass either shape.
+    ///
+    /// A drilled row carries its ancestors between two marks before the row id
+    /// (§2.10); the row id is everything after them, untouched.
     pub fn source_row_id_of(candidate_id: &str) -> &str {
-        candidate_id
+        let Some(rest) = candidate_id
             .strip_prefix(Self::PREFIX_SOURCE)
             .and_then(|rest| rest.split_once(':'))
             .map(|(_, row)| row)
-            .unwrap_or(candidate_id)
+        else {
+            return candidate_id;
+        };
+
+        match rest.strip_prefix(Self::CHAIN_MARK) {
+            Some(after_mark) => match after_mark.split_once(Self::CHAIN_MARK) {
+                Some((_, row)) => row,
+                None => rest,
+            },
+            None => rest,
+        }
+    }
+
+    /// Separators for the ancestor chain a drilled row id carries
+    /// (`specs/user-sources.md` §2.10). A chain segment escapes them; the row
+    /// id, which is free-form script output, is left exactly as the script
+    /// wrote it.
+    const CHAIN_MARK: char = '|';
+    const CHAIN_SEPARATOR: char = ';';
+    const CHAIN_PAIR: char = '/';
+
+    /// The candidate id for a row of `block_id`, reached through `ancestors`
+    /// (outermost first, each a block id and the row picked in it).
+    ///
+    /// The one encoder. Decoding is `source_id_of`, `source_row_id_of`, and
+    /// `source_ancestors_of`, and nothing else may take an id apart: handing a
+    /// script `src:branches:main` where it expected `main` is the bug that looks
+    /// like the user's command being wrong.
+    pub fn source_row_candidate_id(
+        block_id: &str,
+        ancestors: &[(String, String)],
+        row_id: &str,
+    ) -> String {
+        let prefix = Self::source_row_prefix(block_id);
+        if ancestors.is_empty() {
+            // A row id opening with the chain mark would otherwise read as a
+            // chain. Escaping the first character is enough, since that is the
+            // only position the decoder looks at.
+            return match row_id.starts_with(Self::CHAIN_MARK) {
+                true => format!(
+                    "{prefix}{}{}",
+                    escape_chain_char(Self::CHAIN_MARK),
+                    &row_id[1..]
+                ),
+                false => format!("{prefix}{row_id}"),
+            };
+        }
+
+        let chain = ancestors
+            .iter()
+            .map(|(block, row)| {
+                format!(
+                    "{}{}{}",
+                    escape_chain(block),
+                    Self::CHAIN_PAIR,
+                    escape_chain(row)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(&Self::CHAIN_SEPARATOR.to_string());
+
+        format!(
+            "{prefix}{}{chain}{}{row_id}",
+            Self::CHAIN_MARK,
+            Self::CHAIN_MARK
+        )
+    }
+
+    /// The levels a drilled row was reached through, outermost first. Empty for
+    /// a top-level row.
+    pub fn source_ancestors_of(candidate_id: &str) -> Vec<(String, String)> {
+        let Some(chain) = Self::chain_of(candidate_id) else {
+            return Vec::new();
+        };
+        chain
+            .split(Self::CHAIN_SEPARATOR)
+            .filter_map(|pair| pair.split_once(Self::CHAIN_PAIR))
+            .map(|(block, row)| (unescape_chain(block), unescape_chain(row)))
+            .collect()
+    }
+
+    /// The chain between the two marks, when the id carries one.
+    fn chain_of(candidate_id: &str) -> Option<&str> {
+        candidate_id
+            .strip_prefix(Self::PREFIX_SOURCE)?
+            .split_once(':')?
+            .1
+            .strip_prefix(Self::CHAIN_MARK)?
+            .split_once(Self::CHAIN_MARK)
+            .map(|(chain, _)| chain)
     }
 }
+
+/// Percent-escapes what the chain uses as structure. The escape character is
+/// escaped first, or decoding a row named `100%` would be ambiguous.
+fn escape_chain(segment: &str) -> String {
+    segment
+        .replace(CHAIN_ESCAPE, "%25")
+        .replace(CandidateIdKind::CHAIN_MARK, "%7C")
+        .replace(CandidateIdKind::CHAIN_PAIR, "%2F")
+        .replace(CandidateIdKind::CHAIN_SEPARATOR, "%3B")
+}
+
+fn escape_chain_char(value: char) -> String {
+    escape_chain(&value.to_string())
+}
+
+fn unescape_chain(segment: &str) -> String {
+    segment
+        .replace("%7C", "|")
+        .replace("%2F", "/")
+        .replace("%3B", ";")
+        .replace("%25", "%")
+}
+
+/// Escaped by `escape_chain` before anything else, and unescaped last.
+const CHAIN_ESCAPE: char = '%';
 
 #[cfg(test)]
 mod id_tests {
@@ -97,6 +214,87 @@ mod id_tests {
             CandidateIdKind::source_row_id_of(id),
             "326-bug-battery-on-macos"
         );
+    }
+
+    #[test]
+    fn a_drilled_row_keeps_its_block_and_its_own_id() {
+        let id = CandidateIdKind::source_row_candidate_id(
+            "scripts",
+            &[("projects".into(), "animate".into())],
+            "check:watch",
+        );
+        assert_eq!(id, "src:scripts:|projects/animate|check:watch");
+        assert_eq!(CandidateIdKind::source_id_of(&id), Some("scripts"));
+        assert_eq!(CandidateIdKind::source_row_id_of(&id), "check:watch");
+        assert_eq!(
+            CandidateIdKind::source_ancestors_of(&id),
+            [("projects".to_string(), "animate".to_string())]
+        );
+    }
+
+    #[test]
+    fn the_same_row_under_two_parents_is_two_ids() {
+        let here = CandidateIdKind::source_row_candidate_id(
+            "scripts",
+            &[("projects".into(), "animate".into())],
+            "build",
+        );
+        let there = CandidateIdKind::source_row_candidate_id(
+            "scripts",
+            &[("projects".into(), "look".into())],
+            "build",
+        );
+        assert_ne!(here, there, "ranking is keyed on the ancestor path");
+    }
+
+    #[test]
+    fn a_deeper_chain_reads_outermost_first() {
+        let id = CandidateIdKind::source_row_candidate_id(
+            "pods",
+            &[
+                ("contexts".into(), "prod".into()),
+                ("namespaces".into(), "web".into()),
+            ],
+            "api-7d9",
+        );
+        assert_eq!(id, "src:pods:|contexts/prod;namespaces/web|api-7d9");
+        assert_eq!(CandidateIdKind::source_row_id_of(&id), "api-7d9");
+        assert_eq!(
+            CandidateIdKind::source_ancestors_of(&id),
+            [
+                ("contexts".to_string(), "prod".to_string()),
+                ("namespaces".to_string(), "web".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn a_row_id_carrying_the_chain_characters_survives_the_round_trip() {
+        // Script output is free-form: a branch named `feat/a|b;c` and a host
+        // named `user@host:22` must come back exactly as they went in.
+        for row in ["feat/a|b;c", "user@host:22", "100%", "|leading-mark"] {
+            let drilled = CandidateIdKind::source_row_candidate_id(
+                "child",
+                &[("parent".into(), "a/b|c;d%e".into())],
+                row,
+            );
+            assert_eq!(CandidateIdKind::source_row_id_of(&drilled), row);
+            assert_eq!(
+                CandidateIdKind::source_ancestors_of(&drilled),
+                [("parent".to_string(), "a/b|c;d%e".to_string())]
+            );
+
+            let top = CandidateIdKind::source_row_candidate_id("child", &[], row);
+            assert!(CandidateIdKind::source_ancestors_of(&top).is_empty());
+        }
+    }
+
+    #[test]
+    fn a_top_level_id_is_unchanged_and_carries_no_ancestors() {
+        let id = CandidateIdKind::source_row_candidate_id("branches", &[], "main");
+        assert_eq!(id, "src:branches:main");
+        assert!(CandidateIdKind::source_ancestors_of(&id).is_empty());
+        assert!(CandidateIdKind::source_ancestors_of("app:safari").is_empty());
     }
 
     #[test]

--- a/core/indexing/src/lib.rs
+++ b/core/indexing/src/lib.rs
@@ -90,8 +90,7 @@ impl CandidateIdKind {
         let Some(after_mark) = rest.strip_prefix(Self::CHAIN_MARK) else {
             return rest;
         };
-        // Doubled: a top-level row id that starts with the mark, minus the one
-        // the encoder added.
+        // Doubled: a top-level row id, minus the mark the encoder added.
         if after_mark.starts_with(Self::CHAIN_MARK) {
             return after_mark;
         }
@@ -121,9 +120,8 @@ impl CandidateIdKind {
     ) -> String {
         let prefix = Self::source_row_prefix(block_id);
         if ancestors.is_empty() {
-            // A row id opening with the chain mark would otherwise read as a
-            // chain, so it is doubled. Escaping it instead would be lossy: the
-            // decoder hands back a borrowed slice and cannot unescape.
+            // Doubled, not escaped: a row id opening with the mark would read
+            // as a chain, and the decoder returns a slice it cannot unescape.
             return match row_id.starts_with(Self::CHAIN_MARK) {
                 true => format!("{prefix}{}{row_id}", Self::CHAIN_MARK),
                 false => format!("{prefix}{row_id}"),
@@ -170,8 +168,7 @@ impl CandidateIdKind {
             .split_once(':')?
             .1
             .strip_prefix(Self::CHAIN_MARK)?;
-        // Doubled means a top-level row id that begins with the mark, not a
-        // chain.
+        // Doubled means a row id beginning with the mark, not a chain.
         if after_mark.starts_with(Self::CHAIN_MARK) {
             return None;
         }

--- a/core/indexing/src/lib.rs
+++ b/core/indexing/src/lib.rs
@@ -87,11 +87,16 @@ impl CandidateIdKind {
             return candidate_id;
         };
 
-        match rest.strip_prefix(Self::CHAIN_MARK) {
-            Some(after_mark) => match after_mark.split_once(Self::CHAIN_MARK) {
-                Some((_, row)) => row,
-                None => rest,
-            },
+        let Some(after_mark) = rest.strip_prefix(Self::CHAIN_MARK) else {
+            return rest;
+        };
+        // Doubled: a top-level row id that starts with the mark, minus the one
+        // the encoder added.
+        if after_mark.starts_with(Self::CHAIN_MARK) {
+            return after_mark;
+        }
+        match after_mark.split_once(Self::CHAIN_MARK) {
+            Some((_, row)) => row,
             None => rest,
         }
     }
@@ -117,14 +122,10 @@ impl CandidateIdKind {
         let prefix = Self::source_row_prefix(block_id);
         if ancestors.is_empty() {
             // A row id opening with the chain mark would otherwise read as a
-            // chain. Escaping the first character is enough, since that is the
-            // only position the decoder looks at.
+            // chain, so it is doubled. Escaping it instead would be lossy: the
+            // decoder hands back a borrowed slice and cannot unescape.
             return match row_id.starts_with(Self::CHAIN_MARK) {
-                true => format!(
-                    "{prefix}{}{}",
-                    escape_chain_char(Self::CHAIN_MARK),
-                    &row_id[1..]
-                ),
+                true => format!("{prefix}{}{row_id}", Self::CHAIN_MARK),
                 false => format!("{prefix}{row_id}"),
             };
         }
@@ -164,11 +165,17 @@ impl CandidateIdKind {
 
     /// The chain between the two marks, when the id carries one.
     fn chain_of(candidate_id: &str) -> Option<&str> {
-        candidate_id
+        let after_mark = candidate_id
             .strip_prefix(Self::PREFIX_SOURCE)?
             .split_once(':')?
             .1
-            .strip_prefix(Self::CHAIN_MARK)?
+            .strip_prefix(Self::CHAIN_MARK)?;
+        // Doubled means a top-level row id that begins with the mark, not a
+        // chain.
+        if after_mark.starts_with(Self::CHAIN_MARK) {
+            return None;
+        }
+        after_mark
             .split_once(Self::CHAIN_MARK)
             .map(|(chain, _)| chain)
     }
@@ -182,10 +189,6 @@ fn escape_chain(segment: &str) -> String {
         .replace(CandidateIdKind::CHAIN_MARK, "%7C")
         .replace(CandidateIdKind::CHAIN_PAIR, "%2F")
         .replace(CandidateIdKind::CHAIN_SEPARATOR, "%3B")
-}
-
-fn escape_chain_char(value: char) -> String {
-    escape_chain(&value.to_string())
 }
 
 fn unescape_chain(segment: &str) -> String {
@@ -285,6 +288,7 @@ mod id_tests {
 
             let top = CandidateIdKind::source_row_candidate_id("child", &[], row);
             assert!(CandidateIdKind::source_ancestors_of(&top).is_empty());
+            assert_eq!(CandidateIdKind::source_row_id_of(&top), row);
         }
     }
 

--- a/core/indexing/src/lib.rs
+++ b/core/indexing/src/lib.rs
@@ -66,9 +66,8 @@ impl CandidateIdKind {
             .map(|(source, _)| source)
     }
 
-    /// The namespace one block's rows share. Private: ids are built by
-    /// `source_row_candidate_id` and read by the three functions above, and a
-    /// caller assembling one by hand is how the two drift.
+    /// The namespace one block's rows share. Private: an id assembled by hand
+    /// is how an encoder and its readers drift.
     fn source_row_prefix(source_id: &str) -> String {
         format!("{}{source_id}:", Self::PREFIX_SOURCE)
     }
@@ -77,8 +76,8 @@ impl CandidateIdKind {
     /// what a user's command expects `{id}` to be. Anything not namespaced is
     /// returned as-is, so a caller can pass either shape.
     ///
-    /// A drilled row carries its ancestors between two marks before the row id
-    /// (§2.10); the row id is everything after them, untouched.
+    /// A drilled row carries its ancestors between two marks first; the row id
+    /// is everything after them, untouched.
     pub fn source_row_id_of(candidate_id: &str) -> &str {
         let Some(rest) = candidate_id
             .strip_prefix(Self::PREFIX_SOURCE)
@@ -97,10 +96,9 @@ impl CandidateIdKind {
         }
     }
 
-    /// Separators for the ancestor chain a drilled row id carries
-    /// (`specs/user-sources.md` §2.10). A chain segment escapes them; the row
-    /// id, which is free-form script output, is left exactly as the script
-    /// wrote it.
+    /// Separators for the ancestor chain a drilled row id carries. A chain
+    /// segment escapes them; the row id, which is free-form script output, is
+    /// left exactly as the script wrote it.
     const CHAIN_MARK: char = '|';
     const CHAIN_SEPARATOR: char = ';';
     const CHAIN_PAIR: char = '/';
@@ -108,10 +106,9 @@ impl CandidateIdKind {
     /// The candidate id for a row of `block_id`, reached through `ancestors`
     /// (outermost first, each a block id and the row picked in it).
     ///
-    /// The one encoder. Decoding is `source_id_of`, `source_row_id_of`, and
-    /// `source_ancestors_of`, and nothing else may take an id apart: handing a
-    /// script `src:branches:main` where it expected `main` is the bug that looks
-    /// like the user's command being wrong.
+    /// The one encoder; `source_id_of`, `source_row_id_of` and
+    /// `source_ancestors_of` are the only readers. Handing a script
+    /// `src:branches:main` where it expected `main` is the bug this prevents.
     pub fn source_row_candidate_id(
         block_id: &str,
         ancestors: &[(String, String)],

--- a/core/sources/Cargo.toml
+++ b/core/sources/Cargo.toml
@@ -10,4 +10,5 @@ version = "0.1.0"
 globset = "0.4.18"
 look-tools = { path = "../tools" }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 toml = "0.9"

--- a/core/sources/example.toml
+++ b/core/sources/example.toml
@@ -94,6 +94,26 @@ open    = "git -C ~/dev/look checkout {id}"
 then    = ["drop-branch"]
 
 
+# -------------------------------------------------------------------- json --
+# Rows as JSON instead of tab-separated lines, for the two fields lines cannot
+# carry: `subtitle`, and `path`, which makes a row a real filesystem object
+# (Cmd+E, Cmd+T, Cmd+F, and {path} in the verbs below).
+#
+# One array, or one object per line, or pretty-printed objects run together:
+# whichever your tool already prints. `id` is the only required key, a bare
+# string is a row like a bare line, and keys Look does not know are ignored.
+#
+#   [{"id": "look", "title": "Look", "subtitle": "3 uncommitted",
+#     "group": "This week", "path": "~/dev/look"}]
+
+[repos]
+name   = "Repos"
+run    = "~/.look/bin/repos"
+format = "json"
+
+open   = "code {path}"
+
+
 # `confirm` asks before the block does anything. Anything destructive should
 # have one: a launcher makes Enter on the wrong row cheap.
 [drop-branch]

--- a/core/sources/example.toml
+++ b/core/sources/example.toml
@@ -50,7 +50,10 @@ then = ["ghostty"]
 
 # What the standard keys do to a picked row. Each verb has one key across the
 # whole app, so Cmd+E always edits. Declare only what differs from your global
-# default in ~/.look/config (see specs/preferred-tools.md).
+# default in ~/.look/config.
+#
+# `open` is what Enter runs, for rows of ANY producer. Without it, a row that
+# names a path opens that path, which is why most `dir` blocks declare none.
 open     = "open {path}"
 edit     = "nvim {path}"
 terminal = "tmux new-session -As {title} -c {path}"
@@ -64,7 +67,7 @@ do   = ["open -a Ghostty {path}"]
 
 
 # -------------------------------------------------------------------- file --
-# Rows from a text file, one per line: id<TAB>title<TAB>group
+# Rows from a text file, one per line: id<TAB>title<TAB>subtitle
 # A bare line is both id and title. The id is what verbs and `then` receive, so
 # a row can show one thing and act on another.
 
@@ -95,16 +98,16 @@ then    = ["drop-branch"]
 
 
 # -------------------------------------------------------------------- json --
-# Rows as JSON instead of tab-separated lines, for the two fields lines cannot
-# carry: `subtitle`, and `path`, which makes a row a real filesystem object
-# (Cmd+E, Cmd+T, Cmd+F, and {path} in the verbs below).
+# Rows as JSON instead of tab-separated lines, for the field lines cannot carry:
+# `path`, which makes a row a real filesystem object (Cmd+E, Cmd+T, Cmd+F, and
+# {path} in the verbs below).
 #
 # One array, or one object per line, or pretty-printed objects run together:
 # whichever your tool already prints. `id` is the only required key, a bare
 # string is a row like a bare line, and keys Look does not know are ignored.
 #
 #   [{"id": "look", "title": "Look", "subtitle": "3 uncommitted",
-#     "group": "This week", "path": "~/dev/look"}]
+#     "path": "~/dev/look"}]
 
 [repos]
 name   = "Repos"

--- a/core/sources/src/collect.rs
+++ b/core/sources/src/collect.rs
@@ -496,7 +496,7 @@ mod tests {
         assert_eq!(collected.rows.len(), 2);
         assert_eq!(collected.rows[0].id, "web1");
         assert_eq!(collected.rows[0].title, "Production web");
-        assert_eq!(collected.rows[0].group.as_deref(), Some("Servers"));
+        assert_eq!(collected.rows[0].subtitle.as_deref(), Some("Servers"));
         assert_eq!(collected.rows[1].title, "db1");
     }
 

--- a/core/sources/src/collect.rs
+++ b/core/sources/src/collect.rs
@@ -76,13 +76,9 @@ pub fn collect(block: &Block, home: &Path) -> Result<Collected, CollectError> {
     }
 }
 
-/// Rows for `block` produced against `row`, the row a level was launched from
-/// (`specs/user-sources.md` §2.10).
-///
-/// A producer expands against that row, because at this point there is no other:
-/// its own rows are what this call is about to make. A `run` block still needs a
-/// process, so it comes back as `NeedsRunner` and the shell runs the expanded
-/// command.
+/// Rows for `block` produced against the row a level was launched from. The
+/// producer expands against that row, because its own rows do not exist yet. A
+/// `run` block still comes back as `NeedsRunner` for the shell to run.
 pub fn collect_for_row(
     block: &Block,
     home: &Path,

--- a/core/sources/src/collect.rs
+++ b/core/sources/src/collect.rs
@@ -8,7 +8,8 @@ use std::path::{Path, PathBuf};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 
 use crate::def::{Block, Only, Producer, RowFormat};
-use crate::rows::{SourceRow, parse_lines};
+use crate::rows::{SourceRow, parse_rows};
+use crate::run::{RowContext, expand_path};
 
 /// Hard ceiling on rows from one source. A source that hits this is a mistake
 /// (a root pointed at the home directory, a runaway script), and the honest
@@ -35,7 +36,8 @@ pub enum CollectError {
     /// Command sources are collected by the shell, which owns process
     /// execution. Never a user error.
     NeedsRunner,
-    Unsupported(String),
+    /// The rows were read but could not be parsed in the declared format.
+    Malformed(String),
 }
 
 impl std::fmt::Display for CollectError {
@@ -44,7 +46,7 @@ impl std::fmt::Display for CollectError {
             Self::Io(message) => write!(f, "{message}"),
             Self::Glob(message) => write!(f, "{message}"),
             Self::NeedsRunner => write!(f, "command sources are run by the shell"),
-            Self::Unsupported(message) => write!(f, "{message}"),
+            Self::Malformed(message) => write!(f, "{message}"),
         }
     }
 }
@@ -71,6 +73,39 @@ pub fn collect(block: &Block, home: &Path) -> Result<Collected, CollectError> {
         }
         Producer::File { path, format } => collect_list(&expand_home(path, home), *format),
         Producer::Run { .. } => Err(CollectError::NeedsRunner),
+    }
+}
+
+/// Rows for `block` produced against `row`, the row a level was launched from
+/// (`specs/user-sources.md` §2.10).
+///
+/// A producer expands against that row, because at this point there is no other:
+/// its own rows are what this call is about to make. A `run` block still needs a
+/// process, so it comes back as `NeedsRunner` and the shell runs the expanded
+/// command.
+pub fn collect_for_row(
+    block: &Block,
+    home: &Path,
+    row: &RowContext,
+) -> Result<Collected, CollectError> {
+    match &block.producer {
+        Producer::Dir {
+            roots,
+            depth,
+            only,
+            include,
+            exclude,
+        } => {
+            let roots: Vec<PathBuf> = roots
+                .iter()
+                .map(|root| expand_home(&expand_path(root, row), home))
+                .collect();
+            collect_folders(&roots, *depth, *only, include, exclude)
+        }
+        Producer::File { path, format } => {
+            collect_list(&expand_home(&expand_path(path, row), home), *format)
+        }
+        Producer::Bundle { .. } | Producer::Run { .. } => collect(block, home),
     }
 }
 
@@ -202,19 +237,14 @@ fn collect_list(file: &Path, format: RowFormat) -> Result<Collected, CollectErro
         fs::read(file).map_err(|err| CollectError::Io(format!("{}: {err}", file.display())))?;
     let text = String::from_utf8_lossy(&contents);
 
-    match format {
-        RowFormat::Lines => {
-            let (rows, truncated) = parse_lines(&text, MAX_ROWS_PER_SOURCE);
-            Ok(Collected {
-                rows,
-                truncated,
-                unreadable: Vec::new(),
-            })
-        }
-        RowFormat::Json => Err(CollectError::Unsupported(
-            "format = \"json\" is not implemented yet".into(),
-        )),
-    }
+    let (rows, truncated) = parse_rows(&text, MAX_ROWS_PER_SOURCE, format)
+        .map_err(|message| CollectError::Malformed(format!("{}: {message}", file.display())))?;
+
+    Ok(Collected {
+        rows,
+        truncated,
+        unreadable: Vec::new(),
+    })
 }
 
 fn build_globs(patterns: &[String]) -> Result<Option<GlobSet>, CollectError> {
@@ -483,6 +513,81 @@ mod tests {
             .map(|r| r.title)
             .collect();
         assert_eq!(titles, ["zeta", "alpha", "middle"]);
+    }
+
+    #[test]
+    fn a_json_list_source_reads_the_fields_the_line_format_cannot_carry() {
+        let tmp = TempDir::new("json-list");
+        let file = tmp.file(
+            "repos.json",
+            r#"[{"id":"look","title":"Look","subtitle":"3 uncommitted","path":"/dev/look"}]"#,
+        );
+
+        let def = folder_def(&format!(
+            "file = {:?}\nformat = \"json\"\n",
+            file.to_str().unwrap()
+        ));
+        let collected = collect(&def, Path::new("/nonexistent")).unwrap();
+
+        assert_eq!(collected.rows.len(), 1);
+        assert_eq!(collected.rows[0].subtitle.as_deref(), Some("3 uncommitted"));
+        assert_eq!(collected.rows[0].path.as_deref(), Some("/dev/look"));
+    }
+
+    #[test]
+    fn a_json_list_that_does_not_parse_names_the_file() {
+        let tmp = TempDir::new("json-broken");
+        let file = tmp.file("broken.json", "{\"id\": }");
+
+        let def = folder_def(&format!(
+            "file = {:?}\nformat = \"json\"\n",
+            file.to_str().unwrap()
+        ));
+        match collect(&def, Path::new("/nonexistent")) {
+            Err(CollectError::Malformed(message)) => assert!(message.contains("broken.json")),
+            other => panic!("expected a malformed error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_producer_expands_against_the_row_a_level_was_launched_from() {
+        let tmp = TempDir::new("level");
+        std::fs::create_dir_all(tmp.0.join("animate/src")).expect("child dir");
+        std::fs::create_dir_all(tmp.0.join("look/src")).expect("child dir");
+
+        let def = folder_def("dir = \"{path}/src\"\n");
+        let row = RowContext {
+            path: tmp.0.join("animate").to_string_lossy().into_owned(),
+            ..Default::default()
+        };
+
+        let collected = collect_for_row(&def, Path::new("/nonexistent"), &row).unwrap();
+        assert!(
+            collected
+                .rows
+                .iter()
+                .all(|r| r.path.as_deref().unwrap().contains("animate")),
+            "the level lists the selected row's folder, not another's"
+        );
+    }
+
+    #[test]
+    fn a_path_placeholder_is_not_shell_quoted_on_its_way_into_the_filesystem() {
+        // `expand` quotes, which is right for a command and fatal for a path:
+        // the quotes would become part of the name and nothing would be found.
+        let tmp = TempDir::new("quoting");
+        let parent = tmp.0.join("my project");
+        std::fs::create_dir_all(parent.join("inside")).expect("child dir");
+
+        let def = folder_def("dir = \"{path}\"\n");
+        let row = RowContext {
+            path: parent.to_string_lossy().into_owned(),
+            ..Default::default()
+        };
+
+        let collected = collect_for_row(&def, Path::new("/nonexistent"), &row).unwrap();
+        assert_eq!(collected.rows.len(), 1);
+        assert_eq!(collected.rows[0].title, "inside");
     }
 
     #[test]

--- a/core/sources/src/def.rs
+++ b/core/sources/src/def.rs
@@ -15,6 +15,7 @@
 use std::collections::BTreeMap;
 use std::time::Duration;
 
+use look_tools::Action;
 use serde::Deserialize;
 
 use crate::run::{PLACEHOLDER_PARENT, PLACEHOLDERS};
@@ -131,6 +132,17 @@ impl Verbs {
             && self.edit.is_none()
             && self.terminal.is_none()
             && self.reveal.is_none()
+    }
+
+    /// The command this block declares for `action`, if any. The one mapping
+    /// from a tool action to a block key, so `Action::Edit` cannot come to mean
+    /// `terminal` in one caller and `edit` in another.
+    pub fn for_action(&self, action: Action) -> Option<&str> {
+        match action {
+            Action::Edit => self.edit.as_deref(),
+            Action::TerminalHere => self.terminal.as_deref(),
+            Action::Reveal => self.reveal.as_deref(),
+        }
     }
 
     /// Declared verbs in a stable order, for the action menu.

--- a/core/sources/src/def.rs
+++ b/core/sources/src/def.rs
@@ -17,6 +17,8 @@ use std::time::Duration;
 
 use serde::Deserialize;
 
+use crate::run::{PLACEHOLDER_PARENT, PLACEHOLDERS};
+
 /// Immediate children only. Deep walks belong to the file index, not to a
 /// block the user declared to get one short list.
 pub const DEFAULT_FOLDER_DEPTH: usize = 1;
@@ -185,9 +187,12 @@ impl Block {
     /// block's `then`, never as a top-level row: running `make -C {path} deploy`
     /// with nothing selected would substitute an empty path.
     pub fn needs_row(&self) -> bool {
-        self.producer_text()
-            .iter()
-            .any(|text| text.contains(PLACEHOLDER_OPEN))
+        self.producer_text().iter().any(|text| {
+            text.contains(PLACEHOLDER_PARENT)
+                || PLACEHOLDERS
+                    .iter()
+                    .any(|placeholder| text.contains(placeholder))
+        })
     }
 
     fn producer_text(&self) -> Vec<&str> {
@@ -199,9 +204,6 @@ impl Block {
         }
     }
 }
-
-/// Opens a row placeholder such as `{path}`.
-const PLACEHOLDER_OPEN: char = '{';
 
 #[derive(Debug, Default, Deserialize)]
 struct RawBlock {
@@ -579,6 +581,21 @@ dir = "~/notes"
     }
 
     #[test]
+    fn a_producer_emitting_json_is_not_mistaken_for_one_that_needs_a_row() {
+        // Every brace used to count as a placeholder, so a `run` command that
+        // printed JSON was read as "only meaningful against a selected row" and
+        // vanished from the index entirely.
+        let json = one(r#"[branches]
+format = "json"
+run = "git for-each-ref --format='{\"id\":\"%(refname:short)\"}' refs/heads"
+"#);
+        assert!(!json.needs_row());
+
+        let real = one("[deploy]\nrun = \"make -C {path} targets\"\n");
+        assert!(real.needs_row());
+    }
+
+    #[test]
     fn the_shipped_example_parses_with_nothing_left_unexplained() {
         // example.toml is what users copy, so a key renamed here without
         // updating it would hand everyone a file full of ignored settings.
@@ -594,6 +611,7 @@ dir = "~/notes"
                 "ghostty",
                 "hosts",
                 "projects",
+                "repos",
                 "work"
             ]
         );

--- a/core/sources/src/lib.rs
+++ b/core/sources/src/lib.rs
@@ -14,6 +14,7 @@ mod def;
 mod load;
 mod rows;
 mod run;
+mod tools;
 
 pub use collect::{
     CollectError, Collected, MAX_ROWS_PER_SOURCE, collect, collect_for_row, expand_home,
@@ -28,3 +29,4 @@ pub use run::{
     ENV_ID, ENV_PATH, ENV_TITLE, ParentRow, RowContext, StepOutcome, capture, expand, expand_path,
     perform,
 };
+pub use tools::{block_declares, resolve_for_row};

--- a/core/sources/src/lib.rs
+++ b/core/sources/src/lib.rs
@@ -7,8 +7,6 @@
 //! ids, ranking, or process execution: mapping rows into the index is the
 //! engine's job, and running a user's command is the shell's.
 //!
-//! See `specs/user-sources.md`.
-
 mod collect;
 mod def;
 mod load;

--- a/core/sources/src/lib.rs
+++ b/core/sources/src/lib.rs
@@ -23,7 +23,7 @@ pub use def::{
     RowFormat, Verbs, inferred, parse_duration, parse_file,
 };
 pub use load::{Loaded, Problem, SOURCES_DIR_ENV, load_dir, sources_dir};
-pub use rows::{SourceRow, parse_json, parse_line, parse_lines, parse_rows};
+pub use rows::{SourceRow, parse_rows};
 pub use run::{
     ENV_ID, ENV_PATH, ENV_TITLE, ParentRow, RowContext, StepOutcome, capture, expand, expand_path,
     perform,

--- a/core/sources/src/lib.rs
+++ b/core/sources/src/lib.rs
@@ -15,11 +15,16 @@ mod load;
 mod rows;
 mod run;
 
-pub use collect::{CollectError, Collected, MAX_ROWS_PER_SOURCE, collect, expand_home};
+pub use collect::{
+    CollectError, Collected, MAX_ROWS_PER_SOURCE, collect, collect_for_row, expand_home,
+};
 pub use def::{
     Block, DEFAULT_FOLDER_DEPTH, KEY_DIR, KEY_DO, KEY_FILE, KEY_RUN, Only, ParsedFile, Producer,
     RowFormat, Verbs, inferred, parse_duration, parse_file,
 };
 pub use load::{Loaded, Problem, SOURCES_DIR_ENV, load_dir, sources_dir};
-pub use rows::{SourceRow, parse_line, parse_lines};
-pub use run::{ENV_ID, ENV_PATH, ENV_TITLE, RowContext, StepOutcome, capture, expand, perform};
+pub use rows::{SourceRow, parse_json, parse_line, parse_lines, parse_rows};
+pub use run::{
+    ENV_ID, ENV_PATH, ENV_TITLE, ParentRow, RowContext, StepOutcome, capture, expand, expand_path,
+    perform,
+};

--- a/core/sources/src/rows.rs
+++ b/core/sources/src/rows.rs
@@ -1,9 +1,17 @@
-//! The row wire format shared by list and command sources.
+//! The row wire formats shared by list and command sources.
 //!
-//! `id<TAB>title<TAB>group`, where a bare line is a row whose id and title are
-//! the same text. Tab separated rather than anything richer so a naive `ls` or
-//! `awk` one-liner is already a valid source, while a script that wants stable
-//! ranking can still say what the id is.
+//! The default is `id<TAB>title<TAB>group`, where a bare line is a row whose id
+//! and title are the same text. Tab separated rather than anything richer so a
+//! naive `ls` or `awk` one-liner is already a valid source, while a script that
+//! wants stable ranking can still say what the id is.
+//!
+//! `format = "json"` is the opt-in for the two fields tabs cannot carry:
+//! `subtitle`, and `path`, which is what makes a row a real filesystem object
+//! rather than a piece of text. It costs the author a `jq`, so it stays opt-in.
+
+use serde_json::Value;
+
+use crate::def::RowFormat;
 
 /// The id is what actions receive and what usage is recorded against, so a row
 /// can display one thing and act on another.
@@ -78,6 +86,81 @@ pub fn parse_lines(text: &str, limit: usize) -> (Vec<SourceRow>, bool) {
     (rows, false)
 }
 
+/// Field names a JSON row understands. Anything else is ignored rather than
+/// refused, so a script can pipe its own richer output through untouched.
+const KEY_ID: &str = "id";
+const KEY_TITLE: &str = "title";
+const KEY_SUBTITLE: &str = "subtitle";
+const KEY_GROUP: &str = "group";
+const KEY_PATH: &str = "path";
+
+/// Parses rows in whichever encoding the block declared. `Err` means the text
+/// could not be read at all, which the caller reports and, for a `run` block,
+/// treats as a failed refresh that keeps the previous rows.
+pub fn parse_rows(
+    text: &str,
+    limit: usize,
+    format: RowFormat,
+) -> Result<(Vec<SourceRow>, bool), String> {
+    match format {
+        RowFormat::Lines => Ok(parse_lines(text, limit)),
+        RowFormat::Json => parse_json(text, limit),
+    }
+}
+
+/// Accepts the three shapes a real command emits: one top-level array, one
+/// object per line, or pretty-printed objects run together. All three are what
+/// some tool already prints, and telling them apart is free.
+pub fn parse_json(text: &str, limit: usize) -> Result<(Vec<SourceRow>, bool), String> {
+    let mut rows = Vec::new();
+    for value in serde_json::Deserializer::from_str(text).into_iter::<Value>() {
+        let value = value.map_err(|err| format!("not valid JSON: {err}"))?;
+        let items = match value {
+            Value::Array(items) => items,
+            single => vec![single],
+        };
+        for item in items {
+            if rows.len() == limit {
+                return Ok((rows, true));
+            }
+            if let Some(row) = parse_value(&item) {
+                rows.push(row);
+            }
+        }
+    }
+    Ok((rows, false))
+}
+
+/// One JSON row. A bare string or number is a row whose id and title are the
+/// same, so `["main", "dev"]` reads exactly like two bare lines.
+fn parse_value(value: &Value) -> Option<SourceRow> {
+    if let Some(text) = text_field(Some(value)) {
+        return Some(SourceRow::new(text.clone(), text));
+    }
+
+    let object = value.as_object()?;
+    let id = text_field(object.get(KEY_ID))?;
+    Some(SourceRow {
+        title: text_field(object.get(KEY_TITLE)).unwrap_or_else(|| id.clone()),
+        id,
+        subtitle: text_field(object.get(KEY_SUBTITLE)),
+        group: text_field(object.get(KEY_GROUP)),
+        path: text_field(object.get(KEY_PATH)),
+    })
+}
+
+/// A string or a number, trimmed, with empty treated as absent so the fallbacks
+/// match the line format's. Numbers because the tools that already emit JSON
+/// emit them: an issue number, a pid, a port.
+fn text_field(value: Option<&Value>) -> Option<String> {
+    let text = match value? {
+        Value::String(text) => text.trim().to_string(),
+        Value::Number(number) => number.to_string(),
+        _ => return None,
+    };
+    (!text.is_empty()).then_some(text)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -132,5 +215,92 @@ mod tests {
         let (rows, truncated) = parse_lines(&text, 100);
         assert_eq!(rows.len(), 10);
         assert!(!truncated);
+    }
+
+    #[test]
+    fn a_json_row_carries_the_fields_tabs_cannot() {
+        let (rows, _) = parse_json(
+            r#"{"id":"look","title":"Look","subtitle":"3 uncommitted","group":"This week","path":"/dev/look"}"#,
+            10,
+        )
+        .unwrap();
+        let row = &rows[0];
+        assert_eq!(row.id, "look");
+        assert_eq!(row.title, "Look");
+        assert_eq!(row.subtitle.as_deref(), Some("3 uncommitted"));
+        assert_eq!(row.group.as_deref(), Some("This week"));
+        assert_eq!(row.path.as_deref(), Some("/dev/look"));
+    }
+
+    #[test]
+    fn an_array_and_one_object_per_line_read_the_same() {
+        let array = r#"[{"id":"a"},{"id":"b"}]"#;
+        let stream = "{\"id\":\"a\"}\n{\"id\":\"b\"}\n";
+        let pretty = "{\n  \"id\": \"a\"\n}\n{\n  \"id\": \"b\"\n}\n";
+
+        let (from_array, _) = parse_json(array, 10).unwrap();
+        let (from_stream, _) = parse_json(stream, 10).unwrap();
+        let (from_pretty, _) = parse_json(pretty, 10).unwrap();
+        assert_eq!(from_array, from_stream);
+        assert_eq!(from_array, from_pretty);
+        assert_eq!(from_array.len(), 2);
+    }
+
+    #[test]
+    fn a_bare_string_or_number_is_its_own_id_and_title() {
+        let (rows, _) = parse_json(r#"["main", 412]"#, 10).unwrap();
+        assert_eq!(rows[0].id, "main");
+        assert_eq!(rows[0].title, "main");
+        assert_eq!(rows[1].id, "412");
+        assert_eq!(rows[1].title, "412");
+    }
+
+    #[test]
+    fn an_id_that_is_a_number_still_ranks_and_a_missing_one_is_not_a_row() {
+        let (rows, _) = parse_json(
+            r#"[{"id":412,"title":"Crash on launch"},{"title":"no id"}]"#,
+            10,
+        )
+        .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, "412");
+        assert_eq!(rows[0].title, "Crash on launch");
+    }
+
+    #[test]
+    fn keys_the_row_format_does_not_know_are_ignored_rather_than_refused() {
+        let (rows, _) = parse_json(r#"{"id":"a","Image":"postgres:16"}"#, 10).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].title, "a");
+    }
+
+    #[test]
+    fn malformed_json_is_reported_rather_than_read_as_no_rows() {
+        // Silence would look like a source that produced nothing, which for a
+        // `run` block means "keep the old rows" and hides the typo forever.
+        assert!(parse_json("{\"id\": }", 10).is_err());
+        assert!(parse_json("not json at all", 10).is_err());
+    }
+
+    #[test]
+    fn json_output_past_the_limit_is_dropped_and_reported() {
+        let text = format!(
+            "[{}]",
+            (0..10)
+                .map(|i| format!(r#"{{"id":"{i}"}}"#))
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+        let (rows, truncated) = parse_json(&text, 4).unwrap();
+        assert_eq!(rows.len(), 4);
+        assert!(truncated);
+    }
+
+    #[test]
+    fn the_declared_format_picks_the_parser() {
+        let (rows, _) = parse_rows("look\tLook", 10, RowFormat::Lines).unwrap();
+        assert_eq!(rows[0].title, "Look");
+        let (rows, _) = parse_rows(r#"{"id":"look","title":"Look"}"#, 10, RowFormat::Json).unwrap();
+        assert_eq!(rows[0].title, "Look");
     }
 }

--- a/core/sources/src/rows.rs
+++ b/core/sources/src/rows.rs
@@ -1,13 +1,13 @@
 //! The row wire formats shared by list and command sources.
 //!
-//! The default is `id<TAB>title<TAB>group`, where a bare line is a row whose id
-//! and title are the same text. Tab separated rather than anything richer so a
-//! naive `ls` or `awk` one-liner is already a valid source, while a script that
-//! wants stable ranking can still say what the id is.
+//! The default is `id<TAB>title<TAB>subtitle`, where a bare line is a row whose
+//! id and title are the same text. Tab separated rather than anything richer so
+//! a naive `ls` or `awk` one-liner is already a valid source, while a script
+//! that wants stable ranking can still say what the id is.
 //!
-//! `format = "json"` is the opt-in for the two fields tabs cannot carry:
-//! `subtitle`, and `path`, which is what makes a row a real filesystem object
-//! rather than a piece of text. It costs the author a `jq`, so it stays opt-in.
+//! `format = "json"` is the opt-in for the field tabs cannot carry: `path`,
+//! which is what makes a row a real filesystem object rather than a piece of
+//! text. It costs the author a `jq`, so it stays opt-in.
 
 use serde_json::Value;
 
@@ -19,20 +19,25 @@ use crate::def::RowFormat;
 pub struct SourceRow {
     pub id: String,
     pub title: String,
+    /// The row's second line.
     pub subtitle: Option<String>,
-    /// Section header this row sits under, within its own source.
-    pub group: Option<String>,
     /// Filesystem target, when the row has one. Folder sources always do.
     pub path: Option<String>,
 }
 
 impl SourceRow {
+    /// The row's second line: what it said about itself, else where it came
+    /// from. One rule, so an indexed row and a drilled one cannot disagree
+    /// about the same block's rows.
+    pub fn display_subtitle<'a>(&'a self, block_name: &'a str) -> &'a str {
+        self.subtitle.as_deref().unwrap_or(block_name)
+    }
+
     pub fn new(id: impl Into<String>, title: impl Into<String>) -> Self {
         Self {
             id: id.into(),
             title: title.into(),
             subtitle: None,
-            group: None,
             path: None,
         }
     }
@@ -42,7 +47,7 @@ const FIELD_SEPARATOR: char = '\t';
 
 /// Parses one line. Blank lines are not rows; a line that is only whitespace is
 /// almost always an artifact of the script, not something the user wants to see.
-pub fn parse_line(line: &str) -> Option<SourceRow> {
+fn parse_line(line: &str) -> Option<SourceRow> {
     let line = line.strip_suffix('\r').unwrap_or(line);
     if line.trim().is_empty() {
         return None;
@@ -57,7 +62,7 @@ pub fn parse_line(line: &str) -> Option<SourceRow> {
         .next()
         .map(str::trim)
         .filter(|value| !value.is_empty());
-    let group = fields
+    let subtitle = fields
         .next()
         .map(str::trim)
         .filter(|value| !value.is_empty());
@@ -65,15 +70,14 @@ pub fn parse_line(line: &str) -> Option<SourceRow> {
     Some(SourceRow {
         id: id.to_string(),
         title: title.unwrap_or(id).to_string(),
-        subtitle: None,
-        group: group.map(String::from),
+        subtitle: subtitle.map(String::from),
         path: None,
     })
 }
 
 /// Parses stdout or a list file, dropping rows past `limit` so a runaway
 /// producer cannot flood the index. The caller reports the truncation.
-pub fn parse_lines(text: &str, limit: usize) -> (Vec<SourceRow>, bool) {
+fn parse_lines(text: &str, limit: usize) -> (Vec<SourceRow>, bool) {
     let mut rows = Vec::new();
     for line in text.lines() {
         if rows.len() == limit {
@@ -91,7 +95,6 @@ pub fn parse_lines(text: &str, limit: usize) -> (Vec<SourceRow>, bool) {
 const KEY_ID: &str = "id";
 const KEY_TITLE: &str = "title";
 const KEY_SUBTITLE: &str = "subtitle";
-const KEY_GROUP: &str = "group";
 const KEY_PATH: &str = "path";
 
 /// Parses rows in whichever encoding the block declared. `Err` means the text
@@ -111,7 +114,7 @@ pub fn parse_rows(
 /// Accepts the three shapes a real command emits: one top-level array, one
 /// object per line, or pretty-printed objects run together. All three are what
 /// some tool already prints, and telling them apart is free.
-pub fn parse_json(text: &str, limit: usize) -> Result<(Vec<SourceRow>, bool), String> {
+fn parse_json(text: &str, limit: usize) -> Result<(Vec<SourceRow>, bool), String> {
     let mut rows = Vec::new();
     for value in serde_json::Deserializer::from_str(text).into_iter::<Value>() {
         let value = value.map_err(|err| format!("not valid JSON: {err}"))?;
@@ -144,7 +147,6 @@ fn parse_value(value: &Value) -> Option<SourceRow> {
         title: text_field(object.get(KEY_TITLE)).unwrap_or_else(|| id.clone()),
         id,
         subtitle: text_field(object.get(KEY_SUBTITLE)),
-        group: text_field(object.get(KEY_GROUP)),
         path: text_field(object.get(KEY_PATH)),
     })
 }
@@ -170,15 +172,15 @@ mod tests {
         let row = parse_line("look").unwrap();
         assert_eq!(row.id, "look");
         assert_eq!(row.title, "look");
-        assert_eq!(row.group, None);
+        assert_eq!(row.subtitle, None);
     }
 
     #[test]
     fn id_and_title_can_differ_so_a_row_shows_one_thing_and_acts_on_another() {
-        let row = parse_line("look\tlook (main, 3 windows)\tSession").unwrap();
+        let row = parse_line("look\tlook (main, 3 windows)\tattached").unwrap();
         assert_eq!(row.id, "look");
         assert_eq!(row.title, "look (main, 3 windows)");
-        assert_eq!(row.group.as_deref(), Some("Session"));
+        assert_eq!(row.subtitle.as_deref(), Some("attached"));
     }
 
     #[test]
@@ -192,7 +194,7 @@ mod tests {
     fn empty_trailing_fields_fall_back_rather_than_showing_blanks() {
         let row = parse_line("look\t\t").unwrap();
         assert_eq!(row.title, "look");
-        assert_eq!(row.group, None);
+        assert_eq!(row.subtitle, None);
     }
 
     #[test]
@@ -220,7 +222,7 @@ mod tests {
     #[test]
     fn a_json_row_carries_the_fields_tabs_cannot() {
         let (rows, _) = parse_json(
-            r#"{"id":"look","title":"Look","subtitle":"3 uncommitted","group":"This week","path":"/dev/look"}"#,
+            r#"{"id":"look","title":"Look","subtitle":"3 uncommitted","path":"/dev/look"}"#,
             10,
         )
         .unwrap();
@@ -228,7 +230,6 @@ mod tests {
         assert_eq!(row.id, "look");
         assert_eq!(row.title, "Look");
         assert_eq!(row.subtitle.as_deref(), Some("3 uncommitted"));
-        assert_eq!(row.group.as_deref(), Some("This week"));
         assert_eq!(row.path.as_deref(), Some("/dev/look"));
     }
 

--- a/core/sources/src/run.rs
+++ b/core/sources/src/run.rs
@@ -91,20 +91,15 @@ pub struct RowContext {
     pub path: String,
     /// What the user had typed when they picked the row.
     pub query: String,
-    /// The rows this one was reached through while drilling down, NEAREST
-    /// first, so `{parent.id}` is `parents[0]` and each further `parent.` steps
-    /// one out (`specs/user-sources.md` §2.10).
+    /// Rows this one was drilled from, NEAREST first: `{parent.id}` is
+    /// `parents[0]`, and each further `parent.` steps one out.
     pub parents: Vec<ParentRow>,
 }
 
 impl RowContext {
-    /// Where a command for this row should run: its own path, or the nearest
-    /// ancestor that has one.
-    ///
-    /// A drilled row often has no path of its own (a script, a branch, a
-    /// container) while the level above does, and "run this in the project"
-    /// is what the user means. A command that needs to say so explicitly has
-    /// `{parent.path}`; a working directory has no syntax to say it with.
+    /// Its own path, or the nearest ancestor that has one: a script or branch
+    /// row has none while the project above it does, and that is where "run
+    /// this" means. A command can say `{parent.path}`; a directory cannot.
     pub fn working_path(&self) -> &str {
         if !self.path.is_empty() {
             return &self.path;
@@ -116,23 +111,16 @@ impl RowContext {
             .unwrap_or_default()
     }
 
-    /// The FOLDER a command for this row runs in: `working_path` when it is a
-    /// directory, its parent when it is a file.
-    ///
-    /// Never the file itself. `current_dir` on a file fails the spawn outright
-    /// with ENOTDIR, which surfaces as `/bin/zsh: Not a directory` and looks
-    /// like the user's command is broken when nothing has run at all.
+    /// The FOLDER to run in, never the file itself: `current_dir` on a file
+    /// fails the spawn with ENOTDIR, which reads as `/bin/zsh: Not a directory`
+    /// as if the user's command were broken.
     pub fn working_dir(&self) -> String {
         parent_dir(self.working_path())
     }
 }
 
-/// An ancestor row, for `{parent.*}`. Flat rather than a nested `RowContext`:
-/// a level's own query and its own ancestors are not what a placeholder can
-/// name, so carrying them would only invite reading the wrong one.
-///
-/// Deserialized because the shell is what still holds an ancestor's title and
-/// path; the candidate id carries only the ids.
+/// An ancestor row, for `{parent.*}`. Flat rather than a nested `RowContext`,
+/// since a placeholder can name nothing else about it.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(default)]
 pub struct ParentRow {
@@ -141,17 +129,16 @@ pub struct ParentRow {
     pub path: String,
 }
 
-/// The placeholders a template can carry, in one list so that `expand` and
-/// `Block::needs_row` agree on what one is. A brace that opens anything else is
-/// not a placeholder: a `run` command emitting JSON is full of them.
+/// One list, so `expand` and `Block::needs_row` agree on what a placeholder is.
+/// A brace that opens anything else is not one: a `run` command emitting JSON
+/// is full of them.
 pub const PLACEHOLDER_ID: &str = "{id}";
 pub const PLACEHOLDER_TITLE: &str = "{title}";
 pub const PLACEHOLDER_PATH: &str = "{path}";
 pub const PLACEHOLDER_DIR: &str = "{dir}";
 pub const PLACEHOLDER_QUERY: &str = "{query}";
-/// Opens an ancestor placeholder (`{parent.id}`, `{parent.parent.path}`). A
-/// producer mentioning one still needs a row, so `Block::needs_row` looks for
-/// this too.
+/// Opens an ancestor placeholder (`{parent.id}`), which also means a producer
+/// mentioning one needs a row.
 pub const PLACEHOLDER_PARENT: &str = "{parent.";
 pub const PLACEHOLDERS: [&str; 5] = [
     PLACEHOLDER_ID,
@@ -172,21 +159,15 @@ pub fn expand(template: &str, row: &RowContext) -> String {
     substitute(template, row, quote)
 }
 
-/// The same placeholders, substituted raw.
-///
-/// For a value that becomes a filesystem path (`dir`, `file`) rather than shell
-/// text: quoting there would put the quotes in the path and nothing would be
-/// found. Every caller must therefore hand the result to the filesystem, never
-/// to a shell.
+/// The same placeholders, unquoted, for a value that becomes a filesystem path
+/// rather than shell text: quotes there land in the path and nothing is found.
+/// Hand the result to the filesystem, never to a shell.
 pub fn expand_path(template: &str, row: &RowContext) -> String {
     substitute(template, row, |value| value.to_string())
 }
 
-/// One substitution pass, so the shell and filesystem forms cannot drift in
-/// which placeholders they know.
-///
-/// Ancestors are substituted deepest prefix first, and an ancestor that does not
-/// exist reads as empty, exactly like a row with no path.
+/// One pass, so the shell and filesystem forms cannot drift. Ancestors go
+/// deepest prefix first; a missing one reads as empty, like a row with no path.
 fn substitute(template: &str, row: &RowContext, transform: fn(&str) -> String) -> String {
     let mut out = template.to_string();
 

--- a/core/sources/src/run.rs
+++ b/core/sources/src/run.rs
@@ -171,9 +171,8 @@ pub fn expand_path(template: &str, row: &RowContext) -> String {
 fn substitute(template: &str, row: &RowContext, transform: fn(&str) -> String) -> String {
     let mut out = template.to_string();
 
-    // As deep as the row goes OR as deep as the template asks: a template
-    // naming an ancestor the row does not have must still be substituted, or
-    // the literal `{parent.parent.id}` reaches the shell.
+    // As deep as the row goes OR as deep as the template asks: an ancestor the
+    // row lacks must still be substituted, or the literal text reaches a shell.
     let deepest = deepest_parent_depth(template).max(row.parents.len()).max(1);
     for depth in (1..=deepest).rev() {
         let prefix = PLACEHOLDER_PARENT_WORD.repeat(depth);
@@ -204,24 +203,16 @@ fn substitute(template: &str, row: &RowContext, transform: fn(&str) -> String) -
 /// The word an ancestor placeholder repeats, without the brace.
 const PLACEHOLDER_PARENT_WORD: &str = "parent.";
 
-/// Past this a template is not naming an ancestor, it is a typo repeating a
-/// word, and substituting further would only grow the loop.
-const MAX_PARENT_DEPTH: usize = 8;
-
-/// The deepest `{parent.parent....}` the template names.
+/// The deepest `{parent.parent....}` the template names. No ceiling: a depth
+/// the search stops short of is a placeholder handed to a shell as text.
 fn deepest_parent_depth(template: &str) -> usize {
     let mut deepest = 0;
     for (open, _) in template.match_indices(PLACEHOLDER_PARENT) {
         let mut rest = &template[open + 1..];
         let mut depth = 0;
-        while depth < MAX_PARENT_DEPTH {
-            match rest.strip_prefix(PLACEHOLDER_PARENT_WORD) {
-                Some(shorter) => {
-                    depth += 1;
-                    rest = shorter;
-                }
-                None => break,
-            }
+        while let Some(shorter) = rest.strip_prefix(PLACEHOLDER_PARENT_WORD) {
+            depth += 1;
+            rest = shorter;
         }
         deepest = deepest.max(depth);
     }
@@ -513,8 +504,6 @@ mod tests {
 
     #[test]
     fn an_ancestor_deeper_than_the_chain_still_reads_as_empty() {
-        // The template names a grandparent the row does not have. Leaving
-        // `{parent.parent.id}` literal would hand the shell that text.
         let row = drilled(&[("animate", "/dev/animate")]);
         assert_eq!(
             expand(
@@ -523,6 +512,12 @@ mod tests {
             ),
             "k --context '' -n 'animate' logs 'build'"
         );
+    }
+
+    #[test]
+    fn no_depth_is_deep_enough_to_leave_a_placeholder_behind() {
+        let deep = "x {parent.parent.parent.parent.parent.parent.parent.parent.parent.id}";
+        assert_eq!(expand(deep, &drilled(&[("one", "/one")])), "x ''");
     }
 
     #[test]

--- a/core/sources/src/run.rs
+++ b/core/sources/src/run.rs
@@ -171,7 +171,11 @@ pub fn expand_path(template: &str, row: &RowContext) -> String {
 fn substitute(template: &str, row: &RowContext, transform: fn(&str) -> String) -> String {
     let mut out = template.to_string();
 
-    for depth in (1..=row.parents.len().max(1)).rev() {
+    // As deep as the row goes OR as deep as the template asks: a template
+    // naming an ancestor the row does not have must still be substituted, or
+    // the literal `{parent.parent.id}` reaches the shell.
+    let deepest = deepest_parent_depth(template).max(row.parents.len()).max(1);
+    for depth in (1..=deepest).rev() {
         let prefix = PLACEHOLDER_PARENT_WORD.repeat(depth);
         let parent = row.parents.get(depth - 1);
         let (id, title, path) = match parent {
@@ -199,6 +203,30 @@ fn substitute(template: &str, row: &RowContext, transform: fn(&str) -> String) -
 
 /// The word an ancestor placeholder repeats, without the brace.
 const PLACEHOLDER_PARENT_WORD: &str = "parent.";
+
+/// Past this a template is not naming an ancestor, it is a typo repeating a
+/// word, and substituting further would only grow the loop.
+const MAX_PARENT_DEPTH: usize = 8;
+
+/// The deepest `{parent.parent....}` the template names.
+fn deepest_parent_depth(template: &str) -> usize {
+    let mut deepest = 0;
+    for (open, _) in template.match_indices(PLACEHOLDER_PARENT) {
+        let mut rest = &template[open + 1..];
+        let mut depth = 0;
+        while depth < MAX_PARENT_DEPTH {
+            match rest.strip_prefix(PLACEHOLDER_PARENT_WORD) {
+                Some(shorter) => {
+                    depth += 1;
+                    rest = shorter;
+                }
+                None => break,
+            }
+        }
+        deepest = deepest.max(depth);
+    }
+    deepest
+}
 
 /// The row's own folder: itself when it is one, its parent otherwise.
 fn parent_dir(path: &str) -> String {
@@ -480,6 +508,20 @@ mod tests {
                 &row
             ),
             "k --context 'prod' -n 'animate' logs 'build'"
+        );
+    }
+
+    #[test]
+    fn an_ancestor_deeper_than_the_chain_still_reads_as_empty() {
+        // The template names a grandparent the row does not have. Leaving
+        // `{parent.parent.id}` literal would hand the shell that text.
+        let row = drilled(&[("animate", "/dev/animate")]);
+        assert_eq!(
+            expand(
+                "k --context {parent.parent.id} -n {parent.id} logs {id}",
+                &row
+            ),
+            "k --context '' -n 'animate' logs 'build'"
         );
     }
 

--- a/core/sources/src/run.rs
+++ b/core/sources/src/run.rs
@@ -17,6 +17,8 @@
 use std::io::Read;
 use std::process::{Command, Stdio};
 
+use serde::Deserialize;
+
 use look_tools::shell_quote as quote;
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
@@ -89,7 +91,75 @@ pub struct RowContext {
     pub path: String,
     /// What the user had typed when they picked the row.
     pub query: String,
+    /// The rows this one was reached through while drilling down, NEAREST
+    /// first, so `{parent.id}` is `parents[0]` and each further `parent.` steps
+    /// one out (`specs/user-sources.md` §2.10).
+    pub parents: Vec<ParentRow>,
 }
+
+impl RowContext {
+    /// Where a command for this row should run: its own path, or the nearest
+    /// ancestor that has one.
+    ///
+    /// A drilled row often has no path of its own (a script, a branch, a
+    /// container) while the level above does, and "run this in the project"
+    /// is what the user means. A command that needs to say so explicitly has
+    /// `{parent.path}`; a working directory has no syntax to say it with.
+    pub fn working_path(&self) -> &str {
+        if !self.path.is_empty() {
+            return &self.path;
+        }
+        self.parents
+            .iter()
+            .map(|parent| parent.path.as_str())
+            .find(|path| !path.is_empty())
+            .unwrap_or_default()
+    }
+
+    /// The FOLDER a command for this row runs in: `working_path` when it is a
+    /// directory, its parent when it is a file.
+    ///
+    /// Never the file itself. `current_dir` on a file fails the spawn outright
+    /// with ENOTDIR, which surfaces as `/bin/zsh: Not a directory` and looks
+    /// like the user's command is broken when nothing has run at all.
+    pub fn working_dir(&self) -> String {
+        parent_dir(self.working_path())
+    }
+}
+
+/// An ancestor row, for `{parent.*}`. Flat rather than a nested `RowContext`:
+/// a level's own query and its own ancestors are not what a placeholder can
+/// name, so carrying them would only invite reading the wrong one.
+///
+/// Deserialized because the shell is what still holds an ancestor's title and
+/// path; the candidate id carries only the ids.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(default)]
+pub struct ParentRow {
+    pub id: String,
+    pub title: String,
+    pub path: String,
+}
+
+/// The placeholders a template can carry, in one list so that `expand` and
+/// `Block::needs_row` agree on what one is. A brace that opens anything else is
+/// not a placeholder: a `run` command emitting JSON is full of them.
+pub const PLACEHOLDER_ID: &str = "{id}";
+pub const PLACEHOLDER_TITLE: &str = "{title}";
+pub const PLACEHOLDER_PATH: &str = "{path}";
+pub const PLACEHOLDER_DIR: &str = "{dir}";
+pub const PLACEHOLDER_QUERY: &str = "{query}";
+/// Opens an ancestor placeholder (`{parent.id}`, `{parent.parent.path}`). A
+/// producer mentioning one still needs a row, so `Block::needs_row` looks for
+/// this too.
+pub const PLACEHOLDER_PARENT: &str = "{parent.";
+pub const PLACEHOLDERS: [&str; 5] = [
+    PLACEHOLDER_ID,
+    PLACEHOLDER_TITLE,
+    PLACEHOLDER_PATH,
+    PLACEHOLDER_DIR,
+    PLACEHOLDER_QUERY,
+];
 
 /// Substitutes `{id}`, `{title}`, `{path}`, `{dir}`, and `{query}`.
 ///
@@ -99,14 +169,55 @@ pub struct RowContext {
 /// titled `; rm -rf ~` must not execute. A template therefore never quotes its
 /// own placeholders.
 pub fn expand(template: &str, row: &RowContext) -> String {
-    let dir = parent_dir(&row.path);
-    template
-        .replace("{id}", &quote(&row.id))
-        .replace("{title}", &quote(&row.title))
-        .replace("{path}", &quote(&row.path))
-        .replace("{dir}", &quote(&dir))
-        .replace("{query}", &quote(&row.query))
+    substitute(template, row, quote)
 }
+
+/// The same placeholders, substituted raw.
+///
+/// For a value that becomes a filesystem path (`dir`, `file`) rather than shell
+/// text: quoting there would put the quotes in the path and nothing would be
+/// found. Every caller must therefore hand the result to the filesystem, never
+/// to a shell.
+pub fn expand_path(template: &str, row: &RowContext) -> String {
+    substitute(template, row, |value| value.to_string())
+}
+
+/// One substitution pass, so the shell and filesystem forms cannot drift in
+/// which placeholders they know.
+///
+/// Ancestors are substituted deepest prefix first, and an ancestor that does not
+/// exist reads as empty, exactly like a row with no path.
+fn substitute(template: &str, row: &RowContext, transform: fn(&str) -> String) -> String {
+    let mut out = template.to_string();
+
+    for depth in (1..=row.parents.len().max(1)).rev() {
+        let prefix = PLACEHOLDER_PARENT_WORD.repeat(depth);
+        let parent = row.parents.get(depth - 1);
+        let (id, title, path) = match parent {
+            Some(parent) => (
+                parent.id.as_str(),
+                parent.title.as_str(),
+                parent.path.as_str(),
+            ),
+            None => ("", "", ""),
+        };
+        out = out
+            .replace(&format!("{{{prefix}id}}"), &transform(id))
+            .replace(&format!("{{{prefix}title}}"), &transform(title))
+            .replace(&format!("{{{prefix}path}}"), &transform(path))
+            .replace(&format!("{{{prefix}dir}}"), &transform(&parent_dir(path)));
+    }
+
+    let dir = parent_dir(&row.path);
+    out.replace(PLACEHOLDER_ID, &transform(&row.id))
+        .replace(PLACEHOLDER_TITLE, &transform(&row.title))
+        .replace(PLACEHOLDER_PATH, &transform(&row.path))
+        .replace(PLACEHOLDER_DIR, &transform(&dir))
+        .replace(PLACEHOLDER_QUERY, &transform(&row.query))
+}
+
+/// The word an ancestor placeholder repeats, without the brace.
+const PLACEHOLDER_PARENT_WORD: &str = "parent.";
 
 /// The row's own folder: itself when it is one, its parent otherwise.
 fn parent_dir(path: &str) -> String {
@@ -181,7 +292,7 @@ fn spawn(step: &str, row: Option<&RowContext>) -> Result<(), String> {
         // The row's FOLDER, never the row itself: `path` is a file for most
         // rows, and `current_dir` on a file makes every spawn fail with
         // ENOTDIR. Same rule as `{dir}`.
-        let dir = parent_dir(&row.path);
+        let dir = row.working_dir();
         if !dir.is_empty() {
             command.current_dir(&dir);
         }
@@ -327,7 +438,86 @@ mod tests {
             title: "look".into(),
             path: path.into(),
             query: "loo".into(),
+            ..Default::default()
         }
+    }
+
+    fn drilled(parents: &[(&str, &str)]) -> RowContext {
+        RowContext {
+            id: "build".into(),
+            title: "build".into(),
+            query: String::new(),
+            path: String::new(),
+            parents: parents
+                .iter()
+                .map(|(id, path)| ParentRow {
+                    id: (*id).into(),
+                    title: (*id).into(),
+                    path: (*path).into(),
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn a_command_for_a_file_row_runs_in_the_files_folder_not_on_the_file() {
+        // `current_dir` on a file is ENOTDIR: the shell never starts, and the
+        // user sees "/bin/zsh: Not a directory" as if their command were wrong.
+        let dir = std::env::temp_dir().join(format!("look-workdir-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("probe dir");
+        let file = dir.join("changed.txt");
+        std::fs::write(&file, "x").expect("probe file");
+
+        let row = RowContext {
+            path: file.to_string_lossy().into_owned(),
+            ..Default::default()
+        };
+        assert_eq!(row.working_dir(), dir.to_string_lossy());
+
+        // A row with no path of its own borrows the nearest ancestor's folder.
+        let drilled = RowContext {
+            parents: vec![ParentRow {
+                path: dir.to_string_lossy().into_owned(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        assert_eq!(drilled.working_dir(), dir.to_string_lossy());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn an_ancestor_is_named_by_stepping_out_one_level_at_a_time() {
+        let row = drilled(&[("animate", "/dev/animate"), ("prod", "")]);
+        assert_eq!(
+            expand("npm --prefix {parent.path} run {id}", &row),
+            "npm --prefix '/dev/animate' run 'build'"
+        );
+        assert_eq!(
+            expand(
+                "k --context {parent.parent.id} -n {parent.id} logs {id}",
+                &row
+            ),
+            "k --context 'prod' -n 'animate' logs 'build'"
+        );
+    }
+
+    #[test]
+    fn an_ancestor_that_is_not_there_reads_as_empty_rather_than_as_itself() {
+        // A literal `{parent.path}` reaching the shell would be worse: the
+        // command would run against a directory named after the placeholder.
+        let row = drilled(&[]);
+        assert_eq!(expand("ls {parent.path}", &row), "ls ''");
+    }
+
+    #[test]
+    fn an_ancestor_placeholder_is_quoted_for_a_shell_and_raw_for_a_path() {
+        let row = drilled(&[("my project", "/dev/my project")]);
+        assert_eq!(expand("cd {parent.path}", &row), "cd '/dev/my project'");
+        assert_eq!(
+            expand_path("{parent.path}/src", &row),
+            "/dev/my project/src"
+        );
     }
 
     #[test]

--- a/core/sources/src/tools.rs
+++ b/core/sources/src/tools.rs
@@ -72,7 +72,8 @@ mod tests {
 
     #[test]
     fn a_blocks_verb_wins_for_its_own_rows_and_expands_like_any_other() {
-        let block = block("[projects]\ndir = \"~/dev\"\nterminal = \"tmux new -As {title} -c {path}\"\n");
+        let block =
+            block("[projects]\ndir = \"~/dev\"\nterminal = \"tmux new -As {title} -c {path}\"\n");
         let launch = resolve_for_row(
             "terminal",
             "/dev/look",
@@ -134,7 +135,27 @@ mod tests {
     #[test]
     fn an_unknown_action_or_an_empty_path_answers_nothing() {
         let block = block("[projects]\ndir = \"~/dev\"\nterminal = \"tmux new\"\n");
-        assert!(resolve_for_row("nope", "/dev/look", true, &Tools::default(), Some(&block), &row()).is_none());
-        assert!(resolve_for_row("terminal", "", true, &Tools::default(), Some(&block), &row()).is_none());
+        assert!(
+            resolve_for_row(
+                "nope",
+                "/dev/look",
+                true,
+                &Tools::default(),
+                Some(&block),
+                &row()
+            )
+            .is_none()
+        );
+        assert!(
+            resolve_for_row(
+                "terminal",
+                "",
+                true,
+                &Tools::default(),
+                Some(&block),
+                &row()
+            )
+            .is_none()
+        );
     }
 }

--- a/core/sources/src/tools.rs
+++ b/core/sources/src/tools.rs
@@ -1,0 +1,140 @@
+//! Which command a tool action runs for a row: the block's own verb, else the
+//! user's declared tool, else the platform default.
+//!
+//! Here because this is the only crate that sees both: `look-sources` already
+//! depends on `look-tools`, so the dependency cannot run the other way, and a
+//! shell holding the rule would mean every shell reimplementing it.
+
+use look_tools::{Action, Launch, Tools, Unavailable};
+
+use crate::def::Block;
+use crate::run::{RowContext, expand};
+
+/// What `action` does to `row`, or `None` when the action is unknown or the row
+/// has no path, exactly as `look_tools::resolve` answers for a row with no
+/// block.
+///
+/// A block's verb wins for its own rows, expanded like every other command it
+/// declares. Declaring nothing changes nothing.
+pub fn resolve_for_row(
+    action: &str,
+    path: &str,
+    is_dir: bool,
+    tools: &Tools,
+    block: Option<&Block>,
+    row: &RowContext,
+) -> Option<Result<Launch, Unavailable>> {
+    let declared = Action::from_id(action)
+        .and_then(|action| block.and_then(|block| block.verbs.for_action(action)));
+
+    match declared {
+        // The guard `look_tools::resolve` applies, before taking its own path.
+        Some(_) if path.trim().is_empty() => None,
+        Some(command) => Some(Ok(Launch::Shell {
+            // The block, not a tool: no tool was consulted.
+            tool: block.map(|block| block.name.clone()).unwrap_or_default(),
+            command: expand(command, row),
+        })),
+        None => look_tools::resolve(action, path, is_dir, tools),
+    }
+}
+
+/// Whether `block` takes `action` for its own rows, which is what a label needs
+/// to know: the same lookup `resolve_for_row` makes.
+pub fn block_declares(block: Option<&Block>, action: &str) -> bool {
+    Action::from_id(action)
+        .and_then(|action| block.and_then(|block| block.verbs.for_action(action)))
+        .is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::def::parse_file;
+
+    fn block(contents: &str) -> Block {
+        parse_file(contents)
+            .expect("valid file")
+            .blocks
+            .into_iter()
+            .next()
+            .expect("one block")
+    }
+
+    fn row() -> RowContext {
+        RowContext {
+            id: "main".into(),
+            title: "main".into(),
+            path: "/dev/look".into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn a_blocks_verb_wins_for_its_own_rows_and_expands_like_any_other() {
+        let block = block("[projects]\ndir = \"~/dev\"\nterminal = \"tmux new -As {title} -c {path}\"\n");
+        let launch = resolve_for_row(
+            "terminal",
+            "/dev/look",
+            true,
+            &Tools::default(),
+            Some(&block),
+            &row(),
+        )
+        .expect("known action")
+        .expect("declared");
+
+        match launch {
+            Launch::Shell { tool, command } => {
+                assert_eq!(command, "tmux new -As 'main' -c '/dev/look'");
+                assert_eq!(tool, "projects", "the block is what decided");
+            }
+            other => panic!("expected shell, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_verb_the_block_does_not_declare_falls_through_untouched() {
+        // Declaring `terminal` must not change what Cmd+E does.
+        let block = block("[projects]\ndir = \"~/dev\"\nterminal = \"tmux new\"\n");
+        let fell_through = resolve_for_row(
+            "edit",
+            "/dev/look/main.rs",
+            false,
+            &Tools::default(),
+            Some(&block),
+            &row(),
+        );
+        assert_eq!(
+            format!("{fell_through:?}"),
+            format!(
+                "{:?}",
+                look_tools::resolve("edit", "/dev/look/main.rs", false, &Tools::default())
+            )
+        );
+        assert!(!block_declares(Some(&block), "edit"));
+        assert!(block_declares(Some(&block), "terminal"));
+    }
+
+    #[test]
+    fn a_row_from_no_block_resolves_exactly_as_before() {
+        let path = "/dev/look/main.rs";
+        assert_eq!(
+            format!(
+                "{:?}",
+                resolve_for_row("edit", path, false, &Tools::default(), None, &row())
+            ),
+            format!(
+                "{:?}",
+                look_tools::resolve("edit", path, false, &Tools::default())
+            )
+        );
+    }
+
+    #[test]
+    fn an_unknown_action_or_an_empty_path_answers_nothing() {
+        let block = block("[projects]\ndir = \"~/dev\"\nterminal = \"tmux new\"\n");
+        assert!(resolve_for_row("nope", "/dev/look", true, &Tools::default(), Some(&block), &row()).is_none());
+        assert!(resolve_for_row("terminal", "", true, &Tools::default(), Some(&block), &row()).is_none());
+    }
+}

--- a/core/tools/src/resolved.rs
+++ b/core/tools/src/resolved.rs
@@ -31,6 +31,11 @@ pub const KIND_FAILED: &str = "failed";
 /// struct: `kind` says which of the other fields are filled.
 #[derive(Debug, Default, Serialize)]
 pub struct Resolved {
+    /// The row's own block declared this action, so `tool` names the block
+    /// rather than a tool: "Open in WezTerm" is a tool, "Open in Projects" is
+    /// not a sentence. Set by whoever knows about blocks; the default is false.
+    #[serde(rename = "fromBlock")]
+    pub from_block: bool,
     pub kind: &'static str,
     /// The tool that will start, for the label and the installed check.
     pub tool: Option<String>,


### PR DESCRIPTION
## Summary

- Complete user defined source on MacOS
  - Drill down actions added.
  - format = "json" for file and run blocks. Accepts a top-level array, one object per line, or pretty-printed objects, since all three are what some tool already prints
  - `edit / terminal / reveal` on a block have parsed and done nothing since sources shipped
  - Icon enhancement
  - Bug fixes and testcases added

- Brief
  - You declare your blocks (a Look unit) in your ~/.look/source/ folder under toml format. 
  - Look reads your declared source, executes it, returns your expected results
  - You can also declare actions, they will appear in the action panel, which can be summoned by cmd J/K (will add ctrl as-well).
With this feature, we believe that user can declare any their own extensions, tools with-in Look.


## Why

#388 #385 


## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [x] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

MAGIC! You can also do this by your declared scripts

https://github.com/user-attachments/assets/60386f3d-354e-44ab-aa35-210030a98f60



## Checklist

- [x] I have read and agree to the CLA (CLA.md)
- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added drill-down navigation for source results with breadcrumbs, nested rows, filtering, and state restoration.
  * Added JSON source support with truncation and error indicators.
  * Source rows can trigger configured actions and optionally open returned paths.
  * Added ancestor-aware actions and path expansion for nested rows.
* **Improvements**
  * Enhanced action metadata, icons, previews, and reveal behavior.
  * Added limited-line scrolling for code previews.
  * Improved search matching for source names, IDs, aliases, and subtitles.
  * Press Escape to return to the previous drill-down level.
  * Improved handling of cached source results and nested row paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->