### PR TITLE
linows: user declared source

### DIFF
--- a/apps/linows/flake.nix
+++ b/apps/linows/flake.nix
@@ -105,6 +105,8 @@
               xdg-desktop-portal
               xdg-desktop-portal-gtk
               prettier
+              # The CLI a `run` source block shells out to; the app links rusqlite.
+              sqlite
             ];
 
             buildInputs = runtimeLibs;

--- a/apps/linows/src-tauri/src/commands.rs
+++ b/apps/linows/src-tauri/src/commands.rs
@@ -72,11 +72,20 @@ pub fn record_usage(
         .map(|d| d.as_secs() as i64)
         .unwrap_or(0);
 
-    let valid_actions = ["open_app", "open_file", "open_folder"];
-    if !valid_actions.contains(&action.as_str()) {
+    if action.parse::<look_engine::UsageAction>().is_err() {
         return UsageResult {
             ok: false,
             error: Some(format!("Invalid action: {action}")),
+        };
+    }
+
+    // A drilled row is never written to `candidates`, which the `usage_events`
+    // foreign key requires, so there is nothing to record. Reporting a failure
+    // would show a storage error for behaving as designed.
+    if look_engine::sources::is_drilled_row(&candidate_id) {
+        return UsageResult {
+            ok: true,
+            error: None,
         };
     }
 
@@ -333,14 +342,30 @@ pub fn reveal_path(path: String) -> Result<(), String> {
     outcome.map_err(|e| format!("Failed to reveal: {e}"))
 }
 
-#[tauri::command]
-pub fn reload_config(state: State<'_, AppState>) -> bool {
+/// Reload is the one refresh gesture: config, then the `run` blocks, then the
+/// index.
+///
+/// Async because a user's `run` block is a process, and that must not sit on
+/// the request thread. Returns what the blocks did, so a script that broke
+/// says so rather than quietly producing no rows.
+#[tauri::command(async)]
+pub fn reload_config(state: State<'_, AppState>) -> look_engine::sources::RefreshOutcome {
     // The engine caches the parsed `~/.look/config` across calls (skips a disk
     // read on every refresh). When the user explicitly reloads, drop the cache
     // so the next bootstrap picks up their edits.
     RuntimeConfig::invalidate_cache();
     crate::clipboard::reload_from_config();
-    state.request_index_refresh()
+    // Before the index pass, never after: the pass reads the rows these blocks
+    // write, and the other order indexes the previous run's.
+    let sources = look_engine::sources::refresh_run_blocks();
+    // Run rows land in a cache directory no watcher covers, so nothing else
+    // marks the index dirty and the lazy check would decline this refresh.
+    if sources.changed {
+        state.force_index_refresh();
+    } else {
+        state.request_index_refresh();
+    }
+    sources
 }
 
 #[tauri::command]

--- a/apps/linows/src-tauri/src/commands.rs
+++ b/apps/linows/src-tauri/src/commands.rs
@@ -16,6 +16,9 @@ pub struct SearchResult {
     pub subtitle: Option<String>,
     pub path: String,
     pub score: i64,
+    /// What the row declared, which beats its block's icon.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -52,6 +55,7 @@ pub fn search(state: State<'_, AppState>, query: String, limit: u32) -> SearchPa
             subtitle: candidate.subtitle.as_deref().map(str::to_string),
             path: candidate.path.to_string(),
             score,
+            icon: candidate.icon.as_deref().map(str::to_string),
         })
         .collect();
 
@@ -358,8 +362,7 @@ pub fn reload_config(state: State<'_, AppState>) -> look_engine::sources::Refres
     // Before the index pass, never after: the pass reads the rows these blocks
     // write, and the other order indexes the previous run's.
     let sources = look_engine::sources::refresh_run_blocks();
-    // Run rows land in a cache directory no watcher covers, so nothing else
-    // marks the index dirty and the lazy check would decline this refresh.
+    // Run rows land where no watcher covers, so nothing else marks them dirty.
     if sources.changed {
         state.force_index_refresh();
     } else {

--- a/apps/linows/src-tauri/src/files.rs
+++ b/apps/linows/src-tauri/src/files.rs
@@ -22,6 +22,10 @@ pub struct FileMeta {
     pub size: Option<u64>,
     pub modified: Option<String>,
     pub is_image: bool,
+    /// A block's row says nothing about what it points at (`format = "json"`
+    /// carries a path and no kind), so the panel asks the filesystem which
+    /// preview to draw.
+    pub is_dir: bool,
 }
 
 const IMAGE_EXTENSIONS: &[&str] = &[
@@ -51,6 +55,7 @@ pub fn get_file_meta(path: String) -> FileMeta {
         size,
         modified,
         is_image,
+        is_dir: meta.as_ref().map(|m| m.is_dir()).unwrap_or(false),
     }
 }
 

--- a/apps/linows/src-tauri/src/highlight/mod.rs
+++ b/apps/linows/src-tauri/src/highlight/mod.rs
@@ -86,3 +86,18 @@ pub fn highlight_file(path: &str) -> Option<HighlightResult> {
 pub fn highlight_file_cmd(path: String) -> Option<HighlightResult> {
     highlight_file(&path)
 }
+
+/// Tauri command: highlight text the app already holds, as shell.
+///
+/// A block's steps ARE shell (`specs/user-sources.md` §2.8), and the panel
+/// shows them the way an AI answer's code is shown. Never truncated: what is
+/// about to run is shown in full or the panel is lying about it.
+#[tauri::command]
+pub fn highlight_shell_cmd(source: String) -> HighlightResult {
+    let bytes = source.as_bytes();
+    let spans = tokenizer::tokenize(bytes, Language::Shell);
+    HighlightResult {
+        html: html::render(bytes, &spans),
+        truncated: false,
+    }
+}

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -20,6 +20,7 @@ mod platform;
 mod process;
 mod qactions;
 mod shell;
+mod sources;
 mod state;
 mod sysinfo;
 mod todo;
@@ -674,6 +675,14 @@ fn main() {
             // lives in platform::{linux,windows}::tools)
             tools::tool_actions,
             tools::perform_tool_action,
+            // User-declared sources (shared look-engine orchestration over
+            // look-sources; see specs/user-sources.md)
+            sources::source_block,
+            sources::source_blocks,
+            sources::perform_block,
+            sources::source_rows,
+            sources::source_preview,
+            sources::refresh_run_blocks,
             // Platform: icons, detection, window effects
             platform::get_icon,
             platform::get_platform,
@@ -745,6 +754,7 @@ fn main() {
             health::get_health_issues,
             // Highlight
             highlight::highlight_file_cmd,
+            highlight::highlight_shell_cmd,
             // About widget: version only. The update check itself runs in
             // the webview via fetch() - no Rust HTTP/TLS dep needed.
             files::get_lookapp_version,

--- a/apps/linows/src-tauri/src/platform/mod.rs
+++ b/apps/linows/src-tauri/src/platform/mod.rs
@@ -27,6 +27,9 @@ impl IconCache {
     }
 }
 
+/// The kind the frontend asks with for an image a block or row named.
+const DECLARED_ICON_KIND: &str = "declared";
+
 #[derive(Serialize)]
 pub struct IconResult {
     pub data_url: Option<String>,
@@ -50,7 +53,12 @@ pub fn get_icon(
         }
     }
 
-    let data_url = resolve_icon(&kind, &path, id.as_deref());
+    let data_url = if kind == DECLARED_ICON_KIND {
+        // The named image IS the icon, so read it rather than ask the theme.
+        shared::read_icon_file(&path)
+    } else {
+        resolve_icon(&kind, &path, id.as_deref())
+    };
 
     {
         let mut map = cache.0.lock().unwrap();

--- a/apps/linows/src-tauri/src/platform/shared.rs
+++ b/apps/linows/src-tauri/src/platform/shared.rs
@@ -4,7 +4,8 @@ use base64::Engine;
 use std::fs;
 
 /// Read an icon file from disk and return it as a `data:` URL string.
-/// Supports PNG and SVG; returns None for empty files, XPM, or unknown types.
+/// PNG and SVG for themed and app icons, plus the formats a user may declare;
+/// returns None for empty files, XPM, or unknown types.
 // Linux uses this from platform::linux::icons; Windows will reuse it in M2 for
 // the cached-PNG path of the Shell icon pipeline.
 #[allow(dead_code)]
@@ -14,11 +15,22 @@ pub(crate) fn read_icon_file(path: &str) -> Option<String> {
         return None;
     }
 
-    let mime = if path.ends_with(".svg") {
+    let lowered = path.to_lowercase();
+    let mime = if lowered.ends_with(".svg") {
         "image/svg+xml"
-    } else if path.ends_with(".png") {
+    } else if lowered.ends_with(".png") {
         "image/png"
-    } else if path.ends_with(".xpm") {
+    } else if lowered.ends_with(".jpg") || lowered.ends_with(".jpeg") {
+        "image/jpeg"
+    } else if lowered.ends_with(".gif") {
+        "image/gif"
+    } else if lowered.ends_with(".webp") {
+        "image/webp"
+    } else if lowered.ends_with(".bmp") {
+        "image/bmp"
+    } else if lowered.ends_with(".ico") {
+        "image/x-icon"
+    } else if lowered.ends_with(".xpm") {
         return None;
     } else if data.starts_with(b"\x89PNG") {
         "image/png"
@@ -30,4 +42,32 @@ pub(crate) fn read_icon_file(path: &str) -> Option<String> {
 
     let b64 = base64::engine::general_purpose::STANDARD.encode(&data);
     Some(format!("data:{mime};base64,{b64}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A declared icon is read as the file it names, whatever format it is in.
+    #[test]
+    fn a_declared_image_reads_as_its_own_data_url() {
+        let dir = std::env::temp_dir().join(format!("look-icon-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("fixture dir");
+        let png = dir.join("Favicon.PNG");
+        std::fs::write(&png, b"\x89PNG\r\n\x1a\n rest").expect("fixture file");
+
+        let url = read_icon_file(png.to_str().unwrap()).expect("data url");
+        assert!(url.starts_with("data:image/png;base64,"), "{url}");
+
+        let jpg = dir.join("photo.JPG");
+        std::fs::write(&jpg, b"\xff\xd8\xff rest").expect("fixture file");
+        assert!(
+            read_icon_file(jpg.to_str().unwrap())
+                .expect("data url")
+                .starts_with("data:image/jpeg;base64,")
+        );
+
+        assert_eq!(read_icon_file(dir.join("gone.png").to_str().unwrap()), None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/apps/linows/src-tauri/src/sources.rs
+++ b/apps/linows/src-tauri/src/sources.rs
@@ -1,0 +1,108 @@
+//! User-declared blocks: what a row's block is, what Enter will run, and the
+//! rows a `then` target produces.
+//!
+//! Every one of these is a hop into `look_engine::sources`, which owns the
+//! whole answer and is shared with macOS, so the two shells cannot disagree
+//! about what `confirm` expands to or how a drilled id is spelled. Four of them
+//! spawn processes, so they are `async` commands: Tauri runs those off the
+//! request thread, and a `run` block the user wrote may take seconds.
+
+use look_engine::sources::{
+    BlockDetail, BlockSummary, Level, PerformOutcome, PreviewOutcome, RefreshOutcome,
+};
+
+/// The row a command acts on, as the frontend holds it. One struct because the
+/// four always travel together and a block's verbs expand against all of them.
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RowArgs {
+    pub candidate_id: String,
+    #[serde(default)]
+    pub row_title: String,
+    #[serde(default)]
+    pub row_path: String,
+    #[serde(default)]
+    pub query: String,
+    /// The levels this row was reached through, nearest parent first, as
+    /// `[{id, title, path}]`. Empty outside a level.
+    #[serde(default)]
+    pub ancestors: String,
+}
+
+impl RowArgs {
+    pub fn context(&self) -> look_sources::RowContext {
+        look_engine::sources::row_context(
+            // The candidate id: core strips the namespace, so a script asking
+            // for a branch gets `main` rather than `src:branches:main`.
+            &self.candidate_id,
+            &self.row_title,
+            &self.row_path,
+            &self.query,
+            look_engine::sources::parents_from_json(&self.ancestors),
+        )
+    }
+
+    /// The same row without what was typed to reach it. A chord carries no
+    /// query: `{query}` is the search text, and Ctrl+E is not that.
+    pub fn context_without_query(&self) -> look_sources::RowContext {
+        look_sources::RowContext {
+            query: String::new(),
+            ..self.context()
+        }
+    }
+}
+
+/// The block behind a row: its name, the exact steps Enter will perform, the
+/// file that declared it, and where the row can go next. `null` when the row is
+/// not a block row.
+#[tauri::command(async)]
+pub fn source_block(row: RowArgs) -> Option<BlockDetail> {
+    look_engine::sources::block_detail(&row.candidate_id, &row.context())
+}
+
+/// Every declared block as `{id, name, icon}`, for the frontend's row-icon
+/// cache. One disk read per launcher open rather than one per row.
+#[tauri::command(async)]
+pub fn source_blocks() -> Vec<BlockSummary> {
+    look_engine::sources::block_summaries()
+}
+
+/// Runs `block_id` against the row, or reports that it produces rows to descend
+/// into instead.
+///
+/// `as_target` is the caller's intent: Enter on a row means "do what this
+/// block's `open` says", while picking a `then` target means "go to this
+/// block".
+#[tauri::command(async)]
+pub fn perform_block(block_id: String, row: RowArgs, as_target: bool) -> PerformOutcome {
+    look_engine::sources::perform_block(&block_id, &row.context(), as_target)
+}
+
+/// The rows of `block_id` produced against the row the level opens from. Live
+/// on every call: the run cache is keyed by block alone, and a drilled block
+/// produces different rows per parent.
+#[tauri::command(async)]
+pub fn source_rows(block_id: String, parent: RowArgs) -> Level {
+    look_engine::sources::level(
+        &block_id,
+        &parent.candidate_id,
+        &parent.row_title,
+        &parent.row_path,
+        &parent.query,
+        look_engine::sources::parents_from_json(&parent.ancestors),
+    )
+}
+
+/// A block's declared `preview`, run against the selected row. `null` when the
+/// block declares none; a failure comes back as its reason rather than empty.
+#[tauri::command(async)]
+pub fn source_preview(row: RowArgs) -> Option<PreviewOutcome> {
+    look_engine::sources::preview(&row.candidate_id, &row.context())
+}
+
+/// Re-runs every top-level `run` block and stores its rows for the next index
+/// pass. A block that fails keeps the rows it had.
+#[tauri::command(async)]
+pub fn refresh_run_blocks() -> RefreshOutcome {
+    look_engine::sources::refresh_run_blocks()
+}

--- a/apps/linows/src-tauri/src/tools.rs
+++ b/apps/linows/src-tauri/src/tools.rs
@@ -10,7 +10,10 @@
 //! picked up by the same reload every other setting goes through.
 
 use look_engine::config::RuntimeConfig;
+use look_sources::RowContext;
 use look_tools::{Launch, Resolved};
+
+use crate::sources::RowArgs;
 
 #[cfg(target_os = "linux")]
 use crate::platform::linux::tools as platform_tools;
@@ -27,11 +30,19 @@ const LAUNCH_FAILED: &str = "Could not start";
 /// config read instead of one per entry. An action that does not apply comes
 /// back as `null` in its own slot rather than shifting the rest.
 #[tauri::command(async)]
-pub fn tool_actions(actions: Vec<String>, path: String, is_dir: bool) -> Vec<Option<Resolved>> {
-    let tools = RuntimeConfig::tools_cached();
+pub fn tool_actions(
+    actions: Vec<String>,
+    row: RowArgs,
+    is_dir: Option<bool>,
+) -> Vec<Option<Resolved>> {
+    let request = Request::read(row, is_dir);
     actions
         .iter()
-        .map(|action| look_tools::resolve(action, &path, is_dir, &tools).map(Resolved::from))
+        .map(|action| {
+            request
+                .resolve(action)
+                .map(|outcome| request.mark(action, Resolved::from(outcome)))
+        })
         .collect()
 }
 
@@ -40,19 +51,20 @@ pub fn tool_actions(actions: Vec<String>, path: String, is_dir: bool) -> Vec<Opt
 pub async fn perform_tool_action(
     window: tauri::WebviewWindow,
     action: String,
-    path: String,
-    is_dir: bool,
+    row: RowArgs,
+    is_dir: Option<bool>,
 ) -> Option<Resolved> {
-    let launch = match look_tools::resolve(&action, &path, is_dir, &RuntimeConfig::tools_cached())?
-    {
+    let request = Request::read(row, is_dir);
+    let launch = match request.resolve(&action)? {
         Ok(launch) => launch,
         // Nothing to run, so the window stays up behind the banner saying why.
-        Err(unavailable) => return Some(Err(unavailable).into()),
+        Err(unavailable) => return Some(request.mark(&action, Err(unavailable).into())),
     };
 
     crate::commands::hide_armed(&window);
     // Spawning a process is blocking work, so it stays off the async runtime.
-    let outcome = tauri::async_runtime::spawn_blocking(move || perform(launch))
+    let row = request.row.clone();
+    let outcome = tauri::async_runtime::spawn_blocking(move || perform(launch, &row))
         .await
         .ok()?;
 
@@ -62,17 +74,70 @@ pub async fn perform_tool_action(
         crate::commands::show_launcher(&window);
         let _ = window.set_focus();
     }
-    Some(outcome)
+    Some(request.mark(&action, outcome))
 }
 
-fn perform(launch: Launch) -> Resolved {
+/// One row and the tools in play, read once so resolving an action and
+/// performing it cannot answer differently for the same press.
+///
+/// The block a row came from is what makes this more than a `look_tools` call:
+/// its own `edit` / `terminal` / `reveal` wins for its own rows, expanded like
+/// every other command it declares.
+struct Request {
+    block: Option<look_sources::Block>,
+    row: RowContext,
+    path: String,
+    is_dir: bool,
+}
+
+impl Request {
+    fn read(row: RowArgs, is_dir: Option<bool>) -> Self {
+        // An ordinary file never pays for reading the sources directory.
+        let block = look_engine::sources::block_for_candidate(&row.candidate_id);
+        let path = row.row_path.clone();
+        // A file row and a folder row say which they are; a block's row does
+        // not, so the filesystem is what answers. Editing resolves to a
+        // different tool for each and a terminal opens in a different place,
+        // so guessing is not an option.
+        let is_dir = is_dir.unwrap_or_else(|| std::path::Path::new(&path).is_dir());
+        Self {
+            block,
+            // A chord carries no query: `{query}` is what the user typed to
+            // reach a row, and Ctrl+E is not that.
+            row: row.context_without_query(),
+            path,
+            is_dir,
+        }
+    }
+
+    fn resolve(&self, action: &str) -> Option<Result<Launch, look_tools::Unavailable>> {
+        look_sources::resolve_for_row(
+            action,
+            &self.path,
+            self.is_dir,
+            &RuntimeConfig::tools_cached(),
+            self.block.as_ref(),
+            &self.row,
+        )
+    }
+
+    /// Says whether the block took this chord, which is what the label needs.
+    fn mark(&self, action: &str, mut resolved: Resolved) -> Resolved {
+        resolved.from_block = look_sources::block_declares(self.block.as_ref(), action);
+        resolved
+    }
+}
+
+/// With the row, like every other command a block declares: same working
+/// directory, same `LOOK_*` environment.
+fn perform(launch: Launch, row: &RowContext) -> Resolved {
     match launch {
         Launch::Shell { tool, command } => {
             // Through core's runner, which already owns login-shell selection
             // and detaching, so a terminal outlives the launcher that started
             // it. The window it makes is a new one, and every desktop focuses
             // those itself.
-            match look_sources::perform(&[command], None)
+            match look_sources::perform(&[command], Some(row))
                 .into_iter()
                 .find_map(|step| step.error)
             {

--- a/apps/linows/src-tauri/tauri.conf.json
+++ b/apps/linows/src-tauri/tauri.conf.json
@@ -28,7 +28,11 @@
     "security": {
       "csp": null,
       "assetProtocol": {
-        "enable": true
+        "enable": true,
+        "scope": {
+          "allow": ["$HOME/**"],
+          "requireLiteralLeadingDot": false
+        }
       }
     }
   },

--- a/apps/linows/src/css/components/preview.css
+++ b/apps/linows/src/css/components/preview.css
@@ -79,6 +79,11 @@
 .preview-badge.kind-process {
     color: var(--color-info);
 }
+/* A row a user declared: the block it came from, in the accent that marks
+ * everything the user configured. */
+.preview-badge.kind-action {
+    color: var(--accent-color);
+}
 
 .preview-size {
     font-size: calc(var(--font-size) - 2px);
@@ -128,6 +133,28 @@
 }
 
 /* Code/text file preview */
+/* "Enter runs", above the steps it labels. */
+.preview-section-label {
+    margin-top: 12px;
+    font-size: calc(var(--font-size) - 2px);
+    font-weight: 600;
+    color: var(--font-secondary);
+}
+
+/* The copy button floats over the steps rather than taking a header row of its
+ * own: the commands are what the panel is for. */
+.preview-steps {
+    position: relative;
+    margin-top: 6px;
+}
+
+.preview-steps-copy {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    z-index: 1;
+}
+
 .preview-code {
     margin-top: 12px;
     background: var(--control-fill);

--- a/apps/linows/src/css/components/preview.css
+++ b/apps/linows/src/css/components/preview.css
@@ -79,11 +79,6 @@
 .preview-badge.kind-process {
     color: var(--color-info);
 }
-/* A row a user declared: the block it came from, in the accent that marks
- * everything the user configured. */
-.preview-badge.kind-action {
-    color: var(--accent-color);
-}
 
 .preview-size {
     font-size: calc(var(--font-size) - 2px);
@@ -132,9 +127,77 @@
     box-shadow: 0 2px 8px rgba(var(--shadow), 0.2);
 }
 
-/* Code/text file preview */
-/* "Enter runs", above the steps it labels. */
+/* A block row's panel is a column all the way down, so the card is the same
+ * height whatever the block declared: header, what runs, then the declaration
+ * at the foot. Flex rather than height:100% - a percentage needs a definite
+ * parent, and a panel that cannot resolve one collapses to its content. */
+.preview-panel.is-block {
+    display: flex;
+    flex-direction: column;
+}
+
+.preview-panel.is-block > .preview-block {
+    flex: 1;
+    min-height: 0;
+}
+
+.preview-block {
+    display: flex;
+    flex-direction: column;
+}
+
+/* The middle takes the leftover and scrolls, the panel does not: macOS puts a
+ * ScrollView here so the declaration below it never leaves the screen.
+ * Scrollbars are hidden app-wide (reset.css), so this shows none. */
+.preview-block > .preview-slot {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+}
+
+.preview-block-footer {
+    flex-shrink: 0;
+}
+
+.preview-divider {
+    height: 1px;
+    margin-top: 14px;
+    background: var(--divider-color);
+    opacity: 0.5;
+}
+
+/* A chord and what it does. The key wears a cap, so it reads as something to
+ * press rather than as another fact about the row. */
+.preview-hint {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding-top: 2px;
+}
+
+.preview-hint-key {
+    min-width: 36px;
+    padding: 3px 8px;
+    text-align: center;
+    font-size: calc(var(--font-size) - 2px);
+    font-weight: 600;
+    color: var(--accent-color);
+    background: var(--control-fill);
+    border-radius: 6px;
+}
+
+.preview-hint-text {
+    font-size: calc(var(--font-size) - 1px);
+    font-weight: 500;
+    color: var(--font-secondary);
+}
+
+/* "Enter runs", above the steps it labels and above the scroll with them. */
 .preview-section-label {
+    flex-shrink: 0;
     margin-top: 12px;
     font-size: calc(var(--font-size) - 2px);
     font-weight: 600;
@@ -148,6 +211,35 @@
     margin-top: 6px;
 }
 
+/* Inside the block panel both code blocks are columns that scroll themselves,
+ * so neither can push the other out of view and no fixed line cap is needed. */
+.preview-block .preview-code {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+.preview-block .preview-code-text {
+    flex: 1;
+    min-height: 0;
+    max-height: none;
+}
+
+/* The steps take only what they need while a declared `preview` shares the
+ * space below them, and all of it when nothing follows: an eighteen-line
+ * script should not sit in a six-line box above an empty half-panel. */
+.preview-block .preview-steps {
+    flex: 0 1 auto;
+}
+
+.preview-block:not(.has-preview) .preview-steps {
+    flex: 1 1 auto;
+}
+
+.preview-block .preview-code:not(.preview-steps) {
+    flex: 1 1 auto;
+}
+
 .preview-steps-copy {
     position: absolute;
     top: 6px;
@@ -155,6 +247,7 @@
     z-index: 1;
 }
 
+/* Code/text file preview */
 .preview-code {
     margin-top: 12px;
     background: var(--control-fill);

--- a/apps/linows/src/css/components/preview.css
+++ b/apps/linows/src/css/components/preview.css
@@ -162,6 +162,47 @@
     flex-shrink: 0;
 }
 
+/* A file-backed block row: the file's own panel, with the block's section at
+ * the foot of it. Children keep their size and the panel scrolls as one, so a
+ * tall preview pushes the section down rather than squashing anything. */
+.preview-panel.has-block-extra {
+    display: flex;
+    flex-direction: column;
+}
+
+.preview-panel.has-block-extra > * {
+    flex-shrink: 0;
+}
+
+/* The file's own preview is the part that scrolls. Everything under it - the
+ * metadata and the block's section - stays on screen, so "Declared in" is
+ * never something you have to scroll a 2000-line file to reach. */
+.preview-panel.has-block-extra > .preview-slot {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+}
+
+/* Inside that region the content is measured by the region, not by the window:
+ * the file preview's own viewport cap would overflow the panel again. */
+.preview-panel.has-block-extra .preview-code-text {
+    max-height: none;
+}
+
+/* What the block adds to a file's panel, always under the file's own rows and
+ * set off from them by a rule. */
+.preview-block-extra {
+    margin-top: 12px;
+    padding-top: 10px;
+    border-top: 1px solid var(--divider-color);
+}
+
+/* Claimed before it is filled, so it must draw nothing until it is. */
+.preview-block-extra:empty {
+    display: none;
+}
+
 .preview-divider {
     height: 1px;
     margin-top: 14px;

--- a/apps/linows/src/css/components/results.css
+++ b/apps/linows/src/css/components/results.css
@@ -112,6 +112,13 @@
     background: var(--accent-color);
 }
 
+/* A block that declared an emoji draws it in the icon box, which otherwise
+ * holds an SVG or an <img>. */
+.result-icon-glyph {
+    font-size: calc(var(--icon-size) * 0.62);
+    line-height: 1;
+}
+
 .result-icon img {
     width: 100%;
     height: 100%;

--- a/apps/linows/src/css/layout.css
+++ b/apps/linows/src/css/layout.css
@@ -128,6 +128,24 @@ html[data-os="windows"] .launcher-window {
     flex-shrink: 0;
 }
 
+/* Inside a level: where the rows came from, before the text that filters them.
+ * Shrinks before the input does, so a deep chain never crowds out typing. */
+.search-breadcrumb {
+    flex: 0 1 auto;
+    min-width: 0;
+    font-size: calc(var(--font-size) - 1px);
+    font-weight: 600;
+    color: var(--accent-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* A level's empty query is for filtering, not an invitation to search. */
+.search-breadcrumb:not([hidden]) ~ .search-placeholder {
+    opacity: 0;
+}
+
 #query {
     flex: 1;
     font-size: calc(var(--font-size) + 1px);

--- a/apps/linows/src/css/layout.css
+++ b/apps/linows/src/css/layout.css
@@ -141,11 +141,6 @@ html[data-os="windows"] .launcher-window {
     text-overflow: ellipsis;
 }
 
-/* A level's empty query is for filtering, not an invitation to search. */
-.search-breadcrumb:not([hidden]) ~ .search-placeholder {
-    opacity: 0;
-}
-
 #query {
     flex: 1;
     font-size: calc(var(--font-size) + 1px);

--- a/apps/linows/src/html/screens/search.html
+++ b/apps/linows/src/html/screens/search.html
@@ -17,6 +17,9 @@
                     stroke-linecap="round"
                 />
             </svg>
+            <!-- Inside a level: "Projects > animate > Scripts", so the bar says
+                 where the rows came from. Empty and hidden everywhere else. -->
+            <span class="search-breadcrumb" id="search-breadcrumb" hidden></span>
             <input
                 id="query"
                 type="text"

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -15,6 +15,8 @@ import { mountUpdateWidget } from './screens/update_widget.js';
 import * as translatePanel from './components/translate.js';
 import * as runningApps from './components/running-apps.js';
 import * as superactions from './components/superactions.js';
+import * as sourceblocks from './components/sourceblocks.js';
+import * as levels from './levels.js';
 import * as smoothcaret from './components/smoothcaret.js';
 import * as platform from './platform.js';
 import * as motion from './motion.js';
@@ -65,6 +67,8 @@ import {
 // what keeps the clipboard hint to its first two items - all three still work
 // and are still listed in Settings > Shortcuts.
 const HINT_MAIN = 'Enter: Open \u2022 Ctrl+K: Actions \u2022 Ctrl+H: Help';
+// Inside a level the way out is the thing to say.
+const HINT_LEVEL = 'Enter: Open \u2022 Ctrl+K: Actions \u2022 Esc: Back';
 const HINT_TRANSLATE = 'Enter: Translate \u2022 Copy per result \u2022 Ctrl+H: Help';
 const HINT_CLIPBOARD = 'Enter: Copy clip \u2022 Ctrl+D: Remove clip';
 const HINT_PROCESS = 'Enter: CPU \u2022 Ctrl+D: Kill \u2022 Ctrl+C: Copy PID';
@@ -162,6 +166,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const aiCardEl = document.getElementById('ai-answer-card');
     const helpScreen = document.getElementById('help-screen');
     const previewCol = document.getElementById('preview-col');
+    const breadcrumbEl = document.getElementById('search-breadcrumb');
     const previewFooter = document.getElementById('preview-footer');
 
     // Floating "inner-gap" layout state (classes on .launcher-window)
@@ -219,6 +224,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     function isHomeHintContext() {
         return (
+            !levels.isActive() &&
             !commands.isActive() &&
             !settings.isActive() &&
             helpScreen?.hidden !== false &&
@@ -277,6 +283,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
     preview.init(previewPanel);
     actionmenu.init(previewPanel, queryInput);
+    // What each declared block asked to be drawn as, read once: rows render
+    // synchronously and a miss costs them their icon until it lands.
+    sourceblocks.prefill();
+    // `{query}` is whatever is typed right now, at whatever level.
+    sourceblocks.setQueryProvider(() => queryInput.value);
     banner.init(document.getElementById('banner'));
     health.init();
     confirm.init(document.getElementById('confirm-bar'));
@@ -308,6 +319,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Shared "back to the empty home screen" reset, used when leaving
     // settings or command mode.
     function resetHomeQuery() {
+        // A level is a place inside the launcher, and this is the way home.
+        if (levels.isActive()) {
+            levels.clear();
+            syncBreadcrumb();
+        }
         queryInput.value = '';
         search.handleQueryInput('');
         layout.setQuery({ empty: true, translate: false });
@@ -426,6 +442,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     // "/:) own the result area and must NOT trigger AI/web lookups. A query
     // like `t"who is` would otherwise fire isEntityLookup and pull Wikipedia.
     search.setOnResults((items, query) => {
+        // A level owns the list. A search that was in flight when the user
+        // descended must not paint the index over it.
+        if (levels.isActive()) return;
         lastResults = items;
         results.render(items, query);
         applyAiLayoutMode();
@@ -520,6 +539,16 @@ document.addEventListener('DOMContentLoaded', async () => {
     // differs in hint text, preview visibility and empty-state flavor.
     queryInput.addEventListener('input', (e) => {
         const value = e.target.value;
+
+        // A level owns the result list: its rows are produced live and are not
+        // in the index, so typing filters them rather than searching. No
+        // cross-level search - reaching the index again is one Escape.
+        if (levels.isActive()) {
+            actionmenu.close();
+            renderLevel();
+            return;
+        }
+
         if (tryCommandPrefix(value)) return;
 
         // Typing re-renders the list the menu hangs off, and the modes below
@@ -616,6 +645,12 @@ document.addEventListener('DOMContentLoaded', async () => {
             return;
         }
 
+        // A block's row runs what the block declared, by click as by Enter.
+        if (sourceblocks.isSourceRow(item.id)) {
+            sourceblocks.activateRow(item);
+            return;
+        }
+
         import('./ipc.js').then(({ openPath, recordUsage }) => {
             openPath(item.path, item.kind, item.id);
             const actionMap = { app: 'open_app', file: 'open_file', folder: 'open_folder' };
@@ -629,6 +664,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         queryInput.select();
         smoothcaret.refresh(queryInput);
         requestIndexRefresh();
+        // A block edited while Look was away takes effect on this open.
+        sourceblocks.prefill();
         runningApps.refresh();
         // Quick-action state is cached from the last render; the system may have
         // changed while hidden (Bluetooth flipped elsewhere), so re-read it.
@@ -651,6 +688,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     // primary trigger (WebView2 doesn't reliably fire visibilitychange on a
     // native hide); visibilitychange stays as a WebKitGTK fallback.
     onWindowHidden((event) => {
+        // A level does not survive the launcher closing (§2.10): what survives
+        // is the ranking. Dropped here so the next summon opens on the index.
+        if (levels.isActive()) resetHomeQuery();
         superactions.armEntrance();
         motion.armReveal();
         // The next summon keeps the query and the selection, but an open menu
@@ -677,6 +717,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
 
     onIndexReady(() => {
+        // A level's rows are not in the index, and its query filters them.
+        if (levels.isActive()) return;
         search.handleQueryInput(queryInput.value);
     });
 
@@ -701,6 +743,68 @@ document.addEventListener('DOMContentLoaded', async () => {
         search.handleQueryInput('');
         syncControlStrip();
     });
+
+    // --- Levels (drill-down into a `then` target that lists, §2.10) ---
+
+    // The rows of the current level, filtered by what is typed at it. Filtered,
+    // never re-ranked: the block's author ordered them, and they are not
+    // competing with apps and files for the top slot.
+    function renderLevel() {
+        previewPanel.hidden = false;
+        results.render(levels.rows(queryInput.value), queryInput.value);
+    }
+
+    function syncBreadcrumb() {
+        const crumbs = levels.breadcrumb();
+        breadcrumbEl.hidden = crumbs.length === 0;
+        breadcrumbEl.textContent = crumbs.join('  \u203A  ');
+    }
+
+    // A level was pushed: the query that got here means nothing now, and the
+    // launcher's other modes have nothing to say inside one.
+    function enterLevel() {
+        actionmenu.close();
+        aiAnswer.cancel();
+        translatePanel.hide();
+        resultsList.hidden = false;
+        queryInput.value = '';
+        smoothcaret.refresh(queryInput);
+        layout.setQuery({ empty: false, translate: false });
+        syncControlStrip();
+        syncBreadcrumb();
+        setHint(hintMessage, HINT_LEVEL);
+        renderLevel();
+    }
+
+    // Escape: back one level, with the query and selection it opened from, so
+    // descending and coming back is free rather than a re-search.
+    function popLevel() {
+        const left = levels.pop();
+        if (!left) return;
+        queryInput.value = left.restoredQuery;
+        smoothcaret.refresh(queryInput);
+        // Setting the query seeds the selection from the first row, so the
+        // restore waits for whichever pass has the rows.
+        results.restoreSelection(left.restoredSelectionId, left.restoredQuery);
+        syncBreadcrumb();
+
+        if (levels.isActive()) {
+            setHint(hintMessage, HINT_LEVEL);
+            renderLevel();
+            return;
+        }
+        // Back to the index, where that query is a search again.
+        search.handleQueryInput(left.restoredQuery);
+        layout.setQuery({
+            empty: layout.isEmptyQuery(left.restoredQuery),
+            translate: false,
+        });
+        syncControlStrip();
+        renderMainHint();
+    }
+
+    levels.setOnEnter(enterLevel);
+    keyboard.setPopLevel(popLevel);
 
     // --- Command mode helpers ---
 

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -691,7 +691,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     onWindowHidden((event) => {
         // A level does not survive the launcher closing (§2.10): what survives
         // is the ranking. Dropped here so the next summon opens on the index.
+        // Cleared even with no level up: a target that produces rows may still
+        // be running, and its answer must not open a level on the next summon.
         if (levels.isActive()) resetHomeQuery();
+        else levels.clear();
         superactions.armEntrance();
         motion.armReveal();
         // The next summon keeps the query and the selection, but an open menu

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -167,6 +167,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const helpScreen = document.getElementById('help-screen');
     const previewCol = document.getElementById('preview-col');
     const breadcrumbEl = document.getElementById('search-breadcrumb');
+    const placeholderEl = document.querySelector('.search-placeholder');
     const previewFooter = document.getElementById('preview-footer');
 
     // Floating "inner-gap" layout state (classes on .launcher-window)
@@ -758,6 +759,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         const crumbs = levels.breadcrumb();
         breadcrumbEl.hidden = crumbs.length === 0;
         breadcrumbEl.textContent = crumbs.join('  \u203A  ');
+        // A level's empty query is for filtering, not an invitation to search.
+        // Hidden here rather than in CSS: the placeholder's own rule keys on
+        // #query, which outranks anything a sibling selector could say.
+        placeholderEl.hidden = crumbs.length > 0;
     }
 
     // A level was pushed: the query that got here means nothing now, and the

--- a/apps/linows/src/js/catalog.js
+++ b/apps/linows/src/js/catalog.js
@@ -192,6 +192,18 @@ export function webUrlResult(url, subtitle, score) {
     };
 }
 
+/**
+ * Where the synthesized "open this URL" row sits (macOS URLRowPlacement).
+ *
+ * A structural URL cannot be a file or a search term, so it leads. A bare host
+ * sits one below the best local match (issue #232), out of reach of a declared
+ * source that carries the host in every subtitle and would bury it.
+ */
+export function placeUrlRow(url, isBareHost, ranked) {
+    if (!isBareHost) return [url, ...ranked];
+    return [...ranked.slice(0, 1), url, ...ranked.slice(1)];
+}
+
 export function webUrlFromResultId(resultId) {
     return resultId?.startsWith(WEB_URL_ID) ? resultId.slice(WEB_URL_ID.length) : null;
 }

--- a/apps/linows/src/js/components/actionmenu.js
+++ b/apps/linows/src/js/components/actionmenu.js
@@ -27,11 +27,19 @@ const ROW_ID = (index) => `${MENU_ID}-row-${index}`;
 // What a screen reader calls the list, which has no visible label of its own.
 const MENU_LABEL = 'Actions';
 
+// Ids of the two rows shown in place of the action list while a destructive
+// target waits for an answer.
+const CONFIRM_YES = 'srcconfirm:yes';
+const CONFIRM_NO = 'srcconfirm:no';
+const CONFIRM_CANCEL = 'Cancel';
+
 let panel = null;
 let input = null;
 let menuEl = null;
 let rows = [];
 let focusedIndex = 0;
+// The target whose question the menu is asking right now, or null.
+let pendingConfirm = null;
 // Bumped on every open and close, so a list still being resolved when the user
 // changes their mind cannot open the menu behind them.
 let token = 0;
@@ -64,6 +72,7 @@ export function vimKey(e) {
 
 export function close() {
     token += 1;
+    pendingConfirm = null;
     if (!menuEl) return;
     input?.removeAttribute('aria-controls');
     input?.removeAttribute('aria-activedescendant');
@@ -127,6 +136,25 @@ export function handleKey(e) {
     return true;
 }
 
+/**
+ * Ask a target's question in place of the action list, rather than in a modal:
+ * the keys the user already has (move, Enter, Escape) keep working and Escape
+ * means the safe thing.
+ */
+function ask(row) {
+    pendingConfirm = { id: row.id, title: row.title };
+    menuEl?.remove();
+    menuEl = null;
+    mount([
+        { id: CONFIRM_YES, title: row.confirm },
+        { id: CONFIRM_NO, title: CONFIRM_CANCEL },
+    ]);
+    // Start on Cancel: a destructive action should cost one more press than an
+    // accidental double-Enter.
+    focusedIndex = 1;
+    applyFocus();
+}
+
 function mount(descriptors) {
     menuEl = document.createElement('div');
     menuEl.className = 'action-menu';
@@ -158,8 +186,9 @@ function mount(descriptors) {
 
         row.addEventListener('click', () => activate(index));
         menuEl.appendChild(row);
-        // Only the id is read after this; the label and chord are in the DOM.
-        return { id: descriptor.id, el: row };
+        // The confirm question rides along: it is asked in the menu, so the
+        // descriptor has to survive until the row is activated.
+        return { id: descriptor.id, title: descriptor.title, confirm: descriptor.confirm, el: row };
     });
 
     // The menu hangs off the header, so a panel scrolled away from it would
@@ -203,10 +232,27 @@ function applyFocus() {
 }
 
 // The single entry point for running a row, by key or by click, so neither can
-// take a shortcut the other does not.
+// take a shortcut the other does not: a click that bypassed this would skip the
+// confirmation, so a `confirm` target would ask when reached with Enter and act
+// silently when reached with the mouse.
 function activate(index) {
     const row = rows[index];
     if (!row) return;
+
+    // Answering a question.
+    if (pendingConfirm) {
+        const target = pendingConfirm.id;
+        close();
+        if (row.id === CONFIRM_YES) rowactions.activate(target);
+        return;
+    }
+
+    // Asking one. The menu stays open and swaps to the question, so the answer
+    // happens where the user's eyes already are.
+    if (row.confirm) {
+        ask(row);
+        return;
+    }
 
     close();
     rowactions.activate(row.id);

--- a/apps/linows/src/js/components/actionmenu.js
+++ b/apps/linows/src/js/components/actionmenu.js
@@ -152,10 +152,16 @@ export function askConfirm(question) {
     return new Promise((resolve) => {
         close();
         pendingConfirm = { resolve };
-        mount([
-            { id: CONFIRM_YES, title: question },
-            { id: CONFIRM_NO, title: CONFIRM_CANCEL },
-        ]);
+        // The question labels the list, not just the row: focus starts on
+        // Cancel, so a screen reader would otherwise announce "Cancel" with
+        // nothing said about what is being cancelled.
+        mount(
+            [
+                { id: CONFIRM_YES, title: question },
+                { id: CONFIRM_NO, title: CONFIRM_CANCEL },
+            ],
+            question,
+        );
         // Start on Cancel: a destructive action should cost one more press than
         // an accidental double-Enter.
         focusedIndex = 1;
@@ -170,7 +176,7 @@ function answer(yes) {
     pending?.resolve(yes);
 }
 
-function mount(descriptors) {
+function mount(descriptors, label = MENU_LABEL) {
     menuEl = document.createElement('div');
     menuEl.className = 'action-menu';
     menuEl.id = MENU_ID;
@@ -178,7 +184,7 @@ function mount(descriptors) {
     // selection they then run, which is what `option` describes and what the
     // focused input is allowed to point at.
     menuEl.setAttribute('role', 'listbox');
-    menuEl.setAttribute('aria-label', MENU_LABEL);
+    menuEl.setAttribute('aria-label', label);
     menuEl.style.top = `${anchorTop()}px`;
 
     rows = descriptors.map((descriptor, index) => {

--- a/apps/linows/src/js/components/actionmenu.js
+++ b/apps/linows/src/js/components/actionmenu.js
@@ -38,7 +38,9 @@ let input = null;
 let menuEl = null;
 let rows = [];
 let focusedIndex = 0;
-// The target whose question the menu is asking right now, or null.
+// Resolves the answer to the question the menu is asking right now, or null
+// when it is not asking one. Escape and any close answer no, which is what
+// makes Escape mean the safe thing.
 let pendingConfirm = null;
 // Bumped on every open and close, so a list still being resolved when the user
 // changes their mind cannot open the menu behind them.
@@ -72,7 +74,8 @@ export function vimKey(e) {
 
 export function close() {
     token += 1;
-    pendingConfirm = null;
+    // Closing IS the safe answer, whatever closed it.
+    answer(false);
     if (!menuEl) return;
     input?.removeAttribute('aria-controls');
     input?.removeAttribute('aria-activedescendant');
@@ -137,22 +140,34 @@ export function handleKey(e) {
 }
 
 /**
- * Ask a target's question in place of the action list, rather than in a modal:
- * the keys the user already has (move, Enter, Escape) keep working and Escape
- * means the safe thing.
+ * Ask `question` in the menu rather than in a modal: the keys the user already
+ * has (move, Enter, Escape) keep working and Escape means the safe thing.
+ * Resolves true only if they pick the question itself.
+ *
+ * Exported because Enter on a row whose block declares `confirm` has to ask it
+ * too, and asking it twice in two different shapes would be two things to
+ * learn (specs/user-sources.md §2.5).
  */
-function ask(row) {
-    pendingConfirm = { id: row.id, title: row.title };
-    menuEl?.remove();
-    menuEl = null;
-    mount([
-        { id: CONFIRM_YES, title: row.confirm },
-        { id: CONFIRM_NO, title: CONFIRM_CANCEL },
-    ]);
-    // Start on Cancel: a destructive action should cost one more press than an
-    // accidental double-Enter.
-    focusedIndex = 1;
-    applyFocus();
+export function askConfirm(question) {
+    return new Promise((resolve) => {
+        close();
+        pendingConfirm = { resolve };
+        mount([
+            { id: CONFIRM_YES, title: question },
+            { id: CONFIRM_NO, title: CONFIRM_CANCEL },
+        ]);
+        // Start on Cancel: a destructive action should cost one more press than
+        // an accidental double-Enter.
+        focusedIndex = 1;
+        applyFocus();
+    });
+}
+
+/** Settle an outstanding question, once. */
+function answer(yes) {
+    const pending = pendingConfirm;
+    pendingConfirm = null;
+    pending?.resolve(yes);
 }
 
 function mount(descriptors) {
@@ -239,18 +254,22 @@ function activate(index) {
     const row = rows[index];
     if (!row) return;
 
-    // Answering a question.
+    // Answering a question. `close` settles it; picking the question itself is
+    // the only yes.
     if (pendingConfirm) {
-        const target = pendingConfirm.id;
+        const yes = row.id === CONFIRM_YES;
+        answer(yes);
         close();
-        if (row.id === CONFIRM_YES) rowactions.activate(target);
         return;
     }
 
-    // Asking one. The menu stays open and swaps to the question, so the answer
-    // happens where the user's eyes already are.
+    // Asking one. The menu swaps to the question, so the answer happens where
+    // the user's eyes already are.
     if (row.confirm) {
-        ask(row);
+        const id = row.id;
+        askConfirm(row.confirm).then((yes) => {
+            if (yes) rowactions.activate(id);
+        });
         return;
     }
 

--- a/apps/linows/src/js/components/preview.js
+++ b/apps/linows/src/js/components/preview.js
@@ -75,7 +75,7 @@ export function update(result) {
     }
     panel.hidden = false;
     panel.innerHTML = '';
-    panel.classList.remove('is-block');
+    panel.classList.remove('is-block', 'has-block-extra');
     currentProcPid = null;
     // The panel was wiped: invalidate any in-flight Quick Actions render so a
     // late response can't append a stale section for the previous result.
@@ -91,10 +91,16 @@ export function update(result) {
         return;
     }
 
-    // A declared block has no file to describe, so the panel answers the only
-    // question that matters before Enter: exactly what is about to run.
+    // A block's row with nothing on disk has no file to describe, so the panel
+    // answers the only question that matters before Enter: what is about to
+    // run. A row that names a path IS that file (`format = "json"`), so it
+    // previews like one, with what the block adds appended below.
     if (result.kind === 'action' && sourceblocks.isSourceRow(result.id)) {
-        renderBlockPreview(result, cacheKey);
+        if (result.path) {
+            renderFileBackedBlock(result, cacheKey);
+        } else {
+            renderBlockPreview(result, cacheKey);
+        }
         return;
     }
 
@@ -118,6 +124,11 @@ export function update(result) {
             return;
     }
 
+    renderStandard(result, cacheKey);
+}
+
+/** The ordinary panel: icon, title, kind badge, then the file or app detail. */
+function renderStandard(result, cacheKey) {
     // Header: icon + title + badge + size
     const header = document.createElement('div');
     header.className = 'preview-header';
@@ -159,7 +170,10 @@ export function update(result) {
     const badge = document.createElement('span');
     badge.className = `preview-badge kind-${result.kind}`;
     const kindLabels = { app: 'App', file: 'File', folder: 'Folder', setting: 'Setting' };
-    badge.textContent = kindLabels[result.kind] || result.kind;
+    // A row a user's block produced says which block; the kind is on the icon
+    // and in the metadata below, and where it came from is what the list cannot
+    // otherwise tell you.
+    badge.textContent = sourceblocks.blockName(result.id) || kindLabels[result.kind] || result.kind;
     headerSub.appendChild(badge);
 
     headerText.appendChild(headerSub);
@@ -184,9 +198,9 @@ export function update(result) {
     panel.appendChild(metaWrap);
 
     if (result.kind === 'app') {
-        renderAppMeta(metaWrap, result, headerSub);
+        renderAppMeta(metaWrap, result, headerSub, cacheKey);
     } else {
-        renderFileMeta(metaWrap, previewSlot, result, headerSub);
+        renderFileMeta(metaWrap, previewSlot, result, headerSub, cacheKey);
     }
 
     // Quick Actions - interactive controls for results the shared catalog
@@ -414,10 +428,10 @@ function formatStart(epoch) {
     });
 }
 
-function renderAppMeta(metaWrap, result, headerSub) {
+function renderAppMeta(metaWrap, result, headerSub, cacheKey) {
     // Async version lookup
     getAppVersion(result.path).then((version) => {
-        if (currentPath !== result.path) return;
+        if (currentPath !== cacheKey) return;
         if (version) {
             // Insert version as first row
             metaWrap.insertBefore(infoRow('Version', version), metaWrap.firstChild);
@@ -431,9 +445,7 @@ function renderAppMeta(metaWrap, result, headerSub) {
     }
 }
 
-function renderFileMeta(metaWrap, previewSlot, result, headerSub) {
-    const cacheKey = result.path;
-
+function renderFileMeta(metaWrap, previewSlot, result, headerSub, cacheKey) {
     // Metadata: size (in header), then Kind → Path → Modified (matches macOS order)
     getFileMeta(result.path).then((meta) => {
         if (currentPath !== cacheKey) return;
@@ -622,6 +634,58 @@ export function showClipboardHelp() {
       <div class="preview-clip-help-line">• Type <kbd>c"mail</kbd> to filter</div>
       <div class="preview-clip-help-line">• Press <kbd>Enter</kbd> to copy selected item</div>
     </div>`;
+}
+
+/**
+ * A block's row that names a path: the file's own panel, with what the block
+ * adds under it. The row IS that file, so everything a file row shows (the
+ * thumbnail, the text preview, the folder listing, size and modified) is what
+ * the user is looking for; the block only adds what Enter does and where it was
+ * declared.
+ */
+async function renderFileBackedBlock(result, cacheKey) {
+    let meta = null;
+    try {
+        meta = await getFileMeta(result.path);
+    } catch (err) {
+        console.warn('preview: could not stat a block row', err);
+    }
+    if (currentPath !== cacheKey) return;
+
+    // The block never says which it is, so the filesystem answers: a folder
+    // gets its listing, a file its preview.
+    renderStandard({ ...result, kind: meta?.is_dir ? 'folder' : 'file' }, cacheKey);
+
+    // The block's own section is claimed NOW, empty, so it always sits under the
+    // file's metadata. Filling it later would otherwise land above or below
+    // those rows depending on which read answered first - one file's panel
+    // ordered differently from the next one's.
+    const section = document.createElement('div');
+    section.className = 'preview-meta preview-block-extra';
+    // The panel becomes a column so the section sits at its FOOT, wherever the
+    // metadata above it ends: the declaration belongs in one place on every
+    // row, not wherever the content happens to stop.
+    panel.classList.add('has-block-extra');
+    panel.appendChild(section);
+
+    const block = await sourceblocks.loadDetail(result);
+    if (!block || currentPath !== cacheKey) return;
+
+    if (block.steps.length > 0) {
+        const label = document.createElement('div');
+        label.className = 'preview-section-label';
+        label.textContent = 'Enter runs';
+        section.appendChild(label);
+        section.appendChild(await stepsBlock(block.steps));
+        if (currentPath !== cacheKey) return;
+    }
+    if (block.file) {
+        section.appendChild(infoRow('Declared in', sourceblocks.tildePath(block.file)));
+    }
+
+    const preview = await sourcePreview(sourceblocks.rowPayload(result));
+    if (!preview || currentPath !== cacheKey) return;
+    section.appendChild(blockPreviewBody(preview));
 }
 
 /**

--- a/apps/linows/src/js/components/preview.js
+++ b/apps/linows/src/js/components/preview.js
@@ -4,6 +4,9 @@ import {
     getAppVersion,
     deleteClipboardEntry,
     highlightFile,
+    highlightShell,
+    sourcePreview,
+    copyToClipboard,
     listFolder,
     openPath,
     processDetail,
@@ -19,7 +22,10 @@ import {
     settingIcon,
     globeLg,
     calculatorLg,
+    copy as copyIcon,
 } from '../icons.js';
+import * as sourceblocks from './sourceblocks.js';
+import * as banner from './banner.js';
 import { classifyResultId, WEB_URL_OPEN_SUBTITLE } from '../catalog.js';
 import * as qactions from './qactions.js';
 import * as actionmenu from './actionmenu.js';
@@ -51,8 +57,11 @@ export function update(result) {
         return;
     }
 
-    // Clipboard items use id as cache key (not path, since all share clipboard://history)
-    const cacheKey = result.kind === 'clipboard' ? result.id : result.path;
+    // Clipboard items use id as cache key (not path, since all share
+    // clipboard://history); so do block rows, which may name no path at all and
+    // would otherwise all share the empty one.
+    const cacheKey =
+        result.kind === 'clipboard' || result.kind === 'action' ? result.id : result.path;
     if (currentPath === cacheKey) return;
     currentPath = cacheKey;
     // The menu lists the SELECTED row's verbs, so it must not survive a move to
@@ -78,6 +87,13 @@ export function update(result) {
 
     if (result.kind === 'process') {
         renderProcessPreview(result);
+        return;
+    }
+
+    // A declared block has no file to describe, so the panel answers the only
+    // question that matters before Enter: exactly what is about to run.
+    if (result.kind === 'action' && sourceblocks.isSourceRow(result.id)) {
+        renderBlockPreview(result, cacheKey);
         return;
     }
 
@@ -605,6 +621,135 @@ export function showClipboardHelp() {
       <div class="preview-clip-help-line">• Type <kbd>c"mail</kbd> to filter</div>
       <div class="preview-clip-help-line">• Press <kbd>Enter</kbd> to copy selected item</div>
     </div>`;
+}
+
+/**
+ * The panel for a row a user-declared block produced.
+ *
+ * Two reads, in that order: the declaration is cheap and goes up first, then
+ * the declared `preview`, which runs a command. A late answer must not land in
+ * the panel of a row the user has already left, so both check the cache key.
+ */
+async function renderBlockPreview(result, cacheKey) {
+    const header = document.createElement('div');
+    header.className = 'preview-header';
+
+    const iconWrap = document.createElement('div');
+    iconWrap.className = 'preview-icon';
+    iconWrap.innerHTML = sourceblocks.declaredIconHtml(result.id) || sourceblocks.actionIconHtml;
+    iconWrap.style.background = 'var(--control-fill)';
+    iconWrap.style.color = 'var(--accent-color)';
+    header.appendChild(iconWrap);
+
+    const headerText = document.createElement('div');
+    headerText.className = 'preview-header-text';
+    const title = document.createElement('div');
+    title.className = 'preview-title';
+    title.textContent = result.title;
+    headerText.appendChild(title);
+    const headerSub = document.createElement('div');
+    headerSub.className = 'preview-header-sub';
+    const badge = document.createElement('span');
+    badge.className = 'preview-badge kind-action';
+    badge.textContent = sourceblocks.blockName(result.id) || 'Action';
+    headerSub.appendChild(badge);
+    if (result.subtitle) {
+        const detail = document.createElement('span');
+        detail.className = 'preview-size';
+        detail.textContent = result.subtitle;
+        headerSub.appendChild(detail);
+    }
+    headerText.appendChild(headerSub);
+    header.appendChild(headerText);
+    panel.appendChild(header);
+
+    const body = document.createElement('div');
+    body.className = 'preview-slot';
+    panel.appendChild(body);
+
+    const meta = document.createElement('div');
+    meta.className = 'preview-meta';
+    panel.appendChild(meta);
+
+    const block = await sourceblocks.loadDetail(result);
+    if (!block || currentPath !== cacheKey) return;
+
+    if (block.steps.length > 0) {
+        const label = document.createElement('div');
+        label.className = 'preview-section-label';
+        label.textContent = 'Enter runs';
+        body.appendChild(label);
+        body.appendChild(await stepsBlock(block.steps));
+        if (currentPath !== cacheKey) return;
+    }
+
+    if (block.file) {
+        meta.appendChild(infoRow('Declared in', block.file));
+        // A row that names its own path reveals that, like every other row with
+        // one, so the chord belongs to the declaration only when the row has
+        // nothing of its own to point at.
+        if (!result.path) meta.appendChild(infoRow('Ctrl+F', 'Reveal that file'));
+    }
+
+    // The declared `preview` runs a command, so it is read last and only after
+    // the cheap details are on screen.
+    const preview = await sourcePreview(sourceblocks.rowPayload(result));
+    if (!preview || currentPath !== cacheKey) return;
+    body.appendChild(blockPreviewBody(preview));
+}
+
+/** The steps ARE shell, so they get what an AI answer's code gets: highlighted,
+ *  selectable, and copyable in one press. */
+async function stepsBlock(steps) {
+    const source = steps.join('\n');
+    const wrap = document.createElement('div');
+    wrap.className = 'preview-code preview-steps';
+
+    const copyButton = document.createElement('button');
+    copyButton.type = 'button';
+    copyButton.className = 'ai-card-copy preview-steps-copy';
+    copyButton.tabIndex = -1;
+    copyButton.title = 'Copy these steps';
+    copyButton.innerHTML = copyIcon;
+    copyButton.addEventListener('click', () => {
+        copyToClipboard(source)
+            .then(() => banner.show('Steps copied', 'success', 1.0))
+            .catch(() => banner.show('Copy failed', 'error', 1.2));
+    });
+    wrap.appendChild(copyButton);
+
+    const pre = document.createElement('pre');
+    pre.className = 'preview-code-text';
+    // Plain text first: highlighting is a round trip, and the steps must be on
+    // screen either way.
+    pre.textContent = source;
+    wrap.appendChild(pre);
+    try {
+        const highlighted = await highlightShell(source);
+        if (highlighted?.html) pre.innerHTML = highlighted.html;
+    } catch {
+        // The unhighlighted text is already there and says the same thing.
+    }
+    return wrap;
+}
+
+/** A block's `preview` output, or the reason it could not run. A failure is
+ *  shown rather than swallowed: a preview that silently does nothing reads as
+ *  the feature being broken. */
+function blockPreviewBody(preview) {
+    if (preview.error) {
+        const failed = document.createElement('div');
+        failed.className = 'preview-code-truncated';
+        failed.textContent = preview.error;
+        return failed;
+    }
+    const wrap = document.createElement('div');
+    wrap.className = 'preview-code';
+    const pre = document.createElement('pre');
+    pre.className = 'preview-code-text';
+    pre.textContent = preview.text;
+    wrap.appendChild(pre);
+    return wrap;
 }
 
 function infoRow(label, value) {

--- a/apps/linows/src/js/components/preview.js
+++ b/apps/linows/src/js/components/preview.js
@@ -59,9 +59,15 @@ export function update(result) {
 
     // Clipboard items use id as cache key (not path, since all share
     // clipboard://history); so do block rows, which may name no path at all and
-    // would otherwise all share the empty one.
-    const cacheKey =
-        result.kind === 'clipboard' || result.kind === 'action' ? result.id : result.path;
+    // would otherwise all share the empty one. A block row keys on `rowKey`
+    // rather than its id alone: what the panel shows is expanded against the
+    // levels above it as well, so the same id reached at two depths is two
+    // panels.
+    const cacheKey = sourceblocks.isSourceRow(result.id)
+        ? sourceblocks.rowKey(result)
+        : result.kind === 'clipboard' || result.kind === 'action'
+          ? result.id
+          : result.path;
     if (currentPath === cacheKey) return;
     currentPath = cacheKey;
     // The menu lists the SELECTED row's verbs, so it must not survive a move to
@@ -129,16 +135,20 @@ export function update(result) {
 
 /** Swaps the placeholder glyph for the real icon, unless the selection moved on. */
 function loadPreviewIcon(iconWrap, kind, path, id, cacheKey) {
-    getIcon(kind, path, id).then((res) => {
-        if (!res?.data_url || currentPath !== cacheKey) return;
-        const img = document.createElement('img');
-        img.src = res.data_url;
-        img.alt = '';
-        iconWrap.innerHTML = '';
-        iconWrap.style.background = 'none';
-        iconWrap.style.color = '';
-        iconWrap.appendChild(img);
-    });
+    getIcon(kind, path, id)
+        .then((res) => {
+            if (!res?.data_url || currentPath !== cacheKey) return;
+            const img = document.createElement('img');
+            img.src = res.data_url;
+            img.alt = '';
+            iconWrap.innerHTML = '';
+            iconWrap.style.background = 'none';
+            iconWrap.style.color = '';
+            iconWrap.appendChild(img);
+        })
+        // A refused read leaves the placeholder glyph, which is what the wrap
+        // already draws.
+        .catch((err) => console.warn('preview: could not read an icon', err));
 }
 
 /** The ordinary panel: icon, title, kind badge, then the file or app detail. */
@@ -677,7 +687,7 @@ async function renderFileBackedBlock(result, cacheKey) {
         section.appendChild(infoRow('Declared in', sourceblocks.tildePath(block.file)));
     }
 
-    const preview = await sourcePreview(sourceblocks.rowPayload(result));
+    const preview = await readSourcePreview(result);
     if (!preview || currentPath !== cacheKey) return;
     section.appendChild(blockPreviewBody(preview));
 }
@@ -773,12 +783,23 @@ async function renderBlockPreview(result, cacheKey) {
 
     // The declared `preview` runs a command, so it is read last and only after
     // the cheap details are on screen.
-    const preview = await sourcePreview(sourceblocks.rowPayload(result));
+    const preview = await readSourcePreview(result);
     if (!preview || currentPath !== cacheKey) return;
     // Only real output shares the space: a block with none leaves the steps to
     // fill it, and a failure is one line rather than a second pane.
     if (!preview.error && preview.text) column.classList.add('has-preview');
     body.appendChild(blockPreviewBody(preview));
+}
+
+/** The declared `preview` runs a command, so the backend can refuse to: a
+ *  rejection leaves the panel without that section rather than unhandled. */
+async function readSourcePreview(result) {
+    try {
+        return await sourcePreview(sourceblocks.rowPayload(result));
+    } catch (err) {
+        console.warn('preview: could not read a block preview', err);
+        return null;
+    }
 }
 
 /** The steps ARE shell, so they get what an AI answer's code gets: highlighted,

--- a/apps/linows/src/js/components/preview.js
+++ b/apps/linows/src/js/components/preview.js
@@ -127,6 +127,20 @@ export function update(result) {
     renderStandard(result, cacheKey);
 }
 
+/** Swaps the placeholder glyph for the real icon, unless the selection moved on. */
+function loadPreviewIcon(iconWrap, kind, path, id, cacheKey) {
+    getIcon(kind, path, id).then((res) => {
+        if (!res?.data_url || currentPath !== cacheKey) return;
+        const img = document.createElement('img');
+        img.src = res.data_url;
+        img.alt = '';
+        iconWrap.innerHTML = '';
+        iconWrap.style.background = 'none';
+        iconWrap.style.color = '';
+        iconWrap.appendChild(img);
+    });
+}
+
 /** The ordinary panel: icon, title, kind badge, then the file or app detail. */
 function renderStandard(result, cacheKey) {
     // Header: icon + title + badge + size
@@ -144,17 +158,7 @@ function renderStandard(result, cacheKey) {
     iconWrap.style.color = 'var(--font-secondary)';
     header.appendChild(iconWrap);
 
-    getIcon(result.kind, result.path, result.id).then((res) => {
-        if (res?.data_url && currentPath === cacheKey) {
-            const img = document.createElement('img');
-            img.src = res.data_url;
-            img.alt = '';
-            iconWrap.innerHTML = '';
-            iconWrap.style.background = 'none';
-            iconWrap.style.color = '';
-            iconWrap.appendChild(img);
-        }
-    });
+    loadPreviewIcon(iconWrap, result.kind, result.path, result.id, cacheKey);
 
     const headerText = document.createElement('div');
     headerText.className = 'preview-header-text';
@@ -305,17 +309,7 @@ function renderProcessPreview(result) {
 
     // App-backed process: swap the generic glyph for the real app icon.
     if (result.iconPath) {
-        getIcon('app', result.iconPath, result.id).then((res) => {
-            if (res?.data_url && currentPath === cacheKey) {
-                const img = document.createElement('img');
-                img.src = res.data_url;
-                img.alt = '';
-                iconWrap.innerHTML = '';
-                iconWrap.style.background = 'none';
-                iconWrap.style.color = '';
-                iconWrap.appendChild(img);
-            }
-        });
+        loadPreviewIcon(iconWrap, 'app', result.iconPath, result.id, cacheKey);
     }
 
     const headerText = document.createElement('div');
@@ -708,9 +702,13 @@ async function renderBlockPreview(result, cacheKey) {
 
     const iconWrap = document.createElement('div');
     iconWrap.className = 'preview-icon';
-    iconWrap.innerHTML = sourceblocks.declaredIconHtml(result.id) || sourceblocks.actionIconHtml;
+    iconWrap.innerHTML = sourceblocks.declaredIconHtml(result) || sourceblocks.actionIconHtml;
     iconWrap.style.background = 'var(--control-fill)';
     iconWrap.style.color = 'var(--accent-color)';
+    const declaredPath = sourceblocks.declaredIconPath(result);
+    if (declaredPath) {
+        loadPreviewIcon(iconWrap, 'declared', declaredPath, result.id, cacheKey);
+    }
     header.appendChild(iconWrap);
 
     const headerText = document.createElement('div');

--- a/apps/linows/src/js/components/preview.js
+++ b/apps/linows/src/js/components/preview.js
@@ -75,6 +75,7 @@ export function update(result) {
     }
     panel.hidden = false;
     panel.innerHTML = '';
+    panel.classList.remove('is-block');
     currentProcPid = null;
     // The panel was wiped: invalidate any in-flight Quick Actions render so a
     // late response can't append a stale section for the previous result.
@@ -631,6 +632,13 @@ export function showClipboardHelp() {
  * the panel of a row the user has already left, so both check the cache key.
  */
 async function renderBlockPreview(result, cacheKey) {
+    // A column of its own: the declaring file sits at the BOTTOM of the panel
+    // (macOS puts a Spacer above it), and only this preview wants that.
+    const column = document.createElement('div');
+    column.className = 'preview-block';
+    panel.classList.add('is-block');
+    panel.appendChild(column);
+
     const header = document.createElement('div');
     header.className = 'preview-header';
 
@@ -647,54 +655,67 @@ async function renderBlockPreview(result, cacheKey) {
     title.className = 'preview-title';
     title.textContent = result.title;
     headerText.appendChild(title);
+    // No kind badge: the subtitle is already the block's name, and the panel
+    // saying it twice reads as a bug rather than as emphasis (macOS
+    // ResultPreviewView.actionPreview shows title and subtitle only).
     const headerSub = document.createElement('div');
     headerSub.className = 'preview-header-sub';
-    const badge = document.createElement('span');
-    badge.className = 'preview-badge kind-action';
-    badge.textContent = sourceblocks.blockName(result.id) || 'Action';
-    headerSub.appendChild(badge);
-    if (result.subtitle) {
-        const detail = document.createElement('span');
-        detail.className = 'preview-size';
-        detail.textContent = result.subtitle;
-        headerSub.appendChild(detail);
-    }
+    const detail = document.createElement('span');
+    detail.className = 'preview-size';
+    detail.textContent = result.subtitle || sourceblocks.blockName(result.id) || '';
+    headerSub.appendChild(detail);
     headerText.appendChild(headerSub);
     header.appendChild(headerText);
-    panel.appendChild(header);
+    column.appendChild(header);
 
     const body = document.createElement('div');
     body.className = 'preview-slot';
-    panel.appendChild(body);
+    column.appendChild(body);
 
-    const meta = document.createElement('div');
-    meta.className = 'preview-meta';
-    panel.appendChild(meta);
+    // Pushed to the bottom by its own margin, so a block with two steps and a
+    // block with a long preview both say where they came from in the same place.
+    const footer = document.createElement('div');
+    footer.className = 'preview-block-footer';
+    column.appendChild(footer);
 
     const block = await sourceblocks.loadDetail(result);
     if (!block || currentPath !== cacheKey) return;
 
     if (block.steps.length > 0) {
+        // Above the scrolling region, not inside it: what Enter does should not
+        // scroll away from the commands it labels (macOS keeps the same line
+        // outside its ScrollView).
         const label = document.createElement('div');
         label.className = 'preview-section-label';
         label.textContent = 'Enter runs';
-        body.appendChild(label);
+        column.insertBefore(label, body);
         body.appendChild(await stepsBlock(block.steps));
         if (currentPath !== cacheKey) return;
     }
 
     if (block.file) {
-        meta.appendChild(infoRow('Declared in', block.file));
+        const divider = document.createElement('div');
+        divider.className = 'preview-divider';
+        footer.appendChild(divider);
+
+        const meta = document.createElement('div');
+        meta.className = 'preview-meta';
+        meta.appendChild(infoRow('Declared in', sourceblocks.tildePath(block.file)));
+        footer.appendChild(meta);
+
         // A row that names its own path reveals that, like every other row with
         // one, so the chord belongs to the declaration only when the row has
         // nothing of its own to point at.
-        if (!result.path) meta.appendChild(infoRow('Ctrl+F', 'Reveal that file'));
+        if (!result.path) footer.appendChild(hintRow('Ctrl+F', 'Reveal that file'));
     }
 
     // The declared `preview` runs a command, so it is read last and only after
     // the cheap details are on screen.
     const preview = await sourcePreview(sourceblocks.rowPayload(result));
     if (!preview || currentPath !== cacheKey) return;
+    // Only real output shares the space: a block with none leaves the steps to
+    // fill it, and a failure is one line rather than a second pane.
+    if (!preview.error && preview.text) column.classList.add('has-preview');
     body.appendChild(blockPreviewBody(preview));
 }
 
@@ -750,6 +771,25 @@ function blockPreviewBody(preview) {
     pre.textContent = preview.text;
     wrap.appendChild(pre);
     return wrap;
+}
+
+/** A chord and what it does: the key in a cap, the wording beside it. Not an
+ *  info row - that is a fact about the thing, this is something you can press. */
+function hintRow(key, text) {
+    const row = document.createElement('div');
+    row.className = 'preview-hint';
+
+    const cap = document.createElement('span');
+    cap.className = 'preview-hint-key';
+    cap.textContent = key;
+    row.appendChild(cap);
+
+    const label = document.createElement('span');
+    label.className = 'preview-hint-text';
+    label.textContent = text;
+    row.appendChild(label);
+
+    return row;
 }
 
 function infoRow(label, value) {

--- a/apps/linows/src/js/components/results.js
+++ b/apps/linows/src/js/components/results.js
@@ -385,8 +385,9 @@ function createRow(result, index) {
         clipboard: clipboardIcon,
         process: cpuIcon,
         // The bolt says the honest thing for a row with nothing on disk: Enter
-        // performs steps.
-        action: sourceblocks.actionIconHtml,
+        // performs steps. A row that names a path IS that file, so it waits for
+        // the file's own icon behind the same glyph every file row uses.
+        action: result.path ? fileIcon : sourceblocks.actionIconHtml,
     };
     // What the block declared wins for the rows with nothing on disk: the
     // author chose it, and a list of them should not be a column of identical

--- a/apps/linows/src/js/components/results.js
+++ b/apps/linows/src/js/components/results.js
@@ -357,6 +357,16 @@ function displaySubtitle(result) {
     return kindLabels[result.kind] || result.kind;
 }
 
+/**
+ * Whether the row IS the file it names: a branch row is `main`, whose path is
+ * the repo every branch shares, so that folder's icon would lie about it.
+ */
+function rowIsItsPath(result) {
+    if (!result.path) return false;
+    const last = result.path.split(/[/\\]/).pop();
+    return last.toLowerCase() === result.title.toLowerCase();
+}
+
 function createRow(result, index) {
     const row = document.createElement('div');
     row.className = 'result-row';
@@ -384,16 +394,14 @@ function createRow(result, index) {
         setting: settingIcon,
         clipboard: clipboardIcon,
         process: cpuIcon,
-        // The bolt says the honest thing for a row with nothing on disk: Enter
-        // performs steps. A row that names a path IS that file, so it waits for
-        // the file's own icon behind the same glyph every file row uses.
-        action: result.path ? fileIcon : sourceblocks.actionIconHtml,
+        // The bolt is honest for a row that is not the file it names: Enter
+        // performs steps.
+        action: rowIsItsPath(result) ? fileIcon : sourceblocks.actionIconHtml,
     };
-    // What the block declared wins for the rows with nothing on disk: the
-    // author chose it, and a list of them should not be a column of identical
-    // bolts. A `dir` block's rows ARE files and folders and keep their own
-    // icons, the way they keep everything else about being one.
-    const declaredIcon = result.kind === 'action' ? sourceblocks.declaredIconHtml(result.id) : null;
+    // What was declared wins: a list of block rows should not be identical bolts.
+    const declaredIcon = result.kind === 'action' ? sourceblocks.declaredIconHtml(result) : null;
+    // Loaded behind the glyph the list drew first, which stays on a miss.
+    const declaredPath = result.kind === 'action' ? sourceblocks.declaredIconPath(result) : null;
     // Synthetic discovery rows (prefix/command menus) ship their own glyph in
     // result.iconSvg so the list scans visually; everything else falls back to
     // the kind-based stub until the backend icon fetch resolves.
@@ -409,7 +417,9 @@ function createRow(result, index) {
     // Skip backend icon fetch for ms-settings entries - the Shell PNG would just
     // be the generic gear and would clobber our category-specific glyph. Same
     // applies to synthetic discovery rows whose `path` is empty.
-    if (result.kind === 'process') {
+    if (declaredPath) {
+        loadIcon(icon, 'declared', declaredPath, result.id);
+    } else if (result.kind === 'process') {
         // App-backed processes wear their app icon (loaded as an app path);
         // the rest keep the generic process glyph from the fallback above.
         if (result.iconPath) {
@@ -420,7 +430,9 @@ function createRow(result, index) {
         !windowsSettingsSvg &&
         !result.iconSvg &&
         !declaredIcon &&
-        result.path
+        result.path &&
+        // Fetching would hand a branch the icon of the repo it shares.
+        (result.kind !== 'action' || rowIsItsPath(result))
     ) {
         loadIcon(icon, result.kind, result.path, result.id);
     }

--- a/apps/linows/src/js/components/results.js
+++ b/apps/linows/src/js/components/results.js
@@ -9,6 +9,7 @@ import {
     settingIcon,
     historyLg,
 } from '../icons.js';
+import * as sourceblocks from './sourceblocks.js';
 import { getSettingsIcon as getWindowsSettingsIcon } from '../settings-icons/windows.js';
 import { classifyResultId } from '../catalog.js';
 import { prefersReducedMotion } from '../platform.js';
@@ -60,6 +61,10 @@ let emptyState = { mode: 'default' };
 // the gate the cursor follows it there instead of resting on the top result.
 let userNavigated = false;
 let lastRenderQuery = null;
+// A selection to put back once the rows it names are on screen, and the query
+// it was captured under: anything else means the user moved on. Set when a
+// level is left, since the rows it restores to arrive a pass later.
+let pendingRestore = null;
 
 export function init(containerEl) {
     container = containerEl;
@@ -111,6 +116,11 @@ function renderEmptyState() {
     return '<div class="empty-state">No results</div>';
 }
 
+/** Select `id` again as soon as a render for `query` carries it. */
+export function restoreSelection(id, query) {
+    pendingRestore = id ? { id, query } : null;
+}
+
 export function render(results, query = null) {
     // A new query invalidates any manual cursor position.
     if (query !== lastRenderQuery) {
@@ -147,6 +157,21 @@ export function render(results, query = null) {
     if (prevSelectedId != null) {
         const idx = results.findIndex((r) => r.id === prevSelectedId);
         nextIndex = idx >= 0 ? idx : Math.min(prevIndex, results.length - 1);
+    }
+
+    // A restored selection outranks the preserved one: it is where the user was
+    // before they descended, and this is the render that can put them back.
+    if (pendingRestore) {
+        if (pendingRestore.query !== query) {
+            pendingRestore = null;
+        } else {
+            const idx = results.findIndex((r) => r.id === pendingRestore.id);
+            if (idx >= 0) {
+                nextIndex = idx;
+                userNavigated = true;
+                pendingRestore = null;
+            }
+        }
     }
 
     if (layout.isEmptyQuery(query) && layout.hidesResultsForEmptyQuery()) {
@@ -313,6 +338,14 @@ const SETTINGS_SUBTITLE_PREFIXES = ['Windows Settings', 'System Settings'];
 
 function displaySubtitle(result) {
     if (result.kind === 'clipboard') return result.subtitle;
+    // A row a user's block produced says WHICH block, not "action": the kind is
+    // already on the icon, and where the row came from is the thing the list
+    // cannot otherwise tell you. A row that named a path says where it is too,
+    // like every other row with one.
+    if (sourceblocks.isSourceRow(result.id)) {
+        const label = result.subtitle || sourceblocks.blockName(result.id) || 'Action';
+        return result.path ? `${label}  \u2022  ${result.path}` : label;
+    }
     if (result.subtitle) {
         for (const prefix of SETTINGS_SUBTITLE_PREFIXES) {
             if (result.subtitle.startsWith(prefix + ' ')) return prefix;
@@ -351,12 +384,21 @@ function createRow(result, index) {
         setting: settingIcon,
         clipboard: clipboardIcon,
         process: cpuIcon,
+        // The bolt says the honest thing for a row with nothing on disk: Enter
+        // performs steps.
+        action: sourceblocks.actionIconHtml,
     };
+    // What the block declared wins for the rows with nothing on disk: the
+    // author chose it, and a list of them should not be a column of identical
+    // bolts. A `dir` block's rows ARE files and folders and keep their own
+    // icons, the way they keep everything else about being one.
+    const declaredIcon = result.kind === 'action' ? sourceblocks.declaredIconHtml(result.id) : null;
     // Synthetic discovery rows (prefix/command menus) ship their own glyph in
     // result.iconSvg so the list scans visually; everything else falls back to
     // the kind-based stub until the backend icon fetch resolves.
     icon.innerHTML =
         result.iconSvg ||
+        declaredIcon ||
         windowsSettingsSvg ||
         (isLinuxSettings ? settingIcon : fallbacks[result.kind] || appIcon);
     icon.style.background = 'var(--control-fill)';
@@ -376,6 +418,7 @@ function createRow(result, index) {
         result.kind !== 'clipboard' &&
         !windowsSettingsSvg &&
         !result.iconSvg &&
+        !declaredIcon &&
         result.path
     ) {
         loadIcon(icon, result.kind, result.path, result.id);

--- a/apps/linows/src/js/components/rowactions.js
+++ b/apps/linows/src/js/components/rowactions.js
@@ -1,14 +1,19 @@
-// The verbs a row with a path offers, and the tools that carry them out.
+// The verbs a row offers, and the tools that carry them out.
 //
 // Mirrors macOS LauncherView+RowActions and LauncherView+Tools: one declarative
 // table plus one eligibility rule, read by both the Ctrl+K menu and the chords,
 // so the two can never drift. Composition lives in core (look-tools) and the
 // wording of an action that cannot run comes back with it - nothing here writes
 // a message about a missing tool.
+//
+// A row a block produced also carries what the block declared: its own
+// `edit` / `terminal` / `reveal` beat the user's global tool, and its `then`
+// targets join this list.
 
 import { toolActions, performToolAction } from '../ipc.js';
 import * as results from './results.js';
 import * as banner from './banner.js';
+import * as sourceblocks from './sourceblocks.js';
 import { isSyntheticResultId } from '../catalog.js';
 import { systemFileManager } from '../platform.js';
 
@@ -66,17 +71,24 @@ export function setHandlers(own) {
  * thing you launch, and the folder holding it is never "here", so both are
  * absent for app rows rather than quietly acting on the wrong directory.
  * Revealing an app is genuinely useful and stays.
+ *
+ * A block's row qualifies too: one that names a `path` (`format = "json"`) is a
+ * real filesystem object. The callers all require a path, so a row that names
+ * none never reaches here.
  */
 export function applies(action, kind) {
-    const fileOrFolder = kind === 'file' || kind === 'folder';
-    return action === REVEAL ? fileOrFolder || kind === 'app' : fileOrFolder;
+    const place = kind === 'file' || kind === 'folder' || kind === 'action';
+    return action === REVEAL ? place || kind === 'app' : place;
 }
 
 /** The selected row, or null when it is not something actions apply to. */
 function actionableSelection() {
     const selected = results.getSelected();
-    if (!selected?.path || isSyntheticResultId(selected.id)) return null;
+    if (!selected || isSyntheticResultId(selected.id)) return null;
     if (selected.kind === 'clipboard' || selected.kind === 'process') return null;
+    // A block row with nothing on disk still has targets and a declaring file,
+    // so it stays actionable; the path-taking verbs check for themselves.
+    if (!selected.path && !sourceblocks.isSourceRow(selected.id)) return null;
     return selected;
 }
 
@@ -84,17 +96,33 @@ function actionableSelection() {
  * What the Ctrl+K menu lists for the selected row. One IPC hop for every entry
  * that needs a tool name: resolving is string work in core over the cached
  * config, so asking about them together costs one round trip in total.
+ *
+ * A block that declared `then` targets shows those instead of the verb list:
+ * declared beats default in the menu exactly as it does when running, and the
+ * chords still carry every verb regardless.
  */
 export async function descriptorsFor() {
     const selected = actionableSelection();
     if (!selected) return [];
 
+    const block = await sourceblocks.loadDetail(selected);
+    const targets = (block?.then || []).map((target) => ({
+        id: sourceblocks.actionIdFor(target.id),
+        // The ellipsis says this one lists rather than runs: it opens a level.
+        title: target.performs ? target.name : `${target.name}…`,
+        // Already expanded against the row, so the question names what will
+        // actually happen. The menu asks it in place of the action list.
+        confirm: target.confirm,
+    }));
+    if (targets.length > 0) return targets;
+
+    if (!selected.path) return [];
     const offered = CATALOG.filter((entry) => !entry.tool || applies(entry.tool, selected.kind));
     const asked = offered.filter((entry) => entry.tool).map((entry) => entry.tool);
     const resolved = asked.length
-        ? await toolActions(asked, selected.path, selected.kind === 'folder')
+        ? await toolActions(asked, rowFor(selected), isDir(selected))
         : [];
-    const tools = new Map(asked.map((action, index) => [action, resolved[index]?.tool]));
+    const tools = new Map(asked.map((action, index) => [action, resolved[index]]));
 
     return offered.map((entry) => ({
         id: entry.id,
@@ -105,13 +133,21 @@ export async function descriptorsFor() {
     }));
 }
 
-function label(entry, tool) {
-    const named = tool || entry.fallbackTool?.();
+// "Edit in Zed", or "Edit in Projects" when the row's own block took the chord:
+// core says which, so a block name never gets read as a tool name.
+function label(entry, resolved) {
+    const named = resolved?.tool || entry.fallbackTool?.();
     return entry.named && named ? `${entry.named} ${named}` : entry.plain;
 }
 
 /** Run one entry, by menu click or by its chord. */
 export function activate(id) {
+    const blockId = sourceblocks.blockIdFromActionId(id);
+    if (blockId) {
+        runTarget(blockId, id);
+        return;
+    }
+
     const entry = CATALOG.find((candidate) => candidate.id === id);
     if (!entry) return;
     if (entry.tool) {
@@ -128,11 +164,11 @@ export function activate(id) {
  */
 export async function run(action) {
     const selected = actionableSelection();
-    if (!selected || !applies(action, selected.kind)) return;
+    if (!selected?.path || !applies(action, selected.kind)) return;
 
     let outcome = null;
     try {
-        outcome = await performToolAction(action, selected.path, selected.kind === 'folder');
+        outcome = await performToolAction(action, rowFor(selected), isDir(selected));
     } catch (err) {
         console.error('tool action failed', err);
         return;
@@ -141,4 +177,45 @@ export async function run(action) {
     // An action that could not run explains itself here rather than being
     // greyed out with a tool name nobody could find.
     if (outcome?.reason) banner.show(outcome.reason, 'info', BANNER_SECONDS);
+}
+
+/** A `then` target: performed, or descended into when it produces rows. */
+async function runTarget(blockId, actionId) {
+    const selected = actionableSelection();
+    if (!selected) return;
+    const target = sourceblocks
+        .targetsFor(selected)
+        .find((candidate) => sourceblocks.actionIdFor(candidate.id) === actionId);
+    const title = target?.name || blockId;
+
+    const outcome = await sourceblocks.performTarget({
+        blockId,
+        title,
+        result: selected,
+        selectionId: selected.id,
+    });
+    if (outcome?.error) {
+        banner.show(`${title}: ${outcome.error}`, 'error', BANNER_SECONDS);
+        return;
+    }
+    const level = outcome?.level;
+    if (level?.error) {
+        // An empty level and a broken command look identical once you are
+        // inside one, so neither is entered.
+        banner.show(`${title}: ${level.error}`, 'error', BANNER_SECONDS);
+    } else if (level?.truncated) {
+        banner.show(`${title}: showing the first ${level.count}`, 'info', BANNER_SECONDS);
+    }
+}
+
+/** The row as core needs it: its id so a block can override the chord, its
+ *  title and ancestors so that override expands like any other command. */
+function rowFor(selected) {
+    return sourceblocks.rowPayload(selected);
+}
+
+/** A file row and a folder row say which they are; a block's row does not, so
+ *  only the filesystem knows and the backend is what asks it. */
+function isDir(selected) {
+    return selected.kind === 'action' ? null : selected.kind === 'folder';
 }

--- a/apps/linows/src/js/components/sourceblocks.js
+++ b/apps/linows/src/js/components/sourceblocks.js
@@ -89,9 +89,11 @@ export async function prefill() {
 
 /** A reload may have changed what blocks exist and what they declare. */
 export function invalidate() {
-    catalog = null;
     detailByRow.clear();
     detailInFlight.clear();
+    // The catalog is replaced when the new one lands rather than dropped now:
+    // rows render synchronously, and clearing it first paints every row with a
+    // generic icon for as long as the read takes.
     return prefill();
 }
 

--- a/apps/linows/src/js/components/sourceblocks.js
+++ b/apps/linows/src/js/components/sourceblocks.js
@@ -1,0 +1,322 @@
+// Rows a user-declared block produced: which block a row came from, what it
+// asked to be drawn as, and where the row can go next (specs/user-sources.md).
+//
+// Mirrors macOS SourceBlockCatalog / SourceBlockAction / SourceBlockIcons. What
+// a block declares and what performing it does live in core; this is the cache
+// that lets a row render synchronously and the dispatch that keeps a declared
+// target from colliding with a compiled one.
+
+import {
+    sourceBlock,
+    sourceBlocks,
+    performBlock,
+    getHomeDir,
+    openPath,
+    recordUsage,
+    hideWindow,
+    reloadConfig,
+} from '../ipc.js';
+import { zap } from '../icons.js';
+import * as levels from '../levels.js';
+import * as banner from './banner.js';
+
+// `look_indexing::CandidateIdKind::PREFIX_SOURCE`. A drilled row keeps it, so
+// this tells indexed and drilled source rows alike from every other row.
+const ID_PREFIX = 'src:';
+// Namespaces a declared target inside the action menu, so it can never collide
+// with a row verb or a compiled Quick Action id.
+const ACTION_PREFIX = 'srcblock:';
+// `look_indexing::UsageAction::EXECUTE`. Recorded like an open, so a routine
+// run every morning ranks like one.
+const USAGE_ACTION = 'execute';
+const BANNER_SECONDS = 4.0;
+
+// Declared icons and names, keyed by block id. Null until `prefill` lands: rows
+// render synchronously and there are many of them, so a miss falls back to the
+// generic glyph rather than blocking on a disk read.
+let catalog = null;
+// What is typed right now, which is what `{query}` expands to. Set once by
+// app.js rather than threaded through every caller: inside a level it is the
+// text typed AT that level, and there is only ever one input.
+let queryProvider = () => '';
+// The block behind a row, keyed by row rather than by block: a target's
+// `confirm` is expanded against the row ("Delete main?").
+const detailByRow = new Map();
+const detailInFlight = new Map();
+
+/** A row a user-declared block produced. One definition: a namespace check
+ *  spelled out in three files is how one of them drifts. */
+export function isSourceRow(id) {
+    return typeof id === 'string' && id.startsWith(ID_PREFIX);
+}
+
+/** `src:<block>:<row>` and the drilled `src:<block>:|…|<row>` alike -> `<block>`.
+ *  The one place the shell reads a candidate id, and only ever its namespace:
+ *  everything past the block belongs to core. */
+export function blockIdOf(candidateId) {
+    if (!isSourceRow(candidateId)) return null;
+    const rest = candidateId.slice(ID_PREFIX.length);
+    const separator = rest.indexOf(':');
+    return separator > 0 ? rest.slice(0, separator) : null;
+}
+
+export function actionIdFor(blockId) {
+    return ACTION_PREFIX + blockId;
+}
+
+export function blockIdFromActionId(actionId) {
+    return actionId?.startsWith(ACTION_PREFIX) ? actionId.slice(ACTION_PREFIX.length) : null;
+}
+
+export function setQueryProvider(fn) {
+    queryProvider = fn;
+}
+
+/** Reads the block catalog once per launcher open, so the caches are warm
+ *  before anything renders. */
+export async function prefill() {
+    try {
+        const [blocks, dir] = await Promise.all([sourceBlocks(), getHomeDir()]);
+        catalog = new Map((blocks || []).map((block) => [block.id, block]));
+        // A declared icon may be written `~/…`, as readily by a user as by a
+        // script, and only the backend knows what that is.
+        home = dir || null;
+    } catch (err) {
+        console.warn('sourceblocks: could not read the catalog', err);
+    }
+}
+
+/** A reload may have changed what blocks exist and what they declare. */
+export function invalidate() {
+    catalog = null;
+    detailByRow.clear();
+    detailInFlight.clear();
+    return prefill();
+}
+
+/**
+ * The one refresh gesture (Ctrl+Shift+;), from this half's side: the backend
+ * reloads the config, re-runs every top-level `run` block and reindexes, and
+ * the block a script broke is named rather than quietly producing no rows.
+ *
+ * A failed block keeps the rows it had, so the list the user is looking at is
+ * stale rather than empty.
+ */
+export async function reload() {
+    const outcome = await reloadConfig();
+    await invalidate();
+    for (const error of outcome?.errors || []) {
+        banner.show(error, 'error', BANNER_SECONDS);
+    }
+    return outcome;
+}
+
+/** The block's name, for the row's kind label. Null before the catalog lands. */
+export function blockName(candidateId) {
+    const id = blockIdOf(candidateId);
+    return id ? catalog?.get(id)?.name || null : null;
+}
+
+/**
+ * The row icon a source row asked for, as HTML, or null to use the row's own.
+ *
+ * A declared `icon` is portable as an emoji or an image path; an SF Symbol name
+ * is a macOS spelling with no Lucide equivalent, so it falls through to the
+ * generic glyph rather than being guessed at.
+ */
+export function declaredIconHtml(candidateId) {
+    const id = blockIdOf(candidateId);
+    const declared = id ? catalog?.get(id)?.icon?.trim() : null;
+    if (!declared) return null;
+
+    if (isImagePath(declared)) {
+        const src = window.__TAURI__.core.convertFileSrc(expandHome(declared));
+        // A path that no longer resolves leaves the row's own glyph rather than
+        // a broken-image frame.
+        return `<img src="${escapeAttribute(src)}" alt="" onerror="this.remove()">`;
+    }
+    if (isSymbolName(declared)) return null;
+    return `<span class="result-icon-glyph">${escapeText(declared)}</span>`;
+}
+
+/** The bolt, for a block row with nothing on disk: Enter performs steps. */
+export const actionIconHtml = zap;
+
+/** The block already read for this row, or null. Synchronous, for whoever
+ *  already has it: the menu and the panel await `loadDetail` instead. */
+export function detailFor(result) {
+    return (result && detailByRow.get(cacheKey(result))) || null;
+}
+
+/** The `then` targets already read for this row. */
+export function targetsFor(result) {
+    return detailFor(result)?.then || [];
+}
+
+/**
+ * The block behind one row: its name, the steps Enter will run, the file that
+ * declared it, and where the row can go next.
+ *
+ * Awaited rather than answered empty while it loads: an empty first answer
+ * would show the row's verbs in the menu, and the targets that beat them a
+ * press later. Two callers can share the read, so an in-flight one is handed
+ * the same promise.
+ */
+export async function loadDetail(result) {
+    if (!isSourceRow(result?.id)) return null;
+    const key = cacheKey(result);
+    if (detailByRow.has(key)) return detailByRow.get(key);
+    if (!detailInFlight.has(key)) {
+        const reading = sourceBlock(rowPayload(result))
+            .then((block) => {
+                detailByRow.set(key, block || null);
+                return block || null;
+            })
+            .catch((err) => {
+                console.warn('sourceblocks: could not read a block', err);
+                return null;
+            })
+            .finally(() => detailInFlight.delete(key));
+        detailInFlight.set(key, reading);
+    }
+    return detailInFlight.get(key);
+}
+
+/** A target's `confirm` is expanded against the row, so two rows sharing an id
+ *  but differing in title or path must not share an entry. */
+function cacheKey(result) {
+    return `${result.id}${result.title}${result.path || ''}`;
+}
+
+/** The row payload every source command takes. `ancestors` comes from the level
+ *  stack, so a drilled row's `{parent.*}` reaches the rows above it. */
+export function rowPayload(result) {
+    return {
+        candidateId: result.id,
+        rowTitle: result.title,
+        rowPath: result.path || '',
+        query: queryProvider(),
+        ancestors: levels.ancestorsJson(),
+    };
+}
+
+/**
+ * Enter on a block row: what the block's `open` says, or its steps when it is a
+ * bundle. Core decides whether the row's own path is what opens, so the answer
+ * does not come from the row's kind.
+ */
+export async function performRow(result) {
+    const blockId = blockIdOf(result.id);
+    if (!blockId) return { errors: ["couldn't tell which block this row belongs to"] };
+    try {
+        return await performBlock(blockId, rowPayload(result), false);
+    } catch (err) {
+        console.error('sourceblocks: perform failed', err);
+        return { errors: ['the backend did not answer'] };
+    }
+}
+
+/**
+ * Enter on a block row, start to finish: perform it, open the row's path when
+ * core says the row IS the thing, and record the intent either way.
+ *
+ * The outcome is awaited before the launcher goes away, so a step that could
+ * not be started has a window to say so in. Steps are detached, so this only
+ * waits for the spawn; a step's own exit code is its business.
+ */
+export async function activateRow(result) {
+    // Resolved before anything else: an unparseable id would otherwise rank the
+    // row up, close the window, and do nothing, with no way to tell it failed.
+    if (!blockIdOf(result.id)) {
+        banner.show("Couldn't tell which block this row belongs to", 'error', BANNER_SECONDS);
+        return;
+    }
+
+    const outcome = await performRow(result);
+    // On intent, like an open: core skips a drilled row, which is transient and
+    // has nothing in the candidates table to key on.
+    recordUsage(result.id, USAGE_ACTION).catch(() => {});
+
+    if (outcome?.opens_path) {
+        // `open_path` hides the launcher itself, the way it does for any row.
+        openPath(result.path, result.kind, result.id);
+        return;
+    }
+
+    const failure = outcome?.errors?.[0];
+    if (failure) {
+        banner.show(`${result.title}: ${failure}`, 'error', BANNER_SECONDS);
+        return;
+    }
+    hideWindow();
+}
+
+/**
+ * Running a `then` target against the selected row, which is what its
+ * placeholders expand to. A target that produces rows is a level to descend
+ * into rather than something to run, and core is what says which.
+ */
+export async function performTarget({ blockId, title, result, selectionId }) {
+    // Claimed before the block runs: the user can hide the launcher or start
+    // another target while it does.
+    const token = levels.beginRequest();
+    const ancestors = levels.ancestorsJson();
+    const parent = {
+        candidateId: result.id,
+        title: result.title,
+        path: result.path || '',
+        openedFromQuery: queryProvider(),
+        openedFromSelection: selectionId,
+    };
+
+    let outcome;
+    try {
+        outcome = await performBlock(blockId, rowPayload(result), true);
+    } catch (err) {
+        console.error('sourceblocks: target failed', err);
+        return { error: 'the backend did not answer' };
+    }
+    if (!levels.holds(token)) return { stale: true };
+
+    const failure = outcome?.errors?.[0];
+    if (failure) return { error: failure };
+    if (!outcome?.produces_rows) {
+        // It ran. The steps usually bring something up that wants the focus.
+        hideWindow();
+        return { performed: true };
+    }
+
+    // Not a failure and nothing performed: the target lists, so it is a level.
+    const level = await levels.descend({ blockId, title, parent, ancestors, token });
+    return { level };
+}
+
+const IMAGE_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp', '.bmp', '.ico'];
+
+function isImagePath(declared) {
+    const lowered = declared.toLowerCase();
+    return (
+        (declared.startsWith('/') || declared.startsWith('~/') || declared.startsWith('.')) &&
+        IMAGE_EXTENSIONS.some((extension) => lowered.endsWith(extension))
+    );
+}
+
+// "bolt.fill", "folder.badge.gear": a macOS symbol name, which has no Lucide
+// counterpart. Emoji have no ASCII letters, so this never catches one.
+function isSymbolName(declared) {
+    return /^[a-z0-9.]+$/i.test(declared);
+}
+
+let home = null;
+
+function expandHome(path) {
+    return path.startsWith('~/') && home ? `${home}${path.slice(1)}` : path;
+}
+
+function escapeAttribute(value) {
+    return value.replaceAll('&', '&amp;').replaceAll('"', '&quot;');
+}
+
+function escapeText(value) {
+    return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+}

--- a/apps/linows/src/js/components/sourceblocks.js
+++ b/apps/linows/src/js/components/sourceblocks.js
@@ -19,6 +19,7 @@ import {
 import { zap } from '../icons.js';
 import * as levels from '../levels.js';
 import * as banner from './banner.js';
+import * as actionmenu from './actionmenu.js';
 
 // `look_indexing::CandidateIdKind::PREFIX_SOURCE`. A drilled row keeps it, so
 // this tells indexed and drilled source rows alike from every other row.
@@ -232,6 +233,12 @@ export async function activateRow(result) {
         return;
     }
 
+    // A block that declares `confirm` asks before Enter runs it, in the menu
+    // and not a modal, exactly as a `then` target does: it is the same row and
+    // the same risk, reached by a different key (§2.5).
+    const declared = await loadDetail(result);
+    if (declared?.confirm && !(await actionmenu.askConfirm(declared.confirm))) return;
+
     const outcome = await performRow(result);
     // On intent, like an open: core skips a drilled row, which is transient and
     // has nothing in the candidates table to key on.
@@ -308,6 +315,12 @@ function isSymbolName(declared) {
 }
 
 let home = null;
+
+/** `/home/you/.look/sources/x.toml` -> `~/.look/sources/x.toml`, the way macOS
+ *  abbreviates the declaring file in the panel. */
+export function tildePath(path) {
+    return home && path.startsWith(`${home}/`) ? `~${path.slice(home.length)}` : path;
+}
 
 function expandHome(path) {
     return path.startsWith('~/') && home ? `${home}${path.slice(1)}` : path;

--- a/apps/linows/src/js/components/sourceblocks.js
+++ b/apps/linows/src/js/components/sourceblocks.js
@@ -108,7 +108,16 @@ export function invalidate() {
  * stale rather than empty.
  */
 export async function reload() {
-    const outcome = await reloadConfig();
+    let outcome = null;
+    try {
+        outcome = await reloadConfig();
+    } catch (err) {
+        // Caught here rather than left to the caller: this is the first await
+        // of the reload gesture, and a throw would take the theme, the font and
+        // the background down with the blocks.
+        console.error('sourceblocks: reload failed', err);
+        banner.show('the backend did not answer', 'error', BANNER_SECONDS);
+    }
     await invalidate();
     for (const error of outcome?.errors || []) {
         banner.show(error, 'error', BANNER_SECONDS);

--- a/apps/linows/src/js/components/sourceblocks.js
+++ b/apps/linows/src/js/components/sourceblocks.js
@@ -31,6 +31,8 @@ const ACTION_PREFIX = 'srcblock:';
 // run every morning ranks like one.
 const USAGE_ACTION = 'execute';
 const BANNER_SECONDS = 4.0;
+// Cache keys are fields joined, and a field can hold anything a script printed.
+const KEY_SEPARATOR = '\u0001';
 
 // Declared icons and names, keyed by block id. Null until `prefill` lands: rows
 // render synchronously and there are many of them, so a miss falls back to the
@@ -152,7 +154,7 @@ export const actionIconHtml = zap;
 /** The block already read for this row, or null. Synchronous, for whoever
  *  already has it: the menu and the panel await `loadDetail` instead. */
 export function detailFor(result) {
-    return (result && detailByRow.get(cacheKey(result))) || null;
+    return (result && detailByRow.get(readKey(result))) || null;
 }
 
 /** The `then` targets already read for this row. */
@@ -171,7 +173,7 @@ export function targetsFor(result) {
  */
 export async function loadDetail(result) {
     if (!isSourceRow(result?.id)) return null;
-    const key = cacheKey(result);
+    const key = readKey(result);
     if (detailByRow.has(key)) return detailByRow.get(key);
     if (!detailInFlight.has(key)) {
         const reading = sourceBlock(rowPayload(result))
@@ -189,10 +191,29 @@ export async function loadDetail(result) {
     return detailInFlight.get(key);
 }
 
-/** A target's `confirm` is expanded against the row, so two rows sharing an id
- *  but differing in title or path must not share an entry. */
-function cacheKey(result) {
-    return `${result.id}${result.title}${result.path || ''}`;
+/**
+ * What a row IS, for a cache that must not hand one row's answer to another: a
+ * target's `confirm` is expanded against the row, so two rows sharing an id but
+ * differing in title or path must not share an entry, and neither must the same
+ * row seen at two depths, since `{parent.*}` reads the levels above it.
+ *
+ * Exported because the preview panel keys its own render on the same rows.
+ */
+export function rowKey(result) {
+    return [result.id, result.title, result.path || '', levels.ancestorsJson()].join(KEY_SEPARATOR);
+}
+
+/**
+ * `rowKey` plus what is typed, which `{query}` expands to: the identity of one
+ * READ of a block, which is what a cached detail actually is.
+ *
+ * The panel keys on `rowKey` alone rather than on this. It is what decides
+ * whether to rebuild, and a rebuild runs the block's declared `preview`, so
+ * keying it on the query would run a shell command on every keystroke. What the
+ * panel shows can lag the query by a keystroke; the menu and Enter both re-read.
+ */
+function readKey(result) {
+    return `${rowKey(result)}${KEY_SEPARATOR}${queryProvider()}`;
 }
 
 /** The row payload every source command takes. `ancestors` comes from the level

--- a/apps/linows/src/js/components/sourceblocks.js
+++ b/apps/linows/src/js/components/sourceblocks.js
@@ -31,8 +31,6 @@ const ACTION_PREFIX = 'srcblock:';
 // run every morning ranks like one.
 const USAGE_ACTION = 'execute';
 const BANNER_SECONDS = 4.0;
-// Cache keys are fields joined, and a field can hold anything a script printed.
-const KEY_SEPARATOR = '\u0001';
 
 // Declared icons and names, keyed by block id. Null until `prefill` lands: rows
 // render synchronously and there are many of them, so a miss falls back to the
@@ -200,6 +198,12 @@ export async function loadDetail(result) {
     return detailInFlight.get(key);
 }
 
+/** What a row IS, as fields rather than as a string: every one of them can hold
+ *  whatever a script printed, so the joining is JSON's problem, not ours. */
+function keyFields(result) {
+    return [result.id, result.title, result.path || '', levels.ancestorsJson()];
+}
+
 /**
  * What a row IS, for a cache that must not hand one row's answer to another: a
  * target's `confirm` is expanded against the row, so two rows sharing an id but
@@ -209,7 +213,7 @@ export async function loadDetail(result) {
  * Exported because the preview panel keys its own render on the same rows.
  */
 export function rowKey(result) {
-    return [result.id, result.title, result.path || '', levels.ancestorsJson()].join(KEY_SEPARATOR);
+    return JSON.stringify(keyFields(result));
 }
 
 /**
@@ -222,7 +226,7 @@ export function rowKey(result) {
  * panel shows can lag the query by a keystroke; the menu and Enter both re-read.
  */
 function readKey(result) {
-    return `${rowKey(result)}${KEY_SEPARATOR}${queryProvider()}`;
+    return JSON.stringify([...keyFields(result), queryProvider()]);
 }
 
 /** The row payload every source command takes. `ancestors` comes from the level

--- a/apps/linows/src/js/components/sourceblocks.js
+++ b/apps/linows/src/js/components/sourceblocks.js
@@ -120,26 +120,30 @@ export function blockName(candidateId) {
     return id ? catalog?.get(id)?.name || null : null;
 }
 
-/**
- * The row icon a source row asked for, as HTML, or null to use the row's own.
- *
- * A declared `icon` is portable as an emoji or an image path; an SF Symbol name
- * is a macOS spelling with no Lucide equivalent, so it falls through to the
- * generic glyph rather than being guessed at.
- */
-export function declaredIconHtml(candidateId) {
-    const id = blockIdOf(candidateId);
-    const declared = id ? catalog?.get(id)?.icon?.trim() : null;
-    if (!declared) return null;
+/** What the row declared, else its block: the row's own wins whatever its form. */
+function declaredIcon(result) {
+    return result?.icon?.trim() || blockIconOf(result?.id)?.trim() || null;
+}
 
-    if (isImagePath(declared)) {
-        const src = window.__TAURI__.core.convertFileSrc(expandHome(declared));
-        // A path that no longer resolves leaves the row's own glyph rather than
-        // a broken-image frame.
-        return `<img src="${escapeAttribute(src)}" alt="" onerror="this.remove()">`;
-    }
-    if (isSymbolName(declared)) return null;
+function blockIconOf(candidateId) {
+    const id = blockIdOf(candidateId);
+    return id ? catalog?.get(id)?.icon : null;
+}
+
+/**
+ * A declared icon that draws as text, as HTML. An SF Symbol name has no Lucide
+ * equivalent, so it falls through to the generic glyph rather than a guess.
+ */
+export function declaredIconHtml(result) {
+    const declared = declaredIcon(result);
+    if (!declared || isImagePath(declared) || isSymbolName(declared)) return null;
     return `<span class="result-icon-glyph">${escapeText(declared)}</span>`;
+}
+
+/** The image file a row is drawn as, for the icon pipeline to read. */
+export function declaredIconPath(result) {
+    const declared = declaredIcon(result);
+    return declared && isImagePath(declared) ? expandHome(declared) : null;
 }
 
 /** The bolt, for a block row with nothing on disk: Enter performs steps. */
@@ -326,10 +330,6 @@ export function tildePath(path) {
 
 function expandHome(path) {
     return path.startsWith('~/') && home ? `${home}${path.slice(1)}` : path;
-}
-
-function escapeAttribute(value) {
-    return value.replaceAll('&', '&amp;').replaceAll('"', '&quot;');
 }
 
 function escapeText(value) {

--- a/apps/linows/src/js/ipc.js
+++ b/apps/linows/src/js/ipc.js
@@ -25,12 +25,39 @@ export async function revealPath(path) {
 // Preferred tools (core look-tools). `toolActions` resolves a batch without
 // acting, for the menu labels; `performToolAction` resolves one and carries it
 // out. Batched because the menu asks about every action at once.
-export async function toolActions(actions, path, isDir) {
-    return invoke('tool_actions', { actions, path, isDir });
+// `row` is the payload every source-aware command takes:
+// `{candidateId, rowTitle, rowPath, query, ancestors}`. A block that declares
+// its own `edit` / `terminal` / `reveal` wins for its own rows, and it expands
+// against that row, so the chords carry it too.
+export async function toolActions(actions, row, isDir) {
+    return invoke('tool_actions', { actions, row, isDir });
 }
 
-export async function performToolAction(action, path, isDir) {
-    return invoke('perform_tool_action', { action, path, isDir });
+export async function performToolAction(action, row, isDir) {
+    return invoke('perform_tool_action', { action, row, isDir });
+}
+
+// User-declared sources (specs/user-sources.md). Everything below runs a
+// user's command except `sourceBlock` and `sourceBlocks`, which only read the
+// declarations.
+export async function sourceBlock(row) {
+    return invoke('source_block', { row });
+}
+
+export async function sourceBlocks() {
+    return invoke('source_blocks');
+}
+
+export async function performBlock(blockId, row, asTarget) {
+    return invoke('perform_block', { blockId, row, asTarget });
+}
+
+export async function sourceRows(blockId, parent) {
+    return invoke('source_rows', { blockId, parent });
+}
+
+export async function sourcePreview(row) {
+    return invoke('source_preview', { row });
 }
 
 export async function reloadConfig() {
@@ -331,6 +358,11 @@ export async function getAutostart() {
 
 export async function highlightFile(path) {
     return invoke('highlight_file_cmd', { path });
+}
+
+// A block's steps, highlighted as shell for the panel.
+export async function highlightShell(source) {
+    return invoke('highlight_shell_cmd', { source });
 }
 
 export async function listFolder(path) {

--- a/apps/linows/src/js/keyboard.js
+++ b/apps/linows/src/js/keyboard.js
@@ -28,6 +28,8 @@ import * as qactions from './components/qactions.js';
 import * as actionmenu from './components/actionmenu.js';
 import * as rowactions from './components/rowactions.js';
 import * as superactions from './components/superactions.js';
+import * as sourceblocks from './components/sourceblocks.js';
+import * as levels from './levels.js';
 import * as runningApps from './components/running-apps.js';
 import { canRunElevated } from './platform.js';
 import { trash as trashIcon } from './icons.js';
@@ -50,6 +52,8 @@ let helpScreen = null;
 // Re-asserts the empty-state control strip after a screen open/close (set by
 // app.js). The strip must step aside for settings/help and return afterwards.
 let syncHomeFn = null;
+// Leaves one level, restoring what it was opened from (set by app.js).
+let popLevelFn = null;
 
 export function init(inputEl) {
     queryInput = inputEl;
@@ -104,6 +108,10 @@ export function setSettingsMode(mod, contentArea, searchBar) {
 
 export function setSyncHome(fn) {
     syncHomeFn = fn;
+}
+
+export function setPopLevel(fn) {
+    popLevelFn = fn;
 }
 
 function handleKeyDown(e) {
@@ -319,7 +327,11 @@ function handleKeyDown(e) {
 
         case 'Escape':
             e.preventDefault();
-            if (
+            // Inside a level Escape is the way back, one level per press, with
+            // the query and selection it was opened from.
+            if (levels.isActive()) {
+                popLevelFn?.();
+            } else if (
                 search.isClipboardMode() ||
                 search.isTranslateMode() ||
                 search.isProcessMode() ||
@@ -641,6 +653,14 @@ async function openSelected(elevated = false) {
             return;
     }
 
+    // A row a block produced answers to its block first: what Enter does is what
+    // the block declared, whatever kind the row ended up with. Core decides
+    // whether that means opening the row's own path.
+    if (sourceblocks.isSourceRow(item.id)) {
+        await sourceblocks.activateRow(item);
+        return;
+    }
+
     try {
         if (elevated) {
             await openElevated(item.path);
@@ -685,6 +705,15 @@ async function copySelectedPath() {
 async function revealSelected() {
     const item = results.getSelected();
     if (!item) return;
+
+    // A block's row may name a path of its own (`format = "json"`), and then it
+    // reveals like any other filesystem object. Only a row without one falls
+    // back to the declaration that made it.
+    if (!item.path && sourceblocks.isSourceRow(item.id)) {
+        const file = (await sourceblocks.loadDetail(item))?.file;
+        if (file) await revealPath(file);
+        return;
+    }
 
     if (rowactions.applies(rowactions.REVEAL, item.kind)) {
         rowactions.run(rowactions.REVEAL);

--- a/apps/linows/src/js/layout.js
+++ b/apps/linows/src/js/layout.js
@@ -9,6 +9,7 @@
 
 import * as platform from './platform.js';
 import * as superactions from './components/superactions.js';
+import * as levels from './levels.js';
 import * as blur from './blur.js';
 
 const GAP_MIN = 0;
@@ -144,6 +145,9 @@ export function isEmptyQuery(query) {
  *  layout after handing the new query to search.js, and the discovery menus
  *  publish rows synchronously from there. Callers gate on the query itself. */
 export function hidesResultsForEmptyQuery() {
+    // A level is not the rest state: its rows ARE the screen, and it starts
+    // with an empty query because filtering one is the first thing anyone does.
+    if (levels.isActive()) return false;
     return onHome() && (platform.floatingSupported() || superactions.isEnabled());
 }
 

--- a/apps/linows/src/js/levels.js
+++ b/apps/linows/src/js/levels.js
@@ -1,0 +1,148 @@
+// The levels a user has descended into from a block row (specs/user-sources.md
+// §2.10).
+//
+// Port of macOS SourceLevelStack: one value holding the navigation state rather
+// than another handful of booleans beside the search modes. A level owns the
+// result list while it is up, because its rows are produced live and are not in
+// the index.
+
+import { sourceRows } from './ipc.js';
+
+let frames = [];
+// Bumped by every request and every change, so a target still running after the
+// launcher is hidden, or after another starts, answers stale.
+let epoch = 0;
+// Told when a level is pushed: the launcher has to hand it the result list,
+// clear the query and say where it is.
+let onEnter = null;
+
+export function setOnEnter(fn) {
+    onEnter = fn;
+}
+
+export function isActive() {
+    return frames.length > 0;
+}
+
+export function current() {
+    return frames.length > 0 ? frames[frames.length - 1] : null;
+}
+
+/** "Projects > animate > Scripts": the row you came from does not say which of
+ *  its targets you picked, so the block that produced this level is named. */
+export function breadcrumb() {
+    const level = current();
+    if (!level) return [];
+    return [...frames.map((frame) => frame.parentTitle), level.blockName];
+}
+
+/** Ancestors of the rows IN this level, nearest first, for `{parent.*}`. */
+export function ancestorsJson() {
+    return JSON.stringify(
+        [...frames].reverse().map((frame) => ({
+            id: frame.parentRowId,
+            title: frame.parentTitle,
+            path: frame.parentPath,
+        })),
+    );
+}
+
+/** The epoch a request must still hold when it answers. */
+export function beginRequest() {
+    epoch += 1;
+    return epoch;
+}
+
+export function holds(token) {
+    return token === epoch;
+}
+
+export function pop() {
+    epoch += 1;
+    return frames.pop() || null;
+}
+
+export function clear() {
+    // Bumped even with no frames: a first-level request may be in flight.
+    epoch += 1;
+    frames = [];
+}
+
+/**
+ * The rows of the current level, filtered by what is typed at it.
+ *
+ * Not the engine's scorer: these rows are a list the user is looking at, one
+ * block's output against one parent, and narrowing it must not reorder what the
+ * block's author wrote (`--sort=-committerdate` beats a frecency guess).
+ */
+export function rows(query) {
+    const level = current();
+    if (!level) return [];
+    const needle = query.trim().toLowerCase();
+
+    return level.rows
+        .filter((row) => matches(needle, row))
+        .map((row) => ({
+            id: row.candidateId,
+            // Enter runs the block's verbs whatever the row carries; a path
+            // only says where the chords act.
+            kind: 'action',
+            title: row.title,
+            subtitle: row.subtitle,
+            path: row.path || '',
+            score: 0,
+        }));
+}
+
+function matches(needle, row) {
+    if (!needle) return true;
+    return (
+        row.title.toLowerCase().includes(needle) ||
+        row.id.toLowerCase().includes(needle) ||
+        (row.subtitle || '').toLowerCase().includes(needle)
+    );
+}
+
+/**
+ * Opens `blockId` as a level below `parent`, which is passed in rather than
+ * read from the selection: the target that led here ran detached, and the user
+ * may have moved on.
+ *
+ * Returns `{ok, error, truncated, count}`. A failure does not descend, and
+ * neither does an empty result: once you are inside one, they look identical.
+ */
+export async function descend({ blockId, title, parent, ancestors, token }) {
+    let level;
+    try {
+        level = await sourceRows(blockId, {
+            candidateId: parent.candidateId,
+            rowTitle: parent.title,
+            rowPath: parent.path,
+            query: parent.openedFromQuery,
+            ancestors,
+        });
+    } catch (err) {
+        console.error('levels: could not read', blockId, err);
+        return { ok: false, error: 'the backend did not answer' };
+    }
+
+    if (!holds(token)) return { ok: false, stale: true };
+    if (!level) return { ok: false, error: 'the backend did not answer' };
+    if (level.error) return { ok: false, error: level.error };
+
+    frames.push({
+        blockName: title,
+        // The row's OWN id, decoded by core, which is what `{parent.id}`
+        // expands to.
+        parentRowId: level.parentRowId,
+        parentTitle: parent.title,
+        parentPath: parent.path,
+        rows: level.rows,
+        restoredQuery: parent.openedFromQuery,
+        restoredSelectionId: parent.openedFromSelection,
+    });
+    epoch += 1;
+    onEnter?.();
+
+    return { ok: true, truncated: level.truncated, count: level.rows.length };
+}

--- a/apps/linows/src/js/levels.js
+++ b/apps/linows/src/js/levels.js
@@ -93,6 +93,7 @@ export function rows(query) {
             // Descending, so the producer's order IS the score wherever one is
             // read (macOS LauncherView+Levels does the same).
             score: level.rows.length - position,
+            icon: row.icon,
         }));
 }
 

--- a/apps/linows/src/js/levels.js
+++ b/apps/linows/src/js/levels.js
@@ -82,7 +82,7 @@ export function rows(query) {
 
     return level.rows
         .filter((row) => matches(needle, row))
-        .map((row) => ({
+        .map((row, position) => ({
             id: row.candidateId,
             // Enter runs the block's verbs whatever the row carries; a path
             // only says where the chords act.
@@ -90,7 +90,9 @@ export function rows(query) {
             title: row.title,
             subtitle: row.subtitle,
             path: row.path || '',
-            score: 0,
+            // Descending, so the producer's order IS the score wherever one is
+            // read (macOS LauncherView+Levels does the same).
+            score: level.rows.length - position,
         }));
 }
 

--- a/apps/linows/src/js/screens/settings.js
+++ b/apps/linows/src/js/screens/settings.js
@@ -2,7 +2,6 @@ import {
     getConfig,
     setConfig,
     forceIndexRefresh,
-    reloadConfig,
     resetConfig,
     listFonts,
     pickFolder,
@@ -12,6 +11,7 @@ import {
     listCandidateDrives,
 } from '../ipc.js';
 import * as banner from '../components/banner.js';
+import * as sourceblocks from '../components/sourceblocks.js';
 import * as platform from '../platform.js';
 import * as layout from '../layout.js';
 
@@ -433,7 +433,7 @@ export function init(exitFn) {
     document.getElementById('settings-fresh-config').addEventListener('click', async () => {
         try {
             await resetConfig();
-            await reloadConfig();
+            await sourceblocks.reload();
             await forceIndexRefresh();
             await loadConfig();
             clearBackgroundImage();
@@ -613,7 +613,7 @@ export function init(exitFn) {
             // Clearing the field saves the sentinel; the live inline override
             // has to go with it or the old family outlives the config value.
             applyFontFamily(updates.ui_font_name);
-            await reloadConfig();
+            await sourceblocks.reload();
             await forceIndexRefresh();
 
             showSaveMessage('Saved', false);
@@ -630,7 +630,7 @@ export function isActive() {
 // Ctrl+Shift+; - reload all values from .look/config file into running app
 export async function reloadFromFile() {
     try {
-        await reloadConfig();
+        await sourceblocks.reload();
         const map = await loadConfigMap();
 
         // Background image - apply BEFORE the tint pass: effectiveBlurOpacity

--- a/apps/linows/src/js/search.js
+++ b/apps/linows/src/js/search.js
@@ -15,6 +15,7 @@ import {
     commandSuggestionResults,
     webSuggestionResults,
     webUrlResult,
+    placeUrlRow,
     calcResult,
     WEB_URL_OPEN_SUBTITLE,
     WEB_URL_RECENT_SUBTITLE,
@@ -380,10 +381,8 @@ function publish(query, version) {
         combined = [...ranked, ...suggestionRows];
     } else {
         const liveRow = webUrlResult(liveUrl, WEB_URL_OPEN_SUBTITLE, 0);
-        combined =
-            lastUrlMatch.tier === 'structural'
-                ? [liveRow, ...ranked, ...suggestionRows]
-                : [...ranked, liveRow, ...suggestionRows];
+        const placed = placeUrlRow(liveRow, lastUrlMatch.tier !== 'structural', ranked);
+        combined = [...placed, ...suggestionRows];
     }
     // Above everything and takes the selection: an expression is a question,
     // and the answer outranks a file that fuzzy-matched some of its digits.
@@ -526,7 +525,7 @@ function prependQuickFolders(results, query) {
         // don't let the pin bump it out of first place. Surface the folder
         // right below it instead of dropping it, so it's still reachable.
         const rivalAppIndex = merged.findIndex(
-            (r) => r.kind === 'app' && r.title.toLowerCase() === folder.title.toLowerCase()
+            (r) => r.kind === 'app' && r.title.toLowerCase() === folder.title.toLowerCase(),
         );
         if (rivalAppIndex === -1) {
             merged.splice(insertAt, 0, quickFolderResult);

--- a/bridge/ffi/src/sources_api.rs
+++ b/bridge/ffi/src/sources_api.rs
@@ -61,11 +61,7 @@ pub(crate) fn look_perform_block_json_impl(
 /// picks them up. Returns `{refreshed, errors}`.
 pub(crate) fn look_refresh_run_blocks_json_impl() -> *mut c_char {
     let outcome = look_engine::sources::refresh_run_blocks();
-    // The rows a block just produced ARE an index change, and nothing else will
-    // say so: they land in a cache directory no watcher covers. Without this the
-    // refresh the shell asks for next is declined by the dirty check whenever
-    // lazy indexing is on (the default), and the new rows sit in the cache until
-    // something unrelated dirties the index or the app restarts.
+    // Rows land in a cache directory no watcher covers, so nothing else says so.
     if outcome.changed {
         mark_index_dirty();
     }

--- a/bridge/ffi/src/sources_api.rs
+++ b/bridge/ffi/src/sources_api.rs
@@ -1,76 +1,16 @@
-//! C-ABI wrappers over `look_sources`, so the Swift shell can read a
+//! C-ABI wrappers over `look_engine::sources`, so the Swift shell can read a
 //! user-declared block, list what a row can go on to, and perform it.
 //!
-//! A row carries only its candidate id, so every entry point starts by
-//! resolving `src:<block>:<row>` back to the block that declared it. Reading the
-//! directory again on demand (rather than caching it here) means a file the user
-//! just edited takes effect without a reindex.
+//! Transport only. Resolving a candidate id back to its block, expanding a
+//! target's `confirm` against the row, the depth cap and the drilled id
+//! encoding all live in the engine, shared with the Tauri shell, so the two
+//! cannot answer the same question differently.
 
-use std::path::PathBuf;
-
-use look_indexing::CandidateIdKind;
-use look_sources::{Block, ParentRow, Producer, RowContext, load_dir, sources_dir};
+use look_sources::ParentRow;
 use serde::Serialize;
 use std::os::raw::c_char;
-use std::time::{Duration, Instant};
 
 use crate::state::{cstr_to_string, json_cstring_or_null, mark_index_dirty};
-
-/// Somewhere a row can go from here. `performs` is what the target's own
-/// producer decides: steps to run, or rows to descend into.
-#[derive(Serialize)]
-struct ThenTarget {
-    id: String,
-    name: String,
-    icon: Option<String>,
-    performs: bool,
-    /// The question to ask before running it, already expanded against the row,
-    /// or null when it needs no confirmation.
-    confirm: Option<String>,
-}
-
-/// What the panel shows for a block row: its name, the exact steps Enter will
-/// perform, and where a row can go next.
-#[derive(Serialize)]
-struct BlockDetail {
-    id: String,
-    name: String,
-    steps: Vec<String>,
-    /// The file this block was declared in, so the panel can show it and
-    /// reveal-in-Finder has something to point at.
-    file: Option<String>,
-    then: Vec<ThenTarget>,
-    /// Whether a `preview` command will run for this row. Answered with the
-    /// cheap details rather than by waiting for the command, so the panel can
-    /// lay itself out before knowing what the output says - or that there will
-    /// be none at all.
-    #[serde(rename = "hasPreview")]
-    has_preview: bool,
-}
-
-/// One row of the block index the shell caches: enough to render a row without
-/// re-reading the directory for every one of them.
-#[derive(Serialize)]
-struct BlockSummary {
-    id: String,
-    name: String,
-    icon: Option<String>,
-}
-
-#[derive(Serialize, Default)]
-struct PerformOutcome {
-    performed: usize,
-    errors: Vec<String>,
-    /// The target makes rows to pick from rather than steps to run, so the
-    /// caller should descend into it. An explicit signal, because "nothing was
-    /// performed" is also what a failure looks like.
-    produces_rows: bool,
-    /// The block declares no `open` and the row names a path, so the row IS the
-    /// thing: the shell opens it the way it opens any file. One rule for Enter,
-    /// decided here rather than from the row's kind, which says which producer
-    /// made it and nothing the user chose.
-    opens_path: bool,
-}
 
 /// `{id, name, steps, file, then}` for the block a candidate id belongs to, or
 /// the JSON literal `null` when it is not a block row or no longer exists.
@@ -83,76 +23,18 @@ pub(crate) fn look_source_block_json_impl(
 ) -> *mut c_char {
     let candidate_id = cstr_to_string(candidate_id);
     let row = row_context(row_id, row_title, row_path, "", ancestors_json);
-    let Some(block_id) = CandidateIdKind::source_id_of(&candidate_id) else {
-        return json_cstring_or_null(None);
-    };
-    let Some(home) = home_dir() else {
-        return json_cstring_or_null(None);
-    };
-
-    let blocks = load_dir(&sources_dir(&home)).blocks;
-    let Some(block) = blocks.iter().find(|block| block.id == block_id) else {
-        return json_cstring_or_null(None);
-    };
-
-    let then = block
-        .then
-        .iter()
-        .filter_map(|target| blocks.iter().find(|block| &block.id == target))
-        .map(|target| ThenTarget {
-            id: target.id.clone(),
-            name: target.name.clone(),
-            icon: target.icon.clone(),
-            performs: target.is_bundle(),
-            // Expanded here so the question names the row the user is looking
-            // at ("Delete main?"), not the template.
-            confirm: target
-                .confirm
-                .as_deref()
-                .map(|question| look_sources::expand(question, &row)),
-        })
-        .collect();
-
-    json_cstring_or_null(
-        serde_json::to_string(&BlockDetail {
-            id: block.id.clone(),
-            name: block.name.clone(),
-            steps: steps_of(block),
-            file: block.source_file.clone(),
-            then,
-            has_preview: block.preview.is_some(),
-        })
-        .ok(),
-    )
+    json(look_engine::sources::block_detail(&candidate_id, &row))
 }
 
 /// Every declared block as `{id, name, icon}`. The shell caches this once per
 /// launcher open so a row can show its declared icon without a disk read each
 /// time it renders.
 pub(crate) fn look_source_blocks_json_impl() -> *mut c_char {
-    let Some(home) = home_dir() else {
-        return json_cstring_or_null(Some("[]".to_string()));
-    };
-    let summaries: Vec<BlockSummary> = load_dir(&sources_dir(&home))
-        .blocks
-        .into_iter()
-        .map(|block| BlockSummary {
-            id: block.id,
-            name: block.name,
-            icon: block.icon,
-        })
-        .collect();
-    json_cstring_or_null(serde_json::to_string(&summaries).ok())
+    json(Some(look_engine::sources::block_summaries()))
 }
 
 /// Performs `block_id` against the selected row, which is what its placeholders
-/// expand to. Returns `{performed, errors, produces_rows}`.
-///
-/// `as_target` is the caller's intent, and only the caller knows it. Enter on a
-/// row means "do what this block's `open` says", so a row-producing block runs
-/// its verb. A `then` target means "go to this block", so a row-producing one is
-/// a level to descend into and running its `open` would act on the WRONG row -
-/// the one currently selected, not one of the rows the target would list.
+/// expand to. Returns `{performed, errors, produces_rows, opens_path}`.
 pub(crate) fn look_perform_block_json_impl(
     block_id: *const c_char,
     row_id: *const c_char,
@@ -170,210 +52,27 @@ pub(crate) fn look_perform_block_json_impl(
         &cstr_to_string(query),
         ancestors_json,
     );
-
-    let Some(block) = find_block(&block_id) else {
-        return outcome(0, vec!["that block no longer exists".into()]);
-    };
-
-    // A bundle IS its steps. Any other producer makes rows: reached as a target
-    // that means descend, reached by Enter it means run the block's `open`.
-    let steps: Vec<String> = match &block.producer {
-        Producer::Bundle { steps } => steps.clone(),
-        _ if as_target => return produces_rows(),
-        _ => match block.verbs.open.as_deref() {
-            Some(command) => vec![command.to_string()],
-            // A row that names a path needs no verb to be openable, which is
-            // what makes `dir` blocks work without declaring one.
-            None if !row.path.is_empty() => return opens_path(),
-            None => {
-                return outcome(
-                    0,
-                    vec![format!("[{}] declares no `open` for its rows", block.id)],
-                );
-            }
-        },
-    };
-
-    let outcomes = look_sources::perform(&steps, Some(&row));
-    let errors: Vec<String> = outcomes
-        .iter()
-        .filter_map(|step| {
-            step.error
-                .as_ref()
-                .map(|error| format!("{}: {error}", step.step))
-        })
-        .collect();
-    outcome(outcomes.len() - errors.len(), errors)
-}
-
-/// Fallback limits for a captured command, when the block names none. A source
-/// refresh happens while the user waits, so the ceiling is low on purpose.
-const DEFAULT_CAPTURE_TIMEOUT: Duration = Duration::from_secs(5);
-const MAX_CAPTURE_BYTES: usize = 256 * 1024;
-
-/// The longest a single block may declare. `timeout` is the one limit the
-/// format hands to the author, and it only ever raises the default - a block
-/// asking for "24h" parses fine and would hold the refresh for a day.
-const MAX_BLOCK_TIMEOUT: Duration = Duration::from_secs(30);
-
-/// The longest a whole refresh may spend running commands. Blocks run one after
-/// another, so without this the wait is the SUM of every block's timeout, and
-/// each new source a user declares makes every reload slower.
-const REFRESH_TIME_BUDGET: Duration = Duration::from_secs(60);
-
-/// Below this a block is skipped rather than handed a sliver, which would come
-/// back as a timeout it did not earn.
-const MIN_BLOCK_SLICE: Duration = Duration::from_secs(1);
-
-/// What a block is actually given: its own `timeout`, else the default, capped.
-fn capture_timeout(declared: Option<Duration>) -> Duration {
-    declared
-        .unwrap_or(DEFAULT_CAPTURE_TIMEOUT)
-        .min(MAX_BLOCK_TIMEOUT)
-}
-
-/// The same, capped by what the refresh has left. `None` means skip it: gating
-/// entry alone, a block starting just under the budget still spent its whole
-/// timeout on top, so 60s could take 90.
-fn block_slice(declared: Option<Duration>, elapsed: Duration) -> Option<Duration> {
-    let remaining = REFRESH_TIME_BUDGET.saturating_sub(elapsed);
-    (remaining >= MIN_BLOCK_SLICE).then(|| capture_timeout(declared).min(remaining))
+    json(Some(look_engine::sources::perform_block(
+        &block_id, &row, as_target,
+    )))
 }
 
 /// Re-runs every enabled `run` block and stores its rows, so the next index pass
 /// picks them up. Returns `{refreshed, errors}`.
-///
-/// A block that fails keeps the rows it had: losing them would also drop the
-/// usage history keyed to their ids, which is a worse outcome than stale rows.
 pub(crate) fn look_refresh_run_blocks_json_impl() -> *mut c_char {
-    let Some(home) = home_dir() else {
-        return json_cstring_or_null(Some("{\"refreshed\":0,\"errors\":[]}".into()));
-    };
-
-    let mut refreshed = 0usize;
-    let mut errors: Vec<String> = Vec::new();
-    let started_at = Instant::now();
-    let mut skipped: Vec<String> = Vec::new();
-    // Any write to the run cache, not just rows gained: turning a block off
-    // clears its rows, and those have to leave the index too.
-    let mut changed = false;
-    for block in load_dir(&sources_dir(&home)).blocks {
-        let Producer::Run {
-            command,
-            cwd,
-            timeout,
-            format,
-        } = &block.producer
-        else {
-            continue;
-        };
-
-        // A block whose command names a row placeholder is a level, run live
-        // when the user descends. Running it here would execute
-        // `jq ... {path}/package.json` literally and report a useless failure.
-        if block.needs_row() {
-            continue;
-        }
-
-        if !block.enabled {
-            look_engine::index::clear_run_rows(&block.id);
-            changed = true;
-            continue;
-        }
-
-        // Out of budget: the blocks left keep the rows they had, and are named
-        // rather than dropped silently - "my source stopped updating" with no
-        // reason given is worse than a slow one.
-        let Some(timeout) = block_slice(*timeout, started_at.elapsed()) else {
-            skipped.push(block.id.clone());
-            continue;
-        };
-
-        let outcome = look_sources::capture(command, cwd.as_deref(), timeout, MAX_CAPTURE_BYTES)
-            .and_then(|output| look_engine::index::store_run_rows(&block.id, &output, *format));
-
-        match outcome {
-            Ok(rows) => {
-                refreshed += rows;
-                changed = true;
-            }
-            Err(message) => errors.push(format!("[{}] {message}", block.id)),
-        }
-    }
-
+    let outcome = look_engine::sources::refresh_run_blocks();
     // The rows a block just produced ARE an index change, and nothing else will
     // say so: they land in a cache directory no watcher covers. Without this the
     // refresh the shell asks for next is declined by the dirty check whenever
     // lazy indexing is on (the default), and the new rows sit in the cache until
     // something unrelated dirties the index or the app restarts.
-    if changed {
+    if outcome.changed {
         mark_index_dirty();
     }
-
-    if !skipped.is_empty() {
-        errors.push(format!(
-            "refresh ran out of time after {}s; not refreshed: {}",
-            REFRESH_TIME_BUDGET.as_secs(),
-            skipped.join(", ")
-        ));
-    }
-
-    json_cstring_or_null(
-        serde_json::to_string(&serde_json::json!({
-            "refreshed": refreshed,
-            "errors": errors,
-        }))
-        .ok(),
-    )
-}
-
-/// How deep a stack of levels may go. A launcher six levels deep has stopped
-/// being a launcher.
-const MAX_LEVEL_DEPTH: usize = 5;
-
-/// One row of a level: its candidate id carries the ancestors it came through.
-#[derive(Serialize)]
-struct LevelRow {
-    #[serde(rename = "candidateId")]
-    candidate_id: String,
-    id: String,
-    title: String,
-    /// Resolved against the block name by the same rule the index uses.
-    subtitle: String,
-    path: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    icon: Option<String>,
-}
-
-#[derive(Serialize, Default)]
-struct Level {
-    /// The parent's OWN id, decoded here so the shell needs no second decoder
-    /// for the id format.
-    #[serde(rename = "parentRowId")]
-    parent_row_id: String,
-    rows: Vec<LevelRow>,
-    /// The row cap dropped rows, so the caller can say so rather than implying
-    /// the level is all there is.
-    truncated: bool,
-    /// Set when the level could not be produced, and the caller must not
-    /// descend: an empty level and a broken command look identical on screen.
-    error: Option<String>,
-}
-
-fn level_error(message: impl Into<String>) -> *mut c_char {
-    json_cstring_or_null(
-        serde_json::to_string(&Level {
-            error: Some(message.into()),
-            ..Default::default()
-        })
-        .ok(),
-    )
+    json(Some(outcome))
 }
 
 /// The rows of `block_id` produced against the selected row, for descending.
-///
-/// Live on every call, never cached: `~/.look/cache/rows/<block>` is keyed by
-/// block alone, and a level's rows depend on the row it opened from.
 pub(crate) fn look_source_rows_json_impl(
     block_id: *const c_char,
     parent_candidate_id: *const c_char,
@@ -382,109 +81,18 @@ pub(crate) fn look_source_rows_json_impl(
     query: *const c_char,
     ancestors_json: *const c_char,
 ) -> *mut c_char {
-    let block_id = cstr_to_string(block_id);
-    let parent_candidate_id = cstr_to_string(parent_candidate_id);
-    // Not through `row_context`: the parent id is already an owned Rust string,
-    // and handing its bytes back as a C string would read past the end.
-    let row = RowContext {
-        id: CandidateIdKind::source_row_id_of(&parent_candidate_id).to_string(),
-        title: cstr_to_string(parent_title),
-        path: cstr_to_string(parent_path),
-        query: cstr_to_string(query),
-        // The parent's own ancestors: inside this call the parent IS the row, so
-        // a producer saying `{parent.path}` means the grandparent.
-        parents: parents_from(ancestors_json),
-    };
-
-    let Some(home) = home_dir() else {
-        return level_error("no home directory");
-    };
-    let Some(block) = find_block(&block_id) else {
-        return level_error("that block no longer exists");
-    };
-    if !block.enabled {
-        return level_error(format!("[{}] is turned off", block.id));
-    }
-
-    // The chain the child's rows will carry: everything the parent was reached
-    // through, then the parent itself.
-    let Some(parent_block) = CandidateIdKind::source_id_of(&parent_candidate_id) else {
-        return level_error("that row does not belong to a block");
-    };
-    let mut ancestors = CandidateIdKind::source_ancestors_of(&parent_candidate_id);
-    ancestors.push((parent_block.to_string(), row.id.clone()));
-    if ancestors.len() > MAX_LEVEL_DEPTH {
-        return level_error(format!("{MAX_LEVEL_DEPTH} levels is as deep as this goes"));
-    }
-
-    let collected = match &block.producer {
-        Producer::Run {
-            command,
-            cwd,
-            timeout,
-            format,
-        } => {
-            let command = look_sources::expand(command, &row);
-            let cwd = cwd
-                .as_deref()
-                .map(|cwd| look_sources::expand_path(cwd, &row));
-            match look_sources::capture(
-                &command,
-                cwd.as_deref(),
-                capture_timeout(*timeout),
-                MAX_CAPTURE_BYTES,
-            )
-            .and_then(|output| {
-                look_sources::parse_rows(&output, look_sources::MAX_ROWS_PER_SOURCE, *format)
-            }) {
-                Ok((rows, truncated)) => look_sources::Collected {
-                    rows,
-                    truncated,
-                    unreadable: Vec::new(),
-                },
-                Err(message) => return level_error(message),
-            }
-        }
-        _ => match look_sources::collect_for_row(&block, &home, &row) {
-            Ok(collected) => collected,
-            Err(err) => return level_error(err.to_string()),
-        },
-    };
-
-    if collected.rows.is_empty() {
-        return level_error(format!("[{}] produced no rows", block.id));
-    }
-
-    let rows: Vec<LevelRow> = collected
-        .rows
-        .into_iter()
-        .map(|row| LevelRow {
-            candidate_id: CandidateIdKind::source_row_candidate_id(&block.id, &ancestors, &row.id),
-            subtitle: row.display_subtitle(&block.name).to_string(),
-            icon: row.display_icon(&home),
-            id: row.id,
-            title: row.title,
-            path: row.path.map(|path| {
-                look_sources::expand_home(&path, &home)
-                    .to_string_lossy()
-                    .into_owned()
-            }),
-        })
-        .collect();
-
-    json_cstring_or_null(
-        serde_json::to_string(&Level {
-            parent_row_id: row.id.clone(),
-            rows,
-            truncated: collected.truncated,
-            error: None,
-        })
-        .ok(),
-    )
+    json(Some(look_engine::sources::level(
+        &cstr_to_string(block_id),
+        &cstr_to_string(parent_candidate_id),
+        &cstr_to_string(parent_title),
+        &cstr_to_string(parent_path),
+        &cstr_to_string(query),
+        parents_from(ancestors_json),
+    )))
 }
 
 /// Runs a block's declared `preview` against the selected row and returns its
-/// output as `{rows, error}`-shaped text, or `null` when it declares none.
+/// output as `{text, error}`, or `null` when it declares none.
 pub(crate) fn look_source_preview_json_impl(
     candidate_id: *const c_char,
     row_id: *const c_char,
@@ -493,113 +101,40 @@ pub(crate) fn look_source_preview_json_impl(
     ancestors_json: *const c_char,
 ) -> *mut c_char {
     let candidate_id = cstr_to_string(candidate_id);
-    let Some(block_id) = CandidateIdKind::source_id_of(&candidate_id) else {
-        return json_cstring_or_null(None);
-    };
-    let Some(block) = find_block(block_id) else {
-        return json_cstring_or_null(None);
-    };
-    let Some(preview) = block.preview.as_deref() else {
-        return json_cstring_or_null(None);
-    };
-
     let row = row_context(row_id, row_title, row_path, "", ancestors_json);
-    let command = look_sources::expand(preview, &row);
-    let text = look_sources::capture(
-        &command,
-        Some(&row.working_dir()),
-        DEFAULT_CAPTURE_TIMEOUT,
-        MAX_CAPTURE_BYTES,
-    );
-
-    json_cstring_or_null(
-        serde_json::to_string(&match text {
-            Ok(text) => serde_json::json!({ "text": text, "error": serde_json::Value::Null }),
-            Err(message) => serde_json::json!({ "text": "", "error": message }),
-        })
-        .ok(),
-    )
+    json(look_engine::sources::preview(&candidate_id, &row))
 }
 
-/// What Enter will run: a bundle's steps, or the `open` verb that acts on a
-/// row the block produced. Either way the panel shows the real commands.
 /// The selected row as a user's command sees it.
-///
-/// `{id}` is the row's OWN id, never the namespaced candidate id: a script
-/// asking for a branch expects `main`, and handing it `src:branches:main` makes
-/// git read the whole thing as `rev:path`.
 fn row_context(
     row_id: *const c_char,
     row_title: *const c_char,
     row_path: *const c_char,
     query: &str,
     ancestors_json: *const c_char,
-) -> RowContext {
-    let candidate_id = cstr_to_string(row_id);
-    RowContext {
-        id: CandidateIdKind::source_row_id_of(&candidate_id).to_string(),
-        title: cstr_to_string(row_title),
-        path: cstr_to_string(row_path),
-        query: query.to_string(),
-        parents: parents_from(ancestors_json),
-    }
+) -> look_sources::RowContext {
+    look_engine::sources::row_context(
+        &cstr_to_string(row_id),
+        &cstr_to_string(row_title),
+        &cstr_to_string(row_path),
+        query,
+        parents_from(ancestors_json),
+    )
 }
 
-/// The rows a drilled row was reached through, for `{parent.*}`: nearest first,
-/// as `[{id, title, path}]`.
-///
-/// The candidate id already carries the ancestor ids, but a placeholder can name
-/// their titles and paths too, and only the shell still holds those. Anything
-/// unparseable is no ancestors, which reads as empty rather than as a literal
-/// placeholder reaching a shell.
+/// The rows a drilled row was reached through, for `{parent.*}`.
 pub(crate) fn parents_from(ancestors_json: *const c_char) -> Vec<ParentRow> {
-    let raw = cstr_to_string(ancestors_json);
-    if raw.trim().is_empty() {
-        return Vec::new();
-    }
-    serde_json::from_str::<Vec<ParentRow>>(&raw).unwrap_or_default()
+    look_engine::sources::parents_from_json(&cstr_to_string(ancestors_json))
 }
 
-fn steps_of(block: &Block) -> Vec<String> {
-    match &block.producer {
-        Producer::Bundle { steps } => steps.clone(),
-        _ => block.verbs.open.iter().cloned().collect(),
-    }
+pub(crate) fn find_block(block_id: &str) -> Option<look_sources::Block> {
+    look_engine::sources::find_block(block_id)
 }
 
-fn respond(outcome: PerformOutcome) -> *mut c_char {
-    json_cstring_or_null(serde_json::to_string(&outcome).ok())
-}
-
-fn outcome(performed: usize, errors: Vec<String>) -> *mut c_char {
-    respond(PerformOutcome {
-        performed,
-        errors,
-        ..Default::default()
-    })
-}
-
-fn produces_rows() -> *mut c_char {
-    respond(PerformOutcome {
-        produces_rows: true,
-        ..Default::default()
-    })
-}
-
-/// Nothing declared, but the row has somewhere to point.
-fn opens_path() -> *mut c_char {
-    respond(PerformOutcome {
-        opens_path: true,
-        ..Default::default()
-    })
-}
-
-pub(crate) fn find_block(block_id: &str) -> Option<Block> {
-    let home = home_dir()?;
-    load_dir(&sources_dir(&home))
-        .blocks
-        .into_iter()
-        .find(|block| block.id == block_id)
+/// `None` becomes the JSON literal `null`, which every caller already reads as
+/// "nothing to show".
+fn json<T: Serialize>(value: Option<T>) -> *mut c_char {
+    json_cstring_or_null(value.and_then(|value| serde_json::to_string(&value).ok()))
 }
 
 /// The config file this build reads and writes, migrating a legacy
@@ -615,62 +150,18 @@ pub(crate) fn look_config_path_impl(dev: bool) -> *mut c_char {
     json_cstring_or_null(Some(resolved.path.to_string_lossy().into_owned()))
 }
 
-fn home_dir() -> Option<PathBuf> {
+fn home_dir() -> Option<std::path::PathBuf> {
     std::env::var("HOME")
         .or_else(|_| std::env::var("USERPROFILE"))
         .ok()
         .filter(|value| !value.trim().is_empty())
-        .map(PathBuf::from)
+        .map(std::path::PathBuf::from)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::ffi::{CStr, CString};
-
-    #[test]
-    fn a_block_cannot_hold_a_refresh_longer_than_the_ceiling() {
-        assert_eq!(capture_timeout(None), DEFAULT_CAPTURE_TIMEOUT);
-        // Under the ceiling is honoured, including asking for less than default.
-        assert_eq!(
-            capture_timeout(Some(Duration::from_secs(1))),
-            Duration::from_secs(1)
-        );
-        assert_eq!(
-            capture_timeout(Some(Duration::from_secs(20))),
-            Duration::from_secs(20)
-        );
-        assert_eq!(
-            capture_timeout(Some(Duration::from_secs(86_400))),
-            MAX_BLOCK_TIMEOUT
-        );
-    }
-
-    #[test]
-    fn a_block_never_spends_more_than_the_refresh_has_left() {
-        let spent = REFRESH_TIME_BUDGET - Duration::from_secs(3);
-        assert_eq!(
-            block_slice(Some(MAX_BLOCK_TIMEOUT), spent),
-            Some(Duration::from_secs(3)),
-            "the remaining budget wins over the block's own ceiling"
-        );
-        assert_eq!(
-            block_slice(Some(Duration::from_secs(20)), Duration::ZERO),
-            Some(Duration::from_secs(20))
-        );
-
-        assert_eq!(block_slice(None, REFRESH_TIME_BUDGET), None);
-        assert_eq!(
-            block_slice(None, REFRESH_TIME_BUDGET + Duration::from_secs(30)),
-            None,
-            "overrunning the budget must not underflow"
-        );
-        assert_eq!(
-            block_slice(None, REFRESH_TIME_BUDGET - MIN_BLOCK_SLICE / 2),
-            None,
-            "a sliver is a skip"
-        );
-    }
+    use std::path::PathBuf;
 
     /// The sources directory is process-wide state, so these run one at a time.
     static GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -682,21 +173,12 @@ mod tests {
     impl Fixture {
         fn new(label: &str, declarations: &str) -> Self {
             let dir =
-                std::env::temp_dir().join(format!("look-ffi-level-{label}-{}", std::process::id()));
+                std::env::temp_dir().join(format!("look-ffi-src-{label}-{}", std::process::id()));
             let _ = std::fs::remove_dir_all(&dir);
             std::fs::create_dir_all(&dir).expect("fixture dir");
             std::fs::write(dir.join("blocks.toml"), declarations).expect("fixture file");
             unsafe { std::env::set_var(look_sources::SOURCES_DIR_ENV, &dir) };
             Self { dir }
-        }
-
-        /// Rows for a `file` block to read.
-        fn rows(&self, name: &str, contents: &str) {
-            let path = self.dir.join(name);
-            if let Some(parent) = path.parent() {
-                std::fs::create_dir_all(parent).expect("rows dir");
-            }
-            std::fs::write(&path, contents).expect("rows file");
         }
     }
 
@@ -705,181 +187,6 @@ mod tests {
             unsafe { std::env::remove_var(look_sources::SOURCES_DIR_ENV) };
             let _ = std::fs::remove_dir_all(&self.dir);
         }
-    }
-
-    fn descend(block: &str, parent_id: &str, parent_path: &str) -> serde_json::Value {
-        let block = CString::new(block).unwrap();
-        let parent = CString::new(parent_id).unwrap();
-        let title = CString::new("parent").unwrap();
-        let path = CString::new(parent_path).unwrap();
-        let query = CString::new("").unwrap();
-        let ancestors = CString::new("[]").unwrap();
-        let ptr = look_source_rows_json_impl(
-            block.as_ptr(),
-            parent.as_ptr(),
-            title.as_ptr(),
-            path.as_ptr(),
-            query.as_ptr(),
-            ancestors.as_ptr(),
-        );
-        let raw = unsafe { CStr::from_ptr(ptr) }
-            .to_string_lossy()
-            .into_owned();
-        crate::state::free_json_allocation(ptr);
-        serde_json::from_str(&raw).expect("level json")
-    }
-
-    #[test]
-    fn a_level_carries_the_ancestors_its_rows_were_reached_through() {
-        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
-        // A `file` producer: ids and ancestors are not shell behaviour, and
-        // `run` refuses off unix.
-        let fixture = Fixture::new("rows", "[child]\nfile = \"{path}/rows.txt\"\n");
-        fixture.rows("rows.txt", "one\ttitle one\ntwo\n");
-        let root = fixture.dir.to_string_lossy().into_owned();
-
-        let level = descend("child", "src:parent:alpha", &root);
-        assert!(level["error"].is_null(), "{level}");
-        let rows = level["rows"].as_array().unwrap();
-        assert_eq!(rows.len(), 2);
-        assert_eq!(rows[0]["candidateId"], "src:child:|parent/alpha|one");
-        assert_eq!(rows[0]["title"], "title one");
-
-        // The same block under another parent is a different id, which is what
-        // keeps usage ranking from bleeding between levels.
-        let other = descend("child", "src:parent:beta", &root);
-        assert_eq!(
-            other["rows"][0]["candidateId"],
-            "src:child:|parent/beta|one"
-        );
-    }
-
-    #[test]
-    fn a_producer_expands_against_the_row_the_level_opened_from() {
-        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
-        let fixture = Fixture::new("expand", "[child]\nfile = \"{path}/rows.txt\"\n");
-        // A space in the name: the level is empty unless `{path}` was
-        // substituted and left unquoted.
-        fixture.rows("some project/rows.txt", "one\n");
-        let inside = fixture.dir.join("some project");
-
-        let level = descend("child", "src:parent:alpha", &inside.to_string_lossy());
-        assert!(level["error"].is_null(), "{level}");
-        assert_eq!(level["rows"][0]["id"], "one");
-    }
-
-    #[test]
-    fn nothing_to_descend_into_is_an_error_rather_than_an_empty_level() {
-        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
-        let fixture = Fixture::new(
-            "empty",
-            "[child]\nfile = \"{path}/rows.txt\"\n[off]\nfile = \"{path}/rows.txt\"\nenabled = false\n",
-        );
-        // Produced nothing, rather than failed to run: a `run` block would
-        // pass this off unix by reporting the missing shell.
-        fixture.rows("rows.txt", "\n");
-        let root = fixture.dir.to_string_lossy().into_owned();
-
-        let empty = descend("child", "src:parent:alpha", &root);
-        assert!(
-            empty["error"]
-                .as_str()
-                .unwrap_or_default()
-                .contains("no rows"),
-            "{empty}"
-        );
-        assert!(descend("off", "src:parent:alpha", &root)["error"].is_string());
-        assert!(descend("missing", "src:parent:alpha", &root)["error"].is_string());
-        // A row that belongs to no block cannot be a parent.
-        assert!(descend("child", "app:safari", &root)["error"].is_string());
-    }
-
-    #[test]
-    fn an_ancestors_payload_reaches_the_producer_as_parent_placeholders() {
-        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
-        let fixture = Fixture::new(
-            "parents",
-            "[child]\nfile = \"{path}/{parent.title}/rows.txt\"\n",
-        );
-        // The grandparent's title names the folder, so an empty level means
-        // `{parent.title}` never reached the producer.
-        fixture.rows("outer-title/rows.txt", "found\n");
-
-        let block = CString::new("child").unwrap();
-        let parent = CString::new("src:mid:row").unwrap();
-        let title = CString::new("mid").unwrap();
-        let path = CString::new(fixture.dir.to_string_lossy().as_ref()).unwrap();
-        let query = CString::new("").unwrap();
-        let ancestors =
-            CString::new(r#"[{"id":"outer","title":"outer-title","path":"/tmp"}]"#).unwrap();
-        let ptr = look_source_rows_json_impl(
-            block.as_ptr(),
-            parent.as_ptr(),
-            title.as_ptr(),
-            path.as_ptr(),
-            query.as_ptr(),
-            ancestors.as_ptr(),
-        );
-        let raw = unsafe { CStr::from_ptr(ptr) }
-            .to_string_lossy()
-            .into_owned();
-        crate::state::free_json_allocation(ptr);
-        let level: serde_json::Value = serde_json::from_str(&raw).unwrap();
-
-        // Inside a producer the parent IS the row, so `{parent.*}` is the level
-        // above that one.
-        assert_eq!(level["rows"][0]["id"], "found", "{level}");
-    }
-
-    fn perform(block: &str, row_path: &str) -> serde_json::Value {
-        let block = CString::new(block).unwrap();
-        let id = CString::new("src:probe:row").unwrap();
-        let title = CString::new("row").unwrap();
-        let path = CString::new(row_path).unwrap();
-        let query = CString::new("").unwrap();
-        let ancestors = CString::new("[]").unwrap();
-        let ptr = look_perform_block_json_impl(
-            block.as_ptr(),
-            id.as_ptr(),
-            title.as_ptr(),
-            path.as_ptr(),
-            query.as_ptr(),
-            ancestors.as_ptr(),
-            false,
-        );
-        let raw = unsafe { CStr::from_ptr(ptr) }
-            .to_string_lossy()
-            .into_owned();
-        crate::state::free_json_allocation(ptr);
-        serde_json::from_str(&raw).expect("outcome json")
-    }
-
-    #[test]
-    fn enter_runs_the_declared_open_whatever_producer_made_the_row() {
-        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
-        let _fixture = Fixture::new(
-            "enter",
-            "[declared]\ndir = \"/tmp\"\nopen = \"true\"\n             [bare]\ndir = \"/tmp\"\n             [pathless]\nfile = \"/tmp/rows.txt\"\n",
-        );
-
-        // Declared: run it. This is the case a `dir` block could not reach
-        // before, so `open` on one was a key that did nothing.
-        let ran = perform("declared", "/tmp");
-        assert_eq!(ran["opens_path"], false, "{ran}");
-        // The spawn is the platform's business: `run` refuses off unix.
-        #[cfg(unix)]
-        assert_eq!(ran["performed"], 1, "{ran}");
-
-        // Nothing declared but the row has a path: the row IS the thing.
-        let opens = perform("bare", "/tmp");
-        assert_eq!(opens["opens_path"], true, "{opens}");
-        assert_eq!(opens["errors"].as_array().unwrap().len(), 0);
-
-        // Nothing declared and nowhere to point: the only case left that is an
-        // error the user can act on.
-        let stuck = perform("pathless", "");
-        assert_eq!(stuck["opens_path"], false, "{stuck}");
-        assert!(stuck["errors"][0].as_str().unwrap().contains("open"));
     }
 
     fn tool_action(
@@ -940,44 +247,5 @@ mod tests {
         // An ordinary file row never sees the block at all.
         let theirs = tool_action("terminal", "file:/tmp/other", "other", "/tmp/other", "[]");
         assert_ne!(theirs["tool"], serde_json::json!("projects"), "{theirs}");
-    }
-
-    /// Refresh runs a `run` block's command, which `run` refuses off unix.
-    #[cfg(unix)]
-    #[test]
-    fn a_refresh_leaves_the_levels_alone() {
-        // A level's command is written for a selected row. Refresh has none, so
-        // running it would hand the shell a literal `{path}` and report an
-        // error against a block that is working exactly as declared.
-        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
-        let _fixture = Fixture::new(
-            "refresh",
-            "[level]\nrun = \"jq . {path}/package.json\"\n[flat]\nrun = \"echo one\"\n",
-        );
-
-        let ptr = look_refresh_run_blocks_json_impl();
-        let raw = unsafe { CStr::from_ptr(ptr) }
-            .to_string_lossy()
-            .into_owned();
-        crate::state::free_json_allocation(ptr);
-        let outcome: serde_json::Value = serde_json::from_str(&raw).unwrap();
-
-        assert_eq!(outcome["errors"].as_array().unwrap().len(), 0, "{outcome}");
-        assert_eq!(outcome["refreshed"], 1, "only the flat block has rows");
-        look_engine::index::clear_run_rows("flat");
-    }
-
-    #[test]
-    fn the_stack_stops_at_the_declared_depth() {
-        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
-        let _fixture = Fixture::new("depth", "[child]\nrun = \"echo x\"\n");
-
-        let chain = (0..MAX_LEVEL_DEPTH)
-            .map(|i| format!("b{i}/r{i}"))
-            .collect::<Vec<_>>()
-            .join(";");
-        let deep = format!("src:parent:|{chain}|row");
-        let level = descend("child", &deep, "/tmp");
-        assert!(level["error"].as_str().unwrap().contains("deep"), "{level}");
     }
 }

--- a/bridge/ffi/src/sources_api.rs
+++ b/bridge/ffi/src/sources_api.rs
@@ -156,6 +156,10 @@ fn home_dir() -> Option<std::path::PathBuf> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(windows)]
+    use look_tools::cmd_quote as quote;
+    #[cfg(not(windows))]
+    use look_tools::shell_quote as quote;
     use std::ffi::{CStr, CString};
     use std::path::PathBuf;
 
@@ -230,7 +234,12 @@ mod tests {
             r#"[{"id":"dev","title":"dev","path":"/dev"}]"#,
         );
         assert_eq!(mine["kind"], "shell", "{mine}");
-        assert_eq!(mine["command"], "tmux new -As 'look' -c '/dev'");
+        // The platform's quoting, so this says which placeholder was quoted
+        // rather than repeating one shell's spelling of it.
+        assert_eq!(
+            mine["command"],
+            format!("tmux new -As {} -c {}", quote("look"), quote("/dev"))
+        );
         assert_eq!(mine["tool"], "projects", "the block is what decided");
 
         // A chord it did not declare is untouched, so a block cannot quietly

--- a/core/engine/src/lib.rs
+++ b/core/engine/src/lib.rs
@@ -8,10 +8,14 @@ mod query;
 pub mod result;
 mod scoring;
 mod search;
+pub mod sources;
 pub mod url_history;
 
 pub use action::{ActionKind, LaunchAction};
 use config::RuntimeConfig;
+/// Re-exported so a shell can validate a usage verb without depending on the
+/// indexing crate for one enum.
+pub use look_indexing::UsageAction;
 use look_indexing::{Candidate, CandidateIdKind, CandidateKind};
 use look_storage::{SearchSettings, SqliteStore, StorageError};
 use normalize::normalize_for_search;

--- a/core/engine/src/sources.rs
+++ b/core/engine/src/sources.rs
@@ -664,6 +664,16 @@ mod tests {
         }
     }
 
+    /// Rows a `run` block stored outlive the test that made them, so the
+    /// cleanup has to survive a failed assert.
+    struct StoredRows(&'static str);
+
+    impl Drop for StoredRows {
+        fn drop(&mut self) {
+            crate::index::clear_run_rows(self.0);
+        }
+    }
+
     fn descend(block: &str, parent_id: &str, parent_path: &str) -> Level {
         level(block, parent_id, "parent", parent_path, "", Vec::new())
     }
@@ -803,10 +813,11 @@ mod tests {
             "[level]\nrun = \"jq . {path}/package.json\"\n[flat]\nrun = \"echo one\"\n",
         );
 
+        let _rows = StoredRows("flat");
+
         let outcome = refresh_run_blocks();
         assert!(outcome.errors.is_empty(), "{:?}", outcome.errors);
         assert_eq!(outcome.refreshed, 1, "only the flat block has rows");
-        crate::index::clear_run_rows("flat");
     }
 
     #[test]

--- a/core/engine/src/sources.rs
+++ b/core/engine/src/sources.rs
@@ -582,6 +582,10 @@ fn home_dir() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(windows)]
+    use look_tools::cmd_quote as quote;
+    #[cfg(not(windows))]
+    use look_tools::shell_quote as quote;
 
     #[test]
     fn a_block_cannot_hold_a_refresh_longer_than_the_ceiling() {
@@ -820,7 +824,7 @@ mod tests {
         // The command, not the template: the panel is what the user reads
         // before pressing Enter, and its copy button hands them something they
         // can paste.
-        assert_eq!(block.steps, vec!["git checkout 'main'".to_string()]);
+        assert_eq!(block.steps, vec![format!("git checkout {}", quote("main"))]);
 
         // A `then` naming a block that does not exist is reported by the
         // loader, not offered as a target.
@@ -830,7 +834,7 @@ mod tests {
         // serves the command that runs if the answer is yes.
         assert_eq!(
             block.then[0].confirm.as_deref(),
-            Some("Delete local branch 'main'?")
+            Some(format!("Delete local branch {}?", quote("main")).as_str())
         );
         assert!(block.then[0].performs, "steps to run");
         // A target that lists is a level to descend into, and says so.
@@ -847,7 +851,7 @@ mod tests {
                 .expect("a declared block")
                 .confirm
                 .as_deref(),
-            Some("Delete local branch 'main'?")
+            Some(format!("Delete local branch {}?", quote("main")).as_str())
         );
     }
 

--- a/core/engine/src/sources.rs
+++ b/core/engine/src/sources.rs
@@ -532,9 +532,6 @@ pub fn parents_from_json(ancestors_json: &str) -> Vec<look_sources::ParentRow> {
     serde_json::from_str(ancestors_json).unwrap_or_default()
 }
 
-/// What Enter will run: a bundle's steps, or the `open` verb that acts on a row
-<<<<<<< HEAD
-/// the block produced. Either way the panel shows the real commands.
 /// What a block is actually given: its own `timeout`, else the default, capped.
 fn capture_timeout(declared: Option<Duration>) -> Duration {
     declared
@@ -550,12 +547,7 @@ fn block_slice(declared: Option<Duration>, elapsed: Duration) -> Option<Duration
     (remaining >= MIN_BLOCK_SLICE).then(|| capture_timeout(declared).min(remaining))
 }
 
-fn steps_of(block: &Block) -> Vec<String> {
-    match &block.producer {
-        Producer::Bundle { steps } => steps.clone(),
-        _ => block.verbs.open.iter().cloned().collect(),
-    }
-=======
+/// What Enter will run: a bundle's steps, or the `open` verb that acts on a row
 /// the block produced. Either way the panel shows the real commands, expanded
 /// against the row the way the runner will expand them.
 fn steps_of(block: &Block, row: &RowContext) -> Vec<String> {
@@ -567,7 +559,6 @@ fn steps_of(block: &Block, row: &RowContext) -> Vec<String> {
         .into_iter()
         .map(|step| look_sources::expand(step, row))
         .collect()
->>>>>>> 65fc4f3 (cosmetic)
 }
 
 fn failed(errors: Vec<String>) -> PerformOutcome {

--- a/core/engine/src/sources.rs
+++ b/core/engine/src/sources.rs
@@ -1,0 +1,834 @@
+//! What a shell asks about a user-declared block: what a row's block is, what
+//! Enter will run, what a `then` target does, and the rows one produces.
+//!
+//! Here rather than in each shell because none of it is native work. It is
+//! `look_sources` calls plus the id encoding `look_indexing` owns, and the two
+//! shells that need it would otherwise reimplement 350 lines apiece and drift
+//! on what `confirm` expands to. The C ABI over this is transport; the Tauri
+//! commands serialize these structs directly.
+//!
+//! A row carries only its candidate id, so every entry point starts by
+//! resolving `src:<block>:<row>` back to the block that declared it. Reading the
+//! directory again on demand (rather than caching it here) means a file the user
+//! just edited takes effect without a reindex.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use look_indexing::CandidateIdKind;
+use look_sources::{Block, Producer, RowContext, load_dir, sources_dir};
+use serde::Serialize;
+
+/// Fallback limits for a captured command, when the block names none. A source
+/// refresh happens while the user waits, so the ceiling is low on purpose.
+const DEFAULT_CAPTURE_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_CAPTURE_BYTES: usize = 256 * 1024;
+
+/// The longest a single block may declare. `timeout` is the one limit the
+/// format hands to the author, and it only ever raises the default - a block
+/// asking for "24h" parses fine and would hold the refresh for a day.
+const MAX_BLOCK_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// The longest a whole refresh may spend running commands. Blocks run one after
+/// another, so without this the wait is the SUM of every block's timeout, and
+/// each new source a user declares makes every reload slower.
+const REFRESH_TIME_BUDGET: Duration = Duration::from_secs(60);
+
+/// Below this a block is skipped rather than handed a sliver, which would come
+/// back as a timeout it did not earn.
+const MIN_BLOCK_SLICE: Duration = Duration::from_secs(1);
+
+/// How deep a stack of levels may go. A launcher six levels deep has stopped
+/// being a launcher.
+pub const MAX_LEVEL_DEPTH: usize = 5;
+
+/// Recorded like an open, so a routine run every morning ranks like one.
+pub const USAGE_ACTION: &str = look_indexing::UsageAction::EXECUTE;
+
+/// Somewhere a row can go from here. `performs` is what the target's own
+/// producer decides: steps to run, or rows to descend into.
+#[derive(Serialize)]
+pub struct ThenTarget {
+    pub id: String,
+    pub name: String,
+    pub icon: Option<String>,
+    pub performs: bool,
+    /// The question to ask before running it, already expanded against the row,
+    /// or null when it needs no confirmation.
+    pub confirm: Option<String>,
+}
+
+/// What the panel shows for a block row: its name, the exact steps Enter will
+/// perform, and where a row can go next.
+#[derive(Serialize)]
+pub struct BlockDetail {
+    pub id: String,
+    pub name: String,
+    pub steps: Vec<String>,
+    /// The file this block was declared in, so the panel can show it and
+    /// reveal has something to point at.
+    pub file: Option<String>,
+    pub then: Vec<ThenTarget>,
+    /// Whether a `preview` command will run for this row. Answered with the
+    /// cheap details rather than by waiting for the command, so the panel can
+    /// lay itself out before knowing what the output says - or that there will
+    /// be none at all.
+    #[serde(rename = "hasPreview")]
+    pub has_preview: bool,
+}
+
+/// One row of the block index the shell caches: enough to render a row without
+/// re-reading the directory for every one of them.
+#[derive(Serialize)]
+pub struct BlockSummary {
+    pub id: String,
+    pub name: String,
+    pub icon: Option<String>,
+}
+
+#[derive(Serialize, Default)]
+pub struct PerformOutcome {
+    pub performed: usize,
+    pub errors: Vec<String>,
+    /// The target makes rows to pick from rather than steps to run, so the
+    /// caller should descend into it. An explicit signal, because "nothing was
+    /// performed" is also what a failure looks like.
+    pub produces_rows: bool,
+    /// The block declares no `open` and the row names a path, so the row IS the
+    /// thing: the shell opens it the way it opens any file. One rule for Enter,
+    /// decided here rather than from the row's kind, which says which producer
+    /// made it and nothing the user chose.
+    pub opens_path: bool,
+}
+
+/// One row of a level: its candidate id carries the ancestors it came through.
+#[derive(Serialize)]
+pub struct LevelRow {
+    #[serde(rename = "candidateId")]
+    pub candidate_id: String,
+    pub id: String,
+    pub title: String,
+    /// Resolved against the block name by the same rule the index uses.
+    pub subtitle: String,
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
+}
+
+#[derive(Serialize, Default)]
+pub struct Level {
+    /// The parent's OWN id, decoded here so the shell needs no second decoder
+    /// for the id format.
+    #[serde(rename = "parentRowId")]
+    pub parent_row_id: String,
+    pub rows: Vec<LevelRow>,
+    /// The row cap dropped rows, so the caller can say so rather than implying
+    /// the level is all there is.
+    pub truncated: bool,
+    /// Set when the level could not be produced, and the caller must not
+    /// descend: an empty level and a broken command look identical on screen.
+    pub error: Option<String>,
+}
+
+/// A block's declared `preview` output, or the reason it could not run. A
+/// failure is carried rather than swallowed: a preview that silently does
+/// nothing reads as the feature being broken.
+#[derive(Serialize)]
+pub struct PreviewOutcome {
+    pub text: String,
+    pub error: Option<String>,
+}
+
+#[derive(Serialize, Default)]
+pub struct RefreshOutcome {
+    pub refreshed: usize,
+    pub errors: Vec<String>,
+    /// Any write to the run cache, not just rows gained: turning a block off
+    /// clears its rows, and those have to leave the index too. The shells act
+    /// on it, because the dirty flag they gate refreshes on is their own.
+    #[serde(skip)]
+    pub changed: bool,
+}
+
+/// `{id, name, steps, file, then}` for the block a candidate id belongs to, or
+/// `None` when it is not a block row or no longer exists.
+pub fn block_detail(candidate_id: &str, row: &RowContext) -> Option<BlockDetail> {
+    let block_id = CandidateIdKind::source_id_of(candidate_id)?;
+    let blocks = load_dir(&sources_dir(&home_dir()?)).blocks;
+    let block = blocks.iter().find(|block| block.id == block_id)?;
+
+    let then = block
+        .then
+        .iter()
+        .filter_map(|target| blocks.iter().find(|block| &block.id == target))
+        .map(|target| ThenTarget {
+            id: target.id.clone(),
+            name: target.name.clone(),
+            icon: target.icon.clone(),
+            performs: target.is_bundle(),
+            // Expanded here so the question names the row the user is looking
+            // at ("Delete main?"), not the template.
+            confirm: target
+                .confirm
+                .as_deref()
+                .map(|question| look_sources::expand(question, row)),
+        })
+        .collect();
+
+    Some(BlockDetail {
+        id: block.id.clone(),
+        name: block.name.clone(),
+        steps: steps_of(block),
+        file: block.source_file.clone(),
+        then,
+        has_preview: block.preview.is_some(),
+    })
+}
+
+/// Every declared block as `{id, name, icon}`. The shell caches this once per
+/// launcher open so a row can show its declared icon without a disk read each
+/// time it renders.
+pub fn block_summaries() -> Vec<BlockSummary> {
+    let Some(home) = home_dir() else {
+        return Vec::new();
+    };
+    load_dir(&sources_dir(&home))
+        .blocks
+        .into_iter()
+        .map(|block| BlockSummary {
+            id: block.id,
+            name: block.name,
+            icon: block.icon,
+        })
+        .collect()
+}
+
+/// Performs `block_id` against the selected row, which is what its placeholders
+/// expand to.
+///
+/// `as_target` is the caller's intent, and only the caller knows it. Enter on a
+/// row means "do what this block's `open` says", so a row-producing block runs
+/// its verb. A `then` target means "go to this block", so a row-producing one is
+/// a level to descend into and running its `open` would act on the WRONG row -
+/// the one currently selected, not one of the rows the target would list.
+pub fn perform_block(block_id: &str, row: &RowContext, as_target: bool) -> PerformOutcome {
+    let Some(block) = find_block(block_id) else {
+        return failed(vec!["that block no longer exists".into()]);
+    };
+
+    // A bundle IS its steps. Any other producer makes rows: reached as a target
+    // that means descend, reached by Enter it means run the block's `open`.
+    let steps: Vec<String> = match &block.producer {
+        Producer::Bundle { steps } => steps.clone(),
+        _ if as_target => {
+            return PerformOutcome {
+                produces_rows: true,
+                ..Default::default()
+            };
+        }
+        _ => match block.verbs.open.as_deref() {
+            Some(command) => vec![command.to_string()],
+            // A row that names a path needs no verb to be openable, which is
+            // what makes `dir` blocks work without declaring one.
+            None if !row.path.is_empty() => {
+                return PerformOutcome {
+                    opens_path: true,
+                    ..Default::default()
+                };
+            }
+            None => {
+                return failed(vec![format!(
+                    "[{}] declares no `open` for its rows",
+                    block.id
+                )]);
+            }
+        },
+    };
+
+    let outcomes = look_sources::perform(&steps, Some(row));
+    let errors: Vec<String> = outcomes
+        .iter()
+        .filter_map(|step| {
+            step.error
+                .as_ref()
+                .map(|error| format!("{}: {error}", step.step))
+        })
+        .collect();
+
+    PerformOutcome {
+        performed: outcomes.len() - errors.len(),
+        errors,
+        ..Default::default()
+    }
+}
+
+/// The rows of `block_id` produced against the selected row, for descending.
+///
+/// Live on every call, never cached: `~/.look/cache/rows/<block>` is keyed by
+/// block alone, and a level's rows depend on the row it opened from.
+pub fn level(
+    block_id: &str,
+    parent_candidate_id: &str,
+    parent_title: &str,
+    parent_path: &str,
+    query: &str,
+    parents: Vec<look_sources::ParentRow>,
+) -> Level {
+    let row = RowContext {
+        id: CandidateIdKind::source_row_id_of(parent_candidate_id).to_string(),
+        title: parent_title.to_string(),
+        path: parent_path.to_string(),
+        query: query.to_string(),
+        // The parent's own ancestors: inside this call the parent IS the row, so
+        // a producer saying `{parent.path}` means the grandparent.
+        parents,
+    };
+
+    let Some(home) = home_dir() else {
+        return level_error("no home directory");
+    };
+    let Some(block) = find_block(block_id) else {
+        return level_error("that block no longer exists");
+    };
+    if !block.enabled {
+        return level_error(format!("[{}] is turned off", block.id));
+    }
+
+    // The chain the child's rows will carry: everything the parent was reached
+    // through, then the parent itself.
+    let Some(parent_block) = CandidateIdKind::source_id_of(parent_candidate_id) else {
+        return level_error("that row does not belong to a block");
+    };
+    let mut ancestors = CandidateIdKind::source_ancestors_of(parent_candidate_id);
+    ancestors.push((parent_block.to_string(), row.id.clone()));
+    if ancestors.len() > MAX_LEVEL_DEPTH {
+        return level_error(format!("{MAX_LEVEL_DEPTH} levels is as deep as this goes"));
+    }
+
+    let collected = match &block.producer {
+        Producer::Run {
+            command,
+            cwd,
+            timeout,
+            format,
+        } => {
+            let command = look_sources::expand(command, &row);
+            let cwd = cwd
+                .as_deref()
+                .map(|cwd| look_sources::expand_path(cwd, &row));
+            match look_sources::capture(
+                &command,
+                cwd.as_deref(),
+                capture_timeout(*timeout),
+                MAX_CAPTURE_BYTES,
+            )
+            .and_then(|output| {
+                look_sources::parse_rows(&output, look_sources::MAX_ROWS_PER_SOURCE, *format)
+            }) {
+                Ok((rows, truncated)) => look_sources::Collected {
+                    rows,
+                    truncated,
+                    unreadable: Vec::new(),
+                },
+                Err(message) => return level_error(message),
+            }
+        }
+        _ => match look_sources::collect_for_row(&block, &home, &row) {
+            Ok(collected) => collected,
+            Err(err) => return level_error(err.to_string()),
+        },
+    };
+
+    if collected.rows.is_empty() {
+        return level_error(format!("[{}] produced no rows", block.id));
+    }
+
+    let rows: Vec<LevelRow> = collected
+        .rows
+        .into_iter()
+        .map(|row| LevelRow {
+            candidate_id: CandidateIdKind::source_row_candidate_id(&block.id, &ancestors, &row.id),
+            subtitle: row.display_subtitle(&block.name).to_string(),
+            icon: row.display_icon(&home),
+            id: row.id,
+            title: row.title,
+            path: row.path.map(|path| {
+                look_sources::expand_home(&path, &home)
+                    .to_string_lossy()
+                    .into_owned()
+            }),
+        })
+        .collect();
+
+    Level {
+        parent_row_id: row.id,
+        rows,
+        truncated: collected.truncated,
+        error: None,
+    }
+}
+
+/// Runs a block's declared `preview` against the selected row, or `None` when
+/// it declares none.
+pub fn preview(candidate_id: &str, row: &RowContext) -> Option<PreviewOutcome> {
+    let block_id = CandidateIdKind::source_id_of(candidate_id)?;
+    let block = find_block(block_id)?;
+    let preview = block.preview.as_deref()?;
+
+    let command = look_sources::expand(preview, row);
+    Some(
+        match look_sources::capture(
+            &command,
+            Some(&row.working_dir()),
+            DEFAULT_CAPTURE_TIMEOUT,
+            MAX_CAPTURE_BYTES,
+        ) {
+            Ok(text) => PreviewOutcome { text, error: None },
+            Err(message) => PreviewOutcome {
+                text: String::new(),
+                error: Some(message),
+            },
+        },
+    )
+}
+
+/// Re-runs every enabled `run` block and stores its rows, so the next index pass
+/// picks them up.
+///
+/// A block that fails keeps the rows it had: losing them would also drop the
+/// usage history keyed to their ids, which is a worse outcome than stale rows.
+pub fn refresh_run_blocks() -> RefreshOutcome {
+    let Some(home) = home_dir() else {
+        return RefreshOutcome::default();
+    };
+
+    let mut outcome = RefreshOutcome::default();
+    let started_at = Instant::now();
+    let mut skipped: Vec<String> = Vec::new();
+    for block in load_dir(&sources_dir(&home)).blocks {
+        let Producer::Run {
+            command,
+            cwd,
+            timeout,
+            format,
+        } = &block.producer
+        else {
+            continue;
+        };
+
+        // A block whose command names a row placeholder is a level, run live
+        // when the user descends. Running it here would execute
+        // `jq ... {path}/package.json` literally and report a useless failure.
+        if block.needs_row() {
+            continue;
+        }
+
+        if !block.enabled {
+            crate::index::clear_run_rows(&block.id);
+            outcome.changed = true;
+            continue;
+        }
+
+        // Out of budget: the blocks left keep the rows they had, and are named
+        // rather than dropped silently - "my source stopped updating" with no
+        // reason given is worse than a slow one.
+        let Some(timeout) = block_slice(*timeout, started_at.elapsed()) else {
+            skipped.push(block.id.clone());
+            continue;
+        };
+
+        let stored = look_sources::capture(command, cwd.as_deref(), timeout, MAX_CAPTURE_BYTES)
+            .and_then(|output| crate::index::store_run_rows(&block.id, &output, *format));
+
+        match stored {
+            Ok(rows) => {
+                outcome.refreshed += rows;
+                outcome.changed = true;
+            }
+            Err(message) => outcome.errors.push(format!("[{}] {message}", block.id)),
+        }
+    }
+
+    if !skipped.is_empty() {
+        outcome.errors.push(format!(
+            "refresh ran out of time after {}s; not refreshed: {}",
+            REFRESH_TIME_BUDGET.as_secs(),
+            skipped.join(", ")
+        ));
+    }
+
+    outcome
+}
+
+/// The block `block_id` names, read from the directory rather than a cache so
+/// an edited file takes effect on the next press.
+pub fn find_block(block_id: &str) -> Option<Block> {
+    load_dir(&sources_dir(&home_dir()?))
+        .blocks
+        .into_iter()
+        .find(|block| block.id == block_id)
+}
+
+/// The block that produced `candidate_id`, or `None` when no block did.
+///
+/// Here rather than in a shell because `src:<block>:<row>` is the indexing
+/// crate's format: a caller that split the id itself would be the second place
+/// that has to learn the drilled spelling.
+pub fn block_for_candidate(candidate_id: &str) -> Option<Block> {
+    find_block(CandidateIdKind::source_id_of(candidate_id)?)
+}
+
+/// Whether this row was reached by descending, which is what makes it
+/// transient: a drilled row is never written to `candidates`, so there is
+/// nothing for `usage_events` to key on.
+pub fn is_drilled_row(candidate_id: &str) -> bool {
+    !CandidateIdKind::source_ancestors_of(candidate_id).is_empty()
+}
+
+/// The row a user's command sees, built from what the shell holds.
+///
+/// `{id}` is the row's OWN id, never the namespaced candidate id: a script
+/// asking for a branch expects `main`, and handing it `src:branches:main` makes
+/// git read the whole thing as `rev:path`.
+pub fn row_context(
+    candidate_id: &str,
+    title: &str,
+    path: &str,
+    query: &str,
+    parents: Vec<look_sources::ParentRow>,
+) -> RowContext {
+    RowContext {
+        id: CandidateIdKind::source_row_id_of(candidate_id).to_string(),
+        title: title.to_string(),
+        path: path.to_string(),
+        query: query.to_string(),
+        parents,
+    }
+}
+
+/// The rows a drilled row was reached through, for `{parent.*}`: nearest first,
+/// as `[{id, title, path}]`.
+///
+/// The candidate id already carries the ancestor ids, but a placeholder can name
+/// their titles and paths too, and only the shell still holds those. Anything
+/// unparseable is no ancestors, which reads as empty rather than as a literal
+/// placeholder reaching a shell.
+pub fn parents_from_json(ancestors_json: &str) -> Vec<look_sources::ParentRow> {
+    if ancestors_json.trim().is_empty() {
+        return Vec::new();
+    }
+    serde_json::from_str(ancestors_json).unwrap_or_default()
+}
+
+/// What Enter will run: a bundle's steps, or the `open` verb that acts on a row
+/// the block produced. Either way the panel shows the real commands.
+/// What a block is actually given: its own `timeout`, else the default, capped.
+fn capture_timeout(declared: Option<Duration>) -> Duration {
+    declared
+        .unwrap_or(DEFAULT_CAPTURE_TIMEOUT)
+        .min(MAX_BLOCK_TIMEOUT)
+}
+
+/// The same, capped by what the refresh has left. `None` means skip it: gating
+/// entry alone, a block starting just under the budget still spent its whole
+/// timeout on top, so 60s could take 90.
+fn block_slice(declared: Option<Duration>, elapsed: Duration) -> Option<Duration> {
+    let remaining = REFRESH_TIME_BUDGET.saturating_sub(elapsed);
+    (remaining >= MIN_BLOCK_SLICE).then(|| capture_timeout(declared).min(remaining))
+}
+
+fn steps_of(block: &Block) -> Vec<String> {
+    match &block.producer {
+        Producer::Bundle { steps } => steps.clone(),
+        _ => block.verbs.open.iter().cloned().collect(),
+    }
+}
+
+fn failed(errors: Vec<String>) -> PerformOutcome {
+    PerformOutcome {
+        errors,
+        ..Default::default()
+    }
+}
+
+fn level_error(message: impl Into<String>) -> Level {
+    Level {
+        error: Some(message.into()),
+        ..Default::default()
+    }
+}
+
+fn home_dir() -> Option<PathBuf> {
+    crate::config::user_home_dir().map(|home| Path::new(&home).to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_block_cannot_hold_a_refresh_longer_than_the_ceiling() {
+        assert_eq!(capture_timeout(None), DEFAULT_CAPTURE_TIMEOUT);
+        // Under the ceiling is honoured, including asking for less than default.
+        assert_eq!(
+            capture_timeout(Some(Duration::from_secs(1))),
+            Duration::from_secs(1)
+        );
+        assert_eq!(
+            capture_timeout(Some(Duration::from_secs(20))),
+            Duration::from_secs(20)
+        );
+        assert_eq!(
+            capture_timeout(Some(Duration::from_secs(86_400))),
+            MAX_BLOCK_TIMEOUT
+        );
+    }
+
+    #[test]
+    fn a_block_never_spends_more_than_the_refresh_has_left() {
+        let spent = REFRESH_TIME_BUDGET - Duration::from_secs(3);
+        assert_eq!(
+            block_slice(Some(MAX_BLOCK_TIMEOUT), spent),
+            Some(Duration::from_secs(3)),
+            "the remaining budget wins over the block's own ceiling"
+        );
+        assert_eq!(
+            block_slice(Some(Duration::from_secs(20)), Duration::ZERO),
+            Some(Duration::from_secs(20))
+        );
+
+        assert_eq!(block_slice(None, REFRESH_TIME_BUDGET), None);
+        assert_eq!(
+            block_slice(None, REFRESH_TIME_BUDGET + Duration::from_secs(30)),
+            None,
+            "overrunning the budget must not underflow"
+        );
+        assert_eq!(
+            block_slice(None, REFRESH_TIME_BUDGET - MIN_BLOCK_SLICE / 2),
+            None,
+            "a sliver is a skip"
+        );
+    }
+
+    /// The sources directory is process-wide state, so these run one at a time.
+    static GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct Fixture {
+        dir: PathBuf,
+    }
+
+    impl Fixture {
+        fn new(label: &str, declarations: &str) -> Self {
+            let dir = std::env::temp_dir()
+                .join(format!("look-engine-src-{label}-{}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).expect("fixture dir");
+            std::fs::write(dir.join("blocks.toml"), declarations).expect("fixture file");
+            unsafe { std::env::set_var(look_sources::SOURCES_DIR_ENV, &dir) };
+            Self { dir }
+        }
+
+        /// Rows for a `file` block to read.
+        fn rows(&self, name: &str, contents: &str) {
+            let path = self.dir.join(name);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).expect("rows dir");
+            }
+            std::fs::write(&path, contents).expect("rows file");
+        }
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            unsafe { std::env::remove_var(look_sources::SOURCES_DIR_ENV) };
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+
+    fn descend(block: &str, parent_id: &str, parent_path: &str) -> Level {
+        level(block, parent_id, "parent", parent_path, "", Vec::new())
+    }
+
+    #[test]
+    fn a_level_carries_the_ancestors_its_rows_were_reached_through() {
+        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
+        // A `file` producer: ids and ancestors are not shell behaviour, and
+        // `run` refuses off unix.
+        let fixture = Fixture::new("rows", "[child]\nfile = \"{path}/rows.txt\"\n");
+        fixture.rows("rows.txt", "one\ttitle one\ntwo\n");
+        let root = fixture.dir.to_string_lossy().into_owned();
+
+        let level = descend("child", "src:parent:alpha", &root);
+        assert!(level.error.is_none(), "{:?}", level.error);
+        assert_eq!(level.rows.len(), 2);
+        assert_eq!(level.rows[0].candidate_id, "src:child:|parent/alpha|one");
+        assert_eq!(level.rows[0].title, "title one");
+
+        // The same block under another parent is a different id, which is what
+        // keeps usage ranking from bleeding between levels.
+        let other = descend("child", "src:parent:beta", &root);
+        assert_eq!(other.rows[0].candidate_id, "src:child:|parent/beta|one");
+    }
+
+    #[test]
+    fn a_producer_expands_against_the_row_the_level_opened_from() {
+        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
+        let fixture = Fixture::new("expand", "[child]\nfile = \"{path}/rows.txt\"\n");
+        // A space in the name: the level is empty unless `{path}` was
+        // substituted and left unquoted.
+        fixture.rows("some project/rows.txt", "one\n");
+        let inside = fixture.dir.join("some project");
+
+        let level = descend("child", "src:parent:alpha", &inside.to_string_lossy());
+        assert!(level.error.is_none(), "{:?}", level.error);
+        assert_eq!(level.rows[0].id, "one");
+    }
+
+    #[test]
+    fn nothing_to_descend_into_is_an_error_rather_than_an_empty_level() {
+        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
+        let fixture = Fixture::new(
+            "empty",
+            "[child]\nfile = \"{path}/rows.txt\"\n[off]\nfile = \"{path}/rows.txt\"\nenabled = false\n",
+        );
+        // Produced nothing, rather than failed to run: a `run` block would
+        // pass this off unix by reporting the missing shell.
+        fixture.rows("rows.txt", "\n");
+        let root = fixture.dir.to_string_lossy().into_owned();
+
+        let empty = descend("child", "src:parent:alpha", &root);
+        assert!(
+            empty.error.unwrap_or_default().contains("no rows"),
+            "an empty producer must not descend"
+        );
+        assert!(descend("off", "src:parent:alpha", &root).error.is_some());
+        assert!(
+            descend("missing", "src:parent:alpha", &root)
+                .error
+                .is_some()
+        );
+        // A row that belongs to no block cannot be a parent.
+        assert!(descend("child", "app:safari", &root).error.is_some());
+    }
+
+    #[test]
+    fn an_ancestors_payload_reaches_the_producer_as_parent_placeholders() {
+        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
+        let fixture = Fixture::new(
+            "parents",
+            "[child]\nfile = \"{path}/{parent.title}/rows.txt\"\n",
+        );
+        // The grandparent's title names the folder, so an empty level means
+        // `{parent.title}` never reached the producer.
+        fixture.rows("outer-title/rows.txt", "found\n");
+
+        let level = level(
+            "child",
+            "src:mid:row",
+            "mid",
+            &fixture.dir.to_string_lossy(),
+            "",
+            parents_from_json(r#"[{"id":"outer","title":"outer-title","path":"/tmp"}]"#),
+        );
+
+        // Inside a producer the parent IS the row, so `{parent.*}` is the level
+        // above that one.
+        assert_eq!(level.rows[0].id, "found", "{:?}", level.error);
+    }
+
+    #[test]
+    fn enter_runs_the_declared_open_whatever_producer_made_the_row() {
+        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
+        let _fixture = Fixture::new(
+            "enter",
+            "[declared]\ndir = \"/tmp\"\nopen = \"true\"\n[bare]\ndir = \"/tmp\"\n[pathless]\nfile = \"/tmp/rows.txt\"\n",
+        );
+        let perform = |block: &str, path: &str| {
+            perform_block(
+                block,
+                &row_context("src:probe:row", "row", path, "", Vec::new()),
+                false,
+            )
+        };
+
+        // Declared: run it. This is the case a `dir` block could not reach
+        // before, so `open` on one was a key that did nothing.
+        let ran = perform("declared", "/tmp");
+        assert!(!ran.opens_path);
+        // The spawn is the platform's business: `run` refuses off unix.
+        #[cfg(unix)]
+        assert_eq!(ran.performed, 1, "{:?}", ran.errors);
+
+        // Nothing declared but the row has a path: the row IS the thing.
+        let opens = perform("bare", "/tmp");
+        assert!(opens.opens_path);
+        assert!(opens.errors.is_empty());
+
+        // Nothing declared and nowhere to point: the only case left that is an
+        // error the user can act on.
+        let stuck = perform("pathless", "");
+        assert!(!stuck.opens_path);
+        assert!(stuck.errors[0].contains("open"));
+    }
+
+    /// Refresh runs a `run` block's command, which `run` refuses off unix.
+    #[cfg(unix)]
+    #[test]
+    fn a_refresh_leaves_the_levels_alone() {
+        // A level's command is written for a selected row. Refresh has none, so
+        // running it would hand the shell a literal `{path}` and report an
+        // error against a block that is working exactly as declared.
+        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
+        let _fixture = Fixture::new(
+            "refresh",
+            "[level]\nrun = \"jq . {path}/package.json\"\n[flat]\nrun = \"echo one\"\n",
+        );
+
+        let outcome = refresh_run_blocks();
+        assert!(outcome.errors.is_empty(), "{:?}", outcome.errors);
+        assert_eq!(outcome.refreshed, 1, "only the flat block has rows");
+        crate::index::clear_run_rows("flat");
+    }
+
+    #[test]
+    fn a_targets_question_is_expanded_against_the_row_it_will_act_on() {
+        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
+        let _fixture = Fixture::new(
+            "targets",
+            "[branches]\nfile = \"/tmp/rows.txt\"\nopen = \"git checkout {id}\"\nthen = [\"drop\", \"logs\", \"missing\"]\n\n[drop]\nname = \"Delete branch\"\nconfirm = \"Delete local branch {id}?\"\ndo = [\"git branch -d {id}\"]\n\n[logs]\nname = \"Commits\"\nrun = \"git log {id}\"\n",
+        );
+
+        let row = row_context("src:branches:main", "main", "", "", Vec::new());
+        let block = block_detail("src:branches:main", &row).expect("a declared block");
+        assert_eq!(block.steps, vec!["git checkout {id}".to_string()]);
+
+        // A `then` naming a block that does not exist is reported by the
+        // loader, not offered as a target.
+        assert_eq!(block.then.len(), 2);
+        // The question names the row the user is looking at, not the template.
+        // Shell-quoted like every other substitution, since the same expansion
+        // serves the command that runs if the answer is yes.
+        assert_eq!(
+            block.then[0].confirm.as_deref(),
+            Some("Delete local branch 'main'?")
+        );
+        assert!(block.then[0].performs, "steps to run");
+        // A target that lists is a level to descend into, and says so.
+        assert!(!block.then[1].performs, "rows to pick from");
+        assert!(block.then[1].confirm.is_none());
+    }
+
+    #[test]
+    fn the_stack_stops_at_the_declared_depth() {
+        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
+        let _fixture = Fixture::new("depth", "[child]\nrun = \"echo x\"\n");
+
+        let chain = (0..MAX_LEVEL_DEPTH)
+            .map(|i| format!("b{i}/r{i}"))
+            .collect::<Vec<_>>()
+            .join(";");
+        let deep = format!("src:parent:|{chain}|row");
+        let level = descend("child", &deep, "/tmp");
+        assert!(level.error.unwrap_or_default().contains("deep"));
+    }
+}

--- a/core/engine/src/sources.rs
+++ b/core/engine/src/sources.rs
@@ -64,10 +64,18 @@ pub struct ThenTarget {
 pub struct BlockDetail {
     pub id: String,
     pub name: String,
+    /// Expanded against the row, like `confirm` beside it: a panel that
+    /// answers "what is about to run" has to show the command, not the
+    /// template it was written as. Quoting included, since that is what runs.
     pub steps: Vec<String>,
     /// The file this block was declared in, so the panel can show it and
     /// reveal has something to point at.
     pub file: Option<String>,
+    /// The block's OWN question, expanded against the row, or null when it
+    /// declares none. Enter has to ask it: `confirm` exists because a launcher
+    /// makes Enter on the wrong row cheap, and a block reached by Enter rather
+    /// than through another block's `then` is the same row and the same risk.
+    pub confirm: Option<String>,
     pub then: Vec<ThenTarget>,
     /// Whether a `preview` command will run for this row. Answered with the
     /// cheap details rather than by waiting for the command, so the panel can
@@ -178,8 +186,12 @@ pub fn block_detail(candidate_id: &str, row: &RowContext) -> Option<BlockDetail>
     Some(BlockDetail {
         id: block.id.clone(),
         name: block.name.clone(),
-        steps: steps_of(block),
+        steps: steps_of(block, row),
         file: block.source_file.clone(),
+        confirm: block
+            .confirm
+            .as_deref()
+            .map(|question| look_sources::expand(question, row)),
         then,
         has_preview: block.preview.is_some(),
     })
@@ -521,6 +533,7 @@ pub fn parents_from_json(ancestors_json: &str) -> Vec<look_sources::ParentRow> {
 }
 
 /// What Enter will run: a bundle's steps, or the `open` verb that acts on a row
+<<<<<<< HEAD
 /// the block produced. Either way the panel shows the real commands.
 /// What a block is actually given: its own `timeout`, else the default, capped.
 fn capture_timeout(declared: Option<Duration>) -> Duration {
@@ -542,6 +555,19 @@ fn steps_of(block: &Block) -> Vec<String> {
         Producer::Bundle { steps } => steps.clone(),
         _ => block.verbs.open.iter().cloned().collect(),
     }
+=======
+/// the block produced. Either way the panel shows the real commands, expanded
+/// against the row the way the runner will expand them.
+fn steps_of(block: &Block, row: &RowContext) -> Vec<String> {
+    let declared: Vec<&str> = match &block.producer {
+        Producer::Bundle { steps } => steps.iter().map(String::as_str).collect(),
+        _ => block.verbs.open.iter().map(String::as_str).collect(),
+    };
+    declared
+        .into_iter()
+        .map(|step| look_sources::expand(step, row))
+        .collect()
+>>>>>>> 65fc4f3 (cosmetic)
 }
 
 fn failed(errors: Vec<String>) -> PerformOutcome {
@@ -800,7 +826,10 @@ mod tests {
 
         let row = row_context("src:branches:main", "main", "", "", Vec::new());
         let block = block_detail("src:branches:main", &row).expect("a declared block");
-        assert_eq!(block.steps, vec!["git checkout {id}".to_string()]);
+        // The command, not the template: the panel is what the user reads
+        // before pressing Enter, and its copy button hands them something they
+        // can paste.
+        assert_eq!(block.steps, vec!["git checkout 'main'".to_string()]);
 
         // A `then` naming a block that does not exist is reported by the
         // loader, not offered as a target.
@@ -816,6 +845,19 @@ mod tests {
         // A target that lists is a level to descend into, and says so.
         assert!(!block.then[1].performs, "rows to pick from");
         assert!(block.then[1].confirm.is_none());
+        // The row's own block asks nothing, so Enter on it runs straight away.
+        assert!(block.confirm.is_none());
+
+        // A block that DOES declare one carries it here, expanded the same way:
+        // Enter on its row is the same risk as reaching it through a `then`.
+        let target = row_context("src:drop:main", "main", "", "", Vec::new());
+        assert_eq!(
+            block_detail("src:drop:main", &target)
+                .expect("a declared block")
+                .confirm
+                .as_deref(),
+            Some("Delete local branch 'main'?")
+        );
     }
 
     #[test]

--- a/core/engine/src/sources.rs
+++ b/core/engine/src/sources.rs
@@ -151,9 +151,7 @@ pub struct PreviewOutcome {
 pub struct RefreshOutcome {
     pub refreshed: usize,
     pub errors: Vec<String>,
-    /// Any write to the run cache, not just rows gained: turning a block off
-    /// clears its rows, and those have to leave the index too. The shells act
-    /// on it, because the dirty flag they gate refreshes on is their own.
+    /// Any write to the run cache, since the dirty flag belongs to each shell.
     #[serde(skip)]
     pub changed: bool,
 }

--- a/core/sources/examples/parse_check.rs
+++ b/core/sources/examples/parse_check.rs
@@ -1,0 +1,13 @@
+fn main() {
+    let dir = std::env::args().nth(1).expect("dir");
+    let loaded = look_sources::load_dir(std::path::Path::new(&dir));
+    for problem in &loaded.problems {
+        println!("problem: {}", problem.message);
+    }
+    for block in &loaded.blocks {
+        println!(
+            "block {} name={:?} icon={:?} enabled={} preview={:?} unknown={:?}",
+            block.id, block.name, block.icon, block.enabled, block.preview, block.unknown_keys
+        );
+    }
+}

--- a/core/sources/src/load.rs
+++ b/core/sources/src/load.rs
@@ -111,7 +111,7 @@ pub fn load_dir(dir: &Path) -> Loaded {
     }
 
     for (stem, path) in &executables {
-        let mut block = inferred(stem, &path.to_string_lossy());
+        let mut block = inferred(stem, &executable_command(path));
         block.source_file = Some(path.to_string_lossy().into_owned());
         loaded.blocks.push(block);
     }
@@ -169,6 +169,30 @@ pub fn load_dir(dir: &Path) -> Loaded {
     loaded.blocks.sort_by(|a, b| a.id.cmp(&b.id));
     loaded.problems.sort_by(|a, b| a.file.cmp(&b.file));
     loaded
+}
+
+/// The shell text that runs an executable source. Quoted, because the sources
+/// directory sits under a home folder the user named, and plenty of them have a
+/// space in the name.
+#[cfg(not(windows))]
+fn executable_command(path: &Path) -> String {
+    look_tools::shell_quote(&path.to_string_lossy())
+}
+
+/// `cmd` runs what `PATHEXT` covers, and `.ps1` is not on that list: a script
+/// there needs PowerShell named in front of it or the step reads as a missing
+/// command.
+#[cfg(windows)]
+fn executable_command(path: &Path) -> String {
+    let quoted = look_tools::cmd_quote(&path.to_string_lossy());
+    let powershell = path
+        .extension()
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("ps1"));
+    if powershell {
+        format!("powershell -NoProfile -ExecutionPolicy Bypass -File {quoted}")
+    } else {
+        quoted
+    }
 }
 
 #[cfg(unix)]
@@ -265,6 +289,36 @@ mod tests {
         assert_eq!(loaded.blocks.len(), 1);
         assert_eq!(loaded.blocks[0].id, "hosts");
         assert_eq!(loaded.blocks[0].producer.key(), KEY_RUN);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn an_executable_needs_no_declaration() {
+        let tmp = TempDir::new("executable");
+        tmp.write_executable("hosts.cmd", "@echo web1\n");
+        tmp.write_executable("repos.ps1", "Write-Output look\n");
+
+        let loaded = load_dir(&tmp.0);
+        let ids: Vec<&str> = loaded.blocks.iter().map(|b| b.id.as_str()).collect();
+        assert_eq!(ids, ["hosts", "repos"]);
+        assert!(loaded.blocks.iter().all(|b| b.producer.key() == KEY_RUN));
+
+        // The path is quoted for `cmd`, and a `.ps1` names the interpreter that
+        // can actually run it: `PATHEXT` does not cover one.
+        let command = |id: &str| match &loaded.blocks.iter().find(|b| b.id == id).unwrap().producer
+        {
+            crate::def::Producer::Run { command, .. } => command.clone(),
+            other => panic!("{other:?}"),
+        };
+        assert_eq!(
+            command("hosts"),
+            format!("\"{}\"", tmp.0.join("hosts.cmd").display())
+        );
+        assert!(
+            command("repos").starts_with("powershell -NoProfile -ExecutionPolicy Bypass -File \""),
+            "{}",
+            command("repos")
+        );
     }
 
     #[test]

--- a/core/sources/src/run.rs
+++ b/core/sources/src/run.rs
@@ -9,16 +9,21 @@
 //! Steps are detached and not waited on: the launcher window closes immediately
 //! after Enter, and an app it launched must outlive it.
 //!
-//! A step is POSIX shell text down to its punctuation - `&&`, `>`, and the
-//! single quotes `expand` wraps every placeholder in. A `$SHELL` reading
-//! another language is passed over for `/bin/sh`; Windows, having none, refuses
-//! the step rather than hand `cmd` arguments it would mangle.
+//! A step is shell text down to its punctuation - `&&`, `>`, and the quotes
+//! `expand` wraps every placeholder in. Which shell reads it is the platform's
+//! answer: a POSIX one on Unix, where a `$SHELL` speaking another language is
+//! passed over for `/bin/sh`, and `cmd` on Windows, where `COMSPEC` names it.
+//! Quoting follows the same split, so a placeholder is inert in the shell that
+//! will actually read it.
 
 use std::io::Read;
 use std::process::{Command, Stdio};
 
 use serde::Deserialize;
 
+#[cfg(windows)]
+use look_tools::cmd_quote as quote;
+#[cfg(not(windows))]
 use look_tools::shell_quote as quote;
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
@@ -36,10 +41,25 @@ const POSIX_SHELLS: [&str; 9] = [
     "sh", "bash", "dash", "ash", "zsh", "ksh", "ksh93", "mksh", "yash",
 ];
 
+/// What `COMSPEC` is expected to name, and what is used when it names anything
+/// else: the shell whose quoting `expand` writes for.
+#[cfg(windows)]
+const COMMAND_SHELL: &str = "cmd.exe";
+
+/// No console for a step the launcher starts. A `do` block opening an app must
+/// not flash a black window, and a captured command has nothing to show.
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+/// Its own group, so the launcher exiting never signals what it started. The
+/// Windows half of `setsid`.
+#[cfg(windows)]
+const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+
 /// Said instead of running anything, so the step reads as unsupported rather
 /// than as a missing program.
-#[cfg(not(unix))]
-const NO_POSIX_SHELL: &str = "steps are POSIX shell commands, which this platform has no shell for";
+#[cfg(not(any(unix, windows)))]
+const NO_SHELL: &str = "steps are shell commands, which this platform has no shell for";
 
 /// How often a captured command is checked for having finished. Short enough
 /// that a fast command is not held up, long enough not to spin.
@@ -266,9 +286,45 @@ fn shell_command(step: &str) -> Result<Command, String> {
     Ok(command)
 }
 
-#[cfg(not(unix))]
+/// `COMSPEC` when it names `cmd`, which is the only thing it names in practice,
+/// and `cmd.exe` off `PATH` otherwise: a step is written in `cmd`'s language and
+/// quoted for it, so another interpreter would read it wrong rather than better.
+#[cfg(windows)]
+fn command_shell() -> String {
+    let configured = std::env::var("COMSPEC").unwrap_or_default();
+    let names_cmd = std::path::Path::new(&configured)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .is_some_and(|stem| stem.eq_ignore_ascii_case("cmd"));
+    if names_cmd {
+        configured
+    } else {
+        COMMAND_SHELL.to_string()
+    }
+}
+
+/// The one place a step becomes a process on Windows: `cmd /D /S /C "<step>"`.
+///
+/// `/D` skips the AutoRun command the registry can hold, which a launcher must
+/// not inherit into every step. `/S` makes the quoting rule the simple one -
+/// strip the outer pair, take the rest verbatim - which is what lets a step keep
+/// the quotes `expand` put around its placeholders.
+#[cfg(windows)]
+fn shell_command(step: &str) -> Result<Command, String> {
+    use std::os::windows::process::CommandExt;
+
+    let mut command = Command::new(command_shell());
+    // `raw_arg`, never `arg`: std escapes for the MSVCRT argv rules, which `cmd`
+    // does not read, so a step carrying a quote would arrive mangled.
+    command
+        .raw_arg(format!("/D /S /C \"{step}\""))
+        .creation_flags(CREATE_NO_WINDOW);
+    Ok(command)
+}
+
+#[cfg(not(any(unix, windows)))]
 fn shell_command(_step: &str) -> Result<Command, String> {
-    Err(NO_POSIX_SHELL.to_string())
+    Err(NO_SHELL.to_string())
 }
 
 /// Names the shell that could not start: "no such file or directory" alone
@@ -322,7 +378,11 @@ pub fn capture(
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .current_dir(cwd.filter(|dir| !dir.is_empty()).unwrap_or("/"));
+        .current_dir(
+            cwd.filter(|dir| !dir.is_empty())
+                .map(str::to_string)
+                .unwrap_or_else(root_dir),
+        );
     let mut spawned = shell.spawn().map_err(|err| spawn_failure(&shell, err))?;
 
     // Both pipes are drained on their own threads for the whole run. Polling
@@ -362,6 +422,21 @@ pub fn capture(
         });
     }
     Ok(out)
+}
+
+/// Where a captured command runs when its block named no `cwd`: a directory
+/// that is certain to exist, since the launcher's own may have been deleted.
+#[cfg(not(windows))]
+fn root_dir() -> String {
+    "/".to_string()
+}
+
+/// `\` alone is the current drive's root, which is not where the launcher was
+/// started from. `SystemDrive` names the one that is always mounted.
+#[cfg(windows)]
+fn root_dir() -> String {
+    let drive = std::env::var("SystemDrive").unwrap_or_else(|_| "C:".to_string());
+    format!("{drive}\\")
 }
 
 /// Reads a pipe to its end on its own thread, keeping at most `max_bytes`.
@@ -425,7 +500,16 @@ fn libc_setsid() {
     }
 }
 
-#[cfg(not(unix))]
+/// Same intent as the Unix `setsid`, plus the console suppression `cmd` needs:
+/// `creation_flags` replaces rather than adds, so both flags are set here.
+#[cfg(windows)]
+fn detach(command: &mut Command) {
+    use std::os::windows::process::CommandExt;
+
+    command.creation_flags(CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP);
+}
+
+#[cfg(not(any(unix, windows)))]
 fn detach(_command: &mut Command) {}
 
 #[cfg(test)]
@@ -440,6 +524,13 @@ mod tests {
             query: "loo".into(),
             ..Default::default()
         }
+    }
+
+    /// The platform's quoting, so a test says which placeholder was quoted
+    /// rather than repeating one shell's spelling of it. The spellings
+    /// themselves are asserted by `look_tools`.
+    fn q(value: &str) -> String {
+        quote(value)
     }
 
     fn drilled(parents: &[(&str, &str)]) -> RowContext {
@@ -491,14 +582,19 @@ mod tests {
         let row = drilled(&[("animate", "/dev/animate"), ("prod", "")]);
         assert_eq!(
             expand("npm --prefix {parent.path} run {id}", &row),
-            "npm --prefix '/dev/animate' run 'build'"
+            format!("npm --prefix {} run {}", q("/dev/animate"), q("build"))
         );
         assert_eq!(
             expand(
                 "k --context {parent.parent.id} -n {parent.id} logs {id}",
                 &row
             ),
-            "k --context 'prod' -n 'animate' logs 'build'"
+            format!(
+                "k --context {} -n {} logs {}",
+                q("prod"),
+                q("animate"),
+                q("build")
+            )
         );
     }
 
@@ -510,14 +606,22 @@ mod tests {
                 "k --context {parent.parent.id} -n {parent.id} logs {id}",
                 &row
             ),
-            "k --context '' -n 'animate' logs 'build'"
+            format!(
+                "k --context {} -n {} logs {}",
+                q(""),
+                q("animate"),
+                q("build")
+            )
         );
     }
 
     #[test]
     fn no_depth_is_deep_enough_to_leave_a_placeholder_behind() {
         let deep = "x {parent.parent.parent.parent.parent.parent.parent.parent.parent.id}";
-        assert_eq!(expand(deep, &drilled(&[("one", "/one")])), "x ''");
+        assert_eq!(
+            expand(deep, &drilled(&[("one", "/one")])),
+            format!("x {}", q(""))
+        );
     }
 
     #[test]
@@ -525,13 +629,16 @@ mod tests {
         // A literal `{parent.path}` reaching the shell would be worse: the
         // command would run against a directory named after the placeholder.
         let row = drilled(&[]);
-        assert_eq!(expand("ls {parent.path}", &row), "ls ''");
+        assert_eq!(expand("ls {parent.path}", &row), format!("ls {}", q("")));
     }
 
     #[test]
     fn an_ancestor_placeholder_is_quoted_for_a_shell_and_raw_for_a_path() {
         let row = drilled(&[("my project", "/dev/my project")]);
-        assert_eq!(expand("cd {parent.path}", &row), "cd '/dev/my project'");
+        assert_eq!(
+            expand("cd {parent.path}", &row),
+            format!("cd {}", q("/dev/my project"))
+        );
         assert_eq!(
             expand_path("{parent.path}/src", &row),
             "/dev/my project/src"
@@ -541,14 +648,17 @@ mod tests {
     #[test]
     fn placeholders_expand_to_the_selected_row() {
         let expanded = expand("nvim {path} # {title} {query}", &row("/tmp/look"));
-        assert_eq!(expanded, "nvim '/tmp/look' # 'look' 'loo'");
+        assert_eq!(
+            expanded,
+            format!("nvim {} # {} {}", q("/tmp/look"), q("look"), q("loo"))
+        );
     }
 
     #[test]
     fn a_path_with_spaces_stays_one_argument() {
         assert_eq!(
             expand("code {path}", &row("/tmp/my project")),
-            "code '/tmp/my project'"
+            format!("code {}", q("/tmp/my project"))
         );
     }
 
@@ -558,14 +668,31 @@ mod tests {
         // difference between quoting and a deleted home directory.
         let mut hostile = row("");
         hostile.title = "; rm -rf ~".into();
-        assert_eq!(expand("echo {title}", &hostile), "echo '; rm -rf ~'");
+        assert_eq!(
+            expand("echo {title}", &hostile),
+            format!("echo {}", q("; rm -rf ~"))
+        );
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn an_embedded_quote_survives_intact() {
         let mut tricky = row("");
         tricky.title = "it's".into();
         assert_eq!(expand("echo {title}", &tricky), "echo 'it'\\''s'");
+    }
+
+    /// The quote `cmd` cares about is the double one, and a row carrying it must
+    /// not be able to close the argument it sits in.
+    #[cfg(windows)]
+    #[test]
+    fn an_embedded_quote_survives_intact() {
+        let mut tricky = row("");
+        tricky.title = "say \"hi\" & whoami".into();
+        assert_eq!(
+            expand("echo {title}", &tricky),
+            "echo \"say \"\"hi\"\" & whoami\""
+        );
     }
 
     #[test]
@@ -574,13 +701,13 @@ mod tests {
         std::fs::create_dir_all(&dir).expect("probe dir");
         let dir_text = dir.to_str().expect("utf8 path");
 
-        assert_eq!(expand("{dir}", &row(dir_text)), format!("'{dir_text}'"));
+        assert_eq!(expand("{dir}", &row(dir_text)), q(dir_text));
 
         let file = dir.join("probe.txt");
         std::fs::write(&file, "x").expect("probe file");
         assert_eq!(
             expand("{dir}", &row(file.to_str().unwrap())),
-            format!("'{dir_text}'"),
+            q(dir_text),
             "a file row hands its command the folder it lives in"
         );
 
@@ -711,14 +838,99 @@ mod tests {
         }
     }
 
-    /// Off Unix the step is refused by name, not run wrongly.
-    #[cfg(not(unix))]
+    /// Everything below performs a real command through `cmd`.
+    #[cfg(windows)]
+    mod cmd {
+        use super::*;
+
+        #[test]
+        fn comspec_is_used_only_when_it_names_cmd() {
+            // Steps are written in `cmd`'s language and quoted for it, so an
+            // interpreter that reads them differently is not an improvement.
+            let shell = command_shell();
+            assert!(
+                std::path::Path::new(&shell)
+                    .file_stem()
+                    .is_some_and(|stem| stem.eq_ignore_ascii_case("cmd")),
+                "{shell}"
+            );
+        }
+
+        #[test]
+        fn capture_returns_what_the_command_printed() {
+            let out = capture("echo a", None, Duration::from_secs(5), 1024).unwrap();
+            assert_eq!(out.trim_end(), "a");
+        }
+
+        #[test]
+        fn a_command_that_fails_reports_its_first_stderr_line() {
+            let err = capture(
+                "echo boom 1>&2 & exit /b 1",
+                None,
+                Duration::from_secs(5),
+                1024,
+            )
+            .unwrap_err();
+            assert_eq!(err, "boom");
+        }
+
+        #[test]
+        fn a_hung_command_is_killed_rather_than_waited_on() {
+            let err = capture(
+                "ping -n 30 127.0.0.1 >nul",
+                None,
+                Duration::from_millis(150),
+                1024,
+            )
+            .unwrap_err();
+            assert!(err.contains("timed out"), "{err}");
+        }
+
+        #[test]
+        fn a_quoted_placeholder_is_text_and_not_a_second_command() {
+            // Rows come from directory listings and command output, so this is
+            // the difference between quoting and running what a row is named.
+            let mut hostile = row("");
+            hostile.title = "a & echo pwned".into();
+            let out = capture(
+                &expand("echo {title}", &hostile),
+                None,
+                Duration::from_secs(5),
+                1024,
+            )
+            .unwrap();
+            assert_eq!(out.trim_end(), "\"a & echo pwned\"");
+        }
+
+        #[test]
+        fn a_step_runs_through_a_shell_so_shell_syntax_works() {
+            let path = std::env::temp_dir().join(format!("look-run-{}", std::process::id()));
+            let _ = std::fs::remove_file(&path);
+
+            let outcomes = perform(&[format!("echo hi> \"{}\"", path.display())], None);
+            assert!(outcomes[0].error.is_none(), "{:?}", outcomes[0].error);
+
+            let deadline = Instant::now() + Duration::from_secs(10);
+            while !path.exists() && Instant::now() < deadline {
+                std::thread::sleep(POLL_INTERVAL);
+            }
+            assert!(
+                path.exists(),
+                "redirection is shell syntax, so it needs a shell"
+            );
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+
+    /// Where there is no shell at all the step is refused by name, not run
+    /// wrongly.
+    #[cfg(not(any(unix, windows)))]
     #[test]
-    fn a_step_without_a_posix_shell_is_refused_by_name() {
+    fn a_step_without_a_shell_is_refused_by_name() {
         let outcomes = perform(&["true".to_string()], None);
-        assert_eq!(outcomes[0].error.as_deref(), Some(NO_POSIX_SHELL));
+        assert_eq!(outcomes[0].error.as_deref(), Some(NO_SHELL));
 
         let err = capture("true", None, Duration::from_secs(5), 1024).unwrap_err();
-        assert_eq!(err, NO_POSIX_SHELL);
+        assert_eq!(err, NO_SHELL);
     }
 }

--- a/core/sources/src/run.rs
+++ b/core/sources/src/run.rs
@@ -46,6 +46,16 @@ const POSIX_SHELLS: [&str; 9] = [
 #[cfg(windows)]
 const COMMAND_SHELL: &str = "cmd.exe";
 
+/// Where the shell lives, relative to `SystemRoot`. Joined rather than left to
+/// a `PATH` search: a `cmd.exe` dropped in a writable directory earlier on
+/// `PATH` would win one, and every step would then go through it.
+#[cfg(windows)]
+const SYSTEM_SHELL_DIR: &str = "System32";
+
+/// Used when `SystemRoot` is unset, which a stripped environment can be.
+#[cfg(windows)]
+const SYSTEM_ROOT_FALLBACK: &str = r"C:\Windows";
+
 /// No console for a step the launcher starts. A `do` block opening an app must
 /// not flash a black window, and a captured command has nothing to show.
 #[cfg(windows)]
@@ -286,21 +296,34 @@ fn shell_command(step: &str) -> Result<Command, String> {
     Ok(command)
 }
 
-/// `COMSPEC` when it names `cmd`, which is the only thing it names in practice,
-/// and `cmd.exe` off `PATH` otherwise: a step is written in `cmd`'s language and
-/// quoted for it, so another interpreter would read it wrong rather than better.
+/// `COMSPEC` when it names `cmd` by absolute path, which is the only thing it
+/// names in practice, and the copy under `SystemRoot` otherwise: a step is
+/// written in `cmd`'s language and quoted for it, so another interpreter would
+/// read it wrong rather than better.
 #[cfg(windows)]
-fn command_shell() -> String {
-    let configured = std::env::var("COMSPEC").unwrap_or_default();
-    let names_cmd = std::path::Path::new(&configured)
-        .file_stem()
-        .and_then(|stem| stem.to_str())
-        .is_some_and(|stem| stem.eq_ignore_ascii_case("cmd"));
+fn command_shell() -> std::path::PathBuf {
+    let configured = std::path::PathBuf::from(std::env::var_os("COMSPEC").unwrap_or_default());
+    let names_cmd = configured.is_absolute()
+        && configured
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .is_some_and(|stem| stem.eq_ignore_ascii_case("cmd"));
     if names_cmd {
         configured
     } else {
-        COMMAND_SHELL.to_string()
+        system_shell()
     }
+}
+
+/// `%SystemRoot%\System32\cmd.exe`, resolved rather than searched for.
+#[cfg(windows)]
+fn system_shell() -> std::path::PathBuf {
+    let root = std::env::var_os("SystemRoot")
+        .filter(|root| !root.is_empty())
+        .unwrap_or_else(|| SYSTEM_ROOT_FALLBACK.into());
+    std::path::Path::new(&root)
+        .join(SYSTEM_SHELL_DIR)
+        .join(COMMAND_SHELL)
 }
 
 /// The one place a step becomes a process on Windows: `cmd /D /S /C "<step>"`.
@@ -849,11 +872,15 @@ mod tests {
             // interpreter that reads them differently is not an improvement.
             let shell = command_shell();
             assert!(
-                std::path::Path::new(&shell)
+                shell
                     .file_stem()
                     .is_some_and(|stem| stem.eq_ignore_ascii_case("cmd")),
-                "{shell}"
+                "{}",
+                shell.display()
             );
+            // Absolute either way: a bare name is a `PATH` search, and a step
+            // must not go through whatever wins one.
+            assert!(shell.is_absolute(), "{}", shell.display());
         }
 
         #[test]

--- a/core/sources/src/tools.rs
+++ b/core/sources/src/tools.rs
@@ -51,6 +51,10 @@ pub fn block_declares(block: Option<&Block>, action: &str) -> bool {
 mod tests {
     use super::*;
     use crate::def::parse_file;
+    #[cfg(windows)]
+    use look_tools::cmd_quote as quote;
+    #[cfg(not(windows))]
+    use look_tools::shell_quote as quote;
 
     fn block(contents: &str) -> Block {
         parse_file(contents)
@@ -87,7 +91,10 @@ mod tests {
 
         match launch {
             Launch::Shell { tool, command } => {
-                assert_eq!(command, "tmux new -As 'main' -c '/dev/look'");
+                assert_eq!(
+                    command,
+                    format!("tmux new -As {} -c {}", quote("main"), quote("/dev/look"))
+                );
                 assert_eq!(tool, "projects", "the block is what decided");
             }
             other => panic!("expected shell, got {other:?}"),

--- a/core/tools/src/lib.rs
+++ b/core/tools/src/lib.rs
@@ -16,7 +16,7 @@ pub use catalog::{
     TTY_TOOLS, Terminal, command_style, entry, surface,
 };
 pub use compose::{Action, Launch, Target, Unavailable, edit, reveal, terminal_here};
-pub use quote::{applescript_quote, shell_quote};
+pub use quote::{applescript_quote, cmd_quote, shell_quote};
 pub use windows_terminals::{WINDOWS_TERMINALS, WindowsTerminal};
 
 pub use resolved::{

--- a/core/tools/src/quote.rs
+++ b/core/tools/src/quote.rs
@@ -1,8 +1,18 @@
-//! Quoting for the two languages a composed action passes through.
+//! Quoting for the languages a composed action passes through.
 
 /// POSIX single-quoting: close, escape, reopen.
 pub fn shell_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+/// `cmd.exe` quoting: wrap in double quotes, double any inside.
+///
+/// Quoted state is what makes `&`, `|`, `>` and `^` inert, and a doubled quote
+/// leaves and re-enters it in one step, so no value can end the argument or
+/// start a command of its own. `%NAME%` still expands: the command line has no
+/// escape for it, and that is the one thing quoting cannot make literal.
+pub fn cmd_quote(value: &str) -> String {
+    format!("\"{}\"", value.replace('"', "\"\""))
 }
 
 pub fn applescript_quote(value: &str) -> String {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-defined source blocks with actions, previews, custom icons, and nested result levels.
  * Added breadcrumbs, level filtering, Escape-key navigation, and shell syntax highlighting.
  * Added source-aware tool actions that preserve row context.
  * Added improved Windows command execution and live URL result placement.
* **Bug Fixes**
  * Prevented stale results from replacing active level results.
  * Added confirmation prompts for destructive actions.
  * Improved icon loading, executable handling, and configuration refresh.
* **Style**
  * Improved preview panels, breadcrumbs, and result icon rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Why

#385 #406 

## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [x] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

My custom declared script returns web browser history

<img width="1085" height="807" alt="image" src="https://github.com/user-attachments/assets/1e32d89f-1366-4c5b-a417-5e261961f760" />


## Checklist

- [x] I have read and agree to the CLA (CLA.md)
- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered
