### PR TITLE
chore: UDS improvement

### DIFF
--- a/apps/macos/LauncherApp/LauncherLogicTests/PreviewTextTests.swift
+++ b/apps/macos/LauncherApp/LauncherLogicTests/PreviewTextTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import LauncherLogic
+
+/// How much of a `preview` command's output the panel renders.
+final class PreviewTextTests: XCTestCase {
+    private func lines(_ count: Int) -> String {
+        (0..<count).map { "line \($0)" }.joined(separator: "\n")
+    }
+
+    func testShortOutputIsPassedThroughUntouched() {
+        // Byte-identical, not merely equal in content: a preview that fits must
+        // not gain or lose a trailing newline on the way to the panel.
+        let text = "one\ntwo\n"
+        let shown = PreviewText.visible(text)
+        XCTAssertEqual(shown.text, text)
+        XCTAssertEqual(shown.dropped, 0)
+    }
+
+    func testOutputExactlyAtTheCapIsNotTruncated() {
+        let shown = PreviewText.visible(lines(PreviewText.visibleLines))
+        XCTAssertEqual(shown.dropped, 0)
+    }
+
+    func testOutputPastTheCapKeepsTheHeadAndCountsTheRest() {
+        // The head is what answers "what is this row"; the count is what keeps
+        // the panel honest about being a preview.
+        let shown = PreviewText.visible(lines(PreviewText.visibleLines + 37))
+        XCTAssertEqual(shown.dropped, 37)
+        XCTAssertEqual(
+            shown.text.split(separator: "\n", omittingEmptySubsequences: false).count,
+            PreviewText.visibleLines)
+        XCTAssertTrue(shown.text.hasPrefix("line 0\n"))
+        XCTAssertTrue(shown.text.hasSuffix("line \(PreviewText.visibleLines - 1)"))
+    }
+
+    func testEmptyOutputIsNotAThousandBlankLines() {
+        let shown = PreviewText.visible("")
+        XCTAssertEqual(shown.text, "")
+        XCTAssertEqual(shown.dropped, 0)
+    }
+
+    /// The case the cap exists for: a command that prints a whole file.
+    func testAVeryLongOutputIsBoundedRatherThanRendered() {
+        let shown = PreviewText.visible(lines(50_000))
+        XCTAssertEqual(shown.dropped, 50_000 - PreviewText.visibleLines)
+        XCTAssertLessThan(shown.text.count, 4_000)
+    }
+}

--- a/apps/macos/LauncherApp/LauncherLogicTests/SourceLevelStackTests.swift
+++ b/apps/macos/LauncherApp/LauncherLogicTests/SourceLevelStackTests.swift
@@ -5,7 +5,8 @@ import XCTest
 /// ancestors, and what Escape puts back.
 final class SourceLevelStackTests: XCTestCase {
     private func row(_ id: String) -> SourceLevelRow {
-        SourceLevelRow(candidateId: "src:child:\(id)", id: id, title: id, subtitle: "", path: nil)
+        SourceLevelRow(
+            candidateId: "src:child:\(id)", id: id, title: id, subtitle: "", path: nil, icon: nil)
     }
 
     private func frame(

--- a/apps/macos/LauncherApp/LauncherLogicTests/URLRowPlacementTests.swift
+++ b/apps/macos/LauncherApp/LauncherLogicTests/URLRowPlacementTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import LauncherLogic
+
+/// Where the "open this URL" row lands among local results.
+final class URLRowPlacementTests: XCTestCase {
+    private func row(_ id: String) -> LauncherResult {
+        LauncherResult(id: id, kind: .app, title: id, subtitle: nil, path: id, score: 0)
+    }
+
+    private func ids(_ results: [LauncherResult]) -> [String] {
+        results.map(\.id)
+    }
+
+    func testAStructuralURLLeads() {
+        // It has a scheme or a path, so it cannot be a file or a search term.
+        let placed = URLRowPlacement.merged(
+            url: row("url"), isBareHost: false, into: [row("a"), row("b")])
+        XCTAssertEqual(ids(placed), ["url", "a", "b"])
+    }
+
+    func testABareHostSitsBelowTheDefaultSlot() {
+        // Enter still opens the best local match (issue #232), but the row is
+        // always one Down away.
+        let placed = URLRowPlacement.merged(
+            url: row("url"), isBareHost: true, into: [row("a"), row("b"), row("c")])
+        XCTAssertEqual(ids(placed), ["a", "url", "b", "c"])
+    }
+
+    /// The regression this replaces: the row sat after EVERY local result, and a
+    /// declared source that matches a bare host on all of its rows (browser
+    /// history carries the host in each subtitle) buried the address the user
+    /// typed under hundreds of pages from that same address.
+    func testABareHostIsReachableWhateverASourceContributes() {
+        let flood = (0..<500).map { row("history-\($0)") }
+        let placed = URLRowPlacement.merged(url: row("url"), isBareHost: true, into: flood)
+        XCTAssertEqual(placed.count, 501)
+        XCTAssertEqual(placed[1].id, "url")
+    }
+
+    func testWithNoLocalResultsTheURLRowLeadsEitherWay() {
+        // Nothing to keep the default slot, so nothing to sit below.
+        for isBareHost in [true, false] {
+            let placed = URLRowPlacement.merged(url: row("url"), isBareHost: isBareHost, into: [])
+            XCTAssertEqual(ids(placed), ["url"], "bare host: \(isBareHost)")
+        }
+    }
+
+    func testASingleLocalResultKeepsTheDefaultSlot() {
+        let placed = URLRowPlacement.merged(url: row("url"), isBareHost: true, into: [row("a")])
+        XCTAssertEqual(ids(placed), ["a", "url"])
+    }
+}

--- a/apps/macos/LauncherApp/Package.swift
+++ b/apps/macos/LauncherApp/Package.swift
@@ -24,6 +24,7 @@ let package = Package(
                 "Support/Launcher/RevealTargetLogic.swift",
                 "Support/Launcher/BridgeErrorMapping.swift",
                 "Support/Launcher/SyntheticRow.swift",
+                "Support/Launcher/PreviewText.swift",
                 "Support/AI/OllamaCodec.swift",
                 "Support/AI/AIRequest.swift",
                 "Support/AI/LocalHostCheck.swift",

--- a/apps/macos/LauncherApp/look-app/Models/LauncherResult.swift
+++ b/apps/macos/LauncherApp/look-app/Models/LauncherResult.swift
@@ -49,6 +49,9 @@ struct LauncherResult: Identifiable {
     /// it was written into. The URL itself rides in the result id.
     var linkKindLabel: String? = nil
     var linkDetail: String? = nil
+    /// What a declared source row asked to be drawn as. Beats its block's icon,
+    /// which is the whole point of it being per row.
+    var icon: String? = nil
 }
 
 extension LauncherResult {

--- a/apps/macos/LauncherApp/look-app/Models/LauncherResult.swift
+++ b/apps/macos/LauncherApp/look-app/Models/LauncherResult.swift
@@ -61,3 +61,22 @@ extension LauncherResult {
         id.hasPrefix(AppConstants.Launcher.SourceBlock.idPrefix)
     }
 }
+
+/// Where the synthesized "open this URL" row sits among the local results.
+enum URLRowPlacement {
+    /// A structural URL (one with a scheme or a path) cannot be a file or a
+    /// search term, so it leads.
+    ///
+    /// A bare host sits one below the best local match (issue #232): Enter still
+    /// opens that match, and the row stays one keypress away however many rows a
+    /// source contributes. It used to sit after every local result, which a
+    /// declared source can flood - browser history carries the host in every
+    /// subtitle, so typing an address buried the row for that address under
+    /// hundreds of pages from it.
+    static func merged(
+        url: LauncherResult, isBareHost: Bool, into ranked: [LauncherResult]
+    ) -> [LauncherResult] {
+        guard isBareHost else { return [url] + ranked }
+        return Array(ranked.prefix(1)) + [url] + ranked.dropFirst()
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Models/SourceLevel.swift
+++ b/apps/macos/LauncherApp/look-app/Models/SourceLevel.swift
@@ -22,6 +22,8 @@ nonisolated struct SourceLevelRow: Decodable, Identifiable {
     /// Resolved against the block name by the core.
     let subtitle: String
     let path: String?
+    /// The row's own icon, when it declared one.
+    let icon: String?
 }
 
 /// The row a tool action acts on: one value because the four always travel

--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -321,7 +321,8 @@ enum AppConstants {
         /// The Cmd+K action menu: everything you can do to the selected row,
         /// in one place, instead of scattered across Cmd+F / Cmd+C / Cmd+P.
         enum ActionMenu {
-            static let openHint = "⌘K actions"
+            static let openHint = "⌘K / ⌃K actions"
+            static let moveHint = "⌘J / ⌘K or ⌃J / ⌃K move  •  ⏎ run"
             static let runHint = "↵"
             static let maxHeight: CGFloat = 240
             static let cornerRadius: CGFloat = 10

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
@@ -334,16 +334,7 @@ final class EngineBridge: @unchecked Sendable {
             if compactPayload.error != nil {
                 return fallbackResults()
             }
-            return compactPayload.results.map { item in
-                LauncherResult(
-                    id: item.id,
-                    kind: LauncherResultKind(rawValue: item.kind) ?? .app,
-                    title: item.title,
-                    subtitle: item.subtitle,
-                    path: item.path,
-                    score: item.score
-                )
-            }
+            return compactPayload.results.map { LauncherResult($0, defaultKind: .app) }
         }
 
         // Compatibility fallback for older JSON payload shape.
@@ -353,16 +344,7 @@ final class EngineBridge: @unchecked Sendable {
             return fallbackResults()
         }
 
-        return fullPayload.results.map { item in
-            LauncherResult(
-                id: item.id,
-                kind: LauncherResultKind(rawValue: item.kind) ?? .app,
-                title: item.title,
-                subtitle: item.subtitle,
-                path: item.path,
-                score: item.score
-            )
-        }
+        return fullPayload.results.map { LauncherResult($0, defaultKind: .app) }
     }
 
     /// The Rust-core routing decision for submitted AI-mode input (see
@@ -542,16 +524,7 @@ final class EngineBridge: @unchecked Sendable {
     }
 
     private nonisolated static func fileRecallOutcome(from payload: SearchPayload) -> FileRecallOutcome {
-        let results = payload.results.map { item in
-            LauncherResult(
-                id: item.id,
-                kind: LauncherResultKind(rawValue: item.kind) ?? .file,
-                title: item.title,
-                subtitle: item.subtitle,
-                path: item.path,
-                score: item.score
-            )
-        }
+        let results = payload.results.map { LauncherResult($0, defaultKind: .file) }
         return FileRecallOutcome(results: results, relaxed: payload.relaxed)
     }
 
@@ -1523,4 +1496,22 @@ private nonisolated struct SearchItem: Decodable {
     let subtitle: String?
     let path: String
     let score: Int
+    let icon: String?
+}
+
+extension LauncherResult {
+    /// One decode of a search payload row. Spelled out per call site, every new
+    /// field the core adds is a three-site edit, and the sites drift: `icon`
+    /// reached search results and missed file recall entirely.
+    fileprivate nonisolated init(_ item: SearchItem, defaultKind: LauncherResultKind) {
+        self.init(
+            id: item.id,
+            kind: LauncherResultKind(rawValue: item.kind) ?? defaultKind,
+            title: item.title,
+            subtitle: item.subtitle,
+            path: item.path,
+            score: item.score,
+            icon: item.icon
+        )
+    }
 }

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
@@ -1401,6 +1401,8 @@ nonisolated struct SourceBlock: Decodable {
     let file: String?
     /// Where a row of this block can go next.
     let then: [SourceBlockTarget]
+    /// Whether a `preview` command will run, known before it does.
+    let hasPreview: Bool
 }
 
 /// One `then` target. `performs` says what the target's own producer decided:

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/KeyboardSelectionMonitor.swift
@@ -21,6 +21,13 @@ final class KeyboardSelectionMonitor {
         Self.logger.notice("\(message, privacy: .public)")
     }
 
+    /// ⌘ and ⌃ are interchangeable for the action-menu J/K pair, so the same
+    /// vim keys work whichever modifier the hand is already on. Exact match, so
+    /// adding Shift or Option still falls through to whatever owns that chord.
+    nonisolated private static func isActionMenuChord(_ flags: NSEvent.ModifierFlags) -> Bool {
+        flags == [.command] || flags == [.control]
+    }
+
     func start(
         onNext: @escaping @MainActor () -> Void,
         onPrevious: @escaping @MainActor () -> Void,
@@ -117,7 +124,7 @@ final class KeyboardSelectionMonitor {
                 return nil
             }
 
-            // Open: the menu owns navigation. Cmd+J / Cmd+K step through it
+            // Open: the menu owns navigation. ⌘J/⌘K and ⌃J/⌃K step through it
             // (vim-style), arrows do the same, Escape closes. Anything else
             // falls through, so typing still reaches the query field.
             if inActionMenu() {
@@ -131,27 +138,27 @@ final class KeyboardSelectionMonitor {
                     return nil
                 }
                 if event.keyCode == KeyCode.arrowDown
-                    || (flags == [.command] && (event.keyCode == KeyCode.j || character == "j"))
+                    || (Self.isActionMenuChord(flags) && (event.keyCode == KeyCode.j || character == "j"))
                 {
                     onActionMenuMove(1)
                     return nil
                 }
                 if event.keyCode == KeyCode.arrowUp
-                    || (flags == [.command] && (event.keyCode == KeyCode.k || character == "k"))
+                    || (Self.isActionMenuChord(flags) && (event.keyCode == KeyCode.k || character == "k"))
                 {
                     onActionMenuMove(-1)
                     return nil
                 }
             }
 
-            // Cmd+K opens it. Cmd+J opens it too and starts on the first row,
-            // so either half of the pair gets you in.
+            // ⌘K opens it, and ⌘J opens it too and starts on the first row, so
+            // either half of the pair gets you in. ⌃J/⌃K do the same.
             //
             // Never on the launchpad: its tiles ARE the actions, each with its
             // own mnemonic, and ⌘K is already Keep Awake there. Opening a menu
             // of the same tiles would both duplicate what is on screen and
             // shadow the key the user meant.
-            if flags == [.command],
+            if Self.isActionMenuChord(flags),
                 !isLaunchpadActive(),
                 event.keyCode == KeyCode.k || event.keyCode == KeyCode.j
                     || event.charactersIgnoringModifiers?.lowercased() == "k"

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/PreviewText.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/PreviewText.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// What the panel renders of a `preview` command's output.
+///
+/// The capture bounds the command at 256KB, which is far more than a view should
+/// hand to a single Text: the panel would spend its layout on output nobody
+/// scrolls to. The head is what answers "what is this row", and saying how much
+/// was left out keeps the panel honest about being a preview.
+enum PreviewText {
+    static let visibleLines = 200
+
+    static func visible(_ text: String) -> (text: String, dropped: Int) {
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+        guard lines.count > visibleLines else { return (text, 0) }
+        return (
+            lines.prefix(visibleLines).joined(separator: "\n"),
+            lines.count - visibleLines
+        )
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/SourceBlockIcons.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/SourceBlockIcons.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ImageIO
 
 /// What each declared block asked to be drawn as, keyed by block id.
 ///
@@ -127,15 +128,52 @@ enum SourceBlockIcons {
         return nil
     }
 
+    /// The biggest an icon is ever drawn is the preview panel's 48pt, so this
+    /// covers it at 2x with headroom.
+    private static let maxIconPixels = 128
+
+    /// Decodes at icon size rather than at whatever size the file happens to be.
+    ///
+    /// The path comes from a user's script, so nothing bounds it: browsers cache
+    /// 192px PWA icons, and a row could name a 4000px photo, which would decode
+    /// to 64MB to be drawn 20pt wide. ImageIO scales during decode, so the
+    /// oversized bitmap never exists. Nil when the file is not an image the
+    /// system can read, which leaves the caller its other fallbacks.
+    private static func downsampled(atPath path: String) -> NSImage? {
+        let url = URL(fileURLWithPath: path) as CFURL
+        guard let source = CGImageSourceCreateWithURL(url, nil) else { return nil }
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxIconPixels,
+        ]
+        guard let thumbnail = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
+        else { return nil }
+        return NSImage(
+            cgImage: thumbnail,
+            size: NSSize(width: thumbnail.width, height: thumbnail.height))
+    }
+
+    /// What a row is drawn as: its own `icon` if it named one, else its block's.
+    ///
+    /// One resolver rather than one per view, because the preview panel and the
+    /// row it describes must not disagree about what the thing looks like.
+    @MainActor
+    static func declaredIcon(for result: LauncherResult) -> NSImage? {
+        declaredIcon(result.icon)
+            ?? declaredIcon(SourceBlockCatalog.icon(forCandidateID: result.id))
+    }
+
     /// The declared `icon`, resolved as an image path, an SF Symbol name, or
-    /// text to draw (an emoji). Nil when the block declared nothing.
+    /// text to draw (an emoji). Nil when nothing was declared.
     static func declaredIcon(_ declared: String?) -> NSImage? {
-        guard let declared, !declared.trimmingCharacters(in: .whitespaces).isEmpty else {
+        guard let declared, !declared.allSatisfy(\.isWhitespace) else {
             return nil
         }
         return RowIconCache.image(key: "blockicon:\(declared)") {
-            if FileManager.default.fileExists(atPath: declared),
-               let image = NSImage(contentsOfFile: declared) {
+            // No `fileExists` first: both decoders answer nil for a path that is
+            // not there, so the check would only repeat their work.
+            if let image = downsampled(atPath: declared) ?? NSImage(contentsOfFile: declared) {
                 return image
             }
             if let symbol = NSImage(systemSymbolName: declared, accessibilityDescription: nil) {

--- a/apps/macos/LauncherApp/look-app/Support/ShortcutCatalog.swift
+++ b/apps/macos/LauncherApp/look-app/Support/ShortcutCatalog.swift
@@ -68,6 +68,7 @@ enum ShortcutCatalog {
             ShortcutEntry("main.openPicked", "Shift+Enter", "Open all picked files/folders at once"),
             ShortcutEntry("main.clearPicks", "Cmd+Shift+P", "Clear all picked items"),
             ShortcutEntry("main.trash", "Cmd+D", "Trash selected file/folder (Trash pin: empty it) or remove the clipboard item"),
+            ShortcutEntry("main.actions", "Cmd+K / Ctrl+K", "Open the action menu for the selected row (Cmd+J/K or Ctrl+J/K move, Enter runs)"),
             ShortcutEntry("main.moveTab", "Tab / Shift+Tab", "Move selection"),
             ShortcutEntry("main.moveArrows", "Up / Down", "Move selection"),
             ShortcutEntry("main.reveal", "Cmd+F", "Reveal selected app/file/folder in Finder"),

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ActionPanelView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ActionPanelView.swift
@@ -24,7 +24,7 @@ struct ActionPanelView: View {
 
             Spacer(minLength: 0)
 
-            Text("⌘J / ⌘K move  •  ⏎ run")
+            Text(AppConstants.Launcher.ActionMenu.moveHint)
                 .font(themeStore.uiFont(size: CGFloat(max(10, themeStore.settings.fontSize - 3)), weight: .regular))
                 .foregroundStyle(themeStore.mutedTextColor())
         }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
@@ -100,9 +100,7 @@ struct LauncherRowView: View {
         // of identical bolts. The bolt is left for rows with nothing on disk,
         // where it says the honest thing: Enter performs steps.
         if result.kind == .action {
-            if let declared = SourceBlockIcons.declaredIcon(
-                SourceBlockCatalog.icon(forCandidateID: result.id)
-            ) {
+            if let declared = SourceBlockIcons.declaredIcon(for: result) {
                 return declared
             }
             if rowIsItsPath {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Levels.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Levels.swift
@@ -25,7 +25,8 @@ extension LauncherView {
                     subtitle: row.subtitle,
                     path: row.path ?? "",
                     // The producer's order, kept: its author knows the domain.
-                    score: level.rows.count - position
+                    score: level.rows.count - position,
+                    icon: row.icon
                 )
             }
     }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -621,7 +621,7 @@ struct LauncherView: View {
 
         // Inside a level the way out is the thing to say.
         if isInLevel {
-            return [enterHint, "⌘K actions", "Esc back"]
+            return [enterHint, AppConstants.Launcher.ActionMenu.openHint, "Esc back"]
         }
 
         if isCommandMode {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -517,15 +517,11 @@ struct LauncherView: View {
         let tail = webSuggestionResults
         let base: [LauncherResult]
         if let urlResult {
-            // Structural matches can't be a file/search, so rank on top. A bare-host
-            // match must never take the default slot from a real local result, so it
-            // sits after the backend results (issue #232).
-            switch urlResult.tier {
-            case .structural:
-                base = [urlResult.result] + ranked + tail
-            case .bareHost:
-                base = ranked + [urlResult.result] + tail
-            }
+            base = URLRowPlacement.merged(
+                url: urlResult.result,
+                isBareHost: urlResult.tier == .bareHost,
+                into: ranked
+            ) + tail
         } else {
             base = ranked + tail
         }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
@@ -516,10 +516,18 @@ struct ResultPreviewView: View {
     private var actionPreview: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(spacing: 12) {
-                Image(systemName: "bolt.fill")
-                    .font(.system(size: 26))
-                    .foregroundStyle(themeStore.accentColor())
-                    .frame(width: 48, height: 48)
+                // The same icon the row is drawn with, else the bolt.
+                if let declared = SourceBlockIcons.declaredIcon(for: result) {
+                    Image(nsImage: declared)
+                        .resizable()
+                        .interpolation(.high)
+                        .frame(width: 48, height: 48)
+                } else {
+                    Image(systemName: "bolt.fill")
+                        .font(.system(size: 26))
+                        .foregroundStyle(themeStore.accentColor())
+                        .frame(width: 48, height: 48)
+                }
 
                 VStack(alignment: .leading, spacing: 4) {
                     Text(result.title)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
@@ -8,6 +8,21 @@ struct ResultPreviewView: View {
         /// because the steps are context for the row, not the subject of the
         /// panel, and one long command should not push the preview off screen.
         static let visibleStepLines = 2
+
+        /// The cap when the steps are the only thing in the panel. Nothing is
+        /// competing for the space, so a long command is worth reading in full;
+        /// past this it scrolls, without bars (see AICodeBlockView).
+        static let expandedStepLines = 14
+
+        /// How long a row must stay selected before its `preview` command runs.
+        ///
+        /// The command is a process, and a cancelled task only stops the panel
+        /// from being filled - the shell it already spawned runs to completion.
+        /// Without this, holding a arrow key through a source forks one process
+        /// per row it passes, each free to burn its whole timeout after the user
+        /// has moved on. Short enough that a row the user actually stops on
+        /// still fills immediately.
+        static let previewDebounceNanoseconds: UInt64 = 150_000_000
     }
 
     @EnvironmentObject private var themeStore: ThemeStore
@@ -50,6 +65,9 @@ struct ResultPreviewView: View {
     /// with the file that declared it.
     @State private var blockSteps: [String] = []
     @State private var blockFile: String?
+    /// Whether this row's block declares a `preview`, known before it runs, so
+    /// the steps can claim the space when nothing is coming below them.
+    @State private var blockHasPreview = false
     /// Output of the block's declared `preview`, for rows that have one.
     @State private var blockPreview: SourcePreview?
 
@@ -570,11 +588,22 @@ struct ResultPreviewView: View {
                             code: blockSteps.joined(separator: "\n"),
                             language: "sh",
                             themeStore: themeStore,
-                            maxVisibleLines: Layout.visibleStepLines
+                            // Two lines when output is coming below, since the
+                            // steps are context for the row rather than its
+                            // subject. With nothing below them they are the
+                            // subject, so they take the room.
+                            maxVisibleLines: blockHasPreview
+                                ? Layout.visibleStepLines : Layout.expandedStepLines
                         )
                     }
                     if let preview = blockPreview {
                         blockPreviewBody(preview)
+                    } else if blockHasPreview {
+                        // Blank space reads as broken, and the command is
+                        // allowed to take seconds.
+                        Text("Running…")
+                            .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular))
+                            .foregroundStyle(themeStore.mutedTextColor())
                     }
                 }
             }
@@ -606,10 +635,18 @@ struct ResultPreviewView: View {
             if Task.isCancelled { return }
             blockSteps = block?.steps ?? []
             blockFile = block?.file
+            blockHasPreview = block?.hasPreview ?? false
 
             // The declared `preview` runs a command, so it is read separately
-            // and only after the cheap details are on screen.
+            // and only after the cheap details are on screen - and only once the
+            // selection settles. `Task.sleep` throws on cancellation, so a row
+            // arrowed past never reaches the spawn at all.
             blockPreview = nil
+            do {
+                try await Task.sleep(nanoseconds: Layout.previewDebounceNanoseconds)
+            } catch {
+                return
+            }
             let row = (id: result.id, title: result.title, path: result.path)
             let preview = await Task.detached(priority: .userInitiated) {
                 EngineBridge.shared.sourcePreview(
@@ -635,11 +672,17 @@ struct ResultPreviewView: View {
                 .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular))
                 .foregroundStyle(themeStore.mutedTextColor())
         } else if !preview.text.isEmpty {
-            Text(preview.text)
+            let shown = PreviewText.visible(preview.text)
+            Text(shown.text)
                 .font(.system(size: CGFloat(themeStore.settings.fontSize - 2), design: .monospaced))
                 .foregroundStyle(themeStore.secondaryTextColor())
                 .textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
+            if shown.dropped > 0 {
+                Text("… \(shown.dropped) more lines")
+                    .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 3), weight: .regular))
+                    .foregroundStyle(themeStore.mutedTextColor())
+            }
         }
     }
 

--- a/bridge/ffi/src/search_api.rs
+++ b/bridge/ffi/src/search_api.rs
@@ -45,6 +45,8 @@ struct FfiCompactLaunchResult<'a> {
     subtitle: Option<&'a str>,
     path: &'a str,
     score: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    icon: Option<&'a str>,
 }
 
 #[derive(serde::Serialize)]
@@ -223,6 +225,7 @@ pub(crate) fn look_search_json_compact_impl(query: *const c_char, limit: u32) ->
             subtitle: candidate.subtitle.as_deref(),
             path: &candidate.path,
             score: *score,
+            icon: candidate.icon.as_deref(),
         })
         .collect();
     let payload = FfiCompactSearchPayload {
@@ -260,6 +263,7 @@ impl<'a> From<&'a LaunchResult> for FfiCompactLaunchResult<'a> {
             subtitle: value.subtitle.as_deref(),
             path: &value.path,
             score: value.score,
+            icon: value.icon.as_deref(),
         }
     }
 }

--- a/bridge/ffi/src/sources_api.rs
+++ b/bridge/ffi/src/sources_api.rs
@@ -40,6 +40,12 @@ struct BlockDetail {
     /// reveal-in-Finder has something to point at.
     file: Option<String>,
     then: Vec<ThenTarget>,
+    /// Whether a `preview` command will run for this row. Answered with the
+    /// cheap details rather than by waiting for the command, so the panel can
+    /// lay itself out before knowing what the output says - or that there will
+    /// be none at all.
+    #[serde(rename = "hasPreview")]
+    has_preview: bool,
 }
 
 /// One row of the block index the shell caches: enough to render a row without
@@ -114,6 +120,7 @@ pub(crate) fn look_source_block_json_impl(
             steps: steps_of(block),
             file: block.source_file.clone(),
             then,
+            has_preview: block.preview.is_some(),
         })
         .ok(),
     )

--- a/bridge/ffi/src/sources_api.rs
+++ b/bridge/ffi/src/sources_api.rs
@@ -12,9 +12,9 @@ use look_indexing::CandidateIdKind;
 use look_sources::{Block, ParentRow, Producer, RowContext, load_dir, sources_dir};
 use serde::Serialize;
 use std::os::raw::c_char;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use crate::state::{cstr_to_string, json_cstring_or_null};
+use crate::state::{cstr_to_string, json_cstring_or_null, mark_index_dirty};
 
 /// Somewhere a row can go from here. `performs` is what the target's own
 /// producer decides: steps to run, or rows to descend into.
@@ -204,6 +204,23 @@ pub(crate) fn look_perform_block_json_impl(
 const DEFAULT_CAPTURE_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_CAPTURE_BYTES: usize = 256 * 1024;
 
+/// The longest a single block may declare. `timeout` is the one limit the
+/// format hands to the author, and it only ever raises the default - a block
+/// asking for "24h" parses fine and would hold the refresh for a day.
+const MAX_BLOCK_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// The longest a whole refresh may spend running commands. Blocks run one after
+/// another, so without this the wait is the SUM of every block's timeout, and
+/// each new source a user declares makes every reload slower.
+const REFRESH_TIME_BUDGET: Duration = Duration::from_secs(60);
+
+/// What a block is actually given: its own `timeout`, else the default, capped.
+fn capture_timeout(declared: Option<Duration>) -> Duration {
+    declared
+        .unwrap_or(DEFAULT_CAPTURE_TIMEOUT)
+        .min(MAX_BLOCK_TIMEOUT)
+}
+
 /// Re-runs every enabled `run` block and stores its rows, so the next index pass
 /// picks them up. Returns `{refreshed, errors}`.
 ///
@@ -216,6 +233,11 @@ pub(crate) fn look_refresh_run_blocks_json_impl() -> *mut c_char {
 
     let mut refreshed = 0usize;
     let mut errors: Vec<String> = Vec::new();
+    let started_at = Instant::now();
+    let mut skipped: Vec<String> = Vec::new();
+    // Any write to the run cache, not just rows gained: turning a block off
+    // clears its rows, and those have to leave the index too.
+    let mut changed = false;
     for block in load_dir(&sources_dir(&home)).blocks {
         let Producer::Run {
             command,
@@ -236,21 +258,50 @@ pub(crate) fn look_refresh_run_blocks_json_impl() -> *mut c_char {
 
         if !block.enabled {
             look_engine::index::clear_run_rows(&block.id);
+            changed = true;
+            continue;
+        }
+
+        // Out of budget: the blocks left keep the rows they had, and are named
+        // rather than dropped silently - "my source stopped updating" with no
+        // reason given is worse than a slow one.
+        if started_at.elapsed() >= REFRESH_TIME_BUDGET {
+            skipped.push(block.id.clone());
             continue;
         }
 
         let outcome = look_sources::capture(
             command,
             cwd.as_deref(),
-            timeout.unwrap_or(DEFAULT_CAPTURE_TIMEOUT),
+            capture_timeout(*timeout),
             MAX_CAPTURE_BYTES,
         )
         .and_then(|output| look_engine::index::store_run_rows(&block.id, &output, *format));
 
         match outcome {
-            Ok(rows) => refreshed += rows,
+            Ok(rows) => {
+                refreshed += rows;
+                changed = true;
+            }
             Err(message) => errors.push(format!("[{}] {message}", block.id)),
         }
+    }
+
+    // The rows a block just produced ARE an index change, and nothing else will
+    // say so: they land in a cache directory no watcher covers. Without this the
+    // refresh the shell asks for next is declined by the dirty check whenever
+    // lazy indexing is on (the default), and the new rows sit in the cache until
+    // something unrelated dirties the index or the app restarts.
+    if changed {
+        mark_index_dirty();
+    }
+
+    if !skipped.is_empty() {
+        errors.push(format!(
+            "refresh ran out of time after {}s; not refreshed: {}",
+            REFRESH_TIME_BUDGET.as_secs(),
+            skipped.join(", ")
+        ));
     }
 
     json_cstring_or_null(
@@ -276,6 +327,8 @@ struct LevelRow {
     /// Resolved against the block name by the same rule the index uses.
     subtitle: String,
     path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    icon: Option<String>,
 }
 
 #[derive(Serialize, Default)]
@@ -364,7 +417,7 @@ pub(crate) fn look_source_rows_json_impl(
             match look_sources::capture(
                 &command,
                 cwd.as_deref(),
-                timeout.unwrap_or(DEFAULT_CAPTURE_TIMEOUT),
+                capture_timeout(*timeout),
                 MAX_CAPTURE_BYTES,
             )
             .and_then(|output| {
@@ -394,6 +447,7 @@ pub(crate) fn look_source_rows_json_impl(
         .map(|row| LevelRow {
             candidate_id: CandidateIdKind::source_row_candidate_id(&block.id, &ancestors, &row.id),
             subtitle: row.display_subtitle(&block.name).to_string(),
+            icon: row.display_icon(&home),
             id: row.id,
             title: row.title,
             path: row.path.map(|path| {
@@ -559,6 +613,24 @@ fn home_dir() -> Option<PathBuf> {
 mod tests {
     use super::*;
     use std::ffi::{CStr, CString};
+
+    #[test]
+    fn a_block_cannot_hold_a_refresh_longer_than_the_ceiling() {
+        assert_eq!(capture_timeout(None), DEFAULT_CAPTURE_TIMEOUT);
+        // Under the ceiling is honoured, including asking for less than default.
+        assert_eq!(
+            capture_timeout(Some(Duration::from_secs(1))),
+            Duration::from_secs(1)
+        );
+        assert_eq!(
+            capture_timeout(Some(Duration::from_secs(20))),
+            Duration::from_secs(20)
+        );
+        assert_eq!(
+            capture_timeout(Some(Duration::from_secs(86_400))),
+            MAX_BLOCK_TIMEOUT
+        );
+    }
 
     /// The sources directory is process-wide state, so these run one at a time.
     static GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/bridge/ffi/src/sources_api.rs
+++ b/bridge/ffi/src/sources_api.rs
@@ -221,11 +221,23 @@ const MAX_BLOCK_TIMEOUT: Duration = Duration::from_secs(30);
 /// each new source a user declares makes every reload slower.
 const REFRESH_TIME_BUDGET: Duration = Duration::from_secs(60);
 
+/// Below this a block is skipped rather than handed a sliver, which would come
+/// back as a timeout it did not earn.
+const MIN_BLOCK_SLICE: Duration = Duration::from_secs(1);
+
 /// What a block is actually given: its own `timeout`, else the default, capped.
 fn capture_timeout(declared: Option<Duration>) -> Duration {
     declared
         .unwrap_or(DEFAULT_CAPTURE_TIMEOUT)
         .min(MAX_BLOCK_TIMEOUT)
+}
+
+/// The same, capped by what the refresh has left. `None` means skip it: gating
+/// entry alone, a block starting just under the budget still spent its whole
+/// timeout on top, so 60s could take 90.
+fn block_slice(declared: Option<Duration>, elapsed: Duration) -> Option<Duration> {
+    let remaining = REFRESH_TIME_BUDGET.saturating_sub(elapsed);
+    (remaining >= MIN_BLOCK_SLICE).then(|| capture_timeout(declared).min(remaining))
 }
 
 /// Re-runs every enabled `run` block and stores its rows, so the next index pass
@@ -272,18 +284,13 @@ pub(crate) fn look_refresh_run_blocks_json_impl() -> *mut c_char {
         // Out of budget: the blocks left keep the rows they had, and are named
         // rather than dropped silently - "my source stopped updating" with no
         // reason given is worse than a slow one.
-        if started_at.elapsed() >= REFRESH_TIME_BUDGET {
+        let Some(timeout) = block_slice(*timeout, started_at.elapsed()) else {
             skipped.push(block.id.clone());
             continue;
-        }
+        };
 
-        let outcome = look_sources::capture(
-            command,
-            cwd.as_deref(),
-            capture_timeout(*timeout),
-            MAX_CAPTURE_BYTES,
-        )
-        .and_then(|output| look_engine::index::store_run_rows(&block.id, &output, *format));
+        let outcome = look_sources::capture(command, cwd.as_deref(), timeout, MAX_CAPTURE_BYTES)
+            .and_then(|output| look_engine::index::store_run_rows(&block.id, &output, *format));
 
         match outcome {
             Ok(rows) => {
@@ -636,6 +643,32 @@ mod tests {
         assert_eq!(
             capture_timeout(Some(Duration::from_secs(86_400))),
             MAX_BLOCK_TIMEOUT
+        );
+    }
+
+    #[test]
+    fn a_block_never_spends_more_than_the_refresh_has_left() {
+        let spent = REFRESH_TIME_BUDGET - Duration::from_secs(3);
+        assert_eq!(
+            block_slice(Some(MAX_BLOCK_TIMEOUT), spent),
+            Some(Duration::from_secs(3)),
+            "the remaining budget wins over the block's own ceiling"
+        );
+        assert_eq!(
+            block_slice(Some(Duration::from_secs(20)), Duration::ZERO),
+            Some(Duration::from_secs(20))
+        );
+
+        assert_eq!(block_slice(None, REFRESH_TIME_BUDGET), None);
+        assert_eq!(
+            block_slice(None, REFRESH_TIME_BUDGET + Duration::from_secs(30)),
+            None,
+            "overrunning the budget must not underflow"
+        );
+        assert_eq!(
+            block_slice(None, REFRESH_TIME_BUDGET - MIN_BLOCK_SLICE / 2),
+            None,
+            "a sliver is a skip"
         );
     }
 

--- a/bridge/ffi/src/state.rs
+++ b/bridge/ffi/src/state.rs
@@ -551,6 +551,20 @@ mod tests {
     }
 
     #[test]
+    fn rows_a_source_just_produced_can_ask_for_a_refresh() {
+        let _guard = test_lock();
+
+        clear_index_dirty();
+        assert!(
+            !refresh_allowed_by_dirty_mode(true, is_index_dirty()),
+            "a clean index declines, which is the behaviour being worked around"
+        );
+
+        mark_index_dirty();
+        assert!(refresh_allowed_by_dirty_mode(true, is_index_dirty()));
+    }
+
+    #[test]
     fn refresh_slot_acquire_and_guard_release_are_consistent() {
         let _guard = test_lock();
 

--- a/core/engine/src/index/sources.rs
+++ b/core/engine/src/index/sources.rs
@@ -159,6 +159,10 @@ fn row_candidate(block: &Block, row: &SourceRow, home: &Path) -> Candidate {
         .map(|path| expand_home(path, home).to_string_lossy().into_owned())
         .unwrap_or_default();
     let mut candidate = Candidate::new(&id, CandidateKind::Action, &row.title, &path);
+    // What the row asked for, else nothing: the block's icon is applied by the
+    // shell, which already has it cached and would otherwise repeat it on every
+    // row of the block.
+    candidate.icon = row.display_icon(home).map(String::into_boxed_str);
     // What the row said about itself, else where it came from.
     candidate.subtitle = Some(
         row.subtitle

--- a/core/engine/src/result.rs
+++ b/core/engine/src/result.rs
@@ -11,6 +11,8 @@ pub struct LaunchResult {
     pub path: String,
     pub score: i64,
     pub action: LaunchResultAction,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -64,6 +66,7 @@ impl From<(&Candidate, i64)> for LaunchResult {
             path: candidate.path.to_string(),
             score,
             action,
+            icon: candidate.icon.as_deref().map(str::to_string),
         }
     }
 }

--- a/core/indexing/src/lib.rs
+++ b/core/indexing/src/lib.rs
@@ -406,6 +406,9 @@ pub struct Candidate {
     /// Lets the "recent" view surface freshly downloaded/created files the user
     /// hasn't opened through Look yet. `None` for app/settings candidates.
     pub fs_modified_at_unix_s: Option<i64>,
+    /// What to draw this row as, when it asked for something. Only a declared
+    /// source sets it; everything else takes its icon from the kind or the path.
+    pub icon: Option<Box<str>>,
 }
 
 impl Candidate {
@@ -437,6 +440,7 @@ impl Default for Candidate {
             use_count: 0,
             last_used_at_unix_s: None,
             fs_modified_at_unix_s: None,
+            icon: None,
         }
     }
 }

--- a/core/sources/example.toml
+++ b/core/sources/example.toml
@@ -98,9 +98,9 @@ then    = ["drop-branch"]
 
 
 # -------------------------------------------------------------------- json --
-# Rows as JSON instead of tab-separated lines, for the field lines cannot carry:
-# `path`, which makes a row a real filesystem object (Cmd+E, Cmd+T, Cmd+F, and
-# {path} in the verbs below).
+# Rows as JSON instead of tab-separated lines, for the two fields lines cannot
+# carry: `path`, which makes a row a real filesystem object (Cmd+E, Cmd+T,
+# Cmd+F, and {path} in the verbs below), and `icon`.
 #
 # One array, or one object per line, or pretty-printed objects run together:
 # whichever your tool already prints. `id` is the only required key, a bare
@@ -108,6 +108,16 @@ then    = ["drop-branch"]
 #
 #   [{"id": "look", "title": "Look", "subtitle": "3 uncommitted",
 #     "path": "~/dev/look"}]
+#
+# `icon` takes the same three spellings as a block's, and beats it. The block's
+# icon is right when its rows are alike; declare a row's own when they are not -
+# a favicon per browser-history entry, a status glyph per deploy.
+#
+#   {"id": "https://github.com", "title": "GitHub",
+#    "icon": "~/.look/cache/favicons/github.com.png"}
+#
+# A path that does not exist is drawn as its own text, so write the file before
+# naming it.
 
 [repos]
 name   = "Repos"

--- a/core/sources/src/rows.rs
+++ b/core/sources/src/rows.rs
@@ -10,6 +10,8 @@
 //! text. It costs the author a `jq`, so it stays opt-in.
 
 use std::path::Path;
+#[cfg(test)]
+use std::path::PathBuf;
 
 use serde_json::Value;
 
@@ -273,13 +275,14 @@ mod tests {
         // The shell checks the icon it is handed for existence, so a `~` that
         // survived would be drawn as its own text rather than as the image.
         let home = Path::new("/Users/x");
-        let with_path = parse_line("id").map(|row| SourceRow {
+        let with_path = SourceRow {
             icon: Some("~/.look/cache/favicons/github.com.png".into()),
-            ..row
-        });
+            ..SourceRow::new("id", "title")
+        };
+        // As a path, not as text: `join` separates with `\` on Windows.
         assert_eq!(
-            with_path.unwrap().display_icon(home).as_deref(),
-            Some("/Users/x/.look/cache/favicons/github.com.png")
+            with_path.display_icon(home).map(PathBuf::from),
+            Some(home.join(".look/cache/favicons/github.com.png"))
         );
 
         let glyph = SourceRow {

--- a/core/sources/src/rows.rs
+++ b/core/sources/src/rows.rs
@@ -9,8 +9,11 @@
 //! which is what makes a row a real filesystem object rather than a piece of
 //! text. It costs the author a `jq`, so it stays opt-in.
 
+use std::path::Path;
+
 use serde_json::Value;
 
+use crate::collect::expand_home;
 use crate::def::RowFormat;
 
 /// The id is what actions receive and what usage is recorded against, so a row
@@ -23,6 +26,11 @@ pub struct SourceRow {
     pub subtitle: Option<String>,
     /// Filesystem target, when the row has one. Folder sources always do.
     pub path: Option<String>,
+    /// What to draw this row as, in the same three spellings a block's `icon`
+    /// accepts: emoji, SF Symbol name, or an image path. Per row rather than
+    /// per block, so a producer whose rows are not alike - browser history,
+    /// containers, hosts - can say which is which.
+    pub icon: Option<String>,
 }
 
 impl SourceRow {
@@ -33,12 +41,23 @@ impl SourceRow {
         self.subtitle.as_deref().unwrap_or(block_name)
     }
 
+    /// The row's icon with a leading `~` resolved, for the same reason: a row
+    /// reached by search and the same row reached by drilling in must not look
+    /// different. Only a path can start with `~`, so an emoji or an SF Symbol
+    /// name comes back untouched.
+    pub fn display_icon(&self, home: &Path) -> Option<String> {
+        self.icon
+            .as_deref()
+            .map(|icon| expand_home(icon, home).to_string_lossy().into_owned())
+    }
+
     pub fn new(id: impl Into<String>, title: impl Into<String>) -> Self {
         Self {
             id: id.into(),
             title: title.into(),
             subtitle: None,
             path: None,
+            icon: None,
         }
     }
 }
@@ -72,6 +91,7 @@ fn parse_line(line: &str) -> Option<SourceRow> {
         title: title.unwrap_or(id).to_string(),
         subtitle: subtitle.map(String::from),
         path: None,
+        icon: None,
     })
 }
 
@@ -96,6 +116,7 @@ const KEY_ID: &str = "id";
 const KEY_TITLE: &str = "title";
 const KEY_SUBTITLE: &str = "subtitle";
 const KEY_PATH: &str = "path";
+const KEY_ICON: &str = "icon";
 
 /// Parses rows in whichever encoding the block declared. `Err` means the text
 /// could not be read at all, which the caller reports and, for a `run` block,
@@ -148,6 +169,7 @@ fn parse_value(value: &Value) -> Option<SourceRow> {
         id,
         subtitle: text_field(object.get(KEY_SUBTITLE)),
         path: text_field(object.get(KEY_PATH)),
+        icon: text_field(object.get(KEY_ICON)),
     })
 }
 
@@ -231,6 +253,49 @@ mod tests {
         assert_eq!(row.title, "Look");
         assert_eq!(row.subtitle.as_deref(), Some("3 uncommitted"));
         assert_eq!(row.path.as_deref(), Some("/dev/look"));
+    }
+
+    #[test]
+    fn a_json_row_can_name_its_own_icon() {
+        // The point of per-row icons: one block whose rows are not alike. The
+        // line format cannot carry this, and a block's `icon` is one for all.
+        let (rows, _) = parse_json(
+            "{\"id\":\"https://github.com\",\"icon\":\"/tmp/fav/github.com.png\"}\n{\"id\":\"https://x.com\"}",
+            10,
+        )
+        .unwrap();
+        assert_eq!(rows[0].icon.as_deref(), Some("/tmp/fav/github.com.png"));
+        assert_eq!(rows[1].icon, None, "a row that says nothing gets nothing");
+    }
+
+    #[test]
+    fn an_icon_path_gets_a_home_and_a_glyph_is_left_alone() {
+        // The shell checks the icon it is handed for existence, so a `~` that
+        // survived would be drawn as its own text rather than as the image.
+        let home = Path::new("/Users/x");
+        let with_path = parse_line("id").map(|row| SourceRow {
+            icon: Some("~/.look/cache/favicons/github.com.png".into()),
+            ..row
+        });
+        assert_eq!(
+            with_path.unwrap().display_icon(home).as_deref(),
+            Some("/Users/x/.look/cache/favicons/github.com.png")
+        );
+
+        let glyph = SourceRow {
+            icon: Some("🌐".into()),
+            ..SourceRow::new("id", "title")
+        };
+        assert_eq!(glyph.display_icon(home).as_deref(), Some("🌐"));
+        assert_eq!(SourceRow::new("id", "title").display_icon(home), None);
+    }
+
+    #[test]
+    fn a_line_row_has_no_icon_of_its_own() {
+        // Tabs carry three fields; anything richer is what `format = "json"`
+        // is for. A fourth tab must not be read as one.
+        let row = parse_line("id\ttitle\tsubtitle\t/tmp/fav.png").unwrap();
+        assert_eq!(row.icon, None);
     }
 
     #[test]

--- a/core/storage/src/lib.rs
+++ b/core/storage/src/lib.rs
@@ -238,20 +238,15 @@ impl SqliteStore {
     }
 
     pub fn load_candidates(&self, limit: Option<usize>) -> StorageResult<Vec<Candidate>> {
-        let sql = match limit {
-            Some(_) => {
-                "SELECT id, kind, title, subtitle, path, use_count, last_used_at_unix_s, fs_modified_at_unix_s FROM candidates ORDER BY title ASC LIMIT ?1"
-            }
-            None => {
-                "SELECT id, kind, title, subtitle, path, use_count, last_used_at_unix_s, fs_modified_at_unix_s FROM candidates ORDER BY title ASC"
-            }
-        };
-
-        let mut stmt = self.conn.prepare(sql)?;
-        let mut rows = match limit {
-            Some(max) => stmt.query([max as i64])?,
-            None => stmt.query([])?,
-        };
+        // One statement, not one per branch: the column list has to stay aligned
+        // with the `row.get` indices below, and two copies of it means every new
+        // column is two edits that can silently disagree. SQLite reads a
+        // negative LIMIT as unbounded, which is exactly "no limit".
+        let mut stmt = self.conn.prepare(
+            "SELECT id, kind, title, subtitle, path, use_count, last_used_at_unix_s, fs_modified_at_unix_s, icon
+             FROM candidates ORDER BY title ASC LIMIT ?1",
+        )?;
+        let mut rows = stmt.query([limit.map_or(-1, |max| max as i64)])?;
 
         let mut out = match limit {
             Some(max) => Vec::with_capacity(max.min(MAX_CANDIDATE_PREALLOC)),
@@ -269,6 +264,7 @@ impl SqliteStore {
                 use_count: to_use_count(use_count_raw)?,
                 last_used_at_unix_s: row.get(6)?,
                 fs_modified_at_unix_s: row.get(7)?,
+                icon: row.get::<_, Option<String>>(8)?.map(String::into_boxed_str),
             });
         }
 
@@ -298,20 +294,22 @@ impl SqliteStore {
                 // TODO(indexing-scale Direction A): the full walk + per-reindex
                 // re-normalize are still O(total). Move to event-driven incremental
                 // indexing (watcher paths) to make reindex cost ∝ changed files.
-                "INSERT INTO candidates (id, kind, title, subtitle, path, use_count, last_used_at_unix_s, indexed_at_unix_s, fs_modified_at_unix_s)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+                "INSERT INTO candidates (id, kind, title, subtitle, path, use_count, last_used_at_unix_s, indexed_at_unix_s, fs_modified_at_unix_s, icon)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
                  ON CONFLICT(id) DO UPDATE SET
                    kind = excluded.kind,
                    title = excluded.title,
                    subtitle = excluded.subtitle,
                      path = excluded.path,
                     indexed_at_unix_s = excluded.indexed_at_unix_s,
-                    fs_modified_at_unix_s = excluded.fs_modified_at_unix_s
+                    fs_modified_at_unix_s = excluded.fs_modified_at_unix_s,
+                    icon = excluded.icon
                  WHERE candidates.kind <> excluded.kind
                     OR candidates.title <> excluded.title
                     OR candidates.subtitle IS NOT excluded.subtitle
                     OR candidates.path <> excluded.path
-                    OR candidates.fs_modified_at_unix_s IS NOT excluded.fs_modified_at_unix_s",
+                    OR candidates.fs_modified_at_unix_s IS NOT excluded.fs_modified_at_unix_s
+                    OR candidates.icon IS NOT excluded.icon",
             )?;
 
             for candidate in candidates {
@@ -326,6 +324,7 @@ impl SqliteStore {
                     candidate.last_used_at_unix_s,
                     indexed_at_unix_s,
                     candidate.fs_modified_at_unix_s,
+                    candidate.icon.as_deref(),
                 ])?;
             }
         }
@@ -340,8 +339,8 @@ impl SqliteStore {
 
         {
             let mut stmt = tx.prepare(
-                "INSERT INTO candidates (id, kind, title, subtitle, path, use_count, last_used_at_unix_s, indexed_at_unix_s, fs_modified_at_unix_s)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                "INSERT INTO candidates (id, kind, title, subtitle, path, use_count, last_used_at_unix_s, indexed_at_unix_s, fs_modified_at_unix_s, icon)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
             )?;
 
             for candidate in candidates {
@@ -356,6 +355,7 @@ impl SqliteStore {
                     candidate.last_used_at_unix_s,
                     None::<i64>,
                     candidate.fs_modified_at_unix_s,
+                    candidate.icon.as_deref(),
                 ])?;
             }
         }
@@ -893,6 +893,10 @@ impl SqliteStore {
         // "newly added/changed" signal. Additive column on existing DBs.
         ensure_column_exists(&self.conn, "candidates", "fs_modified_at_unix_s", "INTEGER")?;
 
+        // What a declared source row asked to be drawn as. Only source rows set
+        // it, so it is NULL for almost every row. Additive on existing DBs.
+        ensure_column_exists(&self.conn, "candidates", "icon", "TEXT")?;
+
         Ok(())
     }
 }
@@ -1172,6 +1176,30 @@ mod tests {
         assert_eq!(loaded[0].path.as_ref(), "/Applications/Test.app");
         assert_eq!(loaded[0].use_count, 0);
         assert_eq!(loaded[0].last_used_at_unix_s, None);
+    }
+
+    #[test]
+    fn a_declared_row_icon_survives_the_index() {
+        // Source rows are persisted like every other candidate and re-read from
+        // here on the next launch. An icon that did not round-trip would show
+        // once, at index time, and be gone after a restart.
+        let mut store = SqliteStore::open_in_memory().expect("open sqlite in memory");
+        let mut row = candidate("src:history:https://github.com", "GitHub", "");
+        row.icon = Some("/tmp/fav/github.com.png".into());
+        store.upsert_candidates(&[row]).expect("insert candidate");
+
+        let loaded = store.load_candidates(None).expect("load candidates");
+        assert_eq!(loaded[0].icon.as_deref(), Some("/tmp/fav/github.com.png"));
+
+        // A re-index that changes only the icon must still write: it is in the
+        // change-detection list, so a moved favicon is not stale forever.
+        let mut moved = candidate("src:history:https://github.com", "GitHub", "");
+        moved.icon = Some("/tmp/fav2/github.com.png".into());
+        store
+            .upsert_candidates(&[moved])
+            .expect("update candidate icon");
+        let after = store.load_candidates(None).expect("reload candidates");
+        assert_eq!(after[0].icon.as_deref(), Some("/tmp/fav2/github.com.png"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Improve user declared source on Macos:
  - Add ctrl J K for navigating
  - Add icon field, with sources that return icon (web history), Look now can present per row icon
  - Improve performance, add bottle neck guard
  - Add timeout for previewing part from source
  - Bug fixes
  - Testcases addition

## Why

#385 


## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [x] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)


<img width="917" height="673" alt="image" src="https://github.com/user-attachments/assets/03f51da4-f3aa-421a-8b48-34725fa65e86" />


## Checklist

- [x] I have read and agree to the CLA (CLA.md)
- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for custom icons on individual launcher results, with source-level fallbacks and home-directory path expansion.
  - Added improved result previews with loading states, output indicators, 200-line limits, and omitted-line counts.
  - Added support for opening and navigating action menus with either ⌘K or Ctrl+K.
  - Improved URL placement so bare-host results appear after the top local result.
- **Bug Fixes**
  - Preview execution is now delayed briefly to prevent unnecessary commands while changing selections.
  - Added safeguards to limit long-running source refresh and preview operations.
- **Documentation**
  - Expanded source format guidance for per-row icons and file paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->