### PR TITLE
chore: memory usage improvement (MacOS)

### DIFF
--- a/apps/macos/LauncherApp/look-app/Support/HighlightedTextCache.swift
+++ b/apps/macos/LauncherApp/look-app/Support/HighlightedTextCache.swift
@@ -6,9 +6,16 @@ import Foundation
 nonisolated enum HighlightedTextCache {
     // NSCache is documented thread-safe; mark nonisolated(unsafe) to
     // satisfy Swift 6 strict-concurrency without an actor wrapper.
+    /// Attribute runs (one per highlighted token) dominate the real footprint,
+    /// so cost is estimated per character rather than counted per entry.
+    private static let cacheCountLimit = 32
+    private static let cacheCostLimitBytes = 16 * 1024 * 1024
+    private static let estimatedBytesPerCharacter = 10
+
     nonisolated(unsafe) private static let cache: NSCache<NSString, NSAttributedString> = {
         let c = NSCache<NSString, NSAttributedString>()
-        c.countLimit = 32
+        c.countLimit = cacheCountLimit
+        c.totalCostLimit = cacheCostLimitBytes
         return c
     }()
 
@@ -23,6 +30,16 @@ nonisolated enum HighlightedTextCache {
     }
 
     static func set(_ key: String, _ value: NSAttributedString) {
-        cache.setObject(value, forKey: key as NSString)
+        cache.setObject(
+            value,
+            forKey: key as NSString,
+            cost: value.length * estimatedBytesPerCharacter
+        )
+    }
+
+    /// Drops every cached preview. Called when the launcher hides so an idle
+    /// Look does not keep highlighted file contents resident.
+    static func purge() {
+        cache.removeAllObjects()
     }
 }

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/LauncherActiveTicker.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/LauncherActiveTicker.swift
@@ -1,0 +1,49 @@
+import AppKit
+import Combine
+import Foundation
+
+/// A tick source for launchpad tiles that runs only while Look is active.
+///
+/// The launcher window is ordered out on hide but its SwiftUI tree stays
+/// mounted, so a plain `Timer.publish` keeps waking the main thread while
+/// Look idles in the background. Activation tracks visibility: every hide
+/// path either reactivates the previous app or reacts to `didResignActive`,
+/// so resigning active is the moment the launcher left the screen.
+///
+/// `tick` fires once immediately on each show (so a clock repaints with the
+/// current time instead of the time it froze at on hide), then every
+/// `interval` while active. Held via `@StateObject` so the timer survives
+/// view rebuilds and dies with the tile.
+final class LauncherActiveTicker: ObservableObject {
+    let tick = PassthroughSubject<Date, Never>()
+
+    private let interval: TimeInterval
+    private var timer: AnyCancellable?
+    private var activationObservers: [AnyCancellable] = []
+
+    init(every interval: TimeInterval) {
+        self.interval = interval
+        let center = NotificationCenter.default
+        activationObservers = [
+            center.publisher(for: NSApplication.didBecomeActiveNotification)
+                .sink { [weak self] _ in self?.start() },
+            center.publisher(for: NSApplication.didResignActiveNotification)
+                .sink { [weak self] _ in self?.stop() },
+        ]
+        if NSApplication.shared.isActive {
+            start()
+        }
+    }
+
+    private func start() {
+        guard timer == nil else { return }
+        tick.send(Date())
+        timer = Timer.publish(every: interval, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] date in self?.tick.send(date) }
+    }
+
+    private func stop() {
+        timer = nil
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/QuickLookPreviewService.swift
+++ b/apps/macos/LauncherApp/look-app/Support/QuickLookPreviewService.swift
@@ -30,9 +30,14 @@ actor QuickLookPreviewService {
         return width * height * bytesPerPixel
     }
 
+    /// Advanced on purge so a render in flight across the await does not
+    /// repopulate the cache after it was emptied.
+    private var purgeGeneration = 0
+
     /// Drops every cached thumbnail. Called when the launcher hides so an
     /// idle Look does not keep megabytes of preview bitmaps resident.
     func purge() {
+        purgeGeneration += 1
         cache.removeAllObjects()
     }
 
@@ -85,13 +90,14 @@ actor QuickLookPreviewService {
             representationTypes: .thumbnail
         )
 
+        let generation = purgeGeneration
         let image: NSImage? = await withCheckedContinuation { continuation in
             QLThumbnailGenerator.shared.generateBestRepresentation(for: request) { rep, _ in
                 continuation.resume(returning: rep?.nsImage)
             }
         }
 
-        if let image {
+        if let image, generation == purgeGeneration {
             cache.setObject(image, forKey: key, cost: Self.estimatedBitmapBytes(image))
         }
         return image

--- a/apps/macos/LauncherApp/look-app/Support/QuickLookPreviewService.swift
+++ b/apps/macos/LauncherApp/look-app/Support/QuickLookPreviewService.swift
@@ -10,11 +10,31 @@ import QuickLookThumbnailing
 actor QuickLookPreviewService {
     static let shared = QuickLookPreviewService()
 
+    /// Decompressed retina thumbnails run several MB each, so the cache is
+    /// bounded by estimated bitmap bytes, not just entry count.
+    private static let cacheCountLimit = 64
+    private static let cacheCostLimitBytes = 48 * 1024 * 1024
+    private static let bytesPerPixel = 4
+
     private let cache: NSCache<NSString, NSImage> = {
         let c = NSCache<NSString, NSImage>()
-        c.countLimit = 64
+        c.countLimit = cacheCountLimit
+        c.totalCostLimit = cacheCostLimitBytes
         return c
     }()
+
+    private static func estimatedBitmapBytes(_ image: NSImage) -> Int {
+        let rep = image.representations.first
+        let width = rep?.pixelsWide ?? Int(image.size.width)
+        let height = rep?.pixelsHigh ?? Int(image.size.height)
+        return width * height * bytesPerPixel
+    }
+
+    /// Drops every cached thumbnail. Called when the launcher hides so an
+    /// idle Look does not keep megabytes of preview bitmaps resident.
+    func purge() {
+        cache.removeAllObjects()
+    }
 
     // Text/code files: QuickLook renders the *whole* file to produce a
     // thumbnail. Cap aggressively so 5 MB JSON dumps don't stall.
@@ -71,7 +91,9 @@ actor QuickLookPreviewService {
             }
         }
 
-        if let image { cache.setObject(image, forKey: key) }
+        if let image {
+            cache.setObject(image, forKey: key, cost: Self.estimatedBitmapBytes(image))
+        }
         return image
     }
 }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+WindowControl.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+WindowControl.swift
@@ -234,6 +234,12 @@ extension LauncherView {
         window.orderOut(nil)
         hotkeyLog.notice("hide: orderOut wasVisible=\(wasVisible) restore=\(restorePreviousApp)")
 
+        // Preview bitmaps and highlighted text are the largest resident
+        // buffers; drop them while hidden. They rebuild behind the preview
+        // dwell, so reopening never shows the difference.
+        HighlightedTextCache.purge()
+        Task { await QuickLookPreviewService.shared.purge() }
+
         if restorePreviousApp {
             _ = reactivatePreviouslyFocusedAppIfNeeded()
         } else {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LaunchpadLSlotView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LaunchpadLSlotView.swift
@@ -56,11 +56,9 @@ private struct LaunchpadTodoTile: View {
 
     @State private var taskIndex = 0
 
-    private let taskTimer = Timer.publish(
-        every: AppConstants.Launcher.Launchpad.todoTaskRotateSeconds,
-        on: .main,
-        in: .common
-    ).autoconnect()
+    @StateObject private var ticker = LauncherActiveTicker(
+        every: AppConstants.Launcher.Launchpad.todoTaskRotateSeconds
+    )
 
     private var stat: TodoStat { TodoSharedState.shared.todayStat }
     private var openTasks: [String] {
@@ -92,7 +90,7 @@ private struct LaunchpadTodoTile: View {
                 .animation(.easeInOut(duration: 0.35), value: taskIndex)
             }
         }
-        .onReceive(taskTimer) { _ in
+        .onReceive(ticker.tick) { _ in
             guard openTasks.count > 1 else { return }
             taskIndex = (taskIndex + 1) % openTasks.count
         }
@@ -154,11 +152,9 @@ private struct LaunchpadClockTile: View {
     @State private var now = Date()
     @State private var lunar: LunarDate?
 
-    private let tickTimer = Timer.publish(
-        every: AppConstants.Launcher.Launchpad.clockTickSeconds,
-        on: .main,
-        in: .common
-    ).autoconnect()
+    @StateObject private var ticker = LauncherActiveTicker(
+        every: AppConstants.Launcher.Launchpad.clockTickSeconds
+    )
 
     var body: some View {
         LaunchpadSlotCard(
@@ -177,7 +173,7 @@ private struct LaunchpadClockTile: View {
             }
         }
         .onAppear { refreshLunar(for: now) }
-        .onReceive(tickTimer) { tick in
+        .onReceive(ticker.tick) { tick in
             // Recompute only when the calendar day rolls over (the lunar date is
             // stable within a day), or if the first read hasn't landed yet.
             if lunar == nil || !Calendar.current.isDate(tick, inSameDayAs: now) {
@@ -245,11 +241,9 @@ private struct LaunchpadHeaderClock: View {
     @State private var now = Date()
     @State private var lunar: LunarDate?
 
-    private let tickTimer = Timer.publish(
-        every: AppConstants.Launcher.Launchpad.clockTickSeconds,
-        on: .main,
-        in: .common
-    ).autoconnect()
+    @StateObject private var ticker = LauncherActiveTicker(
+        every: AppConstants.Launcher.Launchpad.clockTickSeconds
+    )
 
     var body: some View {
         VStack(alignment: .trailing, spacing: Const.headerClockLineSpacing) {
@@ -268,7 +262,7 @@ private struct LaunchpadHeaderClock: View {
             }
         }
         .onAppear { lunar = LunarToday.resolve(for: now) }
-        .onReceive(tickTimer) { tick in
+        .onReceive(ticker.tick) { tick in
             if lunar == nil || !Calendar.current.isDate(tick, inSameDayAs: now) {
                 lunar = LunarToday.resolve(for: tick)
             }

--- a/bridge/ffi/src/state.rs
+++ b/bridge/ffi/src/state.rs
@@ -16,7 +16,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::sync::{Mutex, OnceLock, RwLock};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 static ENGINE_CACHE: OnceLock<RwLock<QueryEngine>> = OnceLock::new();
 static JSON_ALLOCS: OnceLock<Mutex<HashMap<usize, CString>>> = OnceLock::new();
@@ -25,7 +25,16 @@ static INDEX_WATCHER_BOOTSTRAP_STARTED: OnceLock<()> = OnceLock::new();
 static INDEX_REFRESH_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
 static INDEX_CHANGE_VERSION: AtomicU64 = AtomicU64::new(0);
 static INDEX_CLEARED_VERSION: AtomicU64 = AtomicU64::new(0);
-static INDEX_WATCHER_CONTROL: OnceLock<Mutex<Option<mpsc::Sender<()>>>> = OnceLock::new();
+static INDEX_WATCHER_CONTROL: OnceLock<Mutex<Option<mpsc::Sender<WatcherMessage>>>> =
+    OnceLock::new();
+
+/// Filesystem events and the stop sentinel share one channel so the watcher
+/// thread blocks on `recv` instead of polling a separate stop channel on a
+/// timeout, which woke it every second for the lifetime of the process.
+enum WatcherMessage {
+    Event(notify::Result<Event>),
+    Stop,
+}
 
 /// Scratch database the tests point at, in place of writing `LOOK_DB_PATH`.
 /// The suite shares one process and engine threads resolve the path while other
@@ -189,20 +198,19 @@ pub(crate) fn restart_index_watchers() {
         return;
     }
 
-    let (stop_tx, stop_rx) = mpsc::channel::<()>();
+    let (event_tx, event_rx) = mpsc::channel::<WatcherMessage>();
     let control = INDEX_WATCHER_CONTROL.get_or_init(|| Mutex::new(None));
     {
         let mut guard = control
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        *guard = Some(stop_tx);
+        *guard = Some(event_tx.clone());
     }
 
     thread::spawn(move || {
-        let (event_tx, event_rx) = mpsc::channel::<notify::Result<Event>>();
         let mut watcher = match RecommendedWatcher::new(
             move |result| {
-                let _ = event_tx.send(result);
+                let _ = event_tx.send(WatcherMessage::Event(result));
             },
             notify::Config::default(),
         ) {
@@ -234,21 +242,17 @@ pub(crate) fn restart_index_watchers() {
         log_info(&format!("index watcher active roots={watched_count}"));
 
         loop {
-            if stop_rx.try_recv().is_ok() {
-                break;
-            }
-
-            match event_rx.recv_timeout(Duration::from_secs(1)) {
-                Ok(Ok(event)) => {
+            match event_rx.recv() {
+                Ok(WatcherMessage::Stop) => break,
+                Ok(WatcherMessage::Event(Ok(event))) => {
                     if should_mark_dirty_from_event(&event) {
                         mark_index_dirty();
                     }
                 }
-                Ok(Err(err)) => {
+                Ok(WatcherMessage::Event(Err(err))) => {
                     log_error(&format!("index watcher event error={err}"));
                 }
-                Err(mpsc::RecvTimeoutError::Timeout) => {}
-                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                Err(_) => {
                     log_error("index watcher channel disconnected");
                     break;
                 }
@@ -431,7 +435,7 @@ fn stop_index_watchers() {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         if let Some(tx) = guard.take() {
-            let _ = tx.send(());
+            let _ = tx.send(WatcherMessage::Stop);
         }
     }
 }


### PR DESCRIPTION
## Summary

- Cap the QuickLook thumbnail cache (48 MB) and highlighted-text cache (16 MB) by estimated bytes, not just entry count; worst case before was hundreds of MB.
- Purge both when the launcher hides. Previews rebuild behind the existing 150 ms dwell, so reopening shows no difference.
- Gate launchpad tile timers on app activation (new `LauncherActiveTicker`): the hidden window kept the SwiftUI tree mounted, so the todo/clock timers woke the main thread ~23 times/min forever.
- Rust index watcher: replace the 1 s stop-channel poll with a `Stop` sentinel on the event channel; zero idle wakes, stop stays instant.

## Testing

- `cargo test` (bridge/ffi): 45 passed. Swift 6 typecheck clean.
- `footprint Look`: 81 MB (peak 99), graphics categories ~5 MB.


## Risks / Notes

- Minor

## Checklist

- [x] I have read and agree to the CLA (CLA.md)
- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS launcher responsiveness by ensuring clocks, tasks, and lunar-date displays update reliably while the app is active.
  * Improved file-index monitoring and shutdown handling for more reliable event processing.
  * Prevented outdated Quick Look previews from repopulating after cache cleanup.

* **Performance**
  * Added memory-aware limits for highlighted text and Quick Look preview caches.
  * Automatically clears preview resources when the launcher window is hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->