### PR TITLE
fix: rowref issue on macos

### DIFF
--- a/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
@@ -993,13 +993,12 @@ final class EngineBridge: @unchecked Sendable {
     /// The user-declared block a row belongs to, with the exact steps Enter will
     /// perform. Reads the sources directory, so call it off the main thread.
     nonisolated func sourceBlock(
-        candidateID: String, rowID: String = "", rowTitle: String = "", rowPath: String = "",
-        ancestorsJSON: String = "[]"
+        candidateID: String, row: RowRef, ancestorsJSON: String = "[]"
     ) -> SourceBlock? {
         let ptr = candidateID.withCString { candidate in
-            rowID.withCString { id in
-                rowTitle.withCString { title in
-                    rowPath.withCString { path in
+            row.id.withCString { id in
+                row.title.withCString { title in
+                    row.path.withCString { path in
                         ancestorsJSON.withCString { ancestors in
                             look_source_block_json(candidate, id, title, path, ancestors)
                         }
@@ -1092,13 +1091,12 @@ final class EngineBridge: @unchecked Sendable {
     /// A block's declared `preview`, run against the selected row. Nil when the
     /// block declares none. Runs a command - call off the main thread.
     nonisolated func sourcePreview(
-        candidateID: String, rowID: String, rowTitle: String, rowPath: String,
-        ancestorsJSON: String = "[]"
+        candidateID: String, row: RowRef, ancestorsJSON: String = "[]"
     ) -> SourcePreview? {
         let ptr = candidateID.withCString { candidate in
-            rowID.withCString { id in
-                rowTitle.withCString { title in
-                    rowPath.withCString { path in
+            row.id.withCString { id in
+                row.title.withCString { title in
+                    row.path.withCString { path in
                         ancestorsJSON.withCString { ancestors in
                             look_source_preview_json(candidate, id, title, path, ancestors)
                         }
@@ -1128,17 +1126,15 @@ final class EngineBridge: @unchecked Sendable {
     /// is a level to descend into rather than something to run.
     nonisolated func performBlock(
         blockID: String,
-        rowID: String = "",
-        rowTitle: String = "",
-        rowPath: String = "",
+        row: RowRef,
         query: String = "",
         ancestorsJSON: String = "[]",
         asTarget: Bool = false
     ) -> PerformBlockOutcome {
         let ptr = blockID.withCString { block in
-            rowID.withCString { id in
-                rowTitle.withCString { title in
-                    rowPath.withCString { path in
+            row.id.withCString { id in
+                row.title.withCString { title in
+                    row.path.withCString { path in
                         query.withCString { query in
                             ancestorsJSON.withCString { ancestors in
                                 look_perform_block_json(
@@ -1391,6 +1387,25 @@ nonisolated struct ToolAction: Decodable {
     /// A block declared this action for its own rows, so `tool` names the
     /// block: "Open in Projects" is not a label worth showing.
     let fromBlock: Bool
+}
+
+/// The row a block's placeholders expand against. One struct because the three
+/// always travel together, mirroring `RowArgs` on the Tauri side - and because
+/// they used to be three defaulted parameters, which let a call site drop the
+/// row and render `shortcuts run ''` while Enter still ran the real command.
+nonisolated struct RowRef {
+    let id: String
+    let title: String
+    let path: String
+
+    /// The selected row as the engine takes it. `id` is the candidate id: core
+    /// strips the `src:<block>:` namespace, so a block asking for `{id}` gets
+    /// the row's own id rather than the whole thing.
+    init(_ result: LauncherResult) {
+        id = result.id
+        title = result.title
+        path = result.path
+    }
 }
 
 nonisolated struct SourceBlock: Decodable {

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/SourceBlockIcons.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/SourceBlockIcons.swift
@@ -44,11 +44,7 @@ enum SourceBlockCatalog {
         Task {
             let targets = await Task.detached(priority: .userInitiated) {
                 EngineBridge.shared.sourceBlock(
-                    candidateID: result.id,
-                    rowID: result.id,
-                    rowTitle: result.title,
-                    rowPath: result.path
-                )?.then ?? []
+                    candidateID: result.id, row: RowRef(result))?.then ?? []
             }.value
             await MainActor.run {
                 targetsByCandidateID[key] = targets

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
@@ -183,9 +183,13 @@ extension LauncherView {
     /// sources directory touches disk, so it happens off the main thread.
     private func revealDeclaringFile(for selected: LauncherResult) {
         let candidateID = selected.id
+        // Only `file` is read here, which no placeholder touches, but the row
+        // travels anyway: a call that can omit it is how the panel came to show
+        // `shortcuts run ''`.
+        let row = RowRef(selected)
         Task {
             let block = await Task.detached(priority: .userInitiated) {
-                EngineBridge.shared.sourceBlock(candidateID: candidateID)
+                EngineBridge.shared.sourceBlock(candidateID: candidateID, row: row)
             }.value
             await MainActor.run {
                 guard let file = block?.file, FileManager.default.fileExists(atPath: file) else {
@@ -215,20 +219,15 @@ extension LauncherView {
         hideLauncherWindow(restorePreviousApp: false)
 
         let name = selected.title
-        let row = (id: selected.id, title: selected.title, path: selected.path, query: query)
+        let row = RowRef(selected)
+        let typed = query
         // Inside a level the row's ancestors are what `{parent.*}` names, and
         // without them a command would act on nothing.
         let ancestors = selectedRowAncestorsJSON
         Task {
             let outcome = await Task.detached(priority: .userInitiated) {
                 EngineBridge.shared.performBlock(
-                    blockID: blockID,
-                    rowID: row.id,
-                    rowTitle: row.title,
-                    rowPath: row.path,
-                    query: row.query,
-                    ancestorsJSON: ancestors
-                )
+                    blockID: blockID, row: row, query: typed, ancestorsJSON: ancestors)
             }.value
             await MainActor.run {
                 if outcome.opensPath {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+SourceBlocks.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+SourceBlocks.swift
@@ -46,7 +46,8 @@ extension LauncherView {
     func performSourceBlockTarget(blockID: String, title: String) {
         guard let selected = actionableSelectedResult() else { return }
 
-        let row = (id: selected.id, title: selected.title, path: selected.path, query: query)
+        let row = RowRef(selected)
+        let typed = query
         let ancestors = selectedRowAncestorsJSON
         // Claimed before the block runs: the user can hide the launcher or
         // start another target while it does.
@@ -61,14 +62,8 @@ extension LauncherView {
         Task {
             let outcome = await Task.detached(priority: .userInitiated) {
                 EngineBridge.shared.performBlock(
-                    blockID: blockID,
-                    rowID: row.id,
-                    rowTitle: row.title,
-                    rowPath: row.path,
-                    query: row.query,
-                    ancestorsJSON: ancestors,
-                    asTarget: true
-                )
+                    blockID: blockID, row: row, query: typed, ancestorsJSON: ancestors,
+                    asTarget: true)
             }.value
 
             await MainActor.run {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
@@ -626,9 +626,10 @@ struct ResultPreviewView: View {
         .task(id: result.id) {
             let candidateID = result.id
             let ancestors = rowAncestorsJSON
+            let row = RowRef(result)
             let block = await Task.detached(priority: .userInitiated) {
                 EngineBridge.shared.sourceBlock(
-                    candidateID: candidateID, ancestorsJSON: ancestors)
+                    candidateID: candidateID, row: row, ancestorsJSON: ancestors)
             }.value
             // The detached read outlives a cancelled task, so a late answer must
             // not populate the panel of a row the user has already left.
@@ -647,15 +648,9 @@ struct ResultPreviewView: View {
             } catch {
                 return
             }
-            let row = (id: result.id, title: result.title, path: result.path)
             let preview = await Task.detached(priority: .userInitiated) {
                 EngineBridge.shared.sourcePreview(
-                    candidateID: candidateID,
-                    rowID: row.id,
-                    rowTitle: row.title,
-                    rowPath: row.path,
-                    ancestorsJSON: ancestors
-                )
+                    candidateID: candidateID, row: row, ancestorsJSON: ancestors)
             }.value
             if Task.isCancelled { return }
             blockPreview = preview


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined launcher result handling by bundling each result’s identifier, title, and path into a single reference.
  * Updated source block, preview, and execution flows to use the consolidated result data.
  * Preserved existing launcher actions while simplifying how selected results are passed between components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Testing

- `apps/linows`
  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Manual verification completed (if UI/behavior changed)

## Checklist

- [x] I have read and agree to the CLA (CLA.md)
- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


