### PR TITLE
fix: add helper to sync searching surface

### DIFF
--- a/apps/linows/src/css/components/preview.css
+++ b/apps/linows/src/css/components/preview.css
@@ -28,6 +28,10 @@
 
 /* The tile the list gives the same rows (results.css). */
 .preview-icon-declared {
+    width: calc(var(--glyph-box) + 4px);
+    height: calc(var(--glyph-box) + 4px);
+    padding: 2px;
+    box-sizing: border-box;
     background: var(--declared-fill);
     box-shadow: inset 0 0 0 1px var(--declared-ring);
     color: var(--accent-color);

--- a/apps/linows/src/css/components/results.css
+++ b/apps/linows/src/css/components/results.css
@@ -126,6 +126,10 @@
 /* The same tile the preview header gives these rows. Only these: one on every
  * row is what made the column look striped. */
 .result-row-source .result-icon {
+    width: calc(var(--icon-size) + 2px);
+    height: calc(var(--icon-size) + 2px);
+    padding: 1px;
+    box-sizing: border-box;
     border-radius: 6px;
     background: var(--declared-fill);
     box-shadow: inset 0 0 0 1px var(--declared-ring);

--- a/apps/linows/src/css/components/running-apps.css
+++ b/apps/linows/src/css/components/running-apps.css
@@ -37,8 +37,8 @@
 }
 
 .running-app-icon {
-    width: 26px;
-    height: 26px;
+    width: var(--top-row-height);
+    height: var(--top-row-height);
     border-radius: 22%;
     color: var(--font-muted);
     display: flex;

--- a/apps/linows/src/css/components/translate.css
+++ b/apps/linows/src/css/components/translate.css
@@ -1,12 +1,27 @@
 /* Translation panel - replaces the results row in the main-pane stack
  * (translate mode hides both result columns). */
 .translate-panel {
+    --translate-pad-y: 10px;
+    /* Bottom rows bleed out of the card padding onto the pane-footer gutter. */
+    --translate-bleed: calc(var(--row-inset) - var(--content-padding));
     flex: 1;
     display: flex;
     flex-direction: column;
-    padding: 10px 14px;
+    padding: var(--translate-pad-y) var(--content-padding);
     overflow-y: auto;
     min-height: 0;
+}
+
+/* Floating: layout.js parks the hint here, so both closing rows land on the
+ * gutter the two-card grid uses. */
+.floating .translate-panel > .pane-footer,
+.floating .translate-footer {
+    margin-left: var(--translate-bleed);
+    margin-right: var(--translate-bleed);
+}
+
+.floating .translate-panel > .pane-footer {
+    margin-bottom: calc(var(--row-inset) - var(--translate-pad-y));
 }
 
 /* Placeholder (before Enter) */

--- a/apps/linows/src/css/components/translate.css
+++ b/apps/linows/src/css/components/translate.css
@@ -4,6 +4,7 @@
     --translate-pad-y: 10px;
     /* Bottom rows bleed out of the card padding onto the pane-footer gutter. */
     --translate-bleed: calc(var(--row-inset) - var(--content-padding));
+
     flex: 1;
     display: flex;
     flex-direction: column;

--- a/apps/linows/src/css/layout.css
+++ b/apps/linows/src/css/layout.css
@@ -116,6 +116,7 @@ html[data-os="windows"] .launcher-window {
     position: relative;
     flex: 1;
     min-width: 0;
+    min-height: var(--top-row-height);
     display: flex;
     align-items: center;
     gap: var(--search-gap);
@@ -237,11 +238,16 @@ html[data-os="windows"] .launcher-window {
     display: none;
     align-items: center;
     flex-shrink: 0;
-    padding: 6px 10px 2px;
+    padding: 6px var(--row-padding-x) 2px;
 }
 
-.floating-grid .pane-footer {
+/* Floating: both hints on the grid, one card takes both otherwise. */
+.floating .pane-footer {
     display: flex;
+}
+
+.floating:not(.floating-grid) .pane-footer {
+    justify-content: space-between;
 }
 
 #preview-footer {
@@ -517,7 +523,7 @@ html[data-os="windows"] .launcher-window {
 }
 
 .floating .pane-col {
-    padding: 6px;
+    padding: var(--row-inset);
 }
 
 .floating .preview-panel {
@@ -557,7 +563,8 @@ html[data-os="windows"] .launcher-window {
     display: none;
 }
 
-/* Floating grid: hints/copyright live in the card footers instead. */
-.floating-grid #hint-bar {
+/* Floating: hints live in the card footers; bare on the desktop they are
+ * unreadable. */
+.floating #hint-bar {
     display: none;
 }

--- a/apps/linows/src/css/theme.css
+++ b/apps/linows/src/css/theme.css
@@ -79,6 +79,9 @@
     --input-padding-y: 10px;
     /* Shared by the icon, the flex gap and the placeholder overlay. */
     --search-icon-size: 16px;
+    /* Top row content height: field and running-apps icons both measure to it,
+     * so the bar is the same height with the strip on or off. */
+    --top-row-height: 26px;
     --search-gap: 10px;
     /* The label column every preview info row shares. */
     --preview-label-col: 96px;

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -329,6 +329,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
 
         translatePanel.hide();
+        previewPanel.hidden = false;
     }
 
     // Shared "back to the empty home screen" reset, used when leaving

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -581,8 +581,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             setHint(hintMessage, HINT_TRANSLATE);
             return;
         }
-        translatePanel.hide();
-        if (runningApps.isEnabled()) runningApps.refresh();
 
         if (search.isClipboardMode()) {
             setHint(hintMessage, HINT_CLIPBOARD);
@@ -605,8 +603,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             const empty = search.isRecentMode()
                 ? 'recent'
                 : lastAiState !== AiState.idle
-                    ? 'ai-suggestion'
-                    : 'default';
+                  ? 'ai-suggestion'
+                  : 'default';
             results.setEmptyState({ mode: empty });
         }
     });
@@ -718,7 +716,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         // timeout.
         requestAnimationFrame(() =>
             requestAnimationFrame(() => {
-                confirmHide(event.payload).catch(() => { });
+                confirmHide(event.payload).catch(() => {});
             }),
         );
     });

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -40,8 +40,6 @@ import {
     searchKillTargets,
     killProcess,
     getIcon,
-    copyToClipboard,
-    deleteClipboardEntry,
     isDevBuild,
     getConfig,
 } from './ipc.js';

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -317,6 +317,20 @@ document.addEventListener('DOMContentLoaded', async () => {
             }
         },
     });
+    function syncSearchSurface() {
+        const translating = search.isTranslateMode();
+        resultsList.hidden = translating;
+        runningApps.setSuspended(translating);
+
+        if (translating) {
+            previewPanel.hidden = true;
+            if (!translatePanel.isActive()) translatePanel.showPlaceholder();
+            return;
+        }
+
+        translatePanel.hide();
+    }
+
     // Shared "back to the empty home screen" reset, used when leaving
     // settings or command mode.
     function resetHomeQuery() {
@@ -328,6 +342,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         queryInput.value = '';
         search.handleQueryInput('');
         layout.setQuery({ empty: true, translate: false });
+        syncSearchSurface();
         renderMainHint();
         syncControlStrip();
         queryInput.focus();
@@ -560,16 +575,14 @@ document.addEventListener('DOMContentLoaded', async () => {
         const translating = search.isTranslateMode();
         layout.setQuery({ empty: layout.isEmptyQuery(value), translate: translating });
         syncControlStrip();
-        resultsList.hidden = translating;
-        runningApps.setSuspended(translating);
+        syncSearchSurface();
 
         if (translating) {
             setHint(hintMessage, HINT_TRANSLATE);
-            previewPanel.hidden = true;
-            if (!translatePanel.isActive()) translatePanel.showPlaceholder();
             return;
         }
         translatePanel.hide();
+        if (runningApps.isEnabled()) runningApps.refresh();
 
         if (search.isClipboardMode()) {
             setHint(hintMessage, HINT_CLIPBOARD);
@@ -592,8 +605,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             const empty = search.isRecentMode()
                 ? 'recent'
                 : lastAiState !== AiState.idle
-                  ? 'ai-suggestion'
-                  : 'default';
+                    ? 'ai-suggestion'
+                    : 'default';
             results.setEmptyState({ mode: empty });
         }
     });
@@ -705,7 +718,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         // timeout.
         requestAnimationFrame(() =>
             requestAnimationFrame(() => {
-                confirmHide(event.payload).catch(() => {});
+                confirmHide(event.payload).catch(() => { });
             }),
         );
     });

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -849,13 +849,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
 
     function exitCommandMode() {
+        // The surface itself is resetHomeQuery's job; setModal first, or the
+        // reset re-runs the layout still believing command mode is up.
         queryInput.parentElement.style.display = '';
-        resultsList.hidden = false;
-        previewPanel.hidden = false;
-        translatePanel.hide();
         layout.setModal('command', false);
         resetHomeQuery();
-        runningApps.setSuspended(false);
     }
 
     async function executeCommand(cmdId, input, gen) {

--- a/apps/linows/src/js/components/translate.js
+++ b/apps/linows/src/js/components/translate.js
@@ -19,6 +19,13 @@ export function isActive() {
     return active;
 }
 
+// Floating, layout.js parks the hint text here; collapsed otherwise.
+function hintSlot() {
+    const slot = document.createElement('div');
+    slot.className = 'pane-footer';
+    return slot;
+}
+
 export function showPlaceholder() {
     hide();
     active = true;
@@ -32,6 +39,7 @@ export function showPlaceholder() {
         '</div>' +
         '<div class="translate-placeholder-text">Press Enter to translate</div>';
     panel.appendChild(placeholder);
+    panel.appendChild(hintSlot());
     container.appendChild(panel);
     layout.refresh();
 }
@@ -40,6 +48,7 @@ export function hide() {
     active = false;
     const panel = container.querySelector('.translate-panel');
     if (panel) {
+        layout.releaseHints();
         panel.remove();
         layout.refresh();
     }
@@ -51,7 +60,10 @@ export async function perform(text) {
 
     // Remove old panel
     let panel = container.querySelector('.translate-panel');
-    if (panel) panel.remove();
+    if (panel) {
+        layout.releaseHints();
+        panel.remove();
+    }
 
     panel = document.createElement('div');
     panel.className = 'translate-panel pane-tile';
@@ -123,6 +135,7 @@ export async function perform(text) {
         externalLink +
         '</span>';
     panel.appendChild(footer);
+    panel.appendChild(hintSlot());
     layout.refresh();
 
     // Translate all 3 in parallel

--- a/apps/linows/src/js/components/translate.js
+++ b/apps/linows/src/js/components/translate.js
@@ -30,7 +30,7 @@ export function showPlaceholder() {
         '<div class="translate-placeholder-icon">' +
         globeLg +
         '</div>' +
-        '<div class="translate-placeholder-text">Press Enter after finishing input to translate on web</div>';
+        '<div class="translate-placeholder-text">Press Enter to translate</div>';
     panel.appendChild(placeholder);
     container.appendChild(panel);
     layout.refresh();

--- a/apps/linows/src/js/layout.js
+++ b/apps/linows/src/js/layout.js
@@ -40,7 +40,6 @@ let hintMessage = null;
 let copyright = null;
 let leftFooter = null;
 let rightFooter = null;
-let hintsInFooters = false;
 
 export function init() {
     win = document.getElementById('app');
@@ -180,23 +179,40 @@ function apply() {
     win.classList.toggle('bar-free', barFree);
     win.classList.toggle('floating-grid', floatingGrid);
     mainPane.classList.toggle('translating', translateQuery);
-    placeHints(floatingGrid);
+    placeHints(floating, floatingGrid);
     if (floating) updateTileOrigins();
     blur.sync();
 }
 
-// The nodes MOVE between the bottom bar and the card footers (not clone),
-// so there is a single source of hint text either way.
-function placeHints(floatingGrid) {
-    if (!hintBar || floatingGrid === hintsInFooters) return;
-    hintsInFooters = floatingGrid;
+// The nodes MOVE between the bottom bar and the card footers (not clone), so
+// there is a single source of hint text either way. Floating, the bar is gone:
+// the grid splits them across both footers, a single card takes both. Compared
+// by element, because the translate card rebuilds its footer on every render.
+function placeHints(floating, floatingGrid) {
+    if (!hintBar) return;
+    let msgTarget = hintBar;
+    let copyTarget = hintBar;
     if (floatingGrid) {
-        leftFooter.appendChild(hintMessage);
-        rightFooter.appendChild(copyright);
-    } else {
-        hintBar.appendChild(hintMessage);
-        hintBar.appendChild(copyright);
+        msgTarget = leftFooter;
+        copyTarget = rightFooter;
+    } else if (floating) {
+        // Translation swaps the results row out; every other single-card state
+        // still renders through the left column.
+        const solo = mainPane.querySelector('.translate-panel > .pane-footer') || leftFooter;
+        msgTarget = solo;
+        copyTarget = solo;
     }
+    if (hintMessage.parentElement === msgTarget && copyright.parentElement === copyTarget) return;
+    msgTarget.appendChild(hintMessage);
+    copyTarget.appendChild(copyright);
+}
+
+/** Reclaim the hint nodes before the translate card that parked them is torn
+ *  down, or they go with it. */
+export function releaseHints() {
+    if (!hintBar || !hintMessage.closest('.translate-panel')) return;
+    hintBar.appendChild(hintMessage);
+    hintBar.appendChild(copyright);
 }
 
 function updateTileOrigins() {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -579,7 +579,7 @@ struct LauncherView: View {
 
         switch command {
         case .network:
-            return "Press Enter after finishing input to translate on web"
+            return "Press Enter to translate"
         case .lookup:
             return nil
         }


### PR DESCRIPTION
## Summary

- Reset the Linux launcher surface when leaving Settings so a prior translation session does not remain visible on the Home screen.
- Centralize translate-mode UI toggling in a shared `app.js` helper so query-state changes and Settings exit follow the same surface rules.

## Why
- Closes: #424 

## Changes
- Add a shared syncSearchSurface() helper in apps/linows/src/js/app.js.
- Move translate surface ownership into that helper:
  - hide/show resultsList
  - suspend/resume runningApps
  - hide/show translatePanel
  - hide previewPanel while translating

## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [x] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [ ] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [ ] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

## Risks / Notes

- Testing:
 - [x] Gnome
 - [x] KDE
 - [x] Sway/i3
 - [x] Window

## Checklist

- [x] I have read and agree to the CLA (CLA.md)
- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search behavior when switching between regular search and translation mode.
  * Running applications now refresh appropriately without interrupting translation input.
  * Resetting the home search consistently restores the correct interface state.
  * Improved hint placement and cleanup when opening or closing translation panels.

* **UI Improvements**
  * Shortened the translation prompt to: “Press Enter to translate.”
  * Improved floating-panel spacing, footer alignment, and top-bar sizing.
  * Standardized running-app icon dimensions for a more consistent layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->