### PR TITLE
feat: applies key for source

### DIFF
--- a/apps/linows/src-tauri/src/sources.rs
+++ b/apps/linows/src-tauri/src/sources.rs
@@ -53,8 +53,9 @@ impl RowArgs {
 }
 
 /// The block behind a row: its name, the exact steps Enter will perform, the
-/// file that declared it, and where the row can go next. `null` when the row is
-/// not a block row.
+/// file that declared it, and where the row can go next, plus the actions a
+/// user declared for rows LIKE it (`applies`). `null` when the row is not a
+/// block row and nothing was declared for it.
 #[tauri::command(async)]
 pub fn source_block(row: RowArgs) -> Option<BlockDetail> {
     look_engine::sources::block_detail(&row.candidate_id, &row.context())

--- a/apps/linows/src/js/components/rowactions.js
+++ b/apps/linows/src/js/components/rowactions.js
@@ -8,7 +8,8 @@
 //
 // A row a block produced also carries what the block declared: its own
 // `edit` / `terminal` / `reveal` beat the user's global tool, and its `then`
-// targets join this list.
+// targets join this list. Any row at all can carry an action a `do` block
+// declared with `applies`, whatever produced the row.
 
 import { toolActions, performToolAction } from '../ipc.js';
 import * as results from './results.js';
@@ -100,23 +101,21 @@ function actionableSelection() {
  * A block that declared `then` targets shows those instead of the verb list:
  * declared beats default in the menu exactly as it does when running, and the
  * chords still carry every verb regardless.
+ *
+ * An action declared for rows LIKE this one (`applies`) is not that block's
+ * choice about that row, so it joins the list rather than replacing it, and
+ * goes last: a user's own blocks must never move Ctrl+E out from under them.
  */
 export async function descriptorsFor() {
     const selected = actionableSelection();
     if (!selected) return [];
 
     const block = await sourceblocks.loadDetail(selected);
-    const targets = (block?.then || []).map((target) => ({
-        id: sourceblocks.actionIdFor(target.id),
-        // The ellipsis says this one lists rather than runs: it opens a level.
-        title: target.performs ? target.name : `${target.name}…`,
-        // Already expanded against the row, so the question names what will
-        // actually happen. The menu asks it in place of the action list.
-        confirm: target.confirm,
-    }));
-    if (targets.length > 0) return targets;
+    const targets = describe(block?.then);
+    const declared = describe(block?.globals);
+    if (targets.length > 0) return [...targets, ...declared];
 
-    if (!selected.path) return [];
+    if (!selected.path) return declared;
     const offered = CATALOG.filter((entry) => !entry.tool || applies(entry.tool, selected.kind));
     const asked = offered.filter((entry) => entry.tool).map((entry) => entry.tool);
     const resolved = asked.length
@@ -124,12 +123,26 @@ export async function descriptorsFor() {
         : [];
     const tools = new Map(asked.map((action, index) => [action, resolved[index]]));
 
-    return offered.map((entry) => ({
-        id: entry.id,
-        title: label(entry, entry.tool && tools.get(entry.tool)),
-        // The chord that already performs this, set beside the label rather
-        // than trailing it, so the keys line up down one edge.
-        chord: entry.chord,
+    return [
+        ...offered.map((entry) => ({
+            id: entry.id,
+            title: label(entry, entry.tool && tools.get(entry.tool)),
+            // The chord that already performs this, set beside the label rather
+            // than trailing it, so the keys line up down one edge.
+            chord: entry.chord,
+        })),
+        ...declared,
+    ];
+}
+
+function describe(targets) {
+    return (targets || []).map((target) => ({
+        id: sourceblocks.actionIdFor(target.id),
+        // The ellipsis says this one lists rather than runs: it opens a level.
+        title: target.performs ? target.name : `${target.name}…`,
+        // Already expanded against the row, so the question names what will
+        // actually happen. The menu asks it in place of the action list.
+        confirm: target.confirm,
     }));
 }
 

--- a/apps/linows/src/js/components/sourceblocks.js
+++ b/apps/linows/src/js/components/sourceblocks.js
@@ -164,14 +164,20 @@ export function detailFor(result) {
     return (result && detailByRow.get(readKey(result))) || null;
 }
 
-/** The `then` targets already read for this row. */
+/** Everything the menu can run for this row: what its block chose for its own
+ *  rows, then what a user declared for rows like it (`applies`). */
 export function targetsFor(result) {
-    return detailFor(result)?.then || [];
+    const detail = detailFor(result);
+    return [...(detail?.then || []), ...(detail?.globals || [])];
 }
 
 /**
  * The block behind one row: its name, the steps Enter will run, the file that
  * declared it, and where the row can go next.
+ *
+ * Asked for every row, not only a block's own: a `do` block that declared
+ * `applies` is an action on rows it did not produce, and core is what says
+ * which. A row nothing claims answers null, as it always did.
  *
  * Awaited rather than answered empty while it loads: an empty first answer
  * would show the row's verbs in the menu, and the targets that beat them a
@@ -179,7 +185,10 @@ export function targetsFor(result) {
  * the same promise.
  */
 export async function loadDetail(result) {
-    if (!isSourceRow(result?.id)) return null;
+    // Nothing to ask about: a block's row carries its declaration, and a
+    // declared action needs a path to act on. Every other row is answered
+    // without a disk read, which matters because the menu asks per selection.
+    if (!result?.id || (!result.path && !isSourceRow(result.id))) return null;
     const key = readKey(result);
     if (detailByRow.has(key)) return detailByRow.get(key);
     if (!detailInFlight.has(key)) {

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
@@ -1007,7 +1007,8 @@ final class EngineBridge: @unchecked Sendable {
     }
 
     /// The user-declared block a row belongs to, with the exact steps Enter will
-    /// perform. Reads the sources directory, so call it off the main thread.
+    /// perform, and the actions declared for rows like it. Reads the sources
+    /// directory, so call it off the main thread.
     nonisolated func sourceBlock(
         candidateID: String, row: RowRef, ancestorsJSON: String = "[]"
     ) -> SourceBlock? {
@@ -1472,6 +1473,11 @@ nonisolated struct SourceBlock: Decodable {
     let file: String?
     /// Where a row of this block can go next.
     let then: [SourceBlockTarget]
+    /// Actions a user declared for rows LIKE this one (`applies`) rather than
+    /// for rows of this block. Apart from `then` because the two land
+    /// differently in the menu: a block's own targets replace the built-in
+    /// verbs, while these join them.
+    let globals: [SourceBlockTarget]
     /// Whether a `preview` command will run, known before it does.
     let hasPreview: Bool
 }

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/SourceBlockIcons.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/SourceBlockIcons.swift
@@ -1,6 +1,19 @@
 import AppKit
 import ImageIO
 
+/// One row's declared actions, kept together because one read answers both.
+///
+/// Two lists rather than one because they land differently in the menu: a
+/// block's own targets replace the built-in verbs, since the author chose that
+/// row's vocabulary, while an action declared for rows LIKE this one joins
+/// them, since a file row still needs Edit and Reveal.
+nonisolated struct SourceBlockRowTargets {
+    let own: [SourceBlockTarget]
+    let global: [SourceBlockTarget]
+
+    static let none = SourceBlockRowTargets(own: [], global: [])
+}
+
 /// What each declared block asked to be drawn as, keyed by block id.
 ///
 /// Rows render synchronously and there are many of them, so this is read on
@@ -10,7 +23,7 @@ import ImageIO
 @MainActor
 enum SourceBlockCatalog {
     private static var iconsByBlockID: [String: String]?
-    private static var targetsByCandidateID: [String: [SourceBlockTarget]] = [:]
+    private static var targetsByCandidateID: [String: SourceBlockRowTargets] = [:]
     private static var targetsInFlight: Set<String> = []
 
     static func invalidate() {
@@ -20,17 +33,26 @@ enum SourceBlockCatalog {
         prefill()
     }
 
-    /// The `then` targets for one row.
+    /// The declared actions for one row: its block's `then` targets, and the
+    /// ones a user declared for rows like it.
+    ///
+    /// Asked for every row, not only a block's own: a `do` block that declared
+    /// `applies` acts on rows it did not produce, and core is what says which.
     ///
     /// Keyed on the candidate rather than the block, because a target's confirm
     /// question is expanded against the row ("Delete main?"). Memoised because
     /// this is read while building the panel on every selection change, and
     /// arrow-keying down a list should not re-read the sources directory once
-    /// per row. `invalidate()` on config reload picks up an edited `then`.
-    static func targets(for result: LauncherResult) -> [SourceBlockTarget] {
+    /// per row. `invalidate()` on config reload picks up an edited declaration.
+    static func targets(for result: LauncherResult) -> SourceBlockRowTargets {
+        // Nothing to ask about: a block's row carries its declaration, and a
+        // declared action needs a path to act on. Every other row is answered
+        // without a disk read, which matters because the panel is rebuilt on
+        // every selection change.
+        guard result.isSourceRow || !result.path.isEmpty else { return .none }
         if let cached = targetsByCandidateID[cacheKey(for: result)] { return cached }
         loadTargets(for: result)
-        return []
+        return .none
     }
 
     /// Reads one row's targets off the main actor and caches them. The panel
@@ -43,8 +65,11 @@ enum SourceBlockCatalog {
 
         Task {
             let targets = await Task.detached(priority: .userInitiated) {
-                EngineBridge.shared.sourceBlock(
-                    candidateID: result.id, row: RowRef(result))?.then ?? []
+                () -> SourceBlockRowTargets in
+                guard let block = EngineBridge.shared.sourceBlock(
+                    candidateID: result.id, row: RowRef(result))
+                else { return .none }
+                return SourceBlockRowTargets(own: block.then, global: block.globals)
             }.value
             await MainActor.run {
                 targetsByCandidateID[key] = targets

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+QuickActions.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+QuickActions.swift
@@ -83,15 +83,23 @@ extension LauncherView {
         // A block's `then` targets are actions on this row, so they join the
         // same Cmd+K menu as the compiled controls. They are declared at parse
         // time rather than build time; that is the only difference.
-        let blockTargets = sourceBlockTargets(for: result)
-        descriptors.append(contentsOf: blockTargets)
+        // Read synchronously, from a per-row memo: the panel is built during a
+        // selection change, and an async load that appended later would make
+        // the action list grow under the user's cursor.
+        let targets = SourceBlockCatalog.targets(for: result)
+        descriptors.append(contentsOf: sourceBlockDescriptors(targets.own))
 
         // Declared beats default in the panel exactly as it does when running
         // (`specs/preferred-tools.md` §7.1): a block that named its own actions
         // keeps them unburied, and its rows keep every chord regardless.
-        if blockTargets.isEmpty {
+        if targets.own.isEmpty {
             descriptors.append(contentsOf: rowActionDescriptors(for: result))
         }
+        // An action declared for rows LIKE this one is not that block's choice
+        // about this row, so it joins the list rather than replacing it, and
+        // goes last: a user's own blocks must never move Cmd+E out from under
+        // them.
+        descriptors.append(contentsOf: sourceBlockDescriptors(targets.global))
         quickActionDescriptors = descriptors
 
         // Only a *different* result invalidates what the panel is showing. Re-reading

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+SourceBlocks.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+SourceBlocks.swift
@@ -20,15 +20,10 @@ enum SourceBlockAction {
 }
 
 extension LauncherView {
-    /// The `then` targets of the block behind `result`, as panel descriptors.
-    ///
-    /// Read synchronously, from a per-block memo: the panel is built during a
-    /// selection change, and an async load that appends later would make the
-    /// action list grow under the user's cursor.
-    func sourceBlockTargets(for result: LauncherResult) -> [QuickActionDescriptor] {
-        guard result.isSourceRow else { return [] }
-
-        return SourceBlockCatalog.targets(for: result).map { target in
+    /// Declared targets as panel entries. The ellipsis says one lists rather
+    /// than runs: it opens a level.
+    func sourceBlockDescriptors(_ targets: [SourceBlockTarget]) -> [QuickActionDescriptor] {
+        targets.map { target in
             QuickActionDescriptor(
                 actionId: SourceBlockAction.actionID(forBlockID: target.id),
                 title: target.performs ? target.name : "\(target.name)…",

--- a/core/engine/src/sources.rs
+++ b/core/engine/src/sources.rs
@@ -175,11 +175,26 @@ pub struct RefreshOutcome {
 /// `applies` block.
 pub fn block_detail(candidate_id: &str, row: &RowContext) -> Option<BlockDetail> {
     let blocks = load_dir(&sources_dir(&home_dir()?)).blocks;
-    let globals = global_targets(&blocks, candidate_id, row);
+    let block = CandidateIdKind::source_id_of(candidate_id)
+        .and_then(|block_id| blocks.iter().find(|block| block.id == block_id));
 
-    let Some(block) = CandidateIdKind::source_id_of(candidate_id)
-        .and_then(|block_id| blocks.iter().find(|block| block.id == block_id))
-    else {
+    let then: Vec<ThenTarget> = block
+        .map(|block| {
+            block
+                .then
+                .iter()
+                .filter_map(|target| blocks.iter().find(|block| &block.id == target))
+                .map(|target| then_target(target, row))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // The row's own targets are resolved first because a block already named in
+    // `then` is excluded from the globals BEFORE the cap: counted against it, a
+    // duplicate would spend a slot and hide a distinct action behind it.
+    let globals = global_targets(&blocks, candidate_id, row, &then);
+
+    let Some(block) = block else {
         // Not a block's row. It has nothing else to say about itself, but a
         // declared action still belongs on it.
         if globals.is_empty() {
@@ -197,13 +212,6 @@ pub fn block_detail(candidate_id: &str, row: &RowContext) -> Option<BlockDetail>
         });
     };
 
-    let then: Vec<ThenTarget> = block
-        .then
-        .iter()
-        .filter_map(|target| blocks.iter().find(|block| &block.id == target))
-        .map(|target| then_target(target, row))
-        .collect();
-
     Some(BlockDetail {
         id: block.id.clone(),
         name: block.name.clone(),
@@ -213,13 +221,8 @@ pub fn block_detail(candidate_id: &str, row: &RowContext) -> Option<BlockDetail>
             .confirm
             .as_deref()
             .map(|question| look_sources::expand(question, row)),
-        // A block that names an action in `then` already offers it, so the same
-        // one must not arrive twice because it also declared `applies`.
-        globals: globals
-            .into_iter()
-            .filter(|global| !then.iter().any(|own| own.id == global.id))
-            .collect(),
         then,
+        globals,
         has_preview: block.preview.is_some(),
     })
 }
@@ -240,8 +243,14 @@ fn then_target(target: &Block, row: &RowContext) -> ThenTarget {
 }
 
 /// The blocks that declared themselves actions on rows like this one, most
-/// biased first so a user can rank their own.
-fn global_targets(blocks: &[Block], candidate_id: &str, row: &RowContext) -> Vec<ThenTarget> {
+/// biased first so a user can rank their own. `already` is what the row's own
+/// block offers, which such a block must not repeat.
+fn global_targets(
+    blocks: &[Block],
+    candidate_id: &str,
+    row: &RowContext,
+    already: &[ThenTarget],
+) -> Vec<ThenTarget> {
     let kind = row_kind(candidate_id, &row.path);
     if kind == RowKind::Other {
         return Vec::new();
@@ -250,7 +259,11 @@ fn global_targets(blocks: &[Block], candidate_id: &str, row: &RowContext) -> Vec
 
     let mut matched: Vec<&Block> = blocks
         .iter()
-        .filter(|block| block.enabled && block.applies_to(kind, basename))
+        .filter(|block| {
+            block.enabled
+                && !already.iter().any(|own| own.id == block.id)
+                && block.applies_to(kind, basename)
+        })
         .collect();
     // `bias` is what the format already hands the author for ordering, so it
     // orders these too rather than introducing a second knob.
@@ -1331,6 +1344,39 @@ mod tests {
             detail.globals[0].id,
             format!("a{:02}", MAX_GLOBAL_TARGETS + 1)
         );
+    }
+
+    #[test]
+    fn a_target_the_row_already_offers_spends_no_room_under_the_cap() {
+        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
+        // `dup` is reachable both ways: named in the row's own `then`, and
+        // declaring `applies`. Its high bias would put it first among the
+        // globals, so a cap applied before the duplicate is dropped would spend
+        // a slot on it and hide the least biased action behind it.
+        let mut declarations = String::from(
+            "[rows]\ndir = \"/tmp\"\nthen = [\"dup\"]\n\n[dup]\nbias = 100\napplies = \"files\"\ndo = [\"ls {path}\"]\n\n",
+        );
+        for index in 0..MAX_GLOBAL_TARGETS {
+            declarations.push_str(&format!(
+                "[a{index:02}]\nbias = {index}\napplies = \"files\"\ndo = [\"ls {{path}}\"]\n\n"
+            ));
+        }
+        let fixture = Fixture::new("applies-overlap", &declarations);
+
+        let declared = fixture.dir.join("blocks.toml");
+        let path = declared.to_string_lossy().into_owned();
+        let row = row_context("src:rows:blocks.toml", "blocks.toml", &path, "", Vec::new());
+        let detail = block_detail("src:rows:blocks.toml", &row).expect("a declared block");
+
+        assert_eq!(detail.then.len(), 1, "the row's own target");
+        assert_eq!(detail.globals.len(), MAX_GLOBAL_TARGETS);
+        assert!(
+            !detail.globals.iter().any(|target| target.id == "dup"),
+            "an action the row already offers is not offered twice"
+        );
+        // The least biased action still made it in, which it could not have
+        // done had the duplicate been counted against the cap.
+        assert_eq!(detail.globals.last().expect("a target").id, "a00");
     }
 
     #[test]

--- a/core/engine/src/sources.rs
+++ b/core/engine/src/sources.rs
@@ -17,7 +17,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use look_indexing::CandidateIdKind;
-use look_sources::{Block, Producer, RowContext, load_dir, sources_dir};
+use look_sources::{Block, Producer, RowContext, RowKind, load_dir, sources_dir};
 use serde::Serialize;
 
 /// Fallback limits for a captured command, when the block names none. A source
@@ -38,6 +38,11 @@ const REFRESH_TIME_BUDGET: Duration = Duration::from_secs(60);
 /// Below this a block is skipped rather than handed a sliver, which would come
 /// back as a timeout it did not earn.
 const MIN_BLOCK_SLICE: Duration = Duration::from_secs(1);
+
+/// The most global actions one row's menu may carry. Six blocks declaring
+/// `applies = "paths"` would otherwise put six extra entries on every row in
+/// the launcher, forever.
+const MAX_GLOBAL_TARGETS: usize = 10;
 
 /// How deep a stack of levels may go. A launcher six levels deep has stopped
 /// being a launcher.
@@ -78,6 +83,12 @@ pub struct BlockDetail {
     /// than through another block's `then` is the same row and the same risk.
     pub confirm: Option<String>,
     pub then: Vec<ThenTarget>,
+    /// Actions a user declared for rows LIKE this one (`applies`), rather than
+    /// for rows of this block. Kept apart from `then` because the two land
+    /// differently in the menu: a block's own targets replace the built-in
+    /// verbs, since the author chose that row's vocabulary, while these join
+    /// them, since a file row still needs Edit and Reveal.
+    pub globals: Vec<ThenTarget>,
     /// Whether a `preview` command will run for this row. Answered with the
     /// cheap details rather than by waiting for the command, so the panel can
     /// lay itself out before knowing what the output says - or that there will
@@ -157,29 +168,40 @@ pub struct RefreshOutcome {
     pub changed: bool,
 }
 
-/// `{id, name, steps, file, then}` for the block a candidate id belongs to, or
-/// `None` when it is not a block row or no longer exists.
+/// `{id, name, steps, file, then, globals}` for a row: the block that produced
+/// it, when one did, and the actions a user declared for rows like it.
+///
+/// `None` when there is neither, which is every row until someone declares an
+/// `applies` block.
 pub fn block_detail(candidate_id: &str, row: &RowContext) -> Option<BlockDetail> {
-    let block_id = CandidateIdKind::source_id_of(candidate_id)?;
     let blocks = load_dir(&sources_dir(&home_dir()?)).blocks;
-    let block = blocks.iter().find(|block| block.id == block_id)?;
+    let globals = global_targets(&blocks, candidate_id, row);
 
-    let then = block
+    let Some(block) = CandidateIdKind::source_id_of(candidate_id)
+        .and_then(|block_id| blocks.iter().find(|block| block.id == block_id))
+    else {
+        // Not a block's row. It has nothing else to say about itself, but a
+        // declared action still belongs on it.
+        if globals.is_empty() {
+            return None;
+        }
+        return Some(BlockDetail {
+            id: String::new(),
+            name: String::new(),
+            steps: Vec::new(),
+            file: None,
+            confirm: None,
+            then: Vec::new(),
+            globals,
+            has_preview: false,
+        });
+    };
+
+    let then: Vec<ThenTarget> = block
         .then
         .iter()
         .filter_map(|target| blocks.iter().find(|block| &block.id == target))
-        .map(|target| ThenTarget {
-            id: target.id.clone(),
-            name: target.name.clone(),
-            icon: target.icon.clone(),
-            performs: target.is_bundle(),
-            // Expanded here so the question names the row the user is looking
-            // at ("Delete main?"), not the template.
-            confirm: target
-                .confirm
-                .as_deref()
-                .map(|question| look_sources::expand(question, row)),
-        })
+        .map(|target| then_target(target, row))
         .collect();
 
     Some(BlockDetail {
@@ -191,9 +213,93 @@ pub fn block_detail(candidate_id: &str, row: &RowContext) -> Option<BlockDetail>
             .confirm
             .as_deref()
             .map(|question| look_sources::expand(question, row)),
+        // A block that names an action in `then` already offers it, so the same
+        // one must not arrive twice because it also declared `applies`.
+        globals: globals
+            .into_iter()
+            .filter(|global| !then.iter().any(|own| own.id == global.id))
+            .collect(),
         then,
         has_preview: block.preview.is_some(),
     })
+}
+
+fn then_target(target: &Block, row: &RowContext) -> ThenTarget {
+    ThenTarget {
+        id: target.id.clone(),
+        name: target.name.clone(),
+        icon: target.icon.clone(),
+        performs: target.is_bundle(),
+        // Expanded here so the question names the row the user is looking at
+        // ("Delete main?"), not the template.
+        confirm: target
+            .confirm
+            .as_deref()
+            .map(|question| look_sources::expand(question, row)),
+    }
+}
+
+/// The blocks that declared themselves actions on rows like this one, most
+/// biased first so a user can rank their own.
+fn global_targets(blocks: &[Block], candidate_id: &str, row: &RowContext) -> Vec<ThenTarget> {
+    let kind = row_kind(candidate_id, &row.path);
+    if kind == RowKind::Other {
+        return Vec::new();
+    }
+    let basename = basename_of(&row.path);
+
+    let mut matched: Vec<&Block> = blocks
+        .iter()
+        .filter(|block| block.enabled && block.applies_to(kind, basename))
+        .collect();
+    // `bias` is what the format already hands the author for ordering, so it
+    // orders these too rather than introducing a second knob.
+    matched.sort_by(|left, right| right.bias.cmp(&left.bias).then(left.id.cmp(&right.id)));
+
+    if matched.len() > MAX_GLOBAL_TARGETS {
+        // Said rather than silently dropped: an action that is declared and
+        // never appears reads as the feature being broken.
+        eprintln!(
+            "look sources: {} actions apply to \"{}\", showing the first {MAX_GLOBAL_TARGETS}",
+            matched.len(),
+            row.title
+        );
+        matched.truncate(MAX_GLOBAL_TARGETS);
+    }
+
+    matched
+        .into_iter()
+        .map(|block| then_target(block, row))
+        .collect()
+}
+
+/// What the selected row is, for `applies`. The id prefix already says which
+/// for everything the launcher indexes itself; a block's row only says which
+/// block made it, so the filesystem is what answers, once per menu open.
+fn row_kind(candidate_id: &str, path: &str) -> RowKind {
+    if path.is_empty() {
+        return RowKind::Other;
+    }
+    match CandidateIdKind::from_candidate_id(candidate_id) {
+        Some(CandidateIdKind::App) => RowKind::App,
+        Some(CandidateIdKind::File) => RowKind::File,
+        Some(CandidateIdKind::Folder) => RowKind::Dir,
+        Some(CandidateIdKind::Source) => {
+            if Path::new(path).is_dir() {
+                RowKind::Dir
+            } else {
+                RowKind::File
+            }
+        }
+        _ => RowKind::Other,
+    }
+}
+
+fn basename_of(path: &str) -> &str {
+    Path::new(path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(path)
 }
 
 /// Every declared block as `{id, name, icon}`. The shell caches this once per
@@ -1114,6 +1220,116 @@ mod tests {
                 .confirm
                 .as_deref(),
             Some(format!("Delete local branch {}?", quote("main")).as_str())
+        );
+    }
+
+    #[test]
+    fn an_action_that_declares_applies_joins_the_rows_it_names() {
+        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
+        let _fixture = Fixture::new(
+            "applies",
+            "[optimize]\nname = \"Optimize\"\napplies = { ext = [\"png\"] }\ndo = [\"oxipng {path}\"]\n\n[deploy]\nname = \"Deploy\"\napplies = \"dirs\"\nconfirm = \"Deploy {title}?\"\ndo = [\"make -C {path} deploy\"]\n",
+        );
+
+        // A row the file index produced, which no block declared: it has no
+        // block of its own, and the action still reaches it.
+        let shot = row_context(
+            "file:/tmp/shot.png",
+            "shot.png",
+            "/tmp/shot.png",
+            "",
+            Vec::new(),
+        );
+        let detail = block_detail("file:/tmp/shot.png", &shot).expect("a declared action");
+        assert!(detail.id.is_empty(), "no block produced this row");
+        assert!(detail.then.is_empty());
+        assert_eq!(detail.globals.len(), 1);
+        assert_eq!(detail.globals[0].id, "optimize");
+
+        // The same action, on a row of the wrong shape.
+        let notes = row_context(
+            "file:/tmp/notes.md",
+            "notes.md",
+            "/tmp/notes.md",
+            "",
+            Vec::new(),
+        );
+        assert!(block_detail("file:/tmp/notes.md", &notes).is_none());
+
+        // A folder row gets the folder action, with its question expanded
+        // against the row like any other target's.
+        let dev = row_context("folder:/tmp/look", "look", "/tmp/look", "", Vec::new());
+        let detail = block_detail("folder:/tmp/look", &dev).expect("a declared action");
+        assert_eq!(detail.globals.len(), 1);
+        assert_eq!(
+            detail.globals[0].confirm.as_deref(),
+            Some(format!("Deploy {}?", quote("look")).as_str())
+        );
+
+        // A settings pane has no path, so a user's `{path}` would be empty.
+        let pane = row_context("setting:displays", "Displays", "", "", Vec::new());
+        assert!(block_detail("setting:displays", &pane).is_none());
+    }
+
+    #[test]
+    fn a_block_row_keeps_its_own_targets_and_gains_the_declared_ones() {
+        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
+        let fixture = Fixture::new(
+            "applies-block",
+            "[projects]\ndir = \"/tmp\"\nthen = [\"logs\"]\n\n[logs]\nname = \"Commits\"\nrun = \"git log\"\n\n[send]\nname = \"Send to laptop\"\napplies = \"files\"\ndo = [\"rsync {path} laptop:\"]\n",
+        );
+
+        let declared = fixture.dir.join("blocks.toml");
+        let path = declared.to_string_lossy().into_owned();
+        let row = row_context(
+            "src:projects:blocks.toml",
+            "blocks.toml",
+            &path,
+            "",
+            Vec::new(),
+        );
+        let detail = block_detail("src:projects:blocks.toml", &row).expect("a declared block");
+
+        // What the block chose for its rows, and what a user declared for rows
+        // like this one, in two lists: the shells place them differently.
+        assert_eq!(
+            detail
+                .then
+                .iter()
+                .map(|target| target.id.as_str())
+                .collect::<Vec<_>>(),
+            ["logs"]
+        );
+        assert_eq!(
+            detail
+                .globals
+                .iter()
+                .map(|target| target.id.as_str())
+                .collect::<Vec<_>>(),
+            ["send"]
+        );
+    }
+
+    #[test]
+    fn a_row_never_carries_more_declared_actions_than_the_cap() {
+        let _guard = GUARD.lock().unwrap_or_else(|err| err.into_inner());
+        let declarations: String = (0..MAX_GLOBAL_TARGETS + 2)
+            .map(|index| {
+                format!(
+                    "[a{index:02}]\nbias = {index}\napplies = \"files\"\ndo = [\"ls {{path}}\"]\n\n"
+                )
+            })
+            .collect();
+        let _fixture = Fixture::new("applies-cap", &declarations);
+
+        let row = row_context("file:/tmp/x.txt", "x.txt", "/tmp/x.txt", "", Vec::new());
+        let detail = block_detail("file:/tmp/x.txt", &row).expect("declared actions");
+        assert_eq!(detail.globals.len(), MAX_GLOBAL_TARGETS);
+        // Ordered by the bias the format already hands the author, so which
+        // ones survive the cap is the user's choice rather than the loader's.
+        assert_eq!(
+            detail.globals[0].id,
+            format!("a{:02}", MAX_GLOBAL_TARGETS + 1)
         );
     }
 

--- a/core/sources/example.toml
+++ b/core/sources/example.toml
@@ -68,6 +68,24 @@ name = "Open in Ghostty"
 do   = ["open -a Ghostty {path}"]
 
 
+# ----------------------------------------------------------------- applies --
+# A `do` block that names `applies` is an action on rows it did NOT produce. It
+# joins the Cmd+K menu of every matching row Look already found, so teaching
+# Look a verb for a kind of file needs no list declared to carry it.
+#
+#   applies = "files"                  # or "dirs", "paths", "apps"
+#   applies = { ext = ["png"] }        # case-insensitive, written without the dot
+#   applies = { match = ["*.tar.gz"] } # glob on the file name
+#
+# Only a `do` block may declare it: a block that produces rows is a list, and a
+# list is not a verb.
+
+[optimize]
+name    = "Optimize"
+applies = { ext = ["png", "jpg", "jpeg"] }
+do      = ["oxipng -o4 {path}"]
+
+
 # -------------------------------------------------------------------- file --
 # Rows from a text file, one per line: id<TAB>title<TAB>subtitle
 # A bare line is both id and title. The id is what verbs and `then` receive, so

--- a/core/sources/example.toml
+++ b/core/sources/example.toml
@@ -82,7 +82,7 @@ do   = ["open -a Ghostty {path}"]
 
 [optimize]
 name    = "Optimize"
-applies = { ext = ["png", "jpg", "jpeg"] }
+applies = { ext = ["png"] }        # oxipng is PNG only, so the filter is too
 do      = ["oxipng -o4 {path}"]
 
 

--- a/core/sources/src/collect.rs
+++ b/core/sources/src/collect.rs
@@ -243,7 +243,7 @@ fn collect_list(file: &Path, format: RowFormat) -> Result<Collected, CollectErro
     })
 }
 
-fn build_globs(patterns: &[String]) -> Result<Option<GlobSet>, CollectError> {
+pub(crate) fn build_globs(patterns: &[String]) -> Result<Option<GlobSet>, CollectError> {
     if patterns.is_empty() {
         return Ok(None);
     }

--- a/core/sources/src/def.rs
+++ b/core/sources/src/def.rs
@@ -47,6 +47,110 @@ pub enum RowFormat {
     Json,
 }
 
+/// What a row turned out to be, for deciding whether a declared action belongs
+/// on it. `Other` is everything with nothing on disk (a settings pane, a bundle
+/// row): handing one to a user's command would substitute an empty `{path}`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RowKind {
+    App,
+    File,
+    Dir,
+    Other,
+}
+
+/// The shape of row an action accepts, before `ext` and `match` narrow it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AppliesOnly {
+    Files,
+    Dirs,
+    Paths,
+    Apps,
+}
+
+impl AppliesOnly {
+    pub const FILES: &'static str = "files";
+    pub const DIRS: &'static str = "dirs";
+    pub const PATHS: &'static str = "paths";
+    pub const APPS: &'static str = "apps";
+
+    fn named(word: &str) -> Result<Self, String> {
+        match word.trim() {
+            Self::FILES => Ok(Self::Files),
+            Self::DIRS => Ok(Self::Dirs),
+            Self::PATHS => Ok(Self::Paths),
+            Self::APPS => Ok(Self::Apps),
+            other => Err(format!(
+                "`{KEY_APPLIES}` has no \"{other}\", only {}, {}, {}, and {}",
+                Self::FILES,
+                Self::DIRS,
+                Self::PATHS,
+                Self::APPS
+            )),
+        }
+    }
+
+    fn keeps(self, kind: RowKind) -> bool {
+        match self {
+            Self::Files => kind == RowKind::File,
+            Self::Dirs => kind == RowKind::Dir,
+            Self::Paths => matches!(kind, RowKind::File | RowKind::Dir | RowKind::App),
+            Self::Apps => kind == RowKind::App,
+        }
+    }
+}
+
+/// A `do` block's claim on rows it did not produce: it joins the action menu of
+/// every row the index already found that looks like this.
+///
+/// `ext` is its own key rather than a glob because `ext = ["png"]` is what
+/// people mean and `match = ["*.png"]` is what they would otherwise have to
+/// write.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Applies {
+    pub only: AppliesOnly,
+    /// Lowercased and without the dot, so "PNG", ".png" and "png" are one
+    /// declaration.
+    pub ext: Vec<String>,
+    /// Globs on the row's file name, never its whole path: an action declared
+    /// for `*.png` must not fire on every row under a folder called that.
+    pub globs: Vec<String>,
+}
+
+impl Applies {
+    /// Whether this action belongs on a row of `kind` called `basename`. Every
+    /// declared filter is ANDed: a narrower declaration never matches more.
+    pub fn matches(&self, kind: RowKind, basename: &str) -> bool {
+        if !self.only.keeps(kind) {
+            return false;
+        }
+        if !self.ext.is_empty() && !self.ext.iter().any(|ext| has_extension(basename, ext)) {
+            return false;
+        }
+        if !self.globs.is_empty() && !matches_any_glob(basename, &self.globs) {
+            return false;
+        }
+        true
+    }
+}
+
+/// A leading dot is the name, not an extension: `.gitignore` is not a
+/// `gitignore` file.
+fn has_extension(basename: &str, ext: &str) -> bool {
+    basename
+        .rsplit_once('.')
+        .is_some_and(|(stem, found)| !stem.is_empty() && found.eq_ignore_ascii_case(ext))
+}
+
+/// Compiled here rather than kept on the block: the patterns were validated
+/// when the block was parsed, and this runs once per action menu rather than
+/// once per row rendered.
+fn matches_any_glob(basename: &str, patterns: &[String]) -> bool {
+    crate::collect::build_globs(patterns)
+        .ok()
+        .flatten()
+        .is_some_and(|globs| globs.is_match(basename))
+}
+
 /// Parses a duration such as `30s`, `5m`, `1h`, `2d`.
 pub fn parse_duration(value: &str) -> Result<Duration, String> {
     let trimmed = value.trim();
@@ -109,6 +213,9 @@ pub const KEY_DO: &str = "do";
 pub const KEY_DIR: &str = "dir";
 pub const KEY_FILE: &str = "file";
 pub const KEY_RUN: &str = "run";
+/// Not a producer: the key that makes a `do` block an action on rows it did
+/// not produce.
+pub const KEY_APPLIES: &str = "applies";
 
 /// The standard things a user does to a row. Each has one key across the whole
 /// app, so Cmd+E edits whatever the row is and wherever it came from. A block
@@ -173,6 +280,11 @@ pub struct Block {
     /// The target's own producer decides which, so `then` stays a plain list of
     /// names with no mode to declare.
     pub then: Vec<String>,
+    /// Rows this block acts on although it did not produce them. A `do` block
+    /// declaring one joins the action menu of every matching row in the index,
+    /// so a verb can be added to what the launcher already finds rather than to
+    /// a list the user had to declare to carry it.
+    pub applies: Option<Applies>,
     pub aliases: Vec<String>,
     pub bias: i64,
     pub icon: Option<String>,
@@ -207,6 +319,13 @@ impl Block {
         })
     }
 
+    /// Whether this block declared itself an action on rows like this one.
+    pub fn applies_to(&self, kind: RowKind, basename: &str) -> bool {
+        self.applies
+            .as_ref()
+            .is_some_and(|applies| applies.matches(kind, basename))
+    }
+
     /// Everything the producer needs before it can make a row. `cwd` counts:
     /// it is where the command runs, so a command naming no row from a
     /// directory that does is still a block about one selected row.
@@ -237,6 +356,9 @@ struct RawBlock {
     #[serde(rename = "do")]
     steps: Option<Vec<String>>,
     then: Option<Vec<String>>,
+    /// Left as a raw value: it is a word or a table, and the two shapes read
+    /// better hand-parsed than as an untagged enum behind a flattened map.
+    applies: Option<toml::Value>,
 
     dir: Option<String>,
     dirs: Option<Vec<String>>,
@@ -337,6 +459,19 @@ fn build(id: &str, raw: RawBlock) -> Result<Block, String> {
         ));
     }
 
+    // A block that produces rows is a list, and a list is not a verb. Letting
+    // one declare `applies` would make it an action and a level at once, which
+    // is the ambiguity `perform_block`'s `as_target` already exists to settle.
+    let applies = match raw.applies {
+        Some(_) if !matches!(producer, Producer::Bundle { .. }) => {
+            return Err(format!(
+                "`{KEY_APPLIES}` says which rows an action joins, so only a `{KEY_DO}` block can declare it"
+            ));
+        }
+        Some(value) => Some(applies_from(&value)?),
+        None => None,
+    };
+
     Ok(Block {
         id: id.to_string(),
         name: raw.name.unwrap_or_else(|| id.to_string()),
@@ -348,6 +483,7 @@ fn build(id: &str, raw: RawBlock) -> Result<Block, String> {
             .into_iter()
             .filter(|name| !name.trim().is_empty())
             .collect(),
+        applies,
         aliases: raw.aliases.unwrap_or_default(),
         bias: raw.bias.unwrap_or_default(),
         icon: raw.icon,
@@ -357,6 +493,89 @@ fn build(id: &str, raw: RawBlock) -> Result<Block, String> {
         source_file: None,
         unknown_keys: raw.extra.keys().cloned().collect(),
     })
+}
+
+/// `applies = "files"`, or `applies = { ext = ["png"], only = "files" }`. One
+/// key in two shapes, so the common case is a word and nothing has to be
+/// restructured to narrow it later.
+fn applies_from(value: &toml::Value) -> Result<Applies, String> {
+    const KEY_ONLY: &str = "only";
+    const KEY_EXT: &str = "ext";
+    const KEY_MATCH: &str = "match";
+
+    if let Some(word) = value.as_str() {
+        return Ok(Applies {
+            only: AppliesOnly::named(word)?,
+            ext: Vec::new(),
+            globs: Vec::new(),
+        });
+    }
+    let Some(table) = value.as_table() else {
+        return Err(format!(
+            "`{KEY_APPLIES}` is a word like \"{}\", or a table of {KEY_ONLY}, {KEY_EXT}, and {KEY_MATCH}",
+            AppliesOnly::FILES
+        ));
+    };
+    if let Some(unknown) = table
+        .keys()
+        .find(|key| ![KEY_ONLY, KEY_EXT, KEY_MATCH].contains(&key.as_str()))
+    {
+        return Err(format!(
+            "`{KEY_APPLIES}` has no key \"{unknown}\", only {KEY_ONLY}, {KEY_EXT}, and {KEY_MATCH}"
+        ));
+    }
+
+    let ext: Vec<String> = applies_list(table.get(KEY_EXT), KEY_EXT)?
+        .into_iter()
+        .map(|value| value.trim().trim_start_matches('.').to_lowercase())
+        .filter(|value| !value.is_empty())
+        .collect();
+    let globs: Vec<String> = applies_list(table.get(KEY_MATCH), KEY_MATCH)?
+        .into_iter()
+        .filter(|pattern| !pattern.trim().is_empty())
+        .collect();
+    // Compiled now so a typo is reported against the block that wrote it,
+    // rather than silently matching nothing every time a menu opens.
+    if let Err(err) = crate::collect::build_globs(&globs) {
+        return Err(format!("`{KEY_APPLIES}` {KEY_MATCH} {err}"));
+    }
+
+    let only = match table.get(KEY_ONLY) {
+        Some(value) => AppliesOnly::named(value.as_str().ok_or_else(|| {
+            format!(
+                "`{KEY_APPLIES}` {KEY_ONLY} is a word like \"{}\"",
+                AppliesOnly::FILES
+            )
+        })?)?,
+        // `ext` is about files and `match` is about anything with a name, so
+        // the narrow key implies the narrow shape and neither has to be
+        // spelled out twice.
+        None if !ext.is_empty() => AppliesOnly::Files,
+        None if !globs.is_empty() => AppliesOnly::Paths,
+        None => {
+            return Err(format!(
+                "`{KEY_APPLIES}` needs {KEY_ONLY}, {KEY_EXT}, or {KEY_MATCH}"
+            ));
+        }
+    };
+    Ok(Applies { only, ext, globs })
+}
+
+fn applies_list(value: Option<&toml::Value>, key: &str) -> Result<Vec<String>, String> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+    let items = value
+        .as_array()
+        .ok_or_else(|| format!("`{KEY_APPLIES}` {key} is a list, like [\"png\"]"))?;
+    items
+        .iter()
+        .map(|item| {
+            item.as_str()
+                .map(str::to_string)
+                .ok_or_else(|| format!("`{KEY_APPLIES}` {key} holds text, like \"png\""))
+        })
+        .collect()
 }
 
 fn producer_from(raw: &RawBlock) -> Result<Producer, String> {
@@ -515,6 +734,104 @@ edit = "nvim {path}"
     }
 
     #[test]
+    fn applies_says_which_rows_an_action_joins() {
+        let word = one("[deploy]\ndo = [\"make deploy\"]\napplies = \"dirs\"\n");
+        let table = one("[deploy]\ndo = [\"make deploy\"]\napplies = { only = \"dirs\" }\n");
+        // The word and the table are the same declaration written two ways.
+        assert_eq!(word.applies, table.applies);
+        assert_eq!(
+            word.applies.as_ref().map(|applies| applies.only),
+            Some(AppliesOnly::Dirs)
+        );
+
+        assert!(word.applies_to(RowKind::Dir, "look"));
+        assert!(!word.applies_to(RowKind::File, "notes.md"));
+        assert!(!word.applies_to(RowKind::Other, ""));
+    }
+
+    #[test]
+    fn every_shape_of_applies_matches_what_it_names() {
+        let applies = |declaration: &str| {
+            one(&format!("[a]\ndo = [\"ls\"]\napplies = {declaration}\n"))
+                .applies
+                .expect("a declared applies")
+        };
+
+        let files = applies("\"files\"");
+        assert!(files.matches(RowKind::File, "notes.md"));
+        assert!(!files.matches(RowKind::Dir, "dev"));
+
+        let paths = applies("\"paths\"");
+        assert!(paths.matches(RowKind::File, "notes.md"));
+        assert!(paths.matches(RowKind::Dir, "dev"));
+        assert!(paths.matches(RowKind::App, "Safari.app"));
+
+        let apps = applies("\"apps\"");
+        assert!(apps.matches(RowKind::App, "Safari.app"));
+        assert!(!apps.matches(RowKind::File, "Safari.app"));
+
+        // A glob reads the file name, and saying so is enough to mean paths.
+        let named = applies("{ match = [\"*.tar.gz\"] }");
+        assert_eq!(named.only, AppliesOnly::Paths);
+        assert!(named.matches(RowKind::File, "look-1.0.tar.gz"));
+        assert!(!named.matches(RowKind::File, "look-1.0.zip"));
+
+        // Both keys narrow together rather than either one being enough.
+        let both = applies("{ ext = [\"png\"], match = [\"shot-*\"] }");
+        assert!(both.matches(RowKind::File, "shot-1.png"));
+        assert!(!both.matches(RowKind::File, "logo.png"));
+        assert!(!both.matches(RowKind::File, "shot-1.jpg"));
+    }
+
+    #[test]
+    fn an_extension_is_matched_without_its_dot_and_without_its_case() {
+        let block = one("[a]\ndo = [\"ls\"]\napplies = { ext = [\".PNG\", \"jpg\"] }\n");
+        let applies = block.applies.expect("a declared applies");
+        // Naming an extension is about files, so nothing else has to be said.
+        assert_eq!(applies.only, AppliesOnly::Files);
+        assert_eq!(applies.ext, vec!["png", "jpg"]);
+
+        assert!(applies.matches(RowKind::File, "logo.png"));
+        assert!(applies.matches(RowKind::File, "LOGO.PNG"));
+        assert!(applies.matches(RowKind::File, "photo.jpg"));
+        assert!(!applies.matches(RowKind::File, "notes.md"));
+        // The whole name, not an extension: a dotfile is not a `png` file.
+        assert!(!applies.matches(RowKind::File, ".png"));
+    }
+
+    #[test]
+    fn only_a_do_block_can_declare_applies() {
+        for producer in ["dir = \"~/dev\"", "file = \"~/rows.txt\"", "run = \"ls\""] {
+            let parsed =
+                parse_file(&format!("[projects]\n{producer}\napplies = \"files\"\n")).unwrap();
+            assert!(parsed.blocks.is_empty(), "{producer}");
+            assert!(
+                parsed.problems[0].contains("projects") && parsed.problems[0].contains(KEY_APPLIES),
+                "{:?}",
+                parsed.problems
+            );
+        }
+    }
+
+    #[test]
+    fn a_broken_applies_is_reported_rather_than_guessed_at() {
+        let problem = |declaration: &str| {
+            let parsed =
+                parse_file(&format!("[a]\ndo = [\"ls\"]\napplies = {declaration}\n")).unwrap();
+            assert!(parsed.blocks.is_empty(), "{declaration}");
+            parsed.problems.into_iter().next().expect("one problem")
+        };
+
+        assert!(problem("\"folders\"").contains("folders"));
+        assert!(problem("{ match = [\"[\"] }").contains(KEY_APPLIES));
+        assert!(problem("{ ext = \"png\" }").contains("list"));
+        assert!(problem("{ extension = [\"png\"] }").contains("extension"));
+        // A table that narrows nothing says nothing, so it is a mistake rather
+        // than an action on every row in the launcher.
+        assert!(problem("{ }").contains(KEY_APPLIES));
+    }
+
+    #[test]
     fn name_falls_back_to_the_block_header() {
         assert_eq!(
             one("[downloads]\ndir = \"~/Downloads\"\n").name,
@@ -629,6 +946,7 @@ run = "git for-each-ref --format='{\"id\":\"%(refname:short)\"}' refs/heads"
                 "drop-branch",
                 "ghostty",
                 "hosts",
+                "optimize",
                 "projects",
                 "repos",
                 "work"

--- a/core/sources/src/lib.rs
+++ b/core/sources/src/lib.rs
@@ -18,8 +18,9 @@ pub use collect::{
     CollectError, Collected, MAX_ROWS_PER_SOURCE, collect, collect_for_row, expand_home,
 };
 pub use def::{
-    Block, DEFAULT_FOLDER_DEPTH, KEY_DIR, KEY_DO, KEY_FILE, KEY_RUN, Only, ParsedFile, Producer,
-    RowFormat, Verbs, inferred, parse_duration, parse_file,
+    Applies, AppliesOnly, Block, DEFAULT_FOLDER_DEPTH, KEY_APPLIES, KEY_DIR, KEY_DO, KEY_FILE,
+    KEY_RUN, Only, ParsedFile, Producer, RowFormat, RowKind, Verbs, inferred, parse_duration,
+    parse_file,
 };
 pub use load::{Loaded, Problem, SOURCES_DIR_ENV, load_dir, sources_dir};
 pub use rows::{SourceRow, parse_rows};

--- a/docs/features.md
+++ b/docs/features.md
@@ -119,6 +119,7 @@ This document tracks what `look` supports today and what is planned next.
 - `dir` rows stay real files and folders, so preview, reveal, copy, and the file verbs keep working on them
 - per-block verbs (`open`, `edit`, `terminal`, `reveal`) overriding the global preferred tools for that block's rows only
 - `then` targets reached with `Cmd+K` / `Ctrl+K`: a target that performs steps is an action, a target that produces rows is a drill-down (levels stack 5 deep, `Esc` walks back)
+- `applies` on a `do` block makes it an action on rows it did not produce: `"files"` / `"dirs"` / `"paths"` / `"apps"`, or `{ ext = [...] }` / `{ match = [...] }`, so a verb joins the `Cmd+K` menu of every matching row the index already found. Appended after the built-in verbs, capped at 10 per row, ordered by `bias`
 - placeholders in every declared command (`{id}`, `{title}`, `{path}`, `{dir}`, `{query}`, `{parent.*}`), shell-escaped on substitution, plus `LOOK_ID` / `LOOK_TITLE` / `LOOK_PATH` in the environment
 - `confirm` question before a destructive block acts; `preview` command whose output fills the right panel for the selected row
 - row wire formats: tab-separated lines (`id<TAB>title<TAB>subtitle`) or `format = "json"` for per-row `path` and `icon`

--- a/docs/user-sources.md
+++ b/docs/user-sources.md
@@ -216,6 +216,7 @@ If the command fails, times out, or prints nothing, **the rows it produced last 
 | Key | Type | Belongs to | Notes |
 | --- | --- | --- | --- |
 | `do` | list of strings | `do` | The steps, run in order |
+| `applies` | word or table | `do` | Rows this action joins even though it did not produce them. See [Actions on any row](#actions-on-any-row-applies) |
 | `dir` | string | `dir` | One root |
 | `dirs` | list of strings | `dir` | More roots. `dir` and `dirs` combine |
 | `depth` | integer | `dir` | Default `1`, immediate children |
@@ -318,6 +319,37 @@ Look at `[branches]` twice, because this is the one thing that trips people up:
 Levels stack up to five deep. If you need six, you have stopped using a launcher.
 
 A `then` target may live in another file; names are resolved after everything is loaded, so only a genuine typo is reported.
+
+## Actions on any row (`applies`)
+
+`then` gives a verb to the rows of one block. `applies` gives one to rows **anything** produced, including the files and folders Look already indexes:
+
+```toml
+[optimize]
+name    = "Optimize"
+applies = { ext = ["png", "jpg"] }
+do      = ["oxipng -o4 {path}"]
+```
+
+Select any `.png` anywhere, press `Cmd+K` / `Ctrl+K`, and Optimize is there. No `[images]` block, no folder to keep the pictures in.
+
+Only a `do` block can declare it. A block that produces rows is a list, and a list is not a verb.
+
+| Written as | Matches |
+| --- | --- |
+| `applies = "files"` | any row whose path is not a directory |
+| `applies = "dirs"` | any row whose path is a directory |
+| `applies = "paths"` | any row with a path, apps included |
+| `applies = "apps"` | app rows |
+| `applies = { ext = ["png"] }` | that extension, any case, written without the dot. Files only |
+| `applies = { match = ["*.tar.gz"] }` | a glob on the file **name**, not the whole path |
+| `applies = { only = "dirs", match = ["*.xcodeproj"] }` | both at once |
+
+A row with nothing on disk (a settings pane) matches nothing, since `{path}` would be empty.
+
+**Where these land.** After the standard verbs, never in place of them: `Ctrl+E` still edits and `Ctrl+F` still reveals. A row of a block that declares `then` shows that block's own targets first, and these after.
+
+**Keep them narrow.** Every `applies = "paths"` block puts one more entry on every row in the launcher, forever. Ten per row is the ceiling; past that the rest are dropped, highest `bias` first, and the overflow is reported.
 
 ## Asking before acting (`confirm`)
 
@@ -670,6 +702,17 @@ gh run list --limit 20 --json databaseId,displayTitle,conclusion,url |
                 subtitle: .conclusion,
                 icon: (if .conclusion == "success" then "✅" else "❌" end)}'
 ```
+
+**One verb for every archive you ever download**
+
+```toml
+[unpack]
+name    = "Unpack here"
+applies = { match = ["*.tar.gz", "*.tgz", "*.tar.xz"] }
+do      = ["tar -xf {path} -C {dir}"]
+```
+
+No list to declare and nothing to keep up to date: it appears on the archive wherever the file index found it.
 
 **Search your notes and open the match**
 

--- a/docs/user-sources.md
+++ b/docs/user-sources.md
@@ -327,7 +327,7 @@ A `then` target may live in another file; names are resolved after everything is
 ```toml
 [optimize]
 name    = "Optimize"
-applies = { ext = ["png", "jpg"] }
+applies = { ext = ["png"] }
 do      = ["oxipng -o4 {path}"]
 ```
 


### PR DESCRIPTION
## Summary

Adds one key to a source block, `applies`, which says the block is an action on rows it did not produce. 
A `do` block declaring it joins the Ctrl+K menu of any matching row from the file index, not just rows of a block that named it in `then`.

#428 


## Why

`apps/linows/src/js/components/rowactions.js` holds a `CATALOG` of five entries, mirrored in Swift: Open, Edit, Open terminal here, Reveal, Copy path.

That is the entire vocabulary for an indexed file. Search is extensible through sources and index roots; action is not, so Look can be taught to find anything and then do five things to it.

`then` does not close this. It binds only to rows a block produced, so to get a verb on a project you declare `dir = "~/dev"` and Look indexes the same folder twice: 
once as files, once as your list. The list exists only to carry the verb.

With `applies`, sources stop being about lists and become about verbs:

```toml
[deploy]
name    = "Deploy"
applies = "dirs"
confirm = "Deploy {title}?"
do      = ["make -C {path} deploy"]

[optimize]
name    = "Optimize"
applies = { ext = ["png", "jpg"] }
do      = ["oxipng -o4 {path}"]

[to-laptop]
name    = "Send to laptop"
applies = "files"
do      = ["rsync -a {path} laptop:~/Inbox/"]
```

No `[projects]` block, no staging folder. Each works on whatever the index already found.

## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [x] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)


## Checklist

- [x] I have read and agree to the CLA (CLA.md)
- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `applies` actions for attaching custom commands to matching files, folders, apps, or paths.
  - Matching can be filtered by item type, file extension, or filename pattern.
  - Matching actions appear in the Cmd+K menu alongside existing actions, ordered by priority and limited to 10 per item.
  - Only command actions can use `applies` matching.

- **Documentation**
  - Added configuration guidance and examples, including image optimization and archive extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->