### PR TITLE
fix: translation hint and message

### DIFF
--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -60,10 +60,9 @@ import {
 // colon + bold-bullet format, macOS keeps its space-separated form.
 //
 // Every line here has to fit the left card footer in one row when the panes
-// float, which is the narrowest place a hint is shown. That budget is what
-// dropped "Ctrl+F: Reveal" and "Ctrl+/: Command mode" from the home hints, and
-// what keeps the clipboard hint to its first two items - all three still work
-// and are still listed in Settings > Shortcuts.
+// float, which is the narrowest place a hint is shown. That budget is three
+// items at most, matched by macOS (LauncherView.hintItemBudget); the keys left
+// out still work and are still listed in Settings > Shortcuts.
 const HINT_MAIN = 'Enter: Open \u2022 Ctrl+K: Actions \u2022 Ctrl+H: Help';
 // Inside a level the way out is the thing to say.
 const HINT_LEVEL = 'Enter: Open \u2022 Ctrl+K: Actions \u2022 Esc: Back';
@@ -72,10 +71,8 @@ const HINT_CLIPBOARD = 'Enter: Copy clip \u2022 Ctrl+D: Remove clip';
 const HINT_PROCESS = 'Enter: CPU \u2022 Ctrl+D: Kill \u2022 Ctrl+C: Copy PID';
 // Discovery-menu hints \u2014 mirror macOS prefixSuggestion / commandSuggestion
 // hint bars (LauncherView.swift hintItems).
-const HINT_PREFIX_DISCOVERY =
-    'Enter: Pick prefix \u2022 Up/Down: Move \u2022 Esc: Clear \u2022 Ctrl+H: Help';
-const HINT_COMMAND_DISCOVERY =
-    'Enter: Run command \u2022 Up/Down: Move \u2022 Esc: Clear \u2022 Ctrl+H: Help';
+const HINT_PREFIX_DISCOVERY = 'Enter: Pick prefix \u2022 Up/Down: Move \u2022 Esc: Clear';
+const HINT_COMMAND_DISCOVERY = 'Enter: Run command \u2022 Up/Down: Move \u2022 Esc: Clear';
 
 // "Ctrl+1-7: Switch", derived from the catalog so a new command can't leave the
 // hint stale (mirrors the macOS commandSwitchHint).
@@ -84,13 +81,13 @@ const SWITCH_HINT = `Ctrl+1-${COMMAND_ENTRIES.length}: Switch`;
 // Per-command hint lines while command mode is active; `shell` doubles as
 // the fallback for commands without a dedicated line.
 const COMMAND_HINTS = {
-    pomo: `Space: Start/pause \u2022 R: Reset \u2022 P: Music \u2022 Esc: Back \u2022 Tab/${SWITCH_HINT}`,
-    todo: `Ctrl+N: Switch page \u2022 Ctrl+S: Save \u2022 Tab/${SWITCH_HINT} \u2022 Esc: Back`,
-    speed: `R: Rerun \u2022 E: Show IP \u2022 Esc: Back \u2022 Tab/${SWITCH_HINT}`,
-    kill: `Y: Confirm \u2022 N: Cancel \u2022 Tab/${SWITCH_HINT} \u2022 Esc: Back`,
-    sys: `Esc: Back \u2022 Tab/${SWITCH_HINT} \u2022 Ctrl+/: Command mode \u2022 Ctrl+Shift+,: Settings`,
-    calc: `Enter: Evaluate \u2022 Tab: Select \u2022 ${SWITCH_HINT} \u2022 Esc: Back`,
-    shell: `Enter: Run \u2022 Tab: Select \u2022 ${SWITCH_HINT} \u2022 Esc: Back`,
+    pomo: 'Space: Start/pause \u2022 R: Reset \u2022 Esc: Back',
+    todo: 'Ctrl+N: Switch page \u2022 Ctrl+S: Save \u2022 Esc: Back',
+    speed: 'R: Rerun \u2022 E: Show IP \u2022 Esc: Back',
+    kill: 'Y: Confirm \u2022 N: Cancel \u2022 Esc: Back',
+    sys: `Tab/${SWITCH_HINT} \u2022 Ctrl+Shift+,: Settings \u2022 Esc: Back`,
+    calc: 'Enter: Evaluate \u2022 Tab: Select \u2022 Esc: Back',
+    shell: 'Enter: Run \u2022 Tab: Select \u2022 Esc: Back',
 };
 
 // Hint constants are static, authored in code \u2014 safe to set as innerHTML so

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/BridgeErrorMapping.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/BridgeErrorMapping.swift
@@ -9,6 +9,7 @@ enum BridgeErrorCode: String {
     case decodeFailed = "decode_failed"
     case invalidTargetLang = "invalid_target_lang"
     case translateRequestFailed = "translate_request_failed"
+    case translateRateLimited = "translate_rate_limited"
     case translateExecFailed = "translate_exec_failed"
     case translateParseFailed = "translate_parse_failed"
     case translateDecodeFailed = "translate_decode_failed"
@@ -35,6 +36,8 @@ nonisolated enum BridgeErrorMapping {
             return "Language selection is not supported."
         case .translateRequestFailed, .translateExecFailed:
             return "Translation service is temporarily unavailable."
+        case .translateRateLimited:
+            return "Translation is rate limited. Try again shortly."
         case .translateParseFailed, .translateDecodeFailed, .translateEmptyResult:
             return "Could not read translation response."
         case .serializeFailed:

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -195,6 +195,11 @@ struct LauncherView: View {
     static let bannerTitleLimit = 32
     static let attachedPanelScrimOpacity = 0.16
 
+    /// How many shortcuts a hint line may name. Three is what fits the narrowest
+    /// card footer in one row, and is the budget linows keeps too.
+    static let hintItemBudget = 3
+    static let hintSeparator = "  •  "
+
     var runningAppsPlacement: RunningAppsPlacement {
         themeStore.settings.runningAppsPlacement
     }
@@ -597,17 +602,23 @@ struct LauncherView: View {
     }
 
     var currentHint: String {
-        hintItems.joined(separator: "  •  ")
+        hintItems.prefix(Self.hintItemBudget).joined(separator: Self.hintSeparator)
     }
 
+    /// What the footer says, wherever the footer is drawn. A screen that teaches
+    /// its own keys (the AI session) supplies them here rather than printing a
+    /// second hint line of its own.
+    var panelHint: String {
+        isActionSessionUI ? sessionFooterHint : currentHint
+    }
+
+    /// Every hint line is at most three items, the same budget linows keeps
+    /// (apps/linows/src/js/app.js). The footer sits inside a card, so a fourth
+    /// item wraps or truncates; the keys left out are still listed in
+    /// Settings > Shortcuts.
     var hintItems: [String] {
         if appUIState.showsThemeSettings {
-            return [
-                "Cmd+H help",
-                "Cmd+/ command mode",
-                "Cmd+Shift+, close settings",
-                "Cmd+Shift+; apply config",
-            ]
+            return ["Cmd+Shift+; apply config", "Cmd+Shift+, close settings", "Cmd+H help"]
         }
 
         if isHideAppConfirmationVisible {
@@ -621,52 +632,51 @@ struct LauncherView: View {
 
         if isCommandMode {
             if activeCommandID == AppConstants.Launcher.Command.kill {
-                return ["Y confirm", "N cancel", "Tab/\(commandSwitchHint)", "Esc back"]
+                return ["Y confirm", "N cancel", "Esc back"]
             }
             if activeCommandID == AppConstants.Launcher.Command.sys {
-                return ["Esc back", "Tab/\(commandSwitchHint)", "Cmd+/ command mode", "Cmd+Shift+, settings"]
+                return ["Tab/\(commandSwitchHint)", "Cmd+Shift+, settings", "Esc back"]
             }
             if activeCommandID == AppConstants.Launcher.Command.speed {
-                return ["R rerun", "E show IP", "Esc back", "Tab/\(commandSwitchHint)"]
+                return ["R rerun", "E show IP", "Esc back"]
             }
             if activeCommandID == AppConstants.Launcher.Command.pomo {
-                return ["Space start/pause", "R reset", "P music", "Esc back", "Tab/\(commandSwitchHint)"]
+                return ["Space start/pause", "R reset", "Esc back"]
             }
             if activeCommandID == AppConstants.Launcher.Command.todo {
-                return ["Cmd+N switch page", "Cmd+S save", commandSwitchHint, "Esc back"]
+                return ["Cmd+N switch page", "Cmd+S save", "Esc back"]
             }
-            return ["Enter run", "Tab select", commandSwitchHint, "Esc back"]
+            return ["Enter run", "Tab select", "Esc back"]
         }
 
         if let command = extractTranslationQuery(from: query.trimmingCharacters(in: .whitespacesAndNewlines)) {
             switch command {
             case .network:
-                return ["Enter translate web", "Copy per result", "Cmd+H help", "Cmd+/ command mode"]
+                return ["Enter translate web", "Copy per result", "Cmd+H help"]
             case .lookup:
-                return ["Live lookup", "Type to refine", "Cmd+H help", "Cmd+/ command mode"]
+                return ["Live lookup", "Type to refine", "Cmd+H help"]
             }
         }
 
         if showsHelpScreen {
-            return ["Cmd+H close help", "Esc hide launcher", "Cmd+/ command mode", "Enter open"]
+            return ["Enter open", "Cmd+H close help", "Esc hide launcher"]
         }
 
         if isPrefixSuggestionQuery {
-            return ["Enter pick prefix", "Up/Down move", "Esc clear", "Cmd+H help"]
+            return ["Enter pick prefix", "Up/Down move", "Esc clear"]
         }
 
         if isCommandSuggestionQuery {
-            return ["Enter run command", "Up/Down move", "Esc clear", "Cmd+H help"]
+            return ["Enter run command", "Up/Down move", "Esc clear"]
         }
 
         if isClipboardQuery {
             return ["Enter copy clip", "Cmd+D remove clip"]
         }
 
-        // Mirrors the linows ps" hint (Cmd instead of Ctrl); Enter/CPU dropped
-        // to keep it on one line.
+        // Mirrors the linows ps" hint, with Cmd for Ctrl.
         if isProcessQuery {
-            return ["Cmd+D kill", "Cmd+C copy PID"]
+            return ["Enter CPU", "Cmd+D kill", "Cmd+C copy PID"]
         }
 
         // A proposed action owns Enter: say what it will do, not "open".
@@ -680,14 +690,16 @@ struct LauncherView: View {
             return ["Down pick a row", "Cmd+Enter web search", "Esc dismiss"]
         }
 
-        // The home screen replaces the "Cmd+/ command mode" hint with a
-        // clickable today done/total quick view (see todoQuickView), so it
-        // is intentionally omitted here.
+        // The home screen spends its third slot on the clickable today
+        // done/total quick view when there is one (see todoQuickView), so help
+        // steps aside rather than pushing the line to a fourth item.
         var hints = [enterHint]
         if !isLaunchpadActive {
             hints.append(AppConstants.Launcher.ActionMenu.openHint)
         }
-        hints.append("Cmd+H help")
+        if todoQuickView == nil {
+            hints.append("Cmd+H help")
+        }
         return hints
     }
 
@@ -712,7 +724,7 @@ struct LauncherView: View {
     /// whose hint falls through to the list above), where the /todo quick
     /// view is shown in place of the command-mode hint.
     var isHomeHintScreen: Bool {
-        guard isLauncherIdle else { return false }
+        guard isLauncherIdle, !isActionSessionUI else { return false }
         return !usesOwnResultPanel
     }
 
@@ -1362,16 +1374,15 @@ struct LauncherView: View {
                 Spacer(minLength: 0)
             }
 
-            // The hint bar lives inside the left card only on the floating results
-            // grid; every other state (classic, translation, empty panels) keeps
-            // the full-width bar below.
-            if !showsFloatingGrid
+            // While floating, every card carries its own hint footer; only the
+            // classic (no-gap) layout keeps the full-width bar below the panel.
+            if !showsFloatingCards
                 && !hidesResultsForEmptyQuery
                 && !isKillConfirmationVisible
                 && !isDeleteConfirmationVisible
                 && !isHideAppConfirmationVisible
             {
-                HintBar(hint: currentHint, todo: todoQuickView, themeStore: themeStore)
+                HintBar(hint: panelHint, todo: todoQuickView, themeStore: themeStore)
             }
         }
     }
@@ -1567,15 +1578,15 @@ struct LauncherView: View {
 
     /// The footer keys, matched to what is actually on screen: the browse list
     /// has chords a live conversation does not, and a streaming answer can be
-    /// stopped. One line either way, so the panel height never shifts.
+    /// stopped. Reaches the screen through `panelHint`.
     var sessionFooterHint: String {
         if chat.isStreamingAnswer {
-            return "⌘. stop  ·  Esc leave  ·  ⌘Z undo"
+            return ["⌘. stop", "⌘Z undo", "Esc leave"].joined(separator: Self.hintSeparator)
         }
         if isBrowsingConversations, !filteredConversations.isEmpty {
-            return "⌘1-9 ⌘0 open  ·  ⌘D delete  ·  ⌘H help  ·  Esc leave"
+            return ["⌘1-9 ⌘0 open", "⌘D delete", "Esc leave"].joined(separator: Self.hintSeparator)
         }
-        return "⇧↵ new line  ·  Esc leave  ·  ⌘Z undo  ·  @ sets exact time"
+        return ["⇧↵ new line", "⌘Z undo", "Esc leave"].joined(separator: Self.hintSeparator)
     }
 
     /// ⌘D and ⌘⌫ delete the highlighted session (no-op when nothing is
@@ -1759,11 +1770,6 @@ struct LauncherView: View {
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-
-            Text(sessionFooterHint)
-                .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 3), weight: .regular))
-                .foregroundStyle(themeStore.mutedTextColor())
-                .padding(.horizontal, 4)
         }
         .padding(8)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -2173,16 +2179,48 @@ struct LauncherView: View {
         }
     }
 
+    /// Where a card footer sits, which is what decides its insets: a grid pane
+    /// stops its content right above the footer, while a single panel already
+    /// pads its own edges and the footer only has to match them.
+    private enum CardFooterPlacement {
+        case gridPane
+        case singlePanel
+
+        var horizontal: CGFloat {
+            switch self {
+            case .gridPane: return 6
+            case .singlePanel: return 12
+            }
+        }
+
+        var top: CGFloat {
+            switch self {
+            case .gridPane: return 6
+            case .singlePanel: return 0
+            }
+        }
+
+        var bottom: CGFloat {
+            switch self {
+            case .gridPane: return 2
+            case .singlePanel: return 8
+            }
+        }
+    }
+
     /// A thin footer strip inside a floating card holding a slice of the old
     /// full-width hint bar.
     @ViewBuilder
-    private func cardFooter<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+    private func cardFooter<Content: View>(
+        placement: CardFooterPlacement = .gridPane,
+        @ViewBuilder _ content: () -> Content
+    ) -> some View {
         HStack(spacing: 0) {
             content()
         }
-        .padding(.horizontal, 6)
-        .padding(.top, 6)
-        .padding(.bottom, 2)
+        .padding(.horizontal, placement.horizontal)
+        .padding(.top, placement.top)
+        .padding(.bottom, placement.bottom)
     }
 
     /// i3-style inner gap between the three home panes (0 = classic flat layout).
@@ -2201,16 +2239,6 @@ struct LauncherView: View {
     /// in) churned NSVisualEffectViews on the main thread and froze typing.
     private var showsFloatingCards: Bool {
         usesPanes && isLauncherIdle
-    }
-
-    /// True when the floating content is the two-card grid (results or clipboard
-    /// empty) that carries its hint + copyright inside the cards. Translation and
-    /// the recent-empty state float as a single card and keep the bottom bar.
-    /// Only gates a `Text`, so it may read live state.
-    private var showsFloatingGrid: Bool {
-        showsFloatingCards
-            && !isTranslationQuery
-            && !(isRecentQuery && displayedResults.isEmpty)
     }
 
     private var isQueryEmpty: Bool {
@@ -2360,15 +2388,24 @@ struct LauncherView: View {
                     radius: floats ? 7 : 0, x: 0, y: floats ? 3 : 0)
     }
 
-    /// Wraps a single-panel home state (translation, clipboard/recent empty) in a
-    /// frosted floating card when floating, so it keeps a background once the
-    /// window backdrop is removed. A no-op otherwise.
+    /// Wraps a single-panel home state (translation, AI session, recent empty) in
+    /// a frosted floating card when floating, so it keeps a background once the
+    /// window backdrop is removed. The card carries the hint and copyright footer
+    /// itself, like the two-card grid does, so nothing is left stranded on the
+    /// desktop below it. A no-op otherwise.
     @ViewBuilder
     private func floatingPanel<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
         if showsFloatingCards {
             paneCard(padding: 0) {
-                content()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                VStack(alignment: .leading, spacing: 0) {
+                    content()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    cardFooter(placement: .singlePanel) {
+                        HintBar(hint: panelHint, todo: todoQuickView, themeStore: themeStore)
+                        Spacer(minLength: 8)
+                        copyrightLink
+                    }
+                }
             }
         } else {
             content()
@@ -2434,10 +2471,10 @@ struct LauncherView: View {
 
     @ViewBuilder
     private var copyrightOverlay: some View {
-        // On the floating results grid the copyright moves into the right-hand
-        // card footer; on the empty-rest screen it's hidden entirely; otherwise it
-        // stays in the panel's bottom-right corner.
-        if !showsFloatingGrid && !hidesResultsForEmptyQuery && !isHideAppConfirmationVisible {
+        // While floating the copyright moves into a card footer; on the empty-rest
+        // screen it's hidden entirely; otherwise it stays in the panel's
+        // bottom-right corner.
+        if !showsFloatingCards && !hidesResultsForEmptyQuery && !isHideAppConfirmationVisible {
             copyrightLink
                 .padding(.trailing, 10)
                 .padding(.bottom, 8)

--- a/core/answers/src/http.rs
+++ b/core/answers/src/http.rs
@@ -12,18 +12,47 @@ use std::os::windows::process::CommandExt;
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
 const USER_AGENT: &str = "Look-Launcher";
+/// Appended after the body so one stdout carries both; split on the last newline.
+const WRITE_OUT_STATUS: &str = "\n%{http_code}";
+const HTTP_OK: u16 = 200;
+const HTTP_MULTIPLE_CHOICES: u16 = 300;
+const HTTP_TOO_MANY_REQUESTS: u16 = 429;
 
-/// GETs `url` and parses the body as JSON, or `None` on any failure (spawn
-/// error, non-zero exit, non-UTF-8, non-JSON). `timeout_secs` caps the request.
-pub fn get_json(url: &str, timeout_secs: u32) -> Option<serde_json::Value> {
-    let body = get(url, timeout_secs, USER_AGENT, &[])?;
-    serde_json::from_str(&body).ok()
+/// A completed GET. The status is carried alongside the body because a throttled
+/// host answers 429 with an HTML apology page, which a caller must not mistake
+/// for a malformed reply from a healthy service.
+pub struct Response {
+    pub status: u16,
+    pub body: String,
 }
 
-/// GETs `url` with a custom user agent and extra `-H` headers, returning the raw
-/// body, or `None` on spawn error / non-2xx / non-UTF-8. Lets callers that need
-/// a specific UA or `Accept-Language` (e.g. translation) share one curl path.
-pub fn get(url: &str, timeout_secs: u32, user_agent: &str, headers: &[&str]) -> Option<String> {
+impl Response {
+    pub fn is_success(&self) -> bool {
+        (HTTP_OK..HTTP_MULTIPLE_CHOICES).contains(&self.status)
+    }
+
+    pub fn is_rate_limited(&self) -> bool {
+        self.status == HTTP_TOO_MANY_REQUESTS
+    }
+}
+
+/// GETs `url` and parses the body as JSON, or `None` on any failure (spawn
+/// error, non-zero exit, non-2xx, non-UTF-8, non-JSON). `timeout_secs` caps the
+/// request.
+pub fn get_json(url: &str, timeout_secs: u32) -> Option<serde_json::Value> {
+    let response = get(url, timeout_secs, USER_AGENT, &[])?;
+    if !response.is_success() {
+        return None;
+    }
+    serde_json::from_str(&response.body).ok()
+}
+
+/// GETs `url` with a custom user agent and extra `-H` headers, returning the
+/// status and raw body, or `None` on spawn error / non-zero exit / non-UTF-8.
+/// A non-2xx response IS returned, so callers can tell "throttled" from
+/// "unreadable". Lets callers that need a specific UA or `Accept-Language`
+/// (e.g. translation) share one curl path.
+pub fn get(url: &str, timeout_secs: u32, user_agent: &str, headers: &[&str]) -> Option<Response> {
     let mut command = Command::new("curl");
     // The AppImage points LD_LIBRARY_PATH at bundled Ubuntu libs; the system
     // curl resolves libcurl's deps against them and dies with a symbol
@@ -37,6 +66,8 @@ pub fn get(url: &str, timeout_secs: u32, user_agent: &str, headers: &[&str]) -> 
         "--user-agent",
         user_agent,
         "--tlsv1.2",
+        "-w",
+        WRITE_OUT_STATUS,
     ]);
     for header in headers {
         command.args(["-H", header]);
@@ -49,7 +80,38 @@ pub fn get(url: &str, timeout_secs: u32, user_agent: &str, headers: &[&str]) -> 
     if !output.status.success() {
         return None;
     }
-    String::from_utf8(output.stdout).ok()
+    split_status(&String::from_utf8(output.stdout).ok()?)
+}
+
+/// Splits curl's stdout, which is the body followed by `WRITE_OUT_STATUS`, at
+/// the last newline. The body keeps its own newlines, trailing one included.
+fn split_status(stdout: &str) -> Option<Response> {
+    let (body, status) = stdout.rsplit_once('\n')?;
+    Some(Response {
+        status: status.trim().parse().ok()?,
+        body: body.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splits_body_from_written_out_status() {
+        let ok = split_status("{\"a\":1}\n200").expect("parsed");
+        assert_eq!(ok.body, "{\"a\":1}");
+        assert!(ok.is_success());
+        assert!(!ok.is_rate_limited());
+
+        let multiline = split_status("line1\nline2\n\n429").expect("parsed");
+        assert_eq!(multiline.body, "line1\nline2\n");
+        assert!(!multiline.is_success());
+        assert!(multiline.is_rate_limited());
+
+        assert!(split_status("no status written out").is_none());
+        assert!(split_status("body\nnot-a-status").is_none());
+    }
 }
 
 /// Percent-encodes `value` for use in a URL query component (RFC 3986

--- a/core/answers/src/translate.rs
+++ b/core/answers/src/translate.rs
@@ -25,6 +25,7 @@ pub enum TranslateError {
     EmptyText,
     InvalidTargetLang,
     RequestFailed,
+    RateLimited,
     ParseFailed,
     EmptyResult,
 }
@@ -35,6 +36,7 @@ impl TranslateError {
             Self::EmptyText => "empty_text",
             Self::InvalidTargetLang => "invalid_target_lang",
             Self::RequestFailed => "translate_request_failed",
+            Self::RateLimited => "translate_rate_limited",
             Self::ParseFailed => "translate_parse_failed",
             Self::EmptyResult => "translate_empty_result",
         }
@@ -45,6 +47,7 @@ impl TranslateError {
             Self::EmptyText => "Type text after t\" to translate",
             Self::InvalidTargetLang => "Invalid target language code",
             Self::RequestFailed => "Translation request failed",
+            Self::RateLimited => "Translation is rate limited, try again shortly",
             Self::ParseFailed => "Translation response parse failed",
             Self::EmptyResult => "Translation returned empty result",
         }
@@ -83,10 +86,18 @@ pub fn translate(text: &str, target_lang: &str) -> Translation {
         target_lang.trim(),
         http::encode(&text)
     );
-    let Some(body) = http::get(&url, TIMEOUT_SECS, USER_AGENT, &[ACCEPT_LANGUAGE]) else {
+    let Some(response) = http::get(&url, TIMEOUT_SECS, USER_AGENT, &[ACCEPT_LANGUAGE]) else {
         return Translation::failed(text, TranslateError::RequestFailed);
     };
-    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&body) else {
+    // Google answers a throttled caller with an HTML apology page, which would
+    // otherwise read as an unparseable response from a healthy service.
+    if response.is_rate_limited() {
+        return Translation::failed(text, TranslateError::RateLimited);
+    }
+    if !response.is_success() {
+        return Translation::failed(text, TranslateError::RequestFailed);
+    }
+    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&response.body) else {
         return Translation::failed(text, TranslateError::ParseFailed);
     };
     let translated = extract_translation(&parsed);


### PR DESCRIPTION
## Summary

- Fix translation hint bar for macos
- Error message for quota exceeded issue
- Hint bar fix for AI chat


## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [x] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)


## Checklist

- [x] I have read and agree to the CLA (CLA.md)
- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [ ] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated messaging when translation requests are temporarily rate limited.
  * Improved handling of translation service responses to distinguish throttling from other request failures.

* **Improvements**
  * Updated launcher hints to display no more than three items.
  * Simplified and reordered contextual hints, keeping primary actions and navigation prominent.
  * Refined footer and hint-bar presentation across launcher panels, including AI sessions and quick views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->