### PR TITLE
fix: linux distro fixes (hope this is the final one)

### DIFF
--- a/apps/linows/BUILDING.md
+++ b/apps/linows/BUILDING.md
@@ -30,7 +30,7 @@ sudo apt-get install -y \
   libglib2.0-dev libcairo2-dev libpango1.0-dev \
   libgdk-pixbuf-2.0-dev libharfbuzz-dev libdbus-1-dev \
   libasound2-dev librsvg2-dev libssl-dev \
-  libappindicator3-dev pkg-config
+  libappindicator3-dev pkg-config libgtk-layer-shell0
 
 cd apps/linows
 cargo tauri dev
@@ -42,7 +42,8 @@ cargo tauri dev
 sudo pacman -S --needed \
   base-devel rustup \
   webkit2gtk-4.1 gtk3 libsoup3 glib2 cairo pango \
-  gdk-pixbuf2 harfbuzz dbus alsa-lib librsvg openssl pkg-config
+  gdk-pixbuf2 harfbuzz dbus alsa-lib librsvg openssl pkg-config \
+  gtk-layer-shell
 
 rustup default stable
 cargo install tauri-cli --version "^2" --locked
@@ -52,6 +53,8 @@ cargo tauri dev
 ```
 
 > `base-devel` provides `gcc` / `cc`, without it the Rust build fails with `error: linker 'cc' not found` on a fresh Arch install.
+
+> `gtk-layer-shell` is a runtime dep, dlopened rather than linked. Without it the app starts and logs `libgtk-layer-shell.so.0 not loadable`, then falls back to a normal toplevel window that a fullscreen window can cover. It only matters under sway / niri / Hyprland; mutter has no `wlr-layer-shell` to use it with.
 
 ### NixOS
 

--- a/apps/linows/BUILDING.md
+++ b/apps/linows/BUILDING.md
@@ -30,7 +30,7 @@ sudo apt-get install -y \
   libglib2.0-dev libcairo2-dev libpango1.0-dev \
   libgdk-pixbuf-2.0-dev libharfbuzz-dev libdbus-1-dev \
   libasound2-dev librsvg2-dev libssl-dev \
-  libappindicator3-dev pkg-config libgtk-layer-shell0
+  libappindicator3-dev pkg-config
 
 cd apps/linows
 cargo tauri dev
@@ -42,8 +42,7 @@ cargo tauri dev
 sudo pacman -S --needed \
   base-devel rustup \
   webkit2gtk-4.1 gtk3 libsoup3 glib2 cairo pango \
-  gdk-pixbuf2 harfbuzz dbus alsa-lib librsvg openssl pkg-config \
-  gtk-layer-shell
+  gdk-pixbuf2 harfbuzz dbus alsa-lib librsvg openssl pkg-config
 
 rustup default stable
 cargo install tauri-cli --version "^2" --locked
@@ -54,7 +53,7 @@ cargo tauri dev
 
 > `base-devel` provides `gcc` / `cc`, without it the Rust build fails with `error: linker 'cc' not found` on a fresh Arch install.
 
-> `gtk-layer-shell` is a runtime dep, dlopened rather than linked. Without it the app starts and logs `libgtk-layer-shell.so.0 not loadable`, then falls back to a normal toplevel window that a fullscreen window can cover. It only matters under sway / niri / Hyprland; mutter has no `wlr-layer-shell` to use it with.
+> `gtk-layer-shell` is not needed to build - it is dlopened at runtime, and only under sway / niri / Hyprland. Install it from the optional dependencies in [README.md](README.md#optional-dependencies) if you develop on one of those; without it the app logs `libgtk-layer-shell.so.0 not loadable` and uses a normal toplevel window.
 
 ### NixOS
 

--- a/apps/linows/README.md
+++ b/apps/linows/README.md
@@ -97,22 +97,30 @@ is detected. On i3, sway, or minimal distros without GNOME, these entries are sk
 | `curl`         | Web answers, translation, `/speed` | Answers stay empty; speed test reports "curl is not available on this system" |
 | `xclip`        | Copy files to clipboard (X11)     | Shows "Copy failed" banner |
 | `wl-clipboard` | Copy files to clipboard (Wayland) | Shows "Copy failed" banner |
+| `gtk-layer-shell` | Showing over a fullscreen window on wlroots compositors (sway, niri, Hyprland) | Normal toplevel window: a fullscreen window stays on top |
 
 Text clipboard (copy path, clipboard history) works without any external tools.
 File clipboard (copy a file to paste into a file manager) needs one of the above.
 
+`gtk-layer-shell` is dlopened at runtime, never linked, so a system without it starts
+normally and logs one line. It only changes anything under a compositor that implements
+`wlr-layer-shell`; GNOME/mutter does not, so there it makes no difference either way.
+
 ```bash
 # Debian/Ubuntu
-sudo apt install xclip              # X11
-sudo apt install wl-clipboard       # Wayland
+sudo apt install xclip                    # X11
+sudo apt install wl-clipboard             # Wayland
+sudo apt install libgtk-layer-shell0      # wlroots compositors
 
 # Fedora
-sudo dnf install xclip              # X11
-sudo dnf install wl-clipboard       # Wayland
+sudo dnf install xclip                    # X11
+sudo dnf install wl-clipboard             # Wayland
+sudo dnf install gtk-layer-shell          # wlroots compositors
 
 # Arch
-sudo pacman -S xclip                # X11
-sudo pacman -S wl-clipboard         # Wayland
+sudo pacman -S xclip                      # X11
+sudo pacman -S wl-clipboard               # Wayland
+sudo pacman -S gtk-layer-shell            # wlroots compositors
 ```
 
 ## Build

--- a/apps/linows/src-tauri/src/config.rs
+++ b/apps/linows/src-tauri/src/config.rs
@@ -118,12 +118,14 @@ fn default_config_contents() -> String {
     // the keys are inert on Windows, so don't seed them there.
     #[cfg(target_os = "linux")]
     out.push_str(
-        "# Arch (and other affected stacks) - workarounds for WebKitGTK ghost rendering.\n\
-         # arch_disable_gpu forces HardwareAccelerationPolicy::Never (needs restart);\n\
-         # arch_disable_blur drops backdrop-filter for an opaque tint. Both default off;\n\
-         # flip if you see slider trails or overlapping popovers.\n\
-         arch_disable_gpu=false\n\
-         arch_disable_blur=false\n\
+        "# Rendering - workarounds for WebKitGTK ghost rendering (Arch, Ubuntu, VMs).\n\
+         # disable_gpu_compositing forces HardwareAccelerationPolicy::Never (needs\n\
+         # restart); disable_blur_effect drops the remaining filters for an opaque\n\
+         # tint. Both default off; flip if you see slider trails or overlapping\n\
+         # popovers. Configs written before 0.1.1 use arch_disable_gpu /\n\
+         # arch_disable_blur, which are still read.\n\
+         disable_gpu_compositing=false\n\
+         disable_blur_effect=false\n\
          \n",
     );
 

--- a/apps/linows/src-tauri/src/consts.rs
+++ b/apps/linows/src-tauri/src/consts.rs
@@ -19,3 +19,11 @@ pub const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 /// long enough for the app to have received the input and drawn. Used by the
 /// file/URL open path and by the preferred-tools launcher on both platforms.
 pub const HANDLER_FOCUS_DELAY_MS: u64 = 150;
+
+/// Rendering workarounds (Linux only). Both shipped as `arch_*` before the
+/// ghosting turned out to be a WebKitGTK trait rather than an Arch one; the
+/// old names are still read so an existing config keeps its setting.
+#[cfg(target_os = "linux")]
+pub const KEY_DISABLE_GPU: &str = "disable_gpu_compositing";
+#[cfg(target_os = "linux")]
+pub const KEY_DISABLE_GPU_LEGACY: &str = "arch_disable_gpu";

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -72,8 +72,9 @@ fn supports_transparency() -> bool {
     }
 }
 
-const BASE_W: f64 = 860.0;
-const BASE_H: f64 = 600.0;
+/// tauri.conf's window size, and the 1.0x rung of `scaled_window_size`.
+pub(crate) const BASE_W: f64 = 860.0;
+pub(crate) const BASE_H: f64 = 600.0;
 /// Grace period (ms) after show - ignore focus-loss within this window.
 const AUTO_HIDE_GRACE_MS: u64 = 300;
 /// Guard (ms) to prevent re-showing after auto-hide (GNOME X11 race).
@@ -557,7 +558,7 @@ fn main() {
     setup_dev_env();
 
     #[cfg(target_os = "linux")]
-    let disable_gpu = gpu::detect_and_disable_virtual_gpu() || gpu::arch_disable_gpu_from_config();
+    let disable_gpu = gpu::detect_and_disable_virtual_gpu() || gpu::disable_gpu_from_config();
 
     sync_autostart();
 

--- a/apps/linows/src-tauri/src/nowplaying.rs
+++ b/apps/linows/src-tauri/src/nowplaying.rs
@@ -62,7 +62,7 @@ mod imp {
 
     pub fn current() -> Option<NowPlayingSnapshot> {
         let conn = dbus::session()?;
-        dbus::runtime().block_on(async {
+        dbus::block_on(async {
             let (name, status) = active_player(conn).await?;
             read_snapshot(conn, &name, &status).await
         })
@@ -78,7 +78,7 @@ mod imp {
         let Some(conn) = dbus::session() else {
             return false;
         };
-        dbus::runtime().block_on(async {
+        dbus::block_on(async {
             let name = match target {
                 Some(name) => name.to_string(),
                 None => match active_player(conn).await {

--- a/apps/linows/src-tauri/src/platform/linux/dbus.rs
+++ b/apps/linows/src-tauri/src/platform/linux/dbus.rs
@@ -4,7 +4,9 @@
 use std::sync::OnceLock;
 
 /// Shared tokio runtime for D-Bus calls, avoids creating a new one each call.
-pub fn runtime() -> &'static tokio::runtime::Runtime {
+/// Private: every caller goes through [`block_on`], which is the only spelling
+/// that survives being reached from a thread that is already inside a runtime.
+fn runtime() -> &'static tokio::runtime::Runtime {
     static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
     RT.get_or_init(|| {
         tokio::runtime::Builder::new_current_thread()
@@ -14,16 +16,48 @@ pub fn runtime() -> &'static tokio::runtime::Runtime {
     })
 }
 
+/// Runs a D-Bus call to completion from synchronous code.
+///
+/// `Runtime::block_on` panics when the calling thread is already driving a
+/// runtime, and D-Bus helpers get called from threads on both sides of that
+/// line. A thread that is inside one hands the future to a thread that is not,
+/// which borrows exactly as the direct path does, so a call site reads the same
+/// either way.
+pub fn block_on<F>(future: F) -> F::Output
+where
+    F: Future + Send,
+    F::Output: Send,
+{
+    if tokio::runtime::Handle::try_current().is_err() {
+        return runtime().block_on(future);
+    }
+    std::thread::scope(|scope| scope.spawn(|| runtime().block_on(future)).join())
+        .unwrap_or_else(|payload| std::panic::resume_unwind(payload))
+}
+
 /// Cached D-Bus session connection.
 pub fn session() -> Option<&'static zbus::Connection> {
     static CONN: OnceLock<Option<zbus::Connection>> = OnceLock::new();
-    CONN.get_or_init(|| runtime().block_on(async { zbus::Connection::session().await.ok() }))
+    CONN.get_or_init(|| block_on(async { zbus::Connection::session().await.ok() }))
         .as_ref()
 }
 
 /// Cached D-Bus system connection (system services like BlueZ).
 pub fn system() -> Option<&'static zbus::Connection> {
     static CONN: OnceLock<Option<zbus::Connection>> = OnceLock::new();
-    CONN.get_or_init(|| runtime().block_on(async { zbus::Connection::system().await.ok() }))
+    CONN.get_or_init(|| block_on(async { zbus::Connection::system().await.ok() }))
         .as_ref()
+}
+
+#[cfg(test)]
+mod tests {
+    /// The Wayland toggle service answers its D-Bus method inside a runtime,
+    /// and everything it does to the window reaches this module from there.
+    #[test]
+    fn block_on_works_from_inside_a_runtime() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("test runtime");
+        assert_eq!(rt.block_on(async { super::block_on(async { 7 }) }), 7);
+    }
 }

--- a/apps/linows/src-tauri/src/platform/linux/gnome_ext.rs
+++ b/apps/linows/src-tauri/src/platform/linux/gnome_ext.rs
@@ -6,7 +6,7 @@
 
 use std::path::PathBuf;
 
-use super::dbus::{runtime as dbus_runtime, session as dbus_conn};
+use super::dbus::{block_on as dbus_block_on, session as dbus_conn};
 
 const EXT_UUID: &str = "look-integration@lookapp";
 const DBUS_NAME: &str = "com.look.ShellIntegration";
@@ -114,7 +114,7 @@ fn verify_running_later(changed: bool) {
         };
         // ListWindowedApps is the newest method Rust calls: an old extension
         // still loaded in memory answers other calls but fails this one.
-        let err = dbus_runtime().block_on(async {
+        let err = dbus_block_on(async {
             conn.call_method(
                 Some(DBUS_NAME),
                 DBUS_PATH,
@@ -211,7 +211,7 @@ fn build_extension_zip(path: &std::path::Path) -> std::io::Result<()> {
 /// Works on Wayland where Tauri's cursor_position() is unavailable.
 pub fn get_pointer() -> Option<(i32, i32)> {
     let conn = dbus_conn()?;
-    dbus_runtime().block_on(async {
+    dbus_block_on(async {
         let reply: (i32, i32) = conn
             .call_method(
                 Some(DBUS_NAME),
@@ -261,7 +261,7 @@ fn classify_dbus_error(err: &zbus::Error) -> ExtensionError {
 /// `Some(vec![])` if the extension answered but no apps have windows.
 pub fn list_windowed_apps() -> Option<Vec<String>> {
     let conn = dbus_conn()?;
-    dbus_runtime().block_on(async {
+    dbus_block_on(async {
         match conn
             .call_method(
                 Some(DBUS_NAME),
@@ -308,24 +308,23 @@ pub fn try_focus_app(desktop_id: &str) -> bool {
         return false;
     };
     let id = desktop_id.to_string();
-    dbus_runtime()
-        .block_on(async {
-            let reply: (bool,) = conn
-                .call_method(
-                    Some(DBUS_NAME),
-                    DBUS_PATH,
-                    Some(DBUS_IFACE),
-                    "FocusApp",
-                    &id,
-                )
-                .await
-                .ok()?
-                .body()
-                .deserialize()
-                .ok()?;
-            Some(reply.0)
-        })
-        .unwrap_or(false)
+    dbus_block_on(async {
+        let reply: (bool,) = conn
+            .call_method(
+                Some(DBUS_NAME),
+                DBUS_PATH,
+                Some(DBUS_IFACE),
+                "FocusApp",
+                &id,
+            )
+            .await
+            .ok()?
+            .body()
+            .deserialize()
+            .ok()?;
+        Some(reply.0)
+    })
+    .unwrap_or(false)
 }
 
 fn extension_dir() -> PathBuf {

--- a/apps/linows/src-tauri/src/platform/linux/gpu.rs
+++ b/apps/linows/src-tauri/src/platform/linux/gpu.rs
@@ -66,27 +66,32 @@ pub fn detect_and_disable_virtual_gpu() -> bool {
     detected
 }
 
-/// Read the `arch_disable_gpu` config key. User-opt-in workaround for
-/// the WebKitGTK ghost-rendering bug observed on Arch GNOME 50 + webkit
-/// 2.52.3 (other stacks with same webkit version, e.g. Ubuntu 26.04, are
-/// unaffected, so we don't auto-detect - toggle lives in Advanced settings).
-pub fn arch_disable_gpu_from_config() -> bool {
+/// Read the `disable_gpu_compositing` config key, falling back to the
+/// `arch_disable_gpu` name it shipped under. User-opt-in workaround for the
+/// WebKitGTK ghost-rendering bug first seen on Arch GNOME 50 + webkit 2.52.3,
+/// since reported on Ubuntu and in VMs; the affected stacks share no property
+/// we can test for, so it stays a toggle in Advanced settings.
+pub fn disable_gpu_from_config() -> bool {
     let path = config::config_file_path();
     let Ok(contents) = std::fs::read_to_string(&path) else {
         return false;
     };
+    let mut legacy = false;
     for line in contents.lines() {
         let line = line.trim();
         if line.starts_with('#') {
             continue;
         }
-        if let Some((k, v)) = line.split_once('=')
-            && k.trim() == "arch_disable_gpu"
-        {
-            return v.trim().eq_ignore_ascii_case("true");
+        let Some((k, v)) = line.split_once('=') else {
+            continue;
+        };
+        match k.trim() {
+            consts::KEY_DISABLE_GPU => return v.trim().eq_ignore_ascii_case("true"),
+            consts::KEY_DISABLE_GPU_LEGACY => legacy = v.trim().eq_ignore_ascii_case("true"),
+            _ => {}
         }
     }
-    false
+    legacy
 }
 
 /// Disable hardware acceleration via WebKitGTK API for VM GPUs.

--- a/apps/linows/src-tauri/src/platform/linux/gpu.rs
+++ b/apps/linows/src-tauri/src/platform/linux/gpu.rs
@@ -76,7 +76,11 @@ pub fn disable_gpu_from_config() -> bool {
     let Ok(contents) = std::fs::read_to_string(&path) else {
         return false;
     };
-    let mut legacy = false;
+    // Last value wins, as get_config's entries do once the frontend folds them
+    // into a map - a duplicated key must not mean one thing here and another in
+    // Settings.
+    let mut current = None;
+    let mut legacy = None;
     for line in contents.lines() {
         let line = line.trim();
         if line.starts_with('#') {
@@ -85,13 +89,14 @@ pub fn disable_gpu_from_config() -> bool {
         let Some((k, v)) = line.split_once('=') else {
             continue;
         };
+        let on = v.trim().eq_ignore_ascii_case("true");
         match k.trim() {
-            consts::KEY_DISABLE_GPU => return v.trim().eq_ignore_ascii_case("true"),
-            consts::KEY_DISABLE_GPU_LEGACY => legacy = v.trim().eq_ignore_ascii_case("true"),
+            consts::KEY_DISABLE_GPU => current = Some(on),
+            consts::KEY_DISABLE_GPU_LEGACY => legacy = Some(on),
             _ => {}
         }
     }
-    legacy
+    current.or(legacy).unwrap_or(false)
 }
 
 /// Disable hardware acceleration via WebKitGTK API for VM GPUs.

--- a/apps/linows/src-tauri/src/platform/linux/kde_focus.rs
+++ b/apps/linows/src-tauri/src/platform/linux/kde_focus.rs
@@ -74,11 +74,11 @@ pub fn try_focus(candidates: &[&str]) -> bool {
     let (tx, rx) = channel();
     *REPORT_SLOT.lock().unwrap() = Some((token, tx));
 
-    let script_obj = dbus::runtime().block_on(load_and_run(conn, &script_path));
+    let script_obj = dbus::block_on(load_and_run(conn, &script_path));
     let matched = script_obj.is_some() && rx.recv_timeout(REPORT_TIMEOUT).unwrap_or(false);
 
     if let Some(obj) = script_obj {
-        dbus::runtime().block_on(async {
+        dbus::block_on(async {
             let _ = conn
                 .call_method(
                     Some(KWIN_BUS),
@@ -105,7 +105,7 @@ fn ensure_report_object(conn: &'static zbus::Connection) -> bool {
     if REGISTERED.load(Ordering::Acquire) {
         return true;
     }
-    let ok = dbus::runtime().block_on(async {
+    let ok = dbus::block_on(async {
         conn.object_server()
             .at(REPORT_PATH, FocusReport)
             .await

--- a/apps/linows/src-tauri/src/platform/linux/layer_shell.rs
+++ b/apps/linows/src-tauri/src/platform/linux/layer_shell.rs
@@ -157,7 +157,7 @@ pub fn attach(window: &tauri::WebviewWindow, size: Option<(i32, i32)>) -> bool {
 
     // Anchored nowhere, so the compositor centres it; the size is whatever the
     // widget asks for, and there is no set_position counterpart.
-    let (width, height) = size.unwrap_or_else(|| fallback_size(window));
+    let (width, height) = usable_size(size.unwrap_or_else(|| fallback_size(window)));
     layer.set_default_size(width, height);
     layer.set_size_request(width, height);
 
@@ -182,6 +182,19 @@ fn fallback_size(window: &tauri::WebviewWindow) -> (i32, i32) {
             (logical.width, logical.height)
         })
         .unwrap_or_default()
+}
+
+/// A zero in either axis reaches the compositor as "you pick", and an
+/// unanchored layer surface then gets handed the whole output - the launcher
+/// rendered full-width and top-aligned. Both sources can produce one: the
+/// monitor scan may find no monitor, and `inner_size` reads back 0 on a Wayland
+/// window the compositor has not configured yet.
+fn usable_size((width, height): (i32, i32)) -> (i32, i32) {
+    if width > 0 && height > 0 {
+        return (width, height);
+    }
+    eprintln!("[look:layer-shell] no usable size ({width}x{height}), falling back to the default");
+    (crate::BASE_W as i32, crate::BASE_H as i32)
 }
 
 pub fn is_active() -> bool {

--- a/apps/linows/src-tauri/src/platform/linux/tools.rs
+++ b/apps/linows/src-tauri/src/platform/linux/tools.rs
@@ -128,7 +128,7 @@ fn show_items(path: &str) -> bool {
         return false;
     };
 
-    super::dbus::runtime().block_on(async {
+    super::dbus::block_on(async {
         // Bounded: an unowned but D-Bus-activatable name would otherwise hold
         // the user's reveal for zbus's default 25s before the fallback runs.
         tokio::time::timeout(

--- a/apps/linows/src-tauri/src/platform/linux/wayland_shortcut.rs
+++ b/apps/linows/src-tauri/src/platform/linux/wayland_shortcut.rs
@@ -135,6 +135,37 @@ fn detect_compositor() -> Compositor {
     Compositor::Other
 }
 
+/// Runs the toggle on a thread of its own rather than on whichever one
+/// signalled it.
+///
+/// Both signals - our `Toggle` method and KDE's kglobalaccel - are delivered
+/// inside the tokio runtime `start` builds below, and showing the window makes
+/// D-Bus calls of its own, which cannot block on a runtime from within one.
+/// Answering off the runtime also returns the D-Bus call immediately instead of
+/// holding the caller for as long as the window takes to place and map.
+///
+/// One worker rather than one thread per signal keeps toggles in the order they
+/// arrived: a fast hide/show pair must not land reversed.
+fn off_runtime<F>(on_toggle: F) -> impl Fn() + Send + Sync + 'static
+where
+    F: Fn() + Send + 'static,
+{
+    let (tx, rx) = std::sync::mpsc::channel::<()>();
+    std::thread::spawn(move || {
+        while rx.recv().is_ok() {
+            on_toggle();
+        }
+    });
+    // A Sender is Send but not Sync, and the D-Bus service holds its callback
+    // behind a shared reference.
+    let tx = Mutex::new(tx);
+    move || {
+        if let Ok(tx) = tx.lock() {
+            let _ = tx.send(());
+        }
+    }
+}
+
 /// Start a background thread that:
 /// 1. Registers a compositor-specific keybinding for Alt+Space
 /// 2. Registers a D-Bus service to listen for Toggle calls
@@ -143,6 +174,7 @@ where
     F: Fn() + Send + Sync + 'static,
 {
     let compositor = detect_compositor();
+    let on_toggle = off_runtime(on_toggle);
 
     std::thread::spawn(move || {
         // Reported before registration: health::report keeps the first message

--- a/apps/linows/src-tauri/src/qactions/controls/bluetooth.rs
+++ b/apps/linows/src-tauri/src/qactions/controls/bluetooth.rs
@@ -179,20 +179,19 @@ fn snapshot() -> Result<Snapshot, String> {
     let Some(conn) = dbus::system() else {
         return Err(NO_SERVICE.to_string());
     };
-    let objects: ManagedObjects = dbus::runtime()
-        .block_on(async {
-            conn.call_method(
-                Some(BLUEZ_DEST),
-                "/",
-                Some(OBJECT_MANAGER_IFACE),
-                "GetManagedObjects",
-                &(),
-            )
-            .await?
-            .body()
-            .deserialize()
-        })
-        .map_err(|_| NO_SERVICE.to_string())?;
+    let objects: ManagedObjects = dbus::block_on(async {
+        conn.call_method(
+            Some(BLUEZ_DEST),
+            "/",
+            Some(OBJECT_MANAGER_IFACE),
+            "GetManagedObjects",
+            &(),
+        )
+        .await?
+        .body()
+        .deserialize()
+    })
+    .map_err(|_| NO_SERVICE.to_string())?;
 
     let (adapter_path, adapter_props) = objects
         .iter()
@@ -232,7 +231,7 @@ fn snapshot() -> Result<Snapshot, String> {
 /// Read one device's live `Connected` state and display name by object path.
 fn device_state(path: &str) -> Option<(bool, String)> {
     let conn = dbus::system()?;
-    dbus::runtime().block_on(async {
+    dbus::block_on(async {
         let proxy = zbus::Proxy::new(conn, BLUEZ_DEST, path, DEVICE_IFACE)
             .await
             .ok()?;
@@ -252,7 +251,7 @@ fn set_device_connected(path: &str, connect: bool) -> bool {
         return false;
     };
     let method = if connect { "Connect" } else { "Disconnect" };
-    dbus::runtime().block_on(async {
+    dbus::block_on(async {
         let Ok(proxy) = zbus::Proxy::new(conn, BLUEZ_DEST, path, DEVICE_IFACE).await else {
             return false;
         };
@@ -276,14 +275,13 @@ fn set_powered(adapter_path: &OwnedObjectPath, on: bool) -> Result<(), String> {
     let Some(conn) = dbus::system() else {
         return Err(NO_SERVICE.to_string());
     };
-    dbus::runtime()
-        .block_on(async {
-            zbus::Proxy::new(conn, BLUEZ_DEST, adapter_path.as_str(), ADAPTER_IFACE)
-                .await?
-                .set_property("Powered", on)
-                .await
-        })
-        .map_err(|err| friendly_set_error(&err, on))
+    dbus::block_on(async {
+        zbus::Proxy::new(conn, BLUEZ_DEST, adapter_path.as_str(), ADAPTER_IFACE)
+            .await?
+            .set_property("Powered", on)
+            .await
+    })
+    .map_err(|err| friendly_set_error(&err, on))
 }
 
 fn friendly_set_error(err: &zbus::fdo::Error, target: bool) -> String {
@@ -314,12 +312,11 @@ fn wait_for_power_state(adapter_path: &OwnedObjectPath, target: bool) -> bool {
 
 fn read_powered(adapter_path: &OwnedObjectPath) -> Option<bool> {
     let conn = dbus::system()?;
-    dbus::runtime()
-        .block_on(async {
-            zbus::Proxy::new(conn, BLUEZ_DEST, adapter_path.as_str(), ADAPTER_IFACE)
-                .await?
-                .get_property::<bool>("Powered")
-                .await
-        })
-        .ok()
+    dbus::block_on(async {
+        zbus::Proxy::new(conn, BLUEZ_DEST, adapter_path.as_str(), ADAPTER_IFACE)
+            .await?
+            .get_property::<bool>("Powered")
+            .await
+    })
+    .ok()
 }

--- a/apps/linows/src-tauri/src/qactions/controls/keepawake.rs
+++ b/apps/linows/src-tauri/src/qactions/controls/keepawake.rs
@@ -95,12 +95,11 @@ fn banner(on: bool) -> String {
 /// the lock to hold.
 fn acquire() -> Result<OwnedFd, String> {
     let conn = dbus::system().ok_or_else(|| "Requires systemd-logind".to_string())?;
-    dbus::runtime()
-        .block_on(async {
-            zbus::Proxy::new(conn, LOGIN1_DEST, LOGIN1_PATH, MANAGER_IFACE)
-                .await?
-                .call("Inhibit", &("idle", "Look", "Keep Awake", "block"))
-                .await
-        })
-        .map_err(|_: zbus::Error| "Could not hold a keep-awake lock".to_string())
+    dbus::block_on(async {
+        zbus::Proxy::new(conn, LOGIN1_DEST, LOGIN1_PATH, MANAGER_IFACE)
+            .await?
+            .call("Inhibit", &("idle", "Look", "Keep Awake", "block"))
+            .await
+    })
+    .map_err(|_: zbus::Error| "Could not hold a keep-awake lock".to_string())
 }

--- a/apps/linows/src-tauri/src/qactions/controls/power.rs
+++ b/apps/linows/src-tauri/src/qactions/controls/power.rs
@@ -83,7 +83,7 @@ fn call(method: &str) -> bool {
     let Some(conn) = dbus::system() else {
         return false;
     };
-    dbus::runtime().block_on(async {
+    dbus::block_on(async {
         let Ok(proxy) = zbus::Proxy::new(conn, LOGIN1_DEST, LOGIN1_PATH, MANAGER_IFACE).await
         else {
             return false;

--- a/apps/linows/src-tauri/src/qactions/controls/screensaver.rs
+++ b/apps/linows/src-tauri/src/qactions/controls/screensaver.rs
@@ -67,7 +67,7 @@ fn available() -> bool {
     let Some(conn) = dbus::session() else {
         return false;
     };
-    dbus::runtime().block_on(async {
+    dbus::block_on(async {
         conn.call_method(
             Some(DBUS_DEST),
             DBUS_PATH,
@@ -85,7 +85,7 @@ fn set_active() -> bool {
     let Some(conn) = dbus::session() else {
         return false;
     };
-    dbus::runtime().block_on(async {
+    dbus::block_on(async {
         let Ok(proxy) = zbus::Proxy::new(conn, SS_DEST, SS_PATH, SS_IFACE).await else {
             return false;
         };

--- a/apps/linows/src-tauri/src/qactions/controls/wifi.rs
+++ b/apps/linows/src-tauri/src/qactions/controls/wifi.rs
@@ -87,7 +87,7 @@ fn on_off(on: bool) -> &'static str {
 /// hard-blocked (rfkill) or the machine has no Wi-Fi at all.
 fn read_enabled() -> Result<(bool, bool), String> {
     let conn = dbus::system().ok_or_else(|| NO_SERVICE.to_string())?;
-    dbus::runtime().block_on(async {
+    dbus::block_on(async {
         let proxy = zbus::Proxy::new(conn, NM_DEST, NM_PATH, NM_IFACE)
             .await
             .map_err(|_| NO_SERVICE.to_string())?;
@@ -105,14 +105,13 @@ fn read_enabled() -> Result<(bool, bool), String> {
 
 fn set_enabled(on: bool) -> Result<(), String> {
     let conn = dbus::system().ok_or_else(|| NO_SERVICE.to_string())?;
-    dbus::runtime()
-        .block_on(async {
-            zbus::Proxy::new(conn, NM_DEST, NM_PATH, NM_IFACE)
-                .await?
-                .set_property("WirelessEnabled", on)
-                .await
-        })
-        .map_err(|_| format!("Could not turn Wi-Fi {}", on_off(on)))
+    dbus::block_on(async {
+        zbus::Proxy::new(conn, NM_DEST, NM_PATH, NM_IFACE)
+            .await?
+            .set_property("WirelessEnabled", on)
+            .await
+    })
+    .map_err(|_| format!("Could not turn Wi-Fi {}", on_off(on)))
 }
 
 /// Polls `WirelessEnabled` until it reaches `target` or the settle timeout. Runs

--- a/apps/linows/src/css/components/superactions.css
+++ b/apps/linows/src/css/components/superactions.css
@@ -55,16 +55,19 @@ html.controls-open #hint-bar {
     --ctl-gap: var(--inner-gap);
 }
 
-/* Opaque panel: stack a todo-stats panel under the bento to fill the dead space.
+/* Framed panel: stack a todo-stats panel under the bento to fill the dead space.
+ * data-framed is set by js/layout.js from platform.floatingSupported, so every
+ * stack that cannot rest on a transparent window gets the fill - not just the
+ * ones with no compositor at all.
  * :not([hidden]) is load-bearing: the strip hides on the first keystroke via the
  * `hidden` attribute, and a bare display:flex here outranks it and pins the bento
  * open under the results. */
-html[data-transparent="false"] .control-strip:not([hidden]) {
+html[data-framed] .control-strip:not([hidden]) {
     display: flex;
     flex-direction: column;
 }
 
-html[data-transparent="false"] .control-strip-grid {
+html[data-framed] .control-strip-grid {
     height: auto;
     flex: 0 0 auto;
 }

--- a/apps/linows/src/css/components/superactions.css
+++ b/apps/linows/src/css/components/superactions.css
@@ -55,36 +55,6 @@ html.controls-open #hint-bar {
     --ctl-gap: var(--inner-gap);
 }
 
-/* Framed panel: stack a todo-stats panel under the bento to fill the dead space.
- * data-framed is set by js/layout.js from platform.floatingSupported, so every
- * stack that cannot rest on a transparent window gets the fill - not just the
- * ones with no compositor at all.
- * :not([hidden]) is load-bearing: the strip hides on the first keystroke via the
- * `hidden` attribute, and a bare display:flex here outranks it and pins the bento
- * open under the results. */
-html[data-framed] .control-strip:not([hidden]) {
-    display: flex;
-    flex-direction: column;
-}
-
-html[data-framed] .control-strip-grid {
-    height: auto;
-    flex: 0 0 auto;
-}
-
-/* Charts can't grow (square heatmap cells, fixed insight row), so spread them
- * to fill the leftover height. */
-.control-strip-stats {
-    flex: 1 1 auto;
-    min-height: 0;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    gap: 8px;
-    margin-top: var(--content-padding);
-    overflow: hidden;
-}
-
 /* Entrance: each tile eases up + fades in, staggered by its grid index (--i)
  * so the launchpad cascades in when summoned. `backwards` fill holds the tile
  * hidden through its delay, then hands transform back to the base rule so

--- a/apps/linows/src/css/layout.css
+++ b/apps/linows/src/css/layout.css
@@ -505,14 +505,23 @@ html[data-os="windows"] .bar-free .pane-tile {
     margin-bottom: var(--inner-gap);
 }
 
-/* Classic columns run flush to the window, so the pill's outer edge takes the
- * top bar's inset; inner edges keep --row-inset for the divider. */
-.launcher-window:not(.floating) #results-col .results-list {
-    --row-inset-left: var(--content-padding);
+/* Classic columns run flush to the window, so the chrome around them takes the
+ * rows' inset rather than --content-padding: every left edge in the panel lines
+ * up and each keeps equal gutters. Floating and resting inset the bar as a
+ * tile, so they keep the wider one. */
+.launcher-window:not(.bar-free) .top-bar {
+    margin-left: var(--row-inset);
+    margin-right: var(--row-inset);
 }
 
-.launcher-window:not(.floating) #preview-col .results-list {
-    --row-inset-right: var(--content-padding);
+.launcher-window:not(.bar-free) .hint-bar {
+    padding-left: var(--row-inset);
+    padding-right: var(--row-inset);
+}
+
+.launcher-window:not(.bar-free) .ai-card {
+    margin-left: var(--row-inset);
+    margin-right: var(--row-inset);
 }
 
 /* Unlike the classic row: a rectangular clip slices tile shadows and footer

--- a/apps/linows/src/css/layout.css
+++ b/apps/linows/src/css/layout.css
@@ -505,6 +505,16 @@ html[data-os="windows"] .bar-free .pane-tile {
     margin-bottom: var(--inner-gap);
 }
 
+/* Classic columns run flush to the window, so the pill's outer edge takes the
+ * top bar's inset; inner edges keep --row-inset for the divider. */
+.launcher-window:not(.floating) #results-col .results-list {
+    --row-inset-left: var(--content-padding);
+}
+
+.launcher-window:not(.floating) #preview-col .results-list {
+    --row-inset-right: var(--content-padding);
+}
+
 /* Unlike the classic row: a rectangular clip slices tile shadows and footer
  * popovers along a straight line, which at a rounded corner reads as a sharp
  * angle. Nothing escapes anyway - tiles scroll their own content, and the

--- a/apps/linows/src/css/layout.css
+++ b/apps/linows/src/css/layout.css
@@ -4,8 +4,6 @@
     flex-direction: column;
     height: 100vh;
     background: var(--bg-tint);
-    backdrop-filter: blur(var(--blur-radius, 0px));
-    -webkit-backdrop-filter: blur(var(--blur-radius, 0px));
     border: var(--border-thickness) solid var(--border-color);
     border-radius: var(--corner-radius);
     overflow: hidden;
@@ -64,25 +62,23 @@ html[data-os="windows"] .launcher-window {
     border-radius: var(--panel-radius);
 }
 
-/* WebKitGTK ghost-rendering workaround. Hyprland users hit this automatically
- * (their compositor + webkit combo triggers it); Arch GNOME users opt in via
- * the Advanced > Arch > "Disable blur effect" toggle which sets
- * data-disable-blur on documentElement. Either way: drop backdrop-filter,
- * applytint() forces a near-opaque tint so the window stays readable. */
-[data-compositor="hyprland"] .launcher-window,
-[data-compositor="hyprland"] .launcher-window::before,
-[data-disable-blur] .launcher-window,
-[data-disable-blur] .launcher-window::before {
-    backdrop-filter: none !important;
-    -webkit-backdrop-filter: none !important;
+/* The window backdrop is WebView2's alone. A backdrop-filter samples the page
+ * painted under the element, and on Linux nothing is: a non-zero --blur-radius
+ * means a compositor was found, which is the same test that makes html/body
+ * transparent, so the panel and the floating tiles sit on nothing. WebKitGTK
+ * still builds the filter layer and re-samples it every frame, and the sample
+ * it takes is the frame before - the accumulating blurred ghosts of #256, #330
+ * and #411. Linux frost is the ::before image's own `filter`, plus the
+ * compositor region in platform/linux/blur.rs where one is granted. */
+html[data-os="windows"] .launcher-window:not(.bar-free),
+html[data-os="windows"] .bar-free .pane-tile {
+    backdrop-filter: blur(var(--blur-radius, 0px));
+    -webkit-backdrop-filter: blur(var(--blur-radius, 0px));
 }
 
-/* Same guard for the floating tiles. Readability without blur is already
- * covered: applytint() forces a near-opaque --bg-tint in these environments,
- * and the tiles reuse it as their tint layer. */
-[data-compositor="hyprland"] .pane-tile,
+/* The action menu is the one surface with real page content behind it, so it
+ * keeps the filter - and keeps the opt-out for the stacks that ghost. */
 [data-compositor="hyprland"] .action-menu,
-[data-disable-blur] .pane-tile,
 [data-disable-blur] .action-menu {
     backdrop-filter: none !important;
     -webkit-backdrop-filter: none !important;
@@ -448,12 +444,11 @@ html[data-os="windows"] .launcher-window {
  *   .floating-grid - floating two-card state: hints move into card footers
  */
 
-/* barFloatsFree: no window backdrop box; tiles float on the bare desktop. */
+/* barFloatsFree: no window backdrop box; tiles float on the bare desktop. The
+ * filter is already off here - the rule above excludes .bar-free. */
 .launcher-window.bar-free {
     background: transparent;
     border-color: transparent;
-    backdrop-filter: none;
-    -webkit-backdrop-filter: none;
 }
 
 .launcher-window.bar-free::before {
@@ -476,8 +471,6 @@ html[data-os="windows"] .launcher-window {
     background-image:
         linear-gradient(var(--control-fill), var(--control-fill)),
         linear-gradient(var(--bg-tint), var(--bg-tint));
-    backdrop-filter: blur(var(--blur-radius, 0px));
-    -webkit-backdrop-filter: blur(var(--blur-radius, 0px));
     border: var(--border-thickness) solid var(--border-color);
     border-radius: var(--tile-radius);
     box-shadow: 0 3px 7px rgba(var(--shadow), 0.25);

--- a/apps/linows/src/html/screens/settings.html
+++ b/apps/linows/src/html/screens/settings.html
@@ -808,29 +808,31 @@
 
                 <div class="settings-divider settings-linux-only"></div>
 
-                <!-- Arch: workarounds for WebKitGTK ghost rendering. Linux-only. -->
+                <!-- Rendering: workarounds for WebKitGTK ghost rendering. Not one
+             distro's problem - reported on Arch, Ubuntu and in VMs. Linux-only. -->
                 <div class="settings-section-header settings-linux-only">
-                    <span class="settings-section-arrow">&#9654;</span><span>Arch</span>
+                    <span class="settings-section-arrow">&#9654;</span><span>Rendering</span>
                 </div>
                 <div class="settings-section settings-linux-only">
                     <div class="settings-row">
                         <label class="settings-label">Disable GPU compositing</label>
                         <label class="settings-toggle">
-                            <input type="checkbox" id="settings-arch-disable-gpu" />
+                            <input type="checkbox" id="settings-disable-gpu" />
                             <span class="settings-toggle-track"></span>
                         </label>
                         <span class="settings-hint-text"
-                            >Fixes ghost slider trails on Arch. Requires restart.</span
+                            >Fixes ghost trails on WebKitGTK stacks that smear. Requires
+                            restart.</span
                         >
                     </div>
                     <div class="settings-row">
                         <label class="settings-label">Disable blur effect</label>
                         <label class="settings-toggle">
-                            <input type="checkbox" id="settings-arch-disable-blur" />
+                            <input type="checkbox" id="settings-disable-blur" />
                             <span class="settings-toggle-track"></span>
                         </label>
                         <span class="settings-hint-text"
-                            >Fallback if GPU toggle doesn't help. Drops blur, keeps tint.</span
+                            >Fallback if the GPU toggle doesn't help. Drops blur, keeps tint.</span
                         >
                     </div>
                 </div>

--- a/apps/linows/src/html/screens/settings.html
+++ b/apps/linows/src/html/screens/settings.html
@@ -57,7 +57,9 @@
                         <input type="checkbox" id="settings-running-apps" checked />
                         <span class="settings-toggle-track"></span>
                     </label>
-                    <span style="margin-left: 40px">Super Actions</span>
+                    <span id="settings-super-actions-label" style="margin-left: 40px"
+                        >Super Actions</span
+                    >
                     <label
                         class="settings-toggle"
                         title="Show quick-actions launchpad on the empty home screen (Alt+letter)"

--- a/apps/linows/src/js/components/superactions.js
+++ b/apps/linows/src/js/components/superactions.js
@@ -356,6 +356,13 @@ export function isEnabled() {
     return enabled;
 }
 
+// Drop the built DOM so the next reveal rebuilds it. The stats block below the
+// bento exists only where the panel stays opaque, and the blur toggle flips
+// that (platform.floatingSupported) while the strip is already built.
+export function invalidate() {
+    built = false;
+}
+
 // Build (once) then reveal: read live state, start the timers, play the cascade.
 // Fetches the layout first if needed, so a summon before/after a failed prefetch
 // still builds instead of no-opping forever.
@@ -1025,8 +1032,12 @@ function render(layout) {
 
     // Opaque panel only: fill the dead space below the bento with todo stats.
     // Transparent/floating panels leave it see-through, so nothing to fill.
+    // The test is floatingSupported, not hasCompositor: every stack that keeps
+    // the classic framed panel has the same dead space, whether it lacks a
+    // compositor (i3) or renders translucency too badly to rest on it (VMs,
+    // Hyprland, the blur toggle).
     statsEl = null;
-    if (!platform.hasCompositor()) {
+    if (!platform.floatingSupported()) {
         statsEl = document.createElement('div');
         statsEl.className = 'control-strip-stats';
         container.appendChild(statsEl);

--- a/apps/linows/src/js/components/superactions.js
+++ b/apps/linows/src/js/components/superactions.js
@@ -77,6 +77,8 @@ import { gridPlacement, gridShape } from './launchpad-grid.js';
 
 let container = null;
 let built = false;
+// What the user asked for, before the platform gets a say (see applyEnabled).
+let configEnabled = true;
 let visible = false;
 // Todo-stats panel filling the dead space below the bento on the opaque
 // (no-transparency) panel. Null elsewhere. Populated by refreshTodo.
@@ -347,9 +349,25 @@ export function isVisible() {
 // its accelerators stop firing; turning it on lets the next syncControlStrip
 // reveal it on the empty home screen.
 export function setEnabled(on) {
-    if (enabled === on) return;
-    enabled = on;
-    if (!on) setVisible(false);
+    configEnabled = on;
+    applyEnabled();
+}
+
+// Re-derive after something moved the floating gate at runtime - the blur
+// fallback toggle is the one thing that does.
+export function refreshAvailability() {
+    applyEnabled();
+}
+
+// Same rule as the inner gap: the launchpad is the empty home screen's resting
+// state, and a stack that cannot render that (platform.floatingSupported)
+// shows the results list there instead. The config value is never touched, so
+// the launchpad comes back by itself on a capable setup.
+function applyEnabled() {
+    const next = configEnabled && platform.floatingSupported();
+    if (enabled === next) return;
+    enabled = next;
+    if (!next) setVisible(false);
 }
 
 export function isEnabled() {

--- a/apps/linows/src/js/components/superactions.js
+++ b/apps/linows/src/js/components/superactions.js
@@ -70,7 +70,6 @@ import {
     musicSnapshot,
     musicCommand,
 } from '../screens/commands/pomo.js';
-import { statsWidgetHtml } from '../screens/commands/todo.js';
 import * as platform from '../platform.js';
 import * as banner from './banner.js';
 import { gridPlacement, gridShape } from './launchpad-grid.js';
@@ -80,9 +79,6 @@ let built = false;
 // What the user asked for, before the platform gets a say (see applyEnabled).
 let configEnabled = true;
 let visible = false;
-// Todo-stats panel filling the dead space below the bento on the opaque
-// (no-transparency) panel. Null elsewhere. Populated by refreshTodo.
-let statsEl = null;
 // User setting (Settings -> Appearance -> Super Actions). When off the strip
 // never shows and its accelerators never fire; setVisible collapses to hidden.
 let enabled = true;
@@ -816,15 +812,6 @@ async function refreshTodo() {
     openTasks = mine.filter((t) => !t.done).map((t) => t.name);
     taskCursor = 0;
     renderSlot();
-    renderStatsWidget(tasks);
-}
-
-// Reuses the priority slot's todoList() rows. width = card content (minus 30px
-// chrome: 2x14 padding + 2x1 border) so the heatmap cells scale to fit.
-function renderStatsWidget(tasks) {
-    if (!statsEl) return;
-    const width = Math.max(280, statsEl.clientWidth - 30);
-    statsEl.innerHTML = statsWidgetHtml(tasks || [], width);
 }
 
 // Rotate through the open tasks so a long day's list all gets a turn, matching
@@ -1047,19 +1034,6 @@ function render(layout) {
 
     container.innerHTML = '';
     container.appendChild(grid);
-
-    // Opaque panel only: fill the dead space below the bento with todo stats.
-    // Transparent/floating panels leave it see-through, so nothing to fill.
-    // The test is floatingSupported, not hasCompositor: every stack that keeps
-    // the classic framed panel has the same dead space, whether it lacks a
-    // compositor (i3) or renders translucency too badly to rest on it (VMs,
-    // Hyprland, the blur toggle).
-    statsEl = null;
-    if (!platform.floatingSupported()) {
-        statsEl = document.createElement('div');
-        statsEl.className = 'control-strip-stats';
-        container.appendChild(statsEl);
-    }
 }
 
 function buildTile(tile) {

--- a/apps/linows/src/js/layout.js
+++ b/apps/linows/src/js/layout.js
@@ -151,8 +151,8 @@ export function hidesResultsForEmptyQuery() {
     return onHome() && (platform.floatingSupported() || superactions.isEnabled());
 }
 
-// Re-evaluate the floating gate after environment state changes at runtime
-// (the settings blur-fallback toggle flips data-disable-blur).
+// Re-apply after the settings blur-fallback toggle: the gate itself no longer
+// reads it, but the tint and the blur region behind the tiles change with it.
 export function refresh() {
     apply();
 }
@@ -164,9 +164,9 @@ function onHome() {
 
 function apply() {
     if (!win) return;
-    // Degraded-rendering environments keep the classic framed panel: both the
+    // A setup without a compositor keeps the classic framed panel: both the
     // gaps and the resting bar depend on real transparency. Still coarse -
-    // platform info is static and the attribute only flips from settings.
+    // platform info is static.
     const supported = platform.floatingSupported();
     const home = onHome();
     const floating = supported && innerGap > 0 && home; // showsFloatingCards

--- a/apps/linows/src/js/layout.js
+++ b/apps/linows/src/js/layout.js
@@ -168,6 +168,13 @@ function apply() {
     // gaps and the resting bar depend on real transparency. Still coarse -
     // platform info is static and the attribute only flips from settings.
     const supported = platform.floatingSupported();
+    // The classic framed panel keeps its box whatever the query does, so the
+    // launchpad fills the space under the bento with todo stats instead of
+    // leaving a column of empty tint (css/components/superactions.css).
+    const root = document.documentElement;
+    if (root.hasAttribute('data-framed') === supported) {
+        root.toggleAttribute('data-framed', !supported);
+    }
     const home = onHome();
     const floating = supported && innerGap > 0 && home; // showsFloatingCards
     const resting = supported && queryEmpty && home; // macOS hidesResultsForEmptyQuery, as a CSS state

--- a/apps/linows/src/js/layout.js
+++ b/apps/linows/src/js/layout.js
@@ -168,13 +168,6 @@ function apply() {
     // gaps and the resting bar depend on real transparency. Still coarse -
     // platform info is static and the attribute only flips from settings.
     const supported = platform.floatingSupported();
-    // The classic framed panel keeps its box whatever the query does, so the
-    // launchpad fills the space under the bento with todo stats instead of
-    // leaving a column of empty tint (css/components/superactions.css).
-    const root = document.documentElement;
-    if (root.hasAttribute('data-framed') === supported) {
-        root.toggleAttribute('data-framed', !supported);
-    }
     const home = onHome();
     const floating = supported && innerGap > 0 && home; // showsFloatingCards
     const resting = supported && queryEmpty && home; // macOS hidesResultsForEmptyQuery, as a CSS state

--- a/apps/linows/src/js/layout.js
+++ b/apps/linows/src/js/layout.js
@@ -151,8 +151,8 @@ export function hidesResultsForEmptyQuery() {
     return onHome() && (platform.floatingSupported() || superactions.isEnabled());
 }
 
-// Re-apply after the settings blur-fallback toggle: the gate itself no longer
-// reads it, but the tint and the blur region behind the tiles change with it.
+// Re-evaluate the floating gate after environment state changes at runtime
+// (the settings blur-fallback toggle flips data-disable-blur).
 export function refresh() {
     apply();
 }
@@ -164,9 +164,9 @@ function onHome() {
 
 function apply() {
     if (!win) return;
-    // A setup without a compositor keeps the classic framed panel: both the
+    // Degraded-rendering environments keep the classic framed panel: both the
     // gaps and the resting bar depend on real transparency. Still coarse -
-    // platform info is static.
+    // platform info is static and the attribute only flips from settings.
     const supported = platform.floatingSupported();
     const home = onHome();
     const floating = supported && innerGap > 0 && home; // showsFloatingCards

--- a/apps/linows/src/js/platform.js
+++ b/apps/linows/src/js/platform.js
@@ -40,20 +40,29 @@ export function blurForcedOff() {
     return info?.virtual_gpu ?? false;
 }
 
-// The floating inner-gap layout needs see-through gaps, so it needs a
-// compositor: without one (bare X11/i3) "transparent" pixels come out opaque
-// and the gaps read as empty boxes. That is now the whole requirement. The VM
-// software-rendering fallback and the ghost-rendering stacks (Hyprland auto,
-// Arch toggle) used to be excluded too, because the tiles were frosted with
-// backdrop-filter - but no Linux surface carries one since layout.css made it
-// Windows-only, and a tint gradient in transparent gaps is the same drawing
-// those stacks already do for the window itself.
+// The floating inner-gap layout depends on see-through gaps and frosted
+// tiles, so it needs WebKitGTK to composite translucency faithfully. That
+// rules out: no compositor (bare X11/i3 - "transparent" pixels come out
+// opaque, gaps read as empty boxes), the VM software-rendering fallback, and
+// the ghost-rendering stacks where blur is dropped (Hyprland auto, Arch
+// toggle). Those render the classic framed panel regardless of the inner_gap
+// setting; the config value stays untouched and applies again on a capable
+// setup.
 //
-// An unsupported environment renders the classic framed panel regardless of
-// the inner_gap setting; the config value stays untouched and applies again
-// on a capable setup.
+// The frosting is gone (layout.css made backdrop-filter Windows-only) but the
+// gate is not just about frosting: .bar-free drops the window's opaque tint,
+// and on a stack that leaves stale pixels in the window buffer that opaque
+// fill is the only thing overwriting them each frame. Verified 2026-09-06 in
+// the Arch VM - allowing floating there painted the launchpad and a stale
+// results list on top of each other. Do not widen this without a fix for the
+// buffer itself.
 export function floatingSupported() {
-    return hasCompositor();
+    return (
+        hasCompositor() &&
+        !blurForcedOff() &&
+        compositor() !== 'hyprland' &&
+        !document.documentElement.hasAttribute('data-disable-blur')
+    );
 }
 
 export function os() {

--- a/apps/linows/src/js/platform.js
+++ b/apps/linows/src/js/platform.js
@@ -34,27 +34,26 @@ export function compositorBlur() {
 }
 
 // True when the blur fallback is forced by the platform (VM GPU) rather than
-// the arch_disable_blur config toggle. Settings must not remove the
+// the disable_blur_effect config toggle. Settings must not remove the
 // attribute in this case.
 export function blurForcedOff() {
     return info?.virtual_gpu ?? false;
 }
 
-// The floating inner-gap layout depends on see-through gaps and frosted
-// tiles, so it needs WebKitGTK to composite translucency faithfully. That
-// rules out the same environments applytint() degrades on: no compositor
-// (bare X11/i3 - "transparent" pixels come out opaque, gaps read as empty
-// boxes), the VM software-rendering fallback, and the ghost-rendering
-// stacks where blur is dropped (Hyprland auto, Arch toggle). Those render
-// the classic framed panel regardless of the inner_gap setting; the config
-// value stays untouched and applies again on a capable setup.
+// The floating inner-gap layout needs see-through gaps, so it needs a
+// compositor: without one (bare X11/i3) "transparent" pixels come out opaque
+// and the gaps read as empty boxes. That is now the whole requirement. The VM
+// software-rendering fallback and the ghost-rendering stacks (Hyprland auto,
+// Arch toggle) used to be excluded too, because the tiles were frosted with
+// backdrop-filter - but no Linux surface carries one since layout.css made it
+// Windows-only, and a tint gradient in transparent gaps is the same drawing
+// those stacks already do for the window itself.
+//
+// An unsupported environment renders the classic framed panel regardless of
+// the inner_gap setting; the config value stays untouched and applies again
+// on a capable setup.
 export function floatingSupported() {
-    return (
-        hasCompositor() &&
-        !blurForcedOff() &&
-        compositor() !== 'hyprland' &&
-        !document.documentElement.hasAttribute('data-disable-blur')
-    );
+    return hasCompositor();
 }
 
 export function os() {

--- a/apps/linows/src/js/screens/commands/todo.js
+++ b/apps/linows/src/js/screens/commands/todo.js
@@ -823,25 +823,6 @@ function insightsHtml(trend) {
         .join('<div class="cmd-todo-insight-sep"></div>');
 }
 
-// Year heatmap + 30-day insights for the super-actions strip. Pure: builds its
-// own counts from raw todoList() rows, so it ignores the /todo page's store.
-// width is the heatmap card's content width in px.
-export function statsWidgetHtml(rows, width) {
-    const counts = new Map();
-    for (const r of rows || []) {
-        const c = counts.get(r.due_date) || { done: 0, total: 0 };
-        c.total += 1;
-        if (r.done) c.done += 1;
-        counts.set(r.due_date, c);
-    }
-    const trend = trendData(counts);
-    return `
-    <div class="cmd-todo-section-title">${calendar} ACTIVITY · LAST YEAR${heatLegendHtml()}</div>
-    <div class="cmd-todo-card">${heatmapHtml(counts, width)}</div>
-    <div class="cmd-todo-section-title">${zap} INSIGHTS · LAST ${TREND_DAYS} DAYS (TASKS)</div>
-    <div class="cmd-todo-card cmd-todo-insights">${insightsHtml(trend)}</div>`;
-}
-
 // Leftover panel height is split between the trend chart (which grows a
 // little) and the section gaps (which widen evenly), so the page fills the
 // panel without any one chart ballooning. The heatmap can't grow: its

--- a/apps/linows/src/js/screens/settings.js
+++ b/apps/linows/src/js/screens/settings.js
@@ -412,19 +412,19 @@ export function init(exitFn) {
         saveConfig({ backend_log_level: item.dataset.value });
     });
 
-    // Launch at login
-    document.getElementById('settings-arch-disable-gpu').addEventListener('change', (e) => {
-        saveConfig({ arch_disable_gpu: e.target.checked ? 'true' : 'false' });
+    // Rendering workarounds
+    document.getElementById('settings-disable-gpu').addEventListener('change', (e) => {
+        saveConfig({ disable_gpu_compositing: e.target.checked ? 'true' : 'false' });
     });
 
-    document.getElementById('settings-arch-disable-blur').addEventListener('change', (e) => {
+    document.getElementById('settings-disable-blur').addEventListener('change', (e) => {
         const on = e.target.checked;
         if (on) {
             document.documentElement.setAttribute('data-disable-blur', '');
         } else if (!platform.blurForcedOff()) {
             document.documentElement.removeAttribute('data-disable-blur');
         }
-        saveConfig({ arch_disable_blur: on ? 'true' : 'false' });
+        saveConfig({ disable_blur_effect: on ? 'true' : 'false' });
         applytint();
         updateInnerGapAvailability();
         layout.refresh();
@@ -744,9 +744,9 @@ export async function restoreOnStartup() {
     try {
         const map = await loadConfigMap();
 
-        // Apply Arch blur-disable BEFORE first tint pass so initial render is
+        // Apply the blur-disable BEFORE first tint pass so initial render is
         // already opaque if the user toggled it.
-        if (map.arch_disable_blur === 'true') {
+        if (disableBlurSet(map)) {
             document.documentElement.setAttribute('data-disable-blur', '');
         }
 
@@ -843,6 +843,18 @@ async function loadConfigMap() {
     return map;
 }
 
+// Config keys renamed out of their `arch_` prefix once the ghosting turned out
+// to be a WebKitGTK trait rather than an Arch one. The old name is read when
+// the new one is absent, so an existing config keeps its setting; saving writes
+// the new name.
+function boolKey(map, key, legacyKey) {
+    return (map[key] ?? map[legacyKey]) === 'true';
+}
+
+function disableBlurSet(map) {
+    return boolKey(map, 'disable_blur_effect', 'arch_disable_blur');
+}
+
 // Environments that can't render the floating layout (see
 // platform.floatingSupported) get the slider disabled; the config value is
 // preserved so it applies again on a capable setup.
@@ -936,11 +948,13 @@ async function loadConfig() {
         document.getElementById('settings-super-actions').checked =
             map.super_actions_enabled !== 'false';
         document.getElementById('settings-ai-enabled').checked = map.ai_enabled !== 'false';
-        document.getElementById('settings-arch-disable-gpu').checked =
-            map.arch_disable_gpu === 'true';
-        document.getElementById('settings-arch-disable-blur').checked =
-            map.arch_disable_blur === 'true';
-        if (map.arch_disable_blur === 'true') {
+        document.getElementById('settings-disable-gpu').checked = boolKey(
+            map,
+            'disable_gpu_compositing',
+            'arch_disable_gpu',
+        );
+        document.getElementById('settings-disable-blur').checked = disableBlurSet(map);
+        if (disableBlurSet(map)) {
             document.documentElement.setAttribute('data-disable-blur', '');
         } else if (!platform.blurForcedOff()) {
             document.documentElement.removeAttribute('data-disable-blur');
@@ -1240,7 +1254,8 @@ function getSliderVal(key) {
     return parseFloat(row.querySelector('.settings-slider')?.value || 0);
 }
 
-// Stacks where WebKitGTK ghost-renders backdrop-filter, so the CSS drops it.
+// Stacks where WebKitGTK ghost-renders composited layers, so the CSS drops what
+// filters are left and applytint() stops leaning on translucency.
 function isGhostingStack() {
     return platform.compositor() === 'hyprland';
 }
@@ -1273,9 +1288,10 @@ function applytint() {
         document.documentElement.style.setProperty('--bg-tint', `rgb(${r}, ${g}, ${b})`);
         return;
     }
-    // Hyprland (auto) and Arch toggle (manual): backdrop-filter is disabled
-    // (CSS) due to WebKitGTK ghosting. Force a near-opaque alpha so themes
-    // still pick the color while the window stays readable without blur.
+    // Hyprland (auto) and Arch toggle (manual): the stacks WebKitGTK ghosts on.
+    // The window's own backdrop-filter is gone on Linux either way (layout.css);
+    // this is the extra safety net, a near-opaque alpha so themes still pick the
+    // color while the window stays readable on a stack that renders it badly.
     // Unless the compositor blurs behind the window - then readability is not
     // ours to defend, and the floor would hide the frost we just asked for.
     if (!platform.compositorBlur() && (isGhostingStack() || hasDisableBlur())) {

--- a/apps/linows/src/js/screens/settings.js
+++ b/apps/linows/src/js/screens/settings.js
@@ -427,7 +427,9 @@ export function init(exitFn) {
         saveConfig({ disable_blur_effect: on ? 'true' : 'false' });
         applytint();
         updateInnerGapAvailability();
+        updateSuperActionsAvailability();
         superactions.invalidate();
+        superactions.refreshAvailability();
         layout.refresh();
     });
 
@@ -867,10 +869,26 @@ function updateInnerGapAvailability() {
     row.classList.toggle('settings-row-disabled', !ok);
 }
 
+// Same gate, same deal for the launchpad: where it can't render, the empty home
+// screen shows the results list instead and the toggle is inert until that
+// changes. It shares a row with Running Apps, so only its own label and switch
+// dim.
+function updateSuperActionsAvailability() {
+    const input = document.getElementById('settings-super-actions');
+    if (!input) return;
+    const ok = platform.floatingSupported();
+    input.disabled = !ok;
+    input.closest('.settings-toggle')?.classList.toggle('settings-row-disabled', !ok);
+    document
+        .getElementById('settings-super-actions-label')
+        ?.classList.toggle('settings-row-disabled', !ok);
+}
+
 async function loadConfig() {
     try {
         const cfg = await getConfig();
         updateInnerGapAvailability();
+        updateSuperActionsAvailability();
 
         const map = {};
         for (const entry of cfg.entries) map[entry.key] = entry.value;

--- a/apps/linows/src/js/screens/settings.js
+++ b/apps/linows/src/js/screens/settings.js
@@ -427,6 +427,7 @@ export function init(exitFn) {
         saveConfig({ disable_blur_effect: on ? 'true' : 'false' });
         applytint();
         updateInnerGapAvailability();
+        superactions.invalidate();
         layout.refresh();
     });
 

--- a/apps/linows/src/js/screens/settings.js
+++ b/apps/linows/src/js/screens/settings.js
@@ -887,8 +887,6 @@ function updateSuperActionsAvailability() {
 async function loadConfig() {
     try {
         const cfg = await getConfig();
-        updateInnerGapAvailability();
-        updateSuperActionsAvailability();
 
         const map = {};
         for (const entry of cfg.entries) map[entry.key] = entry.value;
@@ -978,6 +976,12 @@ async function loadConfig() {
         } else if (!platform.blurForcedOff()) {
             document.documentElement.removeAttribute('data-disable-blur');
         }
+
+        // After the blur attribute above: both read floatingSupported, which
+        // depends on it, so a reset or a reload that changes blur would leave
+        // them describing the previous state.
+        updateInnerGapAvailability();
+        updateSuperActionsAvailability();
 
         // Dir lists
         configCache.file_scan_extra_roots = map.file_scan_extra_roots || '';


### PR DESCRIPTION
## Summary

- Try fixing ghosting issue in some linux distros
- Disable all superactions on Linux Vms or non-supported DE (compositor issue, wm issue...)
- Some UI fixes
- Fix crash runtime error on Fedora with AppImage

## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [x] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

## Checklist

- [x] I have read and agree to the CLA (CLA.md)
- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Linux users can optionally display the window above fullscreen applications on supported Wayland compositors.
  - Super Actions availability now reflects platform support.
  - Rendering settings use clearer WebKitGTK-focused names across Linux environments.

- **Bug Fixes**
  - Existing rendering preferences remain compatible after the settings rename.
  - Linux windows avoid invalid zero-sized layouts and fall back to usable defaults.
  - Improved reliability for Linux controls, shortcuts, and platform integrations.
  - Removed the separate opaque-panel Todo statistics display.

- **Documentation**
  - Added installation and compatibility guidance for the optional Wayland layer-shell dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->