### PR TITLE
chore: default inner gap to 7

### DIFF
--- a/apps/linows/src/html/screens/settings.html
+++ b/apps/linows/src/html/screens/settings.html
@@ -93,9 +93,9 @@
                             min="0"
                             max="24"
                             step="1"
-                            value="0"
+                            value="7"
                         />
-                        <span class="settings-slider-value">0</span>
+                        <span class="settings-slider-value">7</span>
                     </div>
                     <div
                         class="settings-row"

--- a/apps/linows/src/js/screens/settings.js
+++ b/apps/linows/src/js/screens/settings.js
@@ -27,6 +27,10 @@ const TABS = ['appearance', 'advanced', 'shortcuts'];
 // Sentinel the Font field falls back to: "let the theme decide", not a family.
 const DEFAULT_FONT_NAME = 'system-ui';
 
+// No config file yet: land on the floating tiles, same as macOS
+// ThemeSettings.innerGap and the template Reset writes.
+const INNER_GAP_DEFAULT = 7;
+
 const SAVE_MSG_MS = 1600;
 let saveMsgTimer = null;
 
@@ -676,7 +680,7 @@ export async function reloadFromFile() {
         if (map.ui_border_thickness) CSS_MAP.ui_border_thickness(map.ui_border_thickness);
 
         // Floating layout gap + corner rounding
-        CSS_MAP.inner_gap(map.inner_gap || 0);
+        CSS_MAP.inner_gap(map.inner_gap || INNER_GAP_DEFAULT);
         if (map.ui_surface_radius) CSS_MAP.ui_surface_radius(map.ui_surface_radius);
 
         // If settings screen is open, refresh the UI sliders too
@@ -790,7 +794,7 @@ export async function restoreOnStartup() {
         }
 
         // Floating layout gap + corner rounding
-        CSS_MAP.inner_gap(map.inner_gap || 0);
+        CSS_MAP.inner_gap(map.inner_gap || INNER_GAP_DEFAULT);
         if (map.ui_surface_radius) CSS_MAP.ui_surface_radius(map.ui_surface_radius);
     } catch {
         // Config may not exist yet

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -409,7 +409,7 @@ The Appearance tab controls:
 - **Font** - name and size for launcher text
 - **Font Color** - text color (RGB + opacity)
 - **Border** - border thickness and color
-- **Inner Gap** - gap between the top row, results list and preview, `0` to `24` in the platform's own unit (points on macOS, pixels on Linux and Windows). `0` is the classic framed panel; above 0 each becomes its own floating card. Fresh configs ship `7`, and an absent key means 0. Saved as `inner_gap`
+- **Inner Gap** - gap between the top row, results list and preview, `0` to `24` in the platform's own unit (points on macOS, pixels on Linux and Windows). `0` is the classic framed panel; above 0 each becomes its own floating card. Both a fresh config and an absent key mean `7`. Saved as `inner_gap`
 - **Corner Radius** - one multiplier on the resting corner rounding of every surface at once: the window, the top bar, the super-action tiles, the controls. Range `0` to `2.5`, default `1.5`; `0` is square. Saved as `ui_surface_radius`. One setting rather than one per surface, so they cannot disagree with each other
 
 Built-in theme presets are available:


### PR DESCRIPTION
## Summary

- Default inner gaps for linows from 0 -7 (nowadays, Look looks better with inner gap)

## Testing

  - [x] Manual verification completed (if UI/behavior changed)


## Checklist

- [x] I have read and agree to the CLA (CLA.md)
- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Inner Gap setting now defaults to 7, providing visible spacing between layout sections.
  - The default applies when creating a new configuration or when no Inner Gap value is specified.

- **Documentation**
  - Updated the user guide to reflect the new Inner Gap default of 7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->