### PR TITLE
feat: clipboard history for images

### DIFF
--- a/apps/macos/LauncherApp/LauncherLogicTests/ClipboardQueryPrefixTests.swift
+++ b/apps/macos/LauncherApp/LauncherLogicTests/ClipboardQueryPrefixTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+
+@testable import LauncherLogic
+
+final class ClipboardQueryPrefixTests: XCTestCase {
+    /// `ci"` begins with `c`, so the two histories are one keystroke apart.
+    /// Each prefix must answer only for itself, whichever order a caller checks
+    /// them in.
+    func testTheTwoClipboardPrefixesDoNotSwallowEachOther() {
+        XCTAssertTrue(ClipboardQueryPrefix.image.matches("ci\"logo"))
+        XCTAssertFalse(ClipboardQueryPrefix.text.matches("ci\"logo"))
+        XCTAssertTrue(ClipboardQueryPrefix.text.matches("c\"logo"))
+        XCTAssertFalse(ClipboardQueryPrefix.image.matches("c\"logo"))
+    }
+
+    func testSearchTermIsWhateverFollowsThePrefix() {
+        XCTAssertEqual(ClipboardQueryPrefix.image.searchTerm(in: "ci\""), "")
+        XCTAssertEqual(ClipboardQueryPrefix.image.searchTerm(in: "ci\"logo"), "logo")
+        XCTAssertEqual(ClipboardQueryPrefix.image.searchTerm(in: "  ci\"  logo  "), "logo")
+        XCTAssertEqual(ClipboardQueryPrefix.text.searchTerm(in: "c\"mail"), "mail")
+    }
+
+    /// The prefix is typed, so it is matched case-insensitively. The term is
+    /// not: it is searched against content the user copied verbatim.
+    func testThePrefixIgnoresCaseButTheTermKeepsIt() {
+        XCTAssertEqual(ClipboardQueryPrefix.image.searchTerm(in: "CI\"Logo"), "Logo")
+    }
+
+    func testAQueryWithNoClipboardPrefixBelongsToNeither() {
+        for query in ["logo", "", "  ", "f\"logo", "\"", "c"] {
+            XCTAssertNil(ClipboardQueryPrefix.text.searchTerm(in: query), query)
+            XCTAssertNil(ClipboardQueryPrefix.image.searchTerm(in: query), query)
+        }
+    }
+}

--- a/apps/macos/LauncherApp/LauncherLogicTests/ClipboardQueryPrefixTests.swift
+++ b/apps/macos/LauncherApp/LauncherLogicTests/ClipboardQueryPrefixTests.swift
@@ -3,9 +3,8 @@ import XCTest
 @testable import LauncherLogic
 
 final class ClipboardQueryPrefixTests: XCTestCase {
-    /// `ci"` begins with `c`, so the two histories are one keystroke apart.
-    /// Each prefix must answer only for itself, whichever order a caller checks
-    /// them in.
+    /// One keystroke apart, so each must answer only for itself, whichever
+    /// order a caller checks them in.
     func testTheTwoClipboardPrefixesDoNotSwallowEachOther() {
         XCTAssertTrue(ClipboardQueryPrefix.image.matches("ci\"logo"))
         XCTAssertFalse(ClipboardQueryPrefix.text.matches("ci\"logo"))

--- a/apps/macos/LauncherApp/Package.swift
+++ b/apps/macos/LauncherApp/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
                 "Support/ConfigFileLines.swift",
                 "Support/Launcher/LauncherSearchLogic.swift",
                 "Support/Launcher/ProcessScoring.swift",
+                "Support/Launcher/ClipboardQueryPrefix.swift",
                 "Support/Launcher/DeleteTargetLogic.swift",
                 "Support/Launcher/RevealTargetLogic.swift",
                 "Support/Launcher/BridgeErrorMapping.swift",

--- a/apps/macos/LauncherApp/look-app/Models/LauncherResult.swift
+++ b/apps/macos/LauncherApp/look-app/Models/LauncherResult.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Foundation
 
 enum LauncherResultKind: String, Codable {
@@ -36,6 +37,13 @@ struct LauncherResult: Identifiable {
     /// What re-copying a clipboard row actually pastes, when it differs from
     /// `clipboardContent` (a labeled entry like `2+2 = 4` pastes `4`).
     var clipboardPayload: String? = nil
+    /// Set only on the `ci"` rows: where the copied image's pixels live, the
+    /// small copy the row draws, and what it is. A clipboard row with a path
+    /// here IS an image row (see `isClipboardImage`).
+    var clipboardImagePath: String? = nil
+    var clipboardImageThumbnailPath: String? = nil
+    var clipboardImagePixelSize: CGSize? = nil
+    var clipboardImageByteSize: Int? = nil
     /// Set only for `.process` rows: the process id and its listening TCP ports.
     var processPID: Int32? = nil
     var processPorts: [Int]? = nil
@@ -59,6 +67,13 @@ extension LauncherResult {
     /// spelled out in three views, which is how a namespace check drifts.
     var isSourceRow: Bool {
         id.hasPrefix(AppConstants.Launcher.SourceBlock.idPrefix)
+    }
+
+    /// A clipboard row whose clip is a picture rather than text. One definition
+    /// for the row icon, the preview and the open handler, so the three cannot
+    /// disagree about what they are looking at.
+    var isClipboardImage: Bool {
+        kind == .clipboard && clipboardImagePath != nil
     }
 }
 

--- a/apps/macos/LauncherApp/look-app/Models/LauncherResult.swift
+++ b/apps/macos/LauncherApp/look-app/Models/LauncherResult.swift
@@ -37,9 +37,8 @@ struct LauncherResult: Identifiable {
     /// What re-copying a clipboard row actually pastes, when it differs from
     /// `clipboardContent` (a labeled entry like `2+2 = 4` pastes `4`).
     var clipboardPayload: String? = nil
-    /// Set only on the `ci"` rows: where the copied image's pixels live, the
-    /// small copy the row draws, and what it is. A clipboard row with a path
-    /// here IS an image row (see `isClipboardImage`).
+    /// Set only on `ci"` rows. A clipboard row with a path here IS an image row
+    /// (see `isClipboardImage`).
     var clipboardImagePath: String? = nil
     var clipboardImageThumbnailPath: String? = nil
     var clipboardImagePixelSize: CGSize? = nil
@@ -69,9 +68,8 @@ extension LauncherResult {
         id.hasPrefix(AppConstants.Launcher.SourceBlock.idPrefix)
     }
 
-    /// A clipboard row whose clip is a picture rather than text. One definition
-    /// for the row icon, the preview and the open handler, so the three cannot
-    /// disagree about what they are looking at.
+    /// One definition for the row icon, the preview and the open handler, so
+    /// the three cannot disagree about what they are looking at.
     var isClipboardImage: Bool {
         kind == .clipboard && clipboardImagePath != nil
     }

--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -136,8 +136,7 @@ enum AppConstants {
             static let folders = "d\""
             static let regex = "r\""
             static let clipboard = "c\""
-            // Copied images, kept apart from `c"` because the two lists share
-            // no search key and no row shape (see LauncherClipboardImageFeature).
+            // Copied images (see LauncherClipboardImageFeature).
             static let clipboardImage = "ci\""
             // Recent files/folders, newest-activity first. Handled engine-side
             // (needs last_used/fs_modified timestamps); the app just sends it
@@ -404,13 +403,12 @@ enum AppConstants {
             ]
         }
 
-        /// `nonisolated` alongside ClipboardImage below: the kinds and limits
-        /// are read by the writer that stores a clip off the main thread.
+        /// `nonisolated`: read by the writer that stores a clip off the main
+        /// thread.
         nonisolated enum Clipboard {
             static let resultIDPrefix = "clipboard:"
             static let resultPath = "clipboard://history"
-            /// The `kind` column's two values, which decide whether a row
-            /// belongs to `c"` or to `ci"`. Must match core/storage.
+            /// The `kind` column's values. Must match core/storage.
             static let textKind = "text"
             static let imageKind = "image"
             // How many clips history keeps. `maxEntries` is the default/fallback used
@@ -435,34 +433,27 @@ enum AppConstants {
             static let infoBannerDuration = 1.1
         }
 
-        /// Copied images: the `ci"` history. Rows and storage are shared with
-        /// Clipboard above; only the capture limits and the labels differ.
-        ///
-        /// `nonisolated` because writing and hashing a copied image happens off
-        /// the main thread, and that work needs these limits.
+        /// The `ci"` history. Shares rows and storage with Clipboard above;
+        /// only the capture limits and the labels differ.
         nonisolated enum ClipboardImage {
             static let resultIDPrefix = "clipimage:"
             static let resultPath = "clipboard://images"
-            /// How many images the list shows. `maxEntries` is the fallback
-            /// when `clipboard_image_limit` in ~/.look/config is absent or out
-            /// of the [minEntries, maxEntriesLimit] range.
+            /// The fallback when `clipboard_image_limit` in ~/.look/config is
+            /// absent or out of range.
             static let maxEntries = 20
             static let minEntries = 5
             static let maxEntriesLimit = 50
             static let limitConfigKey = "clipboard_image_limit"
-            /// Bigger than this is not a clip worth keeping a copy of. A single
-            /// paste of a print-resolution scan would otherwise cost more than
-            /// the whole text history.
+            /// Past this a paste is not a clip worth keeping a copy of.
             static let maxImageBytes = 20 * 1024 * 1024
-            /// Longest edge of the row thumbnail, written at capture time so a
-            /// row never decodes the full image while scrolling.
+            /// Bytes say nothing about what they decode to, at four bytes a
+            /// pixel. Clears an 8K screenshot and bounds the decode.
+            static let maxPixelCount = 64_000_000
+            /// Longest edge of the row thumbnail.
             static let thumbnailMaxPixel: CGFloat = 128
             static let fileExtension = "png"
-            /// Appended to the hash for the thumbnail's filename. Core sweeps
-            /// by hash prefix, so any suffix here is safe.
+            /// Core sweeps by hash prefix, so any suffix here is safe.
             static let thumbnailSuffix = ".thumb"
-            /// What a row is called when the pasteboard carried raw pixels with
-            /// no filename: the app it came from, then when.
             static let unnamedLabelPrefix = "Image from"
             static let unnamedLabelFallbackSource = "screen"
             static let copiedBanner = "Copied image"

--- a/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
+++ b/apps/macos/LauncherApp/look-app/Support/AppConstants.swift
@@ -136,6 +136,9 @@ enum AppConstants {
             static let folders = "d\""
             static let regex = "r\""
             static let clipboard = "c\""
+            // Copied images, kept apart from `c"` because the two lists share
+            // no search key and no row shape (see LauncherClipboardImageFeature).
+            static let clipboardImage = "ci\""
             // Recent files/folders, newest-activity first. Handled engine-side
             // (needs last_used/fs_modified timestamps); the app just sends it
             // through search and suppresses pinned injection (see LauncherSearchLogic).
@@ -206,6 +209,9 @@ enum AppConstants {
                 Entry(
                     prefix: QueryPrefix.clipboard, argHint: "word",
                     description: "Clipboard history search (recent text clips)"),
+                Entry(
+                    prefix: QueryPrefix.clipboardImage, argHint: "word",
+                    description: "Copied images, newest first"),
                 Entry(prefix: QueryPrefix.translate, argHint: "word", description: "Web translate (VI/EN/JA)"),
                 Entry(
                     prefix: QueryPrefix.translateWord, argHint: "word",
@@ -398,9 +404,15 @@ enum AppConstants {
             ]
         }
 
-        enum Clipboard {
+        /// `nonisolated` alongside ClipboardImage below: the kinds and limits
+        /// are read by the writer that stores a clip off the main thread.
+        nonisolated enum Clipboard {
             static let resultIDPrefix = "clipboard:"
             static let resultPath = "clipboard://history"
+            /// The `kind` column's two values, which decide whether a row
+            /// belongs to `c"` or to `ci"`. Must match core/storage.
+            static let textKind = "text"
+            static let imageKind = "image"
             // How many clips history keeps. `maxEntries` is the default/fallback used
             // when `clipboard_history_limit` in ~/.look/config is absent or out of the
             // [minEntries, maxEntriesLimit] range. See ClipboardHistoryStore.
@@ -421,6 +433,40 @@ enum AppConstants {
             static let nonFileBanner = "Clipboard items are not files"
             static let copiedBannerDuration = 1.2
             static let infoBannerDuration = 1.1
+        }
+
+        /// Copied images: the `ci"` history. Rows and storage are shared with
+        /// Clipboard above; only the capture limits and the labels differ.
+        ///
+        /// `nonisolated` because writing and hashing a copied image happens off
+        /// the main thread, and that work needs these limits.
+        nonisolated enum ClipboardImage {
+            static let resultIDPrefix = "clipimage:"
+            static let resultPath = "clipboard://images"
+            /// How many images the list shows. `maxEntries` is the fallback
+            /// when `clipboard_image_limit` in ~/.look/config is absent or out
+            /// of the [minEntries, maxEntriesLimit] range.
+            static let maxEntries = 20
+            static let minEntries = 5
+            static let maxEntriesLimit = 50
+            static let limitConfigKey = "clipboard_image_limit"
+            /// Bigger than this is not a clip worth keeping a copy of. A single
+            /// paste of a print-resolution scan would otherwise cost more than
+            /// the whole text history.
+            static let maxImageBytes = 20 * 1024 * 1024
+            /// Longest edge of the row thumbnail, written at capture time so a
+            /// row never decodes the full image while scrolling.
+            static let thumbnailMaxPixel: CGFloat = 128
+            static let fileExtension = "png"
+            /// Appended to the hash for the thumbnail's filename. Core sweeps
+            /// by hash prefix, so any suffix here is safe.
+            static let thumbnailSuffix = ".thumb"
+            /// What a row is called when the pasteboard carried raw pixels with
+            /// no filename: the app it came from, then when.
+            static let unnamedLabelPrefix = "Image from"
+            static let unnamedLabelFallbackSource = "screen"
+            static let copiedBanner = "Copied image"
+            static let deletedBanner = "Image removed from history"
         }
 
         enum Help {

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/ClipboardHistoryStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/ClipboardHistoryStore.swift
@@ -126,10 +126,9 @@ final class ClipboardHistoryStore: ObservableObject {
     /// Bumped by `clearHistory`, so a capture that raced ahead of the clear can
     /// tell that the list it was joining is gone.
     private var historyGeneration = 0
-    /// Every write runs after the one submitted before it. Actor isolation
-    /// gives the writer mutual exclusion, not ordering: two tasks created
-    /// independently can reach it either way round, so a copy could be stored
-    /// after the clear meant to erase it, or erased by a clear it preceded.
+    /// Every write runs after the one before it. Actor isolation gives mutual
+    /// exclusion, not ordering: two tasks created independently reach the
+    /// writer either way round.
     private var writeChain: Task<Void, Never>?
     private let maxStoredCharacters = AppConstants.Launcher.Clipboard.maxStoredCharacters
 
@@ -161,8 +160,6 @@ final class ClipboardHistoryStore: ObservableObject {
         rows.removeLast(rows.count - limit)
     }
 
-    /// Submission order is the main actor's, and so deterministic; what follows
-    /// it would not be (see `writeChain`).
     private func enqueueWrite(_ work: @escaping @Sendable () async -> Void) {
         let previous = writeChain
         writeChain = Task {
@@ -242,6 +239,7 @@ final class ClipboardHistoryStore: ObservableObject {
     private func loadPersistedHistory() {
         let limit = maxEntries
         let imageLimit = maxImageEntries
+        let generation = historyGeneration
         Task { [weak self] in
             let stored = await Task.detached(priority: .utility) {
                 (
@@ -252,7 +250,7 @@ final class ClipboardHistoryStore: ObservableObject {
                     ).compactMap(Self.restoredImageEntry)
                 )
             }.value
-            guard let self else { return }
+            guard let self, generation == self.historyGeneration else { return }
             if self.entries.isEmpty {
                 self.entries = stored.text.map {
                     ClipboardHistoryEntry(

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/ClipboardHistoryStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/ClipboardHistoryStore.swift
@@ -2,8 +2,8 @@ import AppKit
 import Combine
 import Foundation
 
-/// Serializes clipboard writes: unordered detached tasks let a copy land after
-/// the clear meant to erase it.
+/// Runs clipboard writes off the main thread, one at a time. Their ORDER is
+/// the caller's to establish (see `ClipboardHistoryStore.writeChain`).
 private actor ClipboardWriter {
     static let shared = ClipboardWriter()
 
@@ -123,11 +123,14 @@ final class ClipboardHistoryStore: ObservableObject {
 
     private var maxEntries = ClipboardHistoryStore.resolveMaxEntries()
     private var maxImageEntries = ClipboardHistoryStore.resolveMaxImageEntries()
-    /// Bumped by `clearHistory`. The writer actor serializes its calls but does
-    /// not order them, so a capture can land after the clear meant to erase it.
-    /// Text needs no counter: `attachStoreID` already drops a row whose entry
-    /// has left the list.
+    /// Bumped by `clearHistory`, so a capture that raced ahead of the clear can
+    /// tell that the list it was joining is gone.
     private var historyGeneration = 0
+    /// Every write runs after the one submitted before it. Actor isolation
+    /// gives the writer mutual exclusion, not ordering: two tasks created
+    /// independently can reach it either way round, so a copy could be stored
+    /// after the clear meant to erase it, or erased by a clear it preceded.
+    private var writeChain: Task<Void, Never>?
     private let maxStoredCharacters = AppConstants.Launcher.Clipboard.maxStoredCharacters
 
     /// Re-reads the clipboard section of `~/.look/config` and applies it live, so file-only
@@ -156,6 +159,16 @@ final class ClipboardHistoryStore: ObservableObject {
     private static func trim<Row>(_ rows: inout [Row], to limit: Int) {
         guard rows.count > limit else { return }
         rows.removeLast(rows.count - limit)
+    }
+
+    /// Submission order is the main actor's, and so deterministic; what follows
+    /// it would not be (see `writeChain`).
+    private func enqueueWrite(_ work: @escaping @Sendable () async -> Void) {
+        let previous = writeChain
+        writeChain = Task {
+            await previous?.value
+            await work()
+        }
     }
 
     /// Reads every `key=value` pair from the active config file once, or an empty map when
@@ -277,10 +290,10 @@ final class ClipboardHistoryStore: ObservableObject {
     /// has nothing to remove on disk and the clip returns next launch.
     private func persist(_ content: String, entryID: UUID) {
         let app = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
-        Task { [weak self] in
+        enqueueWrite { [weak self] in
             let storeID = await ClipboardWriter.shared.record(content: content, appBundleID: app)
             guard let self, let storeID else { return }
-            self.attachStoreID(storeID, to: entryID)
+            await self.attachStoreID(storeID, to: entryID)
         }
     }
 
@@ -290,7 +303,7 @@ final class ClipboardHistoryStore: ObservableObject {
         guard let index = entries.firstIndex(where: { $0.id == entryID }) else {
             // The user deleted it before the write landed: forget it on disk
             // too, or it comes back.
-            Task { await ClipboardWriter.shared.delete(id: storeID) }
+            enqueueWrite { await ClipboardWriter.shared.delete(id: storeID) }
             return
         }
         let existing = entries[index]
@@ -308,7 +321,7 @@ final class ClipboardHistoryStore: ObservableObject {
         entries.removeAll()
         imageEntries.removeAll()
         historyGeneration += 1
-        Task { await ClipboardWriter.shared.clear() }
+        enqueueWrite { await ClipboardWriter.shared.clear() }
     }
 
     deinit {
@@ -329,7 +342,7 @@ final class ClipboardHistoryStore: ObservableObject {
         let storeIDs = entries.filter { $0.id == id }.compactMap(\.storeID)
         entries.removeAll { $0.id == id }
         guard !storeIDs.isEmpty else { return }
-        Task {
+        enqueueWrite {
             for storeID in storeIDs { await ClipboardWriter.shared.delete(id: storeID) }
         }
     }
@@ -444,17 +457,17 @@ final class ClipboardHistoryStore: ObservableObject {
                 forSourceNamed: source?.localizedName, capturedAt: capturedAt)
         let appBundleID = source?.bundleIdentifier
         let generation = historyGeneration
-        Task { [weak self] in
+        enqueueWrite { [weak self] in
             let recorded = await ClipboardWriter.shared.recordImage(
                 data: candidate.data, label: label, appBundleID: appBundleID)
             guard let self, let recorded else { return }
-            guard generation == self.historyGeneration else {
+            guard await generation == self.historyGeneration else {
                 // Cleared while in flight: forget it on disk too, or the clip
                 // the user erased comes back with its file.
                 await ClipboardWriter.shared.delete(id: recorded.storeID)
                 return
             }
-            self.prependImage(
+            await self.prependImage(
                 ClipboardImageEntry(
                     label: label,
                     hash: recorded.stored.hash,
@@ -486,7 +499,7 @@ final class ClipboardHistoryStore: ObservableObject {
         imageEntries.removeAll { $0.id == id }
         guard !storeIDs.isEmpty else { return }
         // Core unlinks the file with the row: the pixels are what was deleted.
-        Task {
+        enqueueWrite {
             for storeID in storeIDs { await ClipboardWriter.shared.delete(id: storeID) }
         }
     }

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/ClipboardHistoryStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/ClipboardHistoryStore.swift
@@ -11,9 +11,8 @@ private actor ClipboardWriter {
         EngineBridge.shared.recordClipboard(content: content, appBundleID: appBundleID)
     }
 
-    /// Normalizes, writes and records a copied image in one hop off the main
-    /// thread: hashing and encoding a screenshot takes long enough to stutter
-    /// the poll loop that found it.
+    /// One hop off the main thread: hashing and encoding a screenshot would
+    /// stutter the poll loop that found it.
     func recordImage(data: Data, label: String, appBundleID: String?)
         -> (stored: StoredClipboardImage, storeID: Int64)?
     {
@@ -118,12 +117,17 @@ final class ClipboardHistoryStore: ObservableObject {
     }
 
     @Published private(set) var entries: [ClipboardHistoryEntry] = []
-    /// Copied images, kept apart from `entries` because `c"` and `ci"` share no
-    /// search key and no row shape. The storage underneath is the same table.
+    /// Apart from `entries` because the two share no search key and no row
+    /// shape. The storage underneath is one table.
     @Published private(set) var imageEntries: [ClipboardImageEntry] = []
 
     private var maxEntries = ClipboardHistoryStore.resolveMaxEntries()
     private var maxImageEntries = ClipboardHistoryStore.resolveMaxImageEntries()
+    /// Bumped by `clearHistory`. The writer actor serializes its calls but does
+    /// not order them, so a capture can land after the clear meant to erase it.
+    /// Text needs no counter: `attachStoreID` already drops a row whose entry
+    /// has left the list.
+    private var historyGeneration = 0
     private let maxStoredCharacters = AppConstants.Launcher.Clipboard.maxStoredCharacters
 
     /// Re-reads the clipboard section of `~/.look/config` and applies it live, so file-only
@@ -149,8 +153,6 @@ final class ClipboardHistoryStore: ObservableObject {
         Self.trim(&imageEntries, to: maxImageEntries)
     }
 
-    /// Drops everything past `limit`, oldest last. Both histories are capped
-    /// this way, and both cap on insert and on a config reload.
     private static func trim<Row>(_ rows: inout [Row], to limit: Int) {
         guard rows.count > limit else { return }
         rows.removeLast(rows.count - limit)
@@ -186,8 +188,7 @@ final class ClipboardHistoryStore: ObservableObject {
         resolveMaxImageEntries(from: loadConfigValues())
     }
 
-    /// Images are capped separately from text, and far lower: each one costs
-    /// megabytes on disk rather than characters in a row.
+    /// Capped separately from text, and far lower: megabytes, not characters.
     private static func resolveMaxImageEntries(from values: [String: String]) -> Int {
         typealias Image = AppConstants.Launcher.ClipboardImage
         return resolveLimit(
@@ -197,9 +198,8 @@ final class ClipboardHistoryStore: ObservableObject {
             fallback: Image.maxEntries)
     }
 
-    /// A config value only wins when it parses AND is in range. A limit outside
-    /// it is a typo, not a request, so the default stands rather than the
-    /// nearest bound: silently clamping 1000 to 100 looks like it worked.
+    /// An out-of-range limit is a typo, not a request, so the default stands
+    /// rather than the nearest bound: clamping 1000 to 100 looks like it worked.
     private static func resolveLimit(
         from values: [String: String], key: String, range: ClosedRange<Int>, fallback: Int
     ) -> Int {
@@ -233,8 +233,7 @@ final class ClipboardHistoryStore: ObservableObject {
             let stored = await Task.detached(priority: .utility) {
                 (
                     text: EngineBridge.shared.clipboardEntries(limit: limit),
-                    // Mapped here rather than on arrival: each image row stats
-                    // its file and reads its header.
+                    // Mapped here: each image row stats its file.
                     images: EngineBridge.shared.clipboardEntries(
                         kind: AppConstants.Launcher.Clipboard.imageKind, limit: imageLimit
                     ).compactMap(Self.restoredImageEntry)
@@ -253,9 +252,8 @@ final class ClipboardHistoryStore: ObservableObject {
         }
     }
 
-    /// Rebuilds an image row from its stored record. A row whose file is gone
-    /// is dropped rather than shown as a broken thumbnail: the bytes are the
-    /// clip, and without them there is nothing to paste.
+    /// A row whose file is gone is dropped rather than shown broken: the bytes
+    /// are the clip, and without them there is nothing to paste.
     nonisolated private static func restoredImageEntry(from stored: EngineBridge.ClipboardEntry)
         -> ClipboardImageEntry?
     {
@@ -309,6 +307,7 @@ final class ClipboardHistoryStore: ObservableObject {
     func clearHistory() {
         entries.removeAll()
         imageEntries.removeAll()
+        historyGeneration += 1
         Task { await ClipboardWriter.shared.clear() }
     }
 
@@ -390,12 +389,11 @@ final class ClipboardHistoryStore: ObservableObject {
         // Checked BEFORE the text is read, let alone stored: a password
         // manager marks its clip concealed precisely so history tools skip it,
         // and history is now written to disk. The core cannot enforce this -
-        // pasteboard markers only exist on this side. Images go through the
-        // same gate, and land on disk, so it runs before either branch.
+        // pasteboard markers only exist on this side. Images land on disk too,
+        // so it runs before either branch.
         if typesAreConcealed(types) { return }
 
-        // Before the file bail, because an image copied in Finder IS a file
-        // reference. Everything else on disk still bails below.
+        // Before the file bail: an image copied in Finder IS a file reference.
         if captureImageIfPresent(pasteboard, types: types) { return }
         if typesCarryFileReference(types, pasteboard) { return }
 
@@ -424,9 +422,7 @@ final class ClipboardHistoryStore: ObservableObject {
         persist(text, entryID: captured.id)
     }
 
-    /// Files, hashes and records a copied image, reporting whether the copy was
-    /// one. The work runs on the writer actor: encoding and hashing a
-    /// screenshot would stutter the poll loop that found it.
+    /// Files and records a copied image, reporting whether the copy was one.
     private func captureImageIfPresent(
         _ pasteboard: NSPasteboard, types: [NSPasteboard.PasteboardType]
     ) -> Bool {
@@ -434,8 +430,8 @@ final class ClipboardHistoryStore: ObservableObject {
         else {
             return false
         }
-        // Past this point the copy WAS an image, so it never falls through to
-        // the text branch, whether or not it is one worth keeping.
+        // The copy WAS an image, so it never falls through to the text branch,
+        // whether or not it is one worth keeping.
         guard candidate.data.count <= AppConstants.Launcher.ClipboardImage.maxImageBytes else {
             return true
         }
@@ -447,10 +443,17 @@ final class ClipboardHistoryStore: ObservableObject {
             ?? ClipboardImagePasteboard.label(
                 forSourceNamed: source?.localizedName, capturedAt: capturedAt)
         let appBundleID = source?.bundleIdentifier
+        let generation = historyGeneration
         Task { [weak self] in
             let recorded = await ClipboardWriter.shared.recordImage(
                 data: candidate.data, label: label, appBundleID: appBundleID)
             guard let self, let recorded else { return }
+            guard generation == self.historyGeneration else {
+                // Cleared while in flight: forget it on disk too, or the clip
+                // the user erased comes back with its file.
+                await ClipboardWriter.shared.delete(id: recorded.storeID)
+                return
+            }
             self.prependImage(
                 ClipboardImageEntry(
                     label: label,
@@ -464,10 +467,8 @@ final class ClipboardHistoryStore: ObservableObject {
         return true
     }
 
-    /// Inserts an image row at the front, dropping any older row for the same
-    /// pixels: the store dedupes by hash, so two rows here would be one row on
-    /// disk. The row's id IS the hash, so a re-copy lands on the row it already
-    /// had and the user's selection survives it.
+    /// Drops any older row for the same pixels: the store dedupes by hash, so
+    /// two rows here would be one row on disk.
     private func prependImage(_ entry: ClipboardImageEntry) {
         imageEntries.removeAll { $0.hash == entry.hash }
         imageEntries.insert(entry, at: 0)
@@ -484,16 +485,14 @@ final class ClipboardHistoryStore: ObservableObject {
         let storeIDs = imageEntries.filter { $0.id == id }.compactMap(\.storeID)
         imageEntries.removeAll { $0.id == id }
         guard !storeIDs.isEmpty else { return }
-        // Core unlinks the file as part of forgetting the row: the pixels are
-        // what the user asked to delete.
+        // Core unlinks the file with the row: the pixels are what was deleted.
         Task {
             for storeID in storeIDs { await ClipboardWriter.shared.delete(id: storeID) }
         }
     }
 
-    /// Puts a stored image back on the pasteboard, as both pixels and a file,
-    /// so it pastes into an editor and into Finder alike. Marks the change as
-    /// already seen so the poller does not re-capture Look's own write.
+    /// Both pixels and a file, so it pastes into an editor and into Finder
+    /// alike. Marks the change seen so the poller skips Look's own write.
     @discardableResult
     func copyImage(entry: ClipboardImageEntry) -> Bool {
         guard let url = entry.fileURL, let image = NSImage(contentsOf: url) else { return false }

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/ClipboardHistoryStore.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/ClipboardHistoryStore.swift
@@ -11,6 +11,21 @@ private actor ClipboardWriter {
         EngineBridge.shared.recordClipboard(content: content, appBundleID: appBundleID)
     }
 
+    /// Normalizes, writes and records a copied image in one hop off the main
+    /// thread: hashing and encoding a screenshot takes long enough to stutter
+    /// the poll loop that found it.
+    func recordImage(data: Data, label: String, appBundleID: String?)
+        -> (stored: StoredClipboardImage, storeID: Int64)?
+    {
+        guard let stored = ClipboardImageFiles.store(data),
+            let storeID = EngineBridge.shared.recordClipboardImage(
+                label: label, imageHash: stored.hash, appBundleID: appBundleID)
+        else {
+            return nil
+        }
+        return (stored, storeID)
+    }
+
     func delete(id: Int64) {
         EngineBridge.shared.deleteClipboardEntry(id: id)
     }
@@ -103,8 +118,12 @@ final class ClipboardHistoryStore: ObservableObject {
     }
 
     @Published private(set) var entries: [ClipboardHistoryEntry] = []
+    /// Copied images, kept apart from `entries` because `c"` and `ci"` share no
+    /// search key and no row shape. The storage underneath is the same table.
+    @Published private(set) var imageEntries: [ClipboardImageEntry] = []
 
     private var maxEntries = ClipboardHistoryStore.resolveMaxEntries()
+    private var maxImageEntries = ClipboardHistoryStore.resolveMaxImageEntries()
     private let maxStoredCharacters = AppConstants.Launcher.Clipboard.maxStoredCharacters
 
     /// Re-reads the clipboard section of `~/.look/config` and applies it live, so file-only
@@ -115,14 +134,26 @@ final class ClipboardHistoryStore: ObservableObject {
     func reloadFromConfig() {
         let values = ClipboardHistoryStore.loadConfigValues()
         applyMaxEntries(ClipboardHistoryStore.resolveMaxEntries(from: values))
+        applyMaxImageEntries(ClipboardHistoryStore.resolveMaxImageEntries(from: values))
     }
 
     private func applyMaxEntries(_ newValue: Int) {
         guard newValue != maxEntries else { return }
         maxEntries = newValue
-        if entries.count > maxEntries {
-            entries.removeLast(entries.count - maxEntries)
-        }
+        Self.trim(&entries, to: maxEntries)
+    }
+
+    private func applyMaxImageEntries(_ newValue: Int) {
+        guard newValue != maxImageEntries else { return }
+        maxImageEntries = newValue
+        Self.trim(&imageEntries, to: maxImageEntries)
+    }
+
+    /// Drops everything past `limit`, oldest last. Both histories are capped
+    /// this way, and both cap on insert and on a config reload.
+    private static func trim<Row>(_ rows: inout [Row], to limit: Int) {
+        guard rows.count > limit else { return }
+        rows.removeLast(rows.count - limit)
     }
 
     /// Reads every `key=value` pair from the active config file once, or an empty map when
@@ -143,14 +174,41 @@ final class ClipboardHistoryStore: ObservableObject {
     /// the default (10) when the key is missing, unparseable, or outside the accepted
     /// [10, 100] range.
     private static func resolveMaxEntries(from values: [String: String]) -> Int {
-        let fallback = AppConstants.Launcher.Clipboard.maxEntries
-        guard let rawValue = values[AppConstants.Launcher.Clipboard.historyLimitConfigKey],
-              let parsed = Int(rawValue.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+        typealias Clipboard = AppConstants.Launcher.Clipboard
+        return resolveLimit(
+            from: values,
+            key: Clipboard.historyLimitConfigKey,
+            range: Clipboard.minEntries...Clipboard.maxEntriesLimit,
+            fallback: Clipboard.maxEntries)
+    }
+
+    private static func resolveMaxImageEntries() -> Int {
+        resolveMaxImageEntries(from: loadConfigValues())
+    }
+
+    /// Images are capped separately from text, and far lower: each one costs
+    /// megabytes on disk rather than characters in a row.
+    private static func resolveMaxImageEntries(from values: [String: String]) -> Int {
+        typealias Image = AppConstants.Launcher.ClipboardImage
+        return resolveLimit(
+            from: values,
+            key: Image.limitConfigKey,
+            range: Image.minEntries...Image.maxEntriesLimit,
+            fallback: Image.maxEntries)
+    }
+
+    /// A config value only wins when it parses AND is in range. A limit outside
+    /// it is a typo, not a request, so the default stands rather than the
+    /// nearest bound: silently clamping 1000 to 100 looks like it worked.
+    private static func resolveLimit(
+        from values: [String: String], key: String, range: ClosedRange<Int>, fallback: Int
+    ) -> Int {
+        guard let rawValue = values[key],
+            let parsed = Int(rawValue.trimmingCharacters(in: .whitespacesAndNewlines))
+        else {
             return fallback
         }
-        let lower = AppConstants.Launcher.Clipboard.minEntries
-        let upper = AppConstants.Launcher.Clipboard.maxEntriesLimit
-        return (lower...upper).contains(parsed) ? parsed : fallback
+        return range.contains(parsed) ? parsed : fallback
     }
     private var monitoringMode: MonitoringMode = .foreground
     // nonisolated(unsafe) so the nonisolated deinit can call invalidate()
@@ -170,16 +228,51 @@ final class ClipboardHistoryStore: ObservableObject {
     /// stored corpus so `c"` shows what was copied before the last quit.
     private func loadPersistedHistory() {
         let limit = maxEntries
+        let imageLimit = maxImageEntries
         Task { [weak self] in
             let stored = await Task.detached(priority: .utility) {
-                EngineBridge.shared.clipboardEntries(limit: limit)
+                (
+                    text: EngineBridge.shared.clipboardEntries(limit: limit),
+                    // Mapped here rather than on arrival: each image row stats
+                    // its file and reads its header.
+                    images: EngineBridge.shared.clipboardEntries(
+                        kind: AppConstants.Launcher.Clipboard.imageKind, limit: imageLimit
+                    ).compactMap(Self.restoredImageEntry)
+                )
             }.value
-            guard let self, self.entries.isEmpty else { return }
-            self.entries = stored.map {
-                ClipboardHistoryEntry(
-                    content: $0.content, capturedAt: $0.copiedAt, storeID: $0.id)
+            guard let self else { return }
+            if self.entries.isEmpty {
+                self.entries = stored.text.map {
+                    ClipboardHistoryEntry(
+                        content: $0.content, capturedAt: $0.copiedAt, storeID: $0.id)
+                }
+            }
+            if self.imageEntries.isEmpty {
+                self.imageEntries = stored.images
             }
         }
+    }
+
+    /// Rebuilds an image row from its stored record. A row whose file is gone
+    /// is dropped rather than shown as a broken thumbnail: the bytes are the
+    /// clip, and without them there is nothing to paste.
+    nonisolated private static func restoredImageEntry(from stored: EngineBridge.ClipboardEntry)
+        -> ClipboardImageEntry?
+    {
+        guard let url = ClipboardImageFiles.fileURL(forHash: stored.contentHash),
+            let attributes = try? FileManager.default.attributesOfItem(atPath: url.path),
+            let byteSize = attributes[.size] as? Int
+        else {
+            return nil
+        }
+        return ClipboardImageEntry(
+            label: stored.content,
+            hash: stored.contentHash,
+            capturedAt: stored.copiedAt,
+            pixelSize: ClipboardImageFiles.pixelSize(ofFileAt: url) ?? .zero,
+            byteSize: byteSize,
+            appBundleID: stored.appBundleID,
+            storeID: stored.id)
     }
 
     /// Off the main thread, but the row id comes BACK: without it `deleteEntry`
@@ -215,6 +308,7 @@ final class ClipboardHistoryStore: ObservableObject {
     /// persisting clipboard history acceptable in the first place.
     func clearHistory() {
         entries.removeAll()
+        imageEntries.removeAll()
         Task { await ClipboardWriter.shared.clear() }
     }
 
@@ -260,9 +354,7 @@ final class ClipboardHistoryStore: ObservableObject {
     /// Inserts `entry` at the front and drops anything beyond `maxEntries`.
     private func prepend(_ entry: ClipboardHistoryEntry) {
         entries.insert(entry, at: 0)
-        if entries.count > maxEntries {
-            entries.removeLast(entries.count - maxEntries)
-        }
+        Self.trim(&entries, to: maxEntries)
     }
 
     func setMonitoringMode(_ mode: MonitoringMode) {
@@ -295,12 +387,17 @@ final class ClipboardHistoryStore: ObservableObject {
         // One cross-process read of the type list, shared by both gates: this
         // runs on every copy made anywhere in the OS.
         let types = pasteboard.types ?? []
-        if typesCarryFileReference(types, pasteboard) { return }
         // Checked BEFORE the text is read, let alone stored: a password
         // manager marks its clip concealed precisely so history tools skip it,
         // and history is now written to disk. The core cannot enforce this -
-        // pasteboard markers only exist on this side.
+        // pasteboard markers only exist on this side. Images go through the
+        // same gate, and land on disk, so it runs before either branch.
         if typesAreConcealed(types) { return }
+
+        // Before the file bail, because an image copied in Finder IS a file
+        // reference. Everything else on disk still bails below.
+        if captureImageIfPresent(pasteboard, types: types) { return }
+        if typesCarryFileReference(types, pasteboard) { return }
 
         guard var text = pasteboard.string(forType: .string) else { return }
         if text.count > maxStoredCharacters {
@@ -325,6 +422,86 @@ final class ClipboardHistoryStore: ObservableObject {
         // Re-copying replaces the stored row, so the id is re-attached here
         // rather than assumed to be the one this entry already carried.
         persist(text, entryID: captured.id)
+    }
+
+    /// Files, hashes and records a copied image, reporting whether the copy was
+    /// one. The work runs on the writer actor: encoding and hashing a
+    /// screenshot would stutter the poll loop that found it.
+    private func captureImageIfPresent(
+        _ pasteboard: NSPasteboard, types: [NSPasteboard.PasteboardType]
+    ) -> Bool {
+        guard let candidate = ClipboardImagePasteboard.candidate(from: pasteboard, types: types)
+        else {
+            return false
+        }
+        // Past this point the copy WAS an image, so it never falls through to
+        // the text branch, whether or not it is one worth keeping.
+        guard candidate.data.count <= AppConstants.Launcher.ClipboardImage.maxImageBytes else {
+            return true
+        }
+
+        let source = NSWorkspace.shared.frontmostApplication
+        let capturedAt = Date()
+        let label =
+            candidate.fileName
+            ?? ClipboardImagePasteboard.label(
+                forSourceNamed: source?.localizedName, capturedAt: capturedAt)
+        let appBundleID = source?.bundleIdentifier
+        Task { [weak self] in
+            let recorded = await ClipboardWriter.shared.recordImage(
+                data: candidate.data, label: label, appBundleID: appBundleID)
+            guard let self, let recorded else { return }
+            self.prependImage(
+                ClipboardImageEntry(
+                    label: label,
+                    hash: recorded.stored.hash,
+                    capturedAt: capturedAt,
+                    pixelSize: recorded.stored.pixelSize,
+                    byteSize: recorded.stored.byteSize,
+                    appBundleID: appBundleID,
+                    storeID: recorded.storeID))
+        }
+        return true
+    }
+
+    /// Inserts an image row at the front, dropping any older row for the same
+    /// pixels: the store dedupes by hash, so two rows here would be one row on
+    /// disk. The row's id IS the hash, so a re-copy lands on the row it already
+    /// had and the user's selection survives it.
+    private func prependImage(_ entry: ClipboardImageEntry) {
+        imageEntries.removeAll { $0.hash == entry.hash }
+        imageEntries.insert(entry, at: 0)
+        Self.trim(&imageEntries, to: maxImageEntries)
+    }
+
+    func searchImages(_ term: String) -> [ClipboardImageEntry] {
+        let normalized = term.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else { return imageEntries }
+        return imageEntries.filter { $0.label.localizedCaseInsensitiveContains(normalized) }
+    }
+
+    func deleteImageEntry(id: String) {
+        let storeIDs = imageEntries.filter { $0.id == id }.compactMap(\.storeID)
+        imageEntries.removeAll { $0.id == id }
+        guard !storeIDs.isEmpty else { return }
+        // Core unlinks the file as part of forgetting the row: the pixels are
+        // what the user asked to delete.
+        Task {
+            for storeID in storeIDs { await ClipboardWriter.shared.delete(id: storeID) }
+        }
+    }
+
+    /// Puts a stored image back on the pasteboard, as both pixels and a file,
+    /// so it pastes into an editor and into Finder alike. Marks the change as
+    /// already seen so the poller does not re-capture Look's own write.
+    @discardableResult
+    func copyImage(entry: ClipboardImageEntry) -> Bool {
+        guard let url = entry.fileURL, let image = NSImage(contentsOf: url) else { return false }
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        let wrote = pasteboard.writeObjects([image, url as NSURL])
+        lastChangeCount = pasteboard.changeCount
+        return wrote
     }
 
     /// The `org.nspasteboard.*` convention: apps mark clips that history tools

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/ClipboardImageCapture.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/ClipboardImageCapture.swift
@@ -4,25 +4,21 @@ import Foundation
 import ImageIO
 import UniformTypeIdentifiers
 
-/// One copied image, as the `ci"` list shows it.
-///
-/// The pixels are not here: they live in a file named after `hash`, because a
-/// screenshot is megabytes and the history is a list the user scrolls.
+/// One copied image. The pixels are not here: they live in a file named after
+/// `hash`, since a screenshot is megabytes and this is a list the user scrolls.
 nonisolated struct ClipboardImageEntry: Identifiable, Equatable {
-    /// What the row is titled and searched by. A filename when the image was
-    /// copied as a file, else where it came from and when, since raw pasteboard
-    /// pixels arrive with no name at all.
+    /// A filename when the image arrived as one, else where it came from and
+    /// when, since raw pasteboard pixels have no name.
     let label: String
-    /// Identity of the pixels, and so of the row: it names the files and is
-    /// what the store dedupes on, which is why a re-copy keeps the row it
-    /// already had instead of being given a fresh one.
+    /// Identity of the pixels, and so of the row: a re-copy lands on the row it
+    /// already had rather than a new one.
     let hash: String
     let capturedAt: Date
     let pixelSize: CGSize
     let byteSize: Int
     let appBundleID: String?
-    /// Row id in the persisted history. Without it a delete here would leave
-    /// the image on disk and it would return on the next launch.
+    /// Row id in the persisted history, without which a delete here would
+    /// leave the image on disk to return next launch.
     let storeID: Int64?
 
     var id: String { hash }
@@ -30,24 +26,19 @@ nonisolated struct ClipboardImageEntry: Identifiable, Equatable {
     var thumbnailURL: URL? { ClipboardImageFiles.thumbnailURL(forHash: hash) }
 }
 
-/// What a freshly stored image turned out to be, once its bytes were normalized
-/// and written.
 nonisolated struct StoredClipboardImage {
     let hash: String
     let pixelSize: CGSize
     let byteSize: Int
 }
 
-/// The pixels an image clip is made of: where they live, and what reading or
-/// writing them costs.
-///
-/// Every call here is off the main thread's path - encoding and hashing a
-/// screenshot takes long enough to drop frames while typing.
+/// Where an image clip's pixels live. Every call belongs off the main thread:
+/// encoding and hashing a screenshot drops frames while typing.
 nonisolated enum ClipboardImageFiles {
     private typealias Constants = AppConstants.Launcher.ClipboardImage
 
-    /// Core owns the location, creates it, and sweeps anything in it that no
-    /// row claims, so this side asks rather than assembling a path.
+    /// Core owns the location and sweeps it, so this side asks rather than
+    /// assembling a path.
     private static let directory: URL? = EngineBridge.shared.clipboardImagesDirectory()
 
     static func fileURL(forHash hash: String) -> URL? {
@@ -58,11 +49,16 @@ nonisolated enum ClipboardImageFiles {
         url(forHash: hash, thumbnail: true)
     }
 
-    /// Normalizes `data` to PNG, writes it and its thumbnail under the hash of
-    /// the normalized bytes, and reports what was stored. Re-copying the same
-    /// image finds both files already there and rewrites nothing.
+    /// Normalizes to PNG and writes the image and its thumbnail under the hash
+    /// of the normalized bytes. A re-copy finds both files there already.
     static func store(_ data: Data) -> StoredClipboardImage? {
-        guard let png = pngData(from: data), let pixelSize = pixelSize(of: png) else {
+        // Dimensions off the header first: the byte limit does not bound what
+        // those bytes decode to, and everything below this decodes them.
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+            let pixelSize = pixelSize(in: source),
+            pixelSize.width * pixelSize.height <= CGFloat(Constants.maxPixelCount),
+            let png = pngData(from: data, source: source)
+        else {
             return nil
         }
         let hash = SHA256.hash(data: png).map { String(format: "%02x", $0) }.joined()
@@ -81,19 +77,16 @@ nonisolated enum ClipboardImageFiles {
         return StoredClipboardImage(hash: hash, pixelSize: pixelSize, byteSize: png.count)
     }
 
-    /// Core sweeps the directory by hash prefix, so every name it finds has to
-    /// start with the hash of the row that owns it.
+    /// Core sweeps by hash prefix, so every name has to start with one.
     private static func url(forHash hash: String, thumbnail: Bool) -> URL? {
         guard !hash.isEmpty, let directory else { return nil }
         let suffix = thumbnail ? Constants.thumbnailSuffix : ""
         return directory.appendingPathComponent("\(hash)\(suffix).\(Constants.fileExtension)")
     }
 
-    /// One encoding for every clip, so the same picture pasted as PNG and as
-    /// TIFF is one row rather than two. Already-PNG bytes are kept verbatim:
-    /// re-encoding them would only cost time.
-    private static func pngData(from data: Data) -> Data? {
-        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+    /// One encoding for every clip, so a picture pasted as PNG and as TIFF is
+    /// one row. Already-PNG bytes are kept verbatim.
+    private static func pngData(from data: Data, source: CGImageSource) -> Data? {
         if let type = CGImageSourceGetType(source), (type as String) == UTType.png.identifier {
             return data
         }
@@ -101,15 +94,9 @@ nonisolated enum ClipboardImageFiles {
         return encodePNG(image)
     }
 
-    /// Reads the dimensions out of a stored image's header, without decoding
-    /// the pixels. Used when history is restored at launch.
+    /// From the header, without decoding the pixels.
     static func pixelSize(ofFileAt url: URL) -> CGSize? {
         guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else { return nil }
-        return pixelSize(in: source)
-    }
-
-    private static func pixelSize(of data: Data) -> CGSize? {
-        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
         return pixelSize(in: source)
     }
 
@@ -125,8 +112,7 @@ nonisolated enum ClipboardImageFiles {
         return CGSize(width: width, height: height)
     }
 
-    /// A row draws this, not the full image: decoding a multi-megabyte PNG
-    /// inside a list cell stutters every keystroke.
+    /// A row draws this, not the full image, which would stutter the list.
     private static func thumbnailData(from data: Data) -> Data? {
         guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
         let options: [CFString: Any] = [
@@ -156,31 +142,27 @@ nonisolated enum ClipboardImageFiles {
     }
 }
 
-/// What the pasteboard is offering, when it is offering an image.
 nonisolated struct ClipboardImageCandidate {
     let data: Data
-    /// The filename the image arrived under, when it arrived as a file. Raw
-    /// pixels have none, and get a label built from their source instead.
+    /// Set only when the image arrived as a file. Raw pixels have no name.
     let fileName: String?
 }
 
-/// Reading images off the pasteboard. Separate from the store so the polling
-/// loop stays one method: this decides only whether a copy was an image.
+/// Decides only whether a copy was an image, so the polling loop stays one
+/// method.
 enum ClipboardImagePasteboard {
     private typealias Constants = AppConstants.Launcher.ClipboardImage
 
-    /// The image on the pasteboard, or nil when there is none worth keeping.
-    ///
-    /// Files are checked first because an image copied in Finder carries both a
-    /// file URL and a preview, and the filename is the better label.
+    /// Files first: an image copied in Finder carries both a file URL and a
+    /// preview, and the filename is the better label.
     static func candidate(
         from pasteboard: NSPasteboard, types: [NSPasteboard.PasteboardType]
     ) -> ClipboardImageCandidate? {
         fileCandidate(from: pasteboard) ?? rawCandidate(from: pasteboard, types: types)
     }
 
-    /// A label for pixels that arrived without a filename: the app they came
-    /// from, and when, so a list of them can still be told apart.
+    /// For pixels with no filename: the app and the time, so a list of them can
+    /// still be told apart.
     static func label(forSourceNamed sourceName: String?, capturedAt: Date) -> String {
         let source = sourceName ?? Constants.unnamedLabelFallbackSource
         let time = labelDateFormatter.string(from: capturedAt)
@@ -198,9 +180,8 @@ enum ClipboardImagePasteboard {
         let urls =
             pasteboard.readObjects(
                 forClasses: [NSURL.self], options: [.urlReadingFileURLsOnly: true]) as? [URL] ?? []
-        // Size is checked from the directory entry, before the read: this runs
-        // on the main thread, and pulling a print-resolution scan into memory
-        // to find out it was too big would freeze the launcher.
+        // Size from the directory entry, before the read: this is the main
+        // thread, and reading a huge file to reject it would freeze it.
         guard
             let url = urls.first(where: { url in
                 guard

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/ClipboardImageCapture.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/ClipboardImageCapture.swift
@@ -1,0 +1,230 @@
+import AppKit
+import CryptoKit
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+/// One copied image, as the `ci"` list shows it.
+///
+/// The pixels are not here: they live in a file named after `hash`, because a
+/// screenshot is megabytes and the history is a list the user scrolls.
+nonisolated struct ClipboardImageEntry: Identifiable, Equatable {
+    /// What the row is titled and searched by. A filename when the image was
+    /// copied as a file, else where it came from and when, since raw pasteboard
+    /// pixels arrive with no name at all.
+    let label: String
+    /// Identity of the pixels, and so of the row: it names the files and is
+    /// what the store dedupes on, which is why a re-copy keeps the row it
+    /// already had instead of being given a fresh one.
+    let hash: String
+    let capturedAt: Date
+    let pixelSize: CGSize
+    let byteSize: Int
+    let appBundleID: String?
+    /// Row id in the persisted history. Without it a delete here would leave
+    /// the image on disk and it would return on the next launch.
+    let storeID: Int64?
+
+    var id: String { hash }
+    var fileURL: URL? { ClipboardImageFiles.fileURL(forHash: hash) }
+    var thumbnailURL: URL? { ClipboardImageFiles.thumbnailURL(forHash: hash) }
+}
+
+/// What a freshly stored image turned out to be, once its bytes were normalized
+/// and written.
+nonisolated struct StoredClipboardImage {
+    let hash: String
+    let pixelSize: CGSize
+    let byteSize: Int
+}
+
+/// The pixels an image clip is made of: where they live, and what reading or
+/// writing them costs.
+///
+/// Every call here is off the main thread's path - encoding and hashing a
+/// screenshot takes long enough to drop frames while typing.
+nonisolated enum ClipboardImageFiles {
+    private typealias Constants = AppConstants.Launcher.ClipboardImage
+
+    /// Core owns the location, creates it, and sweeps anything in it that no
+    /// row claims, so this side asks rather than assembling a path.
+    private static let directory: URL? = EngineBridge.shared.clipboardImagesDirectory()
+
+    static func fileURL(forHash hash: String) -> URL? {
+        url(forHash: hash, thumbnail: false)
+    }
+
+    static func thumbnailURL(forHash hash: String) -> URL? {
+        url(forHash: hash, thumbnail: true)
+    }
+
+    /// Normalizes `data` to PNG, writes it and its thumbnail under the hash of
+    /// the normalized bytes, and reports what was stored. Re-copying the same
+    /// image finds both files already there and rewrites nothing.
+    static func store(_ data: Data) -> StoredClipboardImage? {
+        guard let png = pngData(from: data), let pixelSize = pixelSize(of: png) else {
+            return nil
+        }
+        let hash = SHA256.hash(data: png).map { String(format: "%02x", $0) }.joined()
+        guard let fileURL = fileURL(forHash: hash), let thumbnailURL = thumbnailURL(forHash: hash)
+        else {
+            return nil
+        }
+        if !FileManager.default.fileExists(atPath: fileURL.path) {
+            guard (try? png.write(to: fileURL, options: .atomic)) != nil else { return nil }
+        }
+        if !FileManager.default.fileExists(atPath: thumbnailURL.path),
+            let thumbnail = thumbnailData(from: png)
+        {
+            try? thumbnail.write(to: thumbnailURL, options: .atomic)
+        }
+        return StoredClipboardImage(hash: hash, pixelSize: pixelSize, byteSize: png.count)
+    }
+
+    /// Core sweeps the directory by hash prefix, so every name it finds has to
+    /// start with the hash of the row that owns it.
+    private static func url(forHash hash: String, thumbnail: Bool) -> URL? {
+        guard !hash.isEmpty, let directory else { return nil }
+        let suffix = thumbnail ? Constants.thumbnailSuffix : ""
+        return directory.appendingPathComponent("\(hash)\(suffix).\(Constants.fileExtension)")
+    }
+
+    /// One encoding for every clip, so the same picture pasted as PNG and as
+    /// TIFF is one row rather than two. Already-PNG bytes are kept verbatim:
+    /// re-encoding them would only cost time.
+    private static func pngData(from data: Data) -> Data? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+        if let type = CGImageSourceGetType(source), (type as String) == UTType.png.identifier {
+            return data
+        }
+        guard let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else { return nil }
+        return encodePNG(image)
+    }
+
+    /// Reads the dimensions out of a stored image's header, without decoding
+    /// the pixels. Used when history is restored at launch.
+    static func pixelSize(ofFileAt url: URL) -> CGSize? {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else { return nil }
+        return pixelSize(in: source)
+    }
+
+    private static func pixelSize(of data: Data) -> CGSize? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+        return pixelSize(in: source)
+    }
+
+    private static func pixelSize(in source: CGImageSource) -> CGSize? {
+        guard
+            let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil)
+                as? [CFString: Any],
+            let width = properties[kCGImagePropertyPixelWidth] as? Int,
+            let height = properties[kCGImagePropertyPixelHeight] as? Int
+        else {
+            return nil
+        }
+        return CGSize(width: width, height: height)
+    }
+
+    /// A row draws this, not the full image: decoding a multi-megabyte PNG
+    /// inside a list cell stutters every keystroke.
+    private static func thumbnailData(from data: Data) -> Data? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: Constants.thumbnailMaxPixel,
+        ]
+        guard
+            let thumbnail = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
+        else {
+            return nil
+        }
+        return encodePNG(thumbnail)
+    }
+
+    private static func encodePNG(_ image: CGImage) -> Data? {
+        let output = NSMutableData()
+        guard
+            let destination = CGImageDestinationCreateWithData(
+                output, UTType.png.identifier as CFString, 1, nil)
+        else {
+            return nil
+        }
+        CGImageDestinationAddImage(destination, image, nil)
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return output as Data
+    }
+}
+
+/// What the pasteboard is offering, when it is offering an image.
+nonisolated struct ClipboardImageCandidate {
+    let data: Data
+    /// The filename the image arrived under, when it arrived as a file. Raw
+    /// pixels have none, and get a label built from their source instead.
+    let fileName: String?
+}
+
+/// Reading images off the pasteboard. Separate from the store so the polling
+/// loop stays one method: this decides only whether a copy was an image.
+enum ClipboardImagePasteboard {
+    private typealias Constants = AppConstants.Launcher.ClipboardImage
+
+    /// The image on the pasteboard, or nil when there is none worth keeping.
+    ///
+    /// Files are checked first because an image copied in Finder carries both a
+    /// file URL and a preview, and the filename is the better label.
+    static func candidate(
+        from pasteboard: NSPasteboard, types: [NSPasteboard.PasteboardType]
+    ) -> ClipboardImageCandidate? {
+        fileCandidate(from: pasteboard) ?? rawCandidate(from: pasteboard, types: types)
+    }
+
+    /// A label for pixels that arrived without a filename: the app they came
+    /// from, and when, so a list of them can still be told apart.
+    static func label(forSourceNamed sourceName: String?, capturedAt: Date) -> String {
+        let source = sourceName ?? Constants.unnamedLabelFallbackSource
+        let time = labelDateFormatter.string(from: capturedAt)
+        return "\(Constants.unnamedLabelPrefix) \(source), \(time)"
+    }
+
+    private static let labelDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
+    private static func fileCandidate(from pasteboard: NSPasteboard) -> ClipboardImageCandidate? {
+        let urls =
+            pasteboard.readObjects(
+                forClasses: [NSURL.self], options: [.urlReadingFileURLsOnly: true]) as? [URL] ?? []
+        // Size is checked from the directory entry, before the read: this runs
+        // on the main thread, and pulling a print-resolution scan into memory
+        // to find out it was too big would freeze the launcher.
+        guard
+            let url = urls.first(where: { url in
+                guard
+                    let values = try? url.resourceValues(forKeys: [.contentTypeKey, .fileSizeKey]),
+                    values.contentType?.conforms(to: .image) == true
+                else {
+                    return false
+                }
+                return (values.fileSize ?? 0) <= Constants.maxImageBytes
+            }), let data = try? Data(contentsOf: url)
+        else {
+            return nil
+        }
+        return ClipboardImageCandidate(data: data, fileName: url.lastPathComponent)
+    }
+
+    private static func rawCandidate(
+        from pasteboard: NSPasteboard, types: [NSPasteboard.PasteboardType]
+    ) -> ClipboardImageCandidate? {
+        for type in [NSPasteboard.PasteboardType.png, .tiff] where types.contains(type) {
+            if let data = pasteboard.data(forType: type) {
+                return ClipboardImageCandidate(data: data, fileName: nil)
+            }
+        }
+        return nil
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/ClipboardQueryPrefix.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/ClipboardQueryPrefix.swift
@@ -1,12 +1,8 @@
 import Foundation
 
-/// Which clipboard history a query is asking for: the text clips behind `c"`,
-/// or the copied images behind `ci"`.
-///
-/// One rule for both, in one place. The two spellings are a character apart,
-/// and a caller that trims and drops a prefix by hand for each of them is a
-/// caller that will eventually disagree with the other one about which history
-/// `ci"logo` meant.
+/// Which clipboard history a query is asking for. One rule for both: the two
+/// spellings are a character apart, and callers that trim and drop each by hand
+/// eventually disagree about which history `ci"logo` meant.
 enum ClipboardQueryPrefix {
     case text
     case image

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/ClipboardQueryPrefix.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/ClipboardQueryPrefix.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Which clipboard history a query is asking for: the text clips behind `c"`,
+/// or the copied images behind `ci"`.
+///
+/// One rule for both, in one place. The two spellings are a character apart,
+/// and a caller that trims and drops a prefix by hand for each of them is a
+/// caller that will eventually disagree with the other one about which history
+/// `ci"logo` meant.
+enum ClipboardQueryPrefix {
+    case text
+    case image
+
+    var prefix: String {
+        switch self {
+        case .text:
+            return AppConstants.Launcher.QueryPrefix.clipboard
+        case .image:
+            return AppConstants.Launcher.QueryPrefix.clipboardImage
+        }
+    }
+
+    func matches(_ query: String) -> Bool {
+        searchTerm(in: query) != nil
+    }
+
+    /// What follows the prefix, or nil when the query is not this history's.
+    func searchTerm(in query: String) -> String? {
+        let normalized = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard normalized.lowercased().hasPrefix(prefix) else { return nil }
+        return String(normalized.dropFirst(prefix.count))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/EngineBridge.swift
@@ -186,11 +186,19 @@ private func look_recent_urls_json(_ query: UnsafePointer<CChar>?, _ limit: UInt
 
 @_silgen_name("look_clipboard_record")
 nonisolated
-private func look_clipboard_record(_ content: UnsafePointer<CChar>?, _ kind: UnsafePointer<CChar>?, _ appBundleID: UnsafePointer<CChar>?) -> Int64
+private func look_clipboard_record(_ content: UnsafePointer<CChar>?, _ appBundleID: UnsafePointer<CChar>?) -> Int64
+
+@_silgen_name("look_clipboard_record_image")
+nonisolated
+private func look_clipboard_record_image(_ label: UnsafePointer<CChar>?, _ imageHash: UnsafePointer<CChar>?, _ appBundleID: UnsafePointer<CChar>?) -> Int64
+
+@_silgen_name("look_clipboard_images_dir")
+nonisolated
+private func look_clipboard_images_dir() -> UnsafeMutablePointer<CChar>?
 
 @_silgen_name("look_clipboard_list_json")
 nonisolated
-private func look_clipboard_list_json(_ query: UnsafePointer<CChar>?, _ limit: UInt32) -> UnsafeMutablePointer<CChar>?
+private func look_clipboard_list_json(_ kind: UnsafePointer<CChar>?, _ query: UnsafePointer<CChar>?, _ limit: UInt32) -> UnsafeMutablePointer<CChar>?
 
 @_silgen_name("look_clipboard_delete")
 nonisolated
@@ -1201,7 +1209,9 @@ final class EngineBridge: @unchecked Sendable {
     nonisolated struct ClipboardEntry: Decodable, Identifiable, Equatable {
         let id: Int64
         let content: String
-        let kind: String
+        /// Identity of what was copied. For an image clip it is also the stem
+        /// of the file holding the pixels.
+        let contentHash: String
         let appBundleID: String?
         let copiedAtUnixS: Int64
 
@@ -1218,24 +1228,64 @@ final class EngineBridge: @unchecked Sendable {
     /// manager's clip can be kept out of the database.
     /// Opens the shared look.db - call off the main thread.
     @discardableResult
-    nonisolated func recordClipboard(content: String, kind: String = "text", appBundleID: String? = nil) -> Int64? {
+    nonisolated func recordClipboard(content: String, appBundleID: String? = nil) -> Int64? {
         let id = content.withCString { contentC in
-            kind.withCString { kindC in
+            if let appBundleID {
+                return appBundleID.withCString { appC in
+                    look_clipboard_record(contentC, appC)
+                }
+            }
+            return look_clipboard_record(contentC, nil)
+        }
+        return id > 0 ? id : nil
+    }
+
+    /// Remembers a copied image and returns its row id. `imageHash` names the
+    /// file this side already wrote into `clipboardImagesDirectory()`; the row
+    /// is what keeps that file from being swept.
+    ///
+    /// Same concealed-clip rule as `recordClipboard`: only this side sees the
+    /// pasteboard markers.
+    @discardableResult
+    nonisolated func recordClipboardImage(
+        label: String, imageHash: String, appBundleID: String? = nil
+    ) -> Int64? {
+        let id = label.withCString { labelC in
+            imageHash.withCString { hashC in
                 if let appBundleID {
                     return appBundleID.withCString { appC in
-                        look_clipboard_record(contentC, kindC, appC)
+                        look_clipboard_record_image(labelC, hashC, appC)
                     }
                 }
-                return look_clipboard_record(contentC, kindC, nil)
+                return look_clipboard_record_image(labelC, hashC, nil)
             }
         }
         return id > 0 ? id : nil
     }
 
-    /// Up to `limit` remembered clips matching `query` (newest first). An empty
-    /// query returns the most recent. Opens look.db - call off the main thread.
-    nonisolated func clipboardEntries(query: String = "", limit: Int) -> [ClipboardEntry] {
-        let ptr = query.withCString { look_clipboard_list_json($0, UInt32(limit)) }
+    /// Where image clips keep their bytes. Core owns the location and sweeps
+    /// anything in it that no row claims, so this side asks rather than
+    /// assembling the path itself.
+    nonisolated func clipboardImagesDirectory() -> URL? {
+        guard let ptr = look_clipboard_images_dir() else { return nil }
+        defer { look_free_cstring(ptr) }
+        let path = String(cString: ptr)
+        return path.isEmpty ? nil : URL(fileURLWithPath: path)
+    }
+
+    /// Up to `limit` remembered clips of `kind` matching `query` (newest
+    /// first). An empty query returns the most recent. Opens look.db - call off
+    /// the main thread.
+    nonisolated func clipboardEntries(
+        kind: String = AppConstants.Launcher.Clipboard.textKind,
+        query: String = "",
+        limit: Int
+    ) -> [ClipboardEntry] {
+        let ptr = kind.withCString { kindC in
+            query.withCString { queryC in
+                look_clipboard_list_json(kindC, queryC, UInt32(limit))
+            }
+        }
         guard let ptr else { return [] }
         defer { look_free_cstring(ptr) }
         guard let data = String(cString: ptr).data(using: .utf8) else { return [] }

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/LauncherClipboardFeature.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/LauncherClipboardFeature.swift
@@ -2,17 +2,11 @@ import Foundation
 
 enum LauncherClipboardFeature {
     static func isClipboardQuery(_ query: String) -> Bool {
-        query
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased()
-            .hasPrefix(AppConstants.Launcher.QueryPrefix.clipboard)
+        ClipboardQueryPrefix.text.matches(query)
     }
 
     static func searchTerm(from query: String) -> String? {
-        let normalized = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        let prefix = AppConstants.Launcher.QueryPrefix.clipboard
-        guard normalized.lowercased().hasPrefix(prefix) else { return nil }
-        return String(normalized.dropFirst(prefix.count)).trimmingCharacters(in: .whitespacesAndNewlines)
+        ClipboardQueryPrefix.text.searchTerm(in: query)
     }
 
     static func makeResult(entry: ClipboardHistoryEntry, dateFormatter: DateFormatter) -> LauncherResult {

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/LauncherClipboardImageFeature.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/LauncherClipboardImageFeature.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// The `ci"` screen: copied images, listed newest first.
+///
+/// A sibling of LauncherClipboardFeature rather than a branch inside it. The
+/// two share their storage but nothing else: text rows are searched by content
+/// and measured in lines, image rows are searched by name and drawn as
+/// pictures.
+enum LauncherClipboardImageFeature {
+    static func isClipboardImageQuery(_ query: String) -> Bool {
+        ClipboardQueryPrefix.image.matches(query)
+    }
+
+    static func searchTerm(from query: String) -> String? {
+        ClipboardQueryPrefix.image.searchTerm(in: query)
+    }
+
+    static func makeResult(entry: ClipboardImageEntry, dateFormatter: DateFormatter)
+        -> LauncherResult
+    {
+        let timestamp = dateFormatter.string(from: entry.capturedAt)
+        let dimensions = "\(Int(entry.pixelSize.width))×\(Int(entry.pixelSize.height))"
+        let size = ByteCountFormatter.string(
+            fromByteCount: Int64(entry.byteSize), countStyle: .file)
+        let subtitle = "Image  •  \(dimensions)  •  \(size)  •  \(timestamp)"
+
+        var result = LauncherResult(
+            id: "\(AppConstants.Launcher.ClipboardImage.resultIDPrefix)\(entry.id)",
+            kind: .clipboard,
+            title: entry.label,
+            subtitle: subtitle,
+            path: AppConstants.Launcher.ClipboardImage.resultPath,
+            score: 0
+        )
+        result.clipboardCapturedAt = entry.capturedAt
+        result.clipboardImagePath = entry.fileURL?.path
+        result.clipboardImageThumbnailPath = entry.thumbnailURL?.path
+        result.clipboardImagePixelSize = entry.pixelSize
+        result.clipboardImageByteSize = entry.byteSize
+        return result
+    }
+
+    /// The image hash a row id carries, or nil when the id belongs to some
+    /// other row. The delete and copy handlers get nothing but the id.
+    static func entryID(fromResultID resultID: String) -> String? {
+        let idPrefix = AppConstants.Launcher.ClipboardImage.resultIDPrefix
+        guard resultID.hasPrefix(idPrefix) else { return nil }
+        let hash = String(resultID.dropFirst(idPrefix.count))
+        return hash.isEmpty ? nil : hash
+    }
+}

--- a/apps/macos/LauncherApp/look-app/Support/Launcher/LauncherClipboardImageFeature.swift
+++ b/apps/macos/LauncherApp/look-app/Support/Launcher/LauncherClipboardImageFeature.swift
@@ -1,11 +1,8 @@
 import Foundation
 
-/// The `ci"` screen: copied images, listed newest first.
-///
-/// A sibling of LauncherClipboardFeature rather than a branch inside it. The
-/// two share their storage but nothing else: text rows are searched by content
-/// and measured in lines, image rows are searched by name and drawn as
-/// pictures.
+/// The `ci"` screen. A sibling of LauncherClipboardFeature, not a branch in it:
+/// the two share storage but nothing else, since text rows are searched by
+/// content and measured in lines, image rows by name and drawn as pictures.
 enum LauncherClipboardImageFeature {
     static func isClipboardImageQuery(_ query: String) -> Bool {
         ClipboardQueryPrefix.image.matches(query)
@@ -40,8 +37,7 @@ enum LauncherClipboardImageFeature {
         return result
     }
 
-    /// The image hash a row id carries, or nil when the id belongs to some
-    /// other row. The delete and copy handlers get nothing but the id.
+    /// The image hash a row id carries, or nil when the id is another row's.
     static func entryID(fromResultID resultID: String) -> String? {
         let idPrefix = AppConstants.Launcher.ClipboardImage.resultIDPrefix
         guard resultID.hasPrefix(idPrefix) else { return nil }

--- a/apps/macos/LauncherApp/look-app/Support/RowIconCache.swift
+++ b/apps/macos/LauncherApp/look-app/Support/RowIconCache.swift
@@ -23,9 +23,8 @@ nonisolated enum RowIconCache {
         }
     }
 
-    /// The picture itself, for a row that IS one (a copied image). Cached like
-    /// every other row icon, and small on disk already, so the list draws it
-    /// without decoding the full-size original.
+    /// The picture itself, for a row that IS one. Small on disk already, so the
+    /// list never decodes the full-size original.
     static func thumbnail(forFile path: String) -> NSImage? {
         if let cached = cache.object(forKey: path as NSString) {
             return cached

--- a/apps/macos/LauncherApp/look-app/Support/RowIconCache.swift
+++ b/apps/macos/LauncherApp/look-app/Support/RowIconCache.swift
@@ -23,6 +23,18 @@ nonisolated enum RowIconCache {
         }
     }
 
+    /// The picture itself, for a row that IS one (a copied image). Cached like
+    /// every other row icon, and small on disk already, so the list draws it
+    /// without decoding the full-size original.
+    static func thumbnail(forFile path: String) -> NSImage? {
+        if let cached = cache.object(forKey: path as NSString) {
+            return cached
+        }
+        guard let image = NSImage(contentsOfFile: path) else { return nil }
+        cache.setObject(image, forKey: path as NSString)
+        return image
+    }
+
     /// For rows with no path of their own (synthetic rows, system symbols).
     static func image(key: String, resolve: () -> NSImage) -> NSImage {
         if let cached = cache.object(forKey: key as NSString) {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherRowView.swift
@@ -89,6 +89,13 @@ struct LauncherRowView: View {
         }
 
         if result.kind == .clipboard {
+            // A copied image shows itself. A generic icon would leave the user
+            // picking from a column of identical rows named after their source.
+            if let thumbnailPath = result.clipboardImageThumbnailPath,
+                let thumbnail = RowIconCache.thumbnail(forFile: thumbnailPath)
+            {
+                return thumbnail
+            }
             return RowIconCache.image(key: "symbol:doc.on.clipboard") {
                 NSImage(systemSymbolName: "doc.on.clipboard", accessibilityDescription: nil)
                     ?? NSImage(systemSymbolName: "doc.text", accessibilityDescription: nil)
@@ -159,7 +166,7 @@ struct LauncherRowView: View {
         case .folder:
             return "Folder"
         case .clipboard:
-            return "Clipboard"
+            return result.isClipboardImage ? "Image" : "Clipboard"
         case .process:
             return "Process"
         case .action:

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
@@ -473,9 +473,8 @@ struct HintBar: View {
     }
 }
 
-/// What an empty clipboard screen says. `c"` and `ci"` share the layout and
-/// differ only in wording, so the words travel as a value rather than as a
-/// second copy of the views.
+/// The two histories share the empty screen's layout and differ only in
+/// wording, so the words travel as a value rather than a second copy of it.
 struct ClipboardEmptyStateCopy {
     let symbol: String
     let title: String

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherSubviews.swift
@@ -473,19 +473,49 @@ struct HintBar: View {
     }
 }
 
+/// What an empty clipboard screen says. `c"` and `ci"` share the layout and
+/// differ only in wording, so the words travel as a value rather than as a
+/// second copy of the views.
+struct ClipboardEmptyStateCopy {
+    let symbol: String
+    let title: String
+    let headline: String
+    let detail: String
+    let tips: String
+
+    static let text = ClipboardEmptyStateCopy(
+        symbol: "doc.on.clipboard",
+        title: "Clipboard History",
+        headline: "No clipboard items yet",
+        detail: "Copy any text, then search with c\"word to find it here.",
+        tips:
+            "• Type c\" to list latest 10 clips\n• Type c\"mail to filter\n• Press Enter to copy selected item"
+    )
+
+    static let images = ClipboardEmptyStateCopy(
+        symbol: "photo.on.rectangle",
+        title: "Copied Images",
+        headline: "No images copied yet",
+        detail: "Copy a picture or an image file, then find it here with ci\"name.",
+        tips:
+            "• Type ci\" to list the latest images\n• Type ci\"logo to filter by name\n• Press Enter to copy the selected image"
+    )
+}
+
 struct ClipboardEmptyStateView: View {
     let themeStore: ThemeStore
+    var copy: ClipboardEmptyStateCopy = .text
 
     var body: some View {
         HStack(spacing: 0) {
-            ClipboardEmptyInfoView(themeStore: themeStore)
+            ClipboardEmptyInfoView(themeStore: themeStore, copy: copy)
 
             Rectangle()
                 .fill(themeStore.dividerColor())
                 .frame(width: 1)
                 .padding(.vertical, 4)
 
-            ClipboardEmptyHelpView(themeStore: themeStore)
+            ClipboardEmptyHelpView(themeStore: themeStore, copy: copy)
         }
     }
 }
@@ -494,21 +524,22 @@ struct ClipboardEmptyStateView: View {
 /// it as its own card (matching the results list) when the panes are floating.
 struct ClipboardEmptyInfoView: View {
     let themeStore: ThemeStore
+    var copy: ClipboardEmptyStateCopy = .text
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 8) {
-                Image(systemName: "doc.on.clipboard")
+                Image(systemName: copy.symbol)
                     .foregroundStyle(themeStore.accentColor())
-                Text("Clipboard History")
+                Text(copy.title)
                     .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize + 1), weight: .semibold))
             }
 
-            Text("No clipboard items yet")
+            Text(copy.headline)
                 .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize), weight: .medium))
                 .foregroundStyle(themeStore.secondaryTextColor())
 
-            Text("Copy any text, then search with c\"word to find it here.")
+            Text(copy.detail)
                 .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular))
                 .foregroundStyle(themeStore.secondaryTextColor())
                 .lineLimit(2)
@@ -523,13 +554,14 @@ struct ClipboardEmptyInfoView: View {
 /// Right half of the clipboard empty state (the "How to use" tips).
 struct ClipboardEmptyHelpView: View {
     let themeStore: ThemeStore
+    var copy: ClipboardEmptyStateCopy = .text
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             Text("How to use")
                 .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize), weight: .semibold))
                 .foregroundStyle(themeStore.fontColor())
-            Text("• Type c\" to list latest 10 clips\n• Type c\"mail to filter\n• Press Enter to copy selected item")
+            Text(copy.tips)
                 .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular))
                 .foregroundStyle(themeStore.secondaryTextColor())
                 .lineSpacing(4)

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Results.swift
@@ -96,6 +96,10 @@ extension LauncherView {
             // something that wants the focus.
             performSourceBlock(selected)
         case .clipboard:
+            if selected.isClipboardImage {
+                copyClipboardImage(resultID: selected.id)
+                return
+            }
             // Labeled entries (e.g. calculator results) paste their value, not
             // the label shown in the list.
             guard let content = selected.clipboardPayload ?? selected.clipboardContent, !content.isEmpty else { return }
@@ -483,17 +487,41 @@ extension LauncherView {
     }
 
     func deleteClipboardResult(resultID: String) {
-        guard let entryID = LauncherClipboardFeature.entryID(fromResultID: resultID) else { return }
-        clipboardStore.deleteEntry(id: entryID)
+        let banner: String
+        if let imageID = LauncherClipboardImageFeature.entryID(fromResultID: resultID) {
+            clipboardStore.deleteImageEntry(id: imageID)
+            banner = AppConstants.Launcher.ClipboardImage.deletedBanner
+        } else if let entryID = LauncherClipboardFeature.entryID(fromResultID: resultID) {
+            clipboardStore.deleteEntry(id: entryID)
+            banner = AppConstants.Launcher.Clipboard.deletedBanner
+        } else {
+            return
+        }
 
         if selectedResultID == resultID {
             selectedResultID = displayedResults.first?.id
         }
 
         showBanner(
-            AppConstants.Launcher.Clipboard.deletedBanner,
+            banner,
             style: .info,
             duration: AppConstants.Launcher.Clipboard.infoBannerDuration
+        )
+    }
+
+    /// Puts a stored image back on the pasteboard. The launcher stays open, the
+    /// way copying a text clip does.
+    private func copyClipboardImage(resultID: String) {
+        guard let entryID = LauncherClipboardImageFeature.entryID(fromResultID: resultID),
+            let entry = clipboardStore.imageEntries.first(where: { $0.id == entryID }),
+            clipboardStore.copyImage(entry: entry)
+        else {
+            return
+        }
+        showBanner(
+            AppConstants.Launcher.ClipboardImage.copiedBanner,
+            style: .success,
+            duration: AppConstants.Launcher.Clipboard.copiedBannerDuration
         )
     }
 
@@ -650,7 +678,7 @@ extension LauncherView {
     }
 
     func refreshClipboardSelectionIfNeeded() {
-        guard !isCommandMode, isClipboardQuery else { return }
+        guard !isCommandMode, isClipboardQuery || isClipboardImageQuery else { return }
 
         if let selectedResultID,
            displayedResults.contains(where: { $0.id == selectedResultID }) {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Search.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+Search.swift
@@ -18,7 +18,7 @@ extension LauncherView {
         fileRecallEmptyMessage = nil
         fileRecallNote = nil
         mainBarAction = nil
-        guard !isClipboardQuery else {
+        guard !isClipboardQuery, !isClipboardImageQuery else {
             invalidateSearchRequests()
             setInitialSelection()
             return
@@ -298,7 +298,7 @@ extension LauncherView {
         let trimmed = currentQuery.trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard themeStore.settings.aiEnabled,
-              !isCommandMode, !isClipboardQuery, !isPrefixSuggestionQuery,
+              !isCommandMode, !isClipboardQuery, !isClipboardImageQuery, !isPrefixSuggestionQuery,
               !isCommandSuggestionQuery, !isTranslationQuery,
               trimmed.count >= AppConstants.Launcher.minSuggestionQueryLength
         else {

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+URLResults.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView+URLResults.swift
@@ -9,7 +9,8 @@ extension LauncherView {
     /// Modes where synthesized suggestion rows (URLs, web search) must not show:
     /// command, clipboard, and the `"`/`:` discovery menus.
     var allowsSuggestionRows: Bool {
-        !isCommandMode && !isClipboardQuery && !isPrefixSuggestionQuery && !isCommandSuggestionQuery
+        !isCommandMode && !isClipboardQuery && !isClipboardImageQuery && !isPrefixSuggestionQuery
+            && !isCommandSuggestionQuery
     }
 
     /// Builds a synthesized URL row. Shared by the live row and history rows so

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/LauncherView.swift
@@ -399,6 +399,10 @@ struct LauncherView: View {
         LauncherClipboardFeature.isClipboardQuery(query)
     }
 
+    var isClipboardImageQuery: Bool {
+        LauncherClipboardImageFeature.isClipboardImageQuery(query)
+    }
+
     var isRecentQuery: Bool {
         query.trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
@@ -488,6 +492,15 @@ struct LauncherView: View {
         }
     }
 
+    var clipboardImageResults: [LauncherResult] {
+        guard let term = LauncherClipboardImageFeature.searchTerm(from: query) else { return [] }
+
+        return clipboardStore.searchImages(term).map { entry in
+            LauncherClipboardImageFeature.makeResult(
+                entry: entry, dateFormatter: Self.clipboardSubtitleDateFormatter)
+        }
+    }
+
     /// Google autocomplete rows, appended after the engine results. Built by
     /// hand like `prefixSuggestionResults`; `openSelectedApp` recognises the id
     /// prefix and runs a web search instead of opening a file.
@@ -513,6 +526,8 @@ struct LauncherView: View {
         if isInLevel { return levelResults }
         if isPrefixSuggestionQuery { return prefixSuggestionResults }
         if isCommandSuggestionQuery { return commandSuggestionResults }
+        // Before the text history: `ci"` starts with `c`, but not with `c"`.
+        if isClipboardImageQuery { return clipboardImageResults }
         if isClipboardQuery { return clipboardResults }
         if isProcessQuery { return processResults }
         // Recent URLs interleave with local results by frecency; web-search rows
@@ -566,8 +581,8 @@ struct LauncherView: View {
     /// the disjunction out by hand, and they had already drifted apart. A new
     /// mode belongs HERE, not in each caller.
     var usesOwnResultPanel: Bool {
-        isInLevel || isClipboardQuery || isPrefixSuggestionQuery || isCommandSuggestionQuery
-            || isTranslationQuery || isProcessQuery
+        isInLevel || isClipboardQuery || isClipboardImageQuery || isPrefixSuggestionQuery
+            || isCommandSuggestionQuery || isTranslationQuery || isProcessQuery
     }
 
     var isTranslationQuery: Bool {
@@ -668,6 +683,10 @@ struct LauncherView: View {
 
         if isCommandSuggestionQuery {
             return ["Enter run command", "Up/Down move", "Esc clear"]
+        }
+
+        if isClipboardImageQuery {
+            return ["Enter copy", "Cmd+D remove"]
         }
 
         if isClipboardQuery {
@@ -956,6 +975,9 @@ struct LauncherView: View {
     private var notificationHandlers: some View {
         Color.clear
         .onReceive(clipboardStore.$entries) { _ in
+            refreshClipboardSelectionIfNeeded()
+        }
+        .onReceive(clipboardStore.$imageEntries) { _ in
             refreshClipboardSelectionIfNeeded()
         }
         .onChange(of: commandInput) { _, _ in
@@ -1339,17 +1361,18 @@ struct LauncherView: View {
                         themeStore: themeStore
                     )
                 }
-            } else if isClipboardQuery && displayedResults.isEmpty {
+            } else if (isClipboardQuery || isClipboardImageQuery) && displayedResults.isEmpty {
                 // The empty clipboard screen is naturally two columns (history /
                 // how-to), so float it as the same two-card grid as the results.
+                let copy: ClipboardEmptyStateCopy = isClipboardImageQuery ? .images : .text
                 if showsFloatingCards {
                     twoPaneGrid(hasRight: true) {
-                        ClipboardEmptyInfoView(themeStore: themeStore)
+                        ClipboardEmptyInfoView(themeStore: themeStore, copy: copy)
                     } right: {
-                        ClipboardEmptyHelpView(themeStore: themeStore)
+                        ClipboardEmptyHelpView(themeStore: themeStore, copy: copy)
                     }
                 } else {
-                    ClipboardEmptyStateView(themeStore: themeStore)
+                    ClipboardEmptyStateView(themeStore: themeStore, copy: copy)
                 }
             } else if isRecentQuery && displayedResults.isEmpty {
                 floatingPanel { RecentEmptyStateView(themeStore: themeStore) }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
@@ -388,6 +388,8 @@ struct ResultPreviewView: View {
             actionPreview.overlay(alignment: .top) { floatingActionMenu }
         } else if result.kind == .process {
             processPreview
+        } else if result.isClipboardImage {
+            clipboardImagePreview
         } else if result.kind == .clipboard {
             clipboardPreview
         } else if isCalcResult {
@@ -676,6 +678,45 @@ struct ResultPreviewView: View {
         }
     }
 
+    /// Icon, what the clip is, and the delete affordance. Shared by the text
+    /// and image panels: the two differ below this line, not at it.
+    ///
+    /// The capture time belongs to the InfoRow at the foot of both panels, and
+    /// only there. Repeated up here it pushed a long title onto a second line
+    /// to say what the panel already said.
+    private func clipboardPreviewHeader(icon: NSImage, title: String) -> some View {
+        HStack(spacing: 10) {
+            Image(nsImage: icon)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 34, height: 34)
+                .foregroundStyle(themeStore.accentColor())
+            Text(title)
+                .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize + 1), weight: .semibold))
+                .foregroundStyle(themeStore.fontColor())
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer()
+
+            // Solid danger with contrasting text, as the kill and delete
+            // confirmations use. Tinted text on a tinted fill was the same hue
+            // twice and read as disabled.
+            if let onDeleteClipboard {
+                Button {
+                    onDeleteClipboard()
+                } label: {
+                    Label("Delete", systemImage: "trash")
+                        .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .semibold))
+                        .foregroundStyle(themeStore.onDangerColor())
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 5)
+                        .background(themeStore.dangerColor(), in: Capsule())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
     private var clipboardPreview: some View {
         let content = result.clipboardContent ?? ""
         let capturedAt = result.clipboardCapturedAt.map { Self.clipboardDateFormatter.string(from: $0) } ?? "Unknown"
@@ -687,36 +728,7 @@ struct ResultPreviewView: View {
         )
 
         return VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 10) {
-                Image(nsImage: clipboardIcon)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 34, height: 34)
-                    .foregroundStyle(themeStore.accentColor())
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Clipboard item")
-                        .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize + 1), weight: .semibold))
-                        .foregroundStyle(themeStore.fontColor())
-                    Text("Captured \(capturedAt)")
-                        .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular))
-                        .foregroundStyle(themeStore.mutedTextColor())
-                }
-                Spacer()
-
-                if let onDeleteClipboard {
-                    Button {
-                        onDeleteClipboard()
-                    } label: {
-                        Label("Delete", systemImage: "trash")
-                    }
-                    .buttonStyle(.plain)
-                    .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .semibold))
-                    .foregroundStyle(themeStore.dangerColor().opacity(0.95))
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 5)
-                    .background(themeStore.dangerColor().opacity(0.16), in: Capsule())
-                }
-            }
+            clipboardPreviewHeader(icon: clipboardIcon, title: "Clipboard item")
 
             HStack(spacing: 8) {
                 KindBadge(kind: "clipboard")
@@ -747,6 +759,62 @@ struct ResultPreviewView: View {
         }
         .padding(12)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    // MARK: - Copied image preview
+
+    /// The `ci"` panel. The picture is the whole point of the row, so it gets
+    /// the space the text preview gives the clip's characters.
+    private var clipboardImagePreview: some View {
+        let capturedAt =
+            result.clipboardCapturedAt.map { Self.clipboardDateFormatter.string(from: $0) }
+            ?? "Unknown"
+        let image = result.clipboardImagePath.flatMap { NSImage(contentsOfFile: $0) }
+        let pixelSize = result.clipboardImagePixelSize
+
+        return VStack(alignment: .leading, spacing: 10) {
+            clipboardPreviewHeader(icon: clipboardImageIcon, title: result.title)
+
+            HStack(spacing: 8) {
+                KindBadge(kind: "image")
+                if let pixelSize {
+                    Text("\(Int(pixelSize.width)) × \(Int(pixelSize.height))")
+                        .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular))
+                        .foregroundStyle(themeStore.secondaryTextColor())
+                }
+                if let byteSize = result.clipboardImageByteSize {
+                    Text(formatFileSize(Int64(byteSize)))
+                        .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 2), weight: .regular))
+                        .foregroundStyle(themeStore.secondaryTextColor())
+                }
+            }
+
+            if let image {
+                Image(nsImage: image)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(
+                        themeStore.controlFillColor(),
+                        in: RoundedRectangle(cornerRadius: themeStore.controlRadius, style: .continuous))
+            } else {
+                // The row survives its file only until the next sweep, and the
+                // gap between is not the place to pretend.
+                Text("The image is no longer on disk")
+                    .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular))
+                    .foregroundStyle(themeStore.mutedTextColor())
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+
+            InfoRow(label: "Captured", value: capturedAt)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private var clipboardImageIcon: NSImage {
+        NSImage(systemSymbolName: "photo.on.rectangle", accessibilityDescription: nil)
+            ?? clipboardIcon
     }
 
     // MARK: - Process preview
@@ -839,7 +907,7 @@ struct KindBadge: View {
         case "app": return themeStore.accentColor()
         case "file": return themeStore.successColor()
         case "folder": return themeStore.warningColor()
-        case "clipboard": return themeStore.accentColor()
+        case "clipboard", "image": return themeStore.accentColor()
         default: return themeStore.mutedTextColor()
         }
     }

--- a/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
+++ b/apps/macos/LauncherApp/look-app/Views/Launcher/ResultPreviewView.swift
@@ -678,12 +678,8 @@ struct ResultPreviewView: View {
         }
     }
 
-    /// Icon, what the clip is, and the delete affordance. Shared by the text
-    /// and image panels: the two differ below this line, not at it.
-    ///
-    /// The capture time belongs to the InfoRow at the foot of both panels, and
-    /// only there. Repeated up here it pushed a long title onto a second line
-    /// to say what the panel already said.
+    /// Shared by the text and image panels: the two differ below this line, not
+    /// at it. The capture time lives in the InfoRow at the foot and only there.
     private func clipboardPreviewHeader(icon: NSImage, title: String) -> some View {
         HStack(spacing: 10) {
             Image(nsImage: icon)
@@ -698,9 +694,8 @@ struct ResultPreviewView: View {
                 .truncationMode(.middle)
             Spacer()
 
-            // Solid danger with contrasting text, as the kill and delete
-            // confirmations use. Tinted text on a tinted fill was the same hue
-            // twice and read as disabled.
+            // Solid, as the kill and delete confirmations are: tinted text on
+            // a tinted fill was one hue twice and read as disabled.
             if let onDeleteClipboard {
                 Button {
                     onDeleteClipboard()
@@ -763,8 +758,7 @@ struct ResultPreviewView: View {
 
     // MARK: - Copied image preview
 
-    /// The `ci"` panel. The picture is the whole point of the row, so it gets
-    /// the space the text preview gives the clip's characters.
+    /// The picture gets the space the text panel gives the clip's characters.
     private var clipboardImagePreview: some View {
         let capturedAt =
             result.clipboardCapturedAt.map { Self.clipboardDateFormatter.string(from: $0) }
@@ -798,8 +792,6 @@ struct ResultPreviewView: View {
                         themeStore.controlFillColor(),
                         in: RoundedRectangle(cornerRadius: themeStore.controlRadius, style: .continuous))
             } else {
-                // The row survives its file only until the next sweep, and the
-                // gap between is not the place to pretend.
                 Text("The image is no longer on disk")
                     .font(themeStore.uiFont(size: CGFloat(themeStore.settings.fontSize - 1), weight: .regular))
                     .foregroundStyle(themeStore.mutedTextColor())

--- a/bridge/ffi/src/clipboard_api.rs
+++ b/bridge/ffi/src/clipboard_api.rs
@@ -5,14 +5,18 @@
 //! the pasteboard markers. This layer trusts what it is handed.
 
 use crate::state::{cstr_to_string, default_db_path, store_json_allocation};
-use look_storage::{ClipboardEntry, SqliteStore};
+use look_storage::{CLIPBOARD_KIND_TEXT, ClipboardEntry, SqliteStore};
 use serde::Serialize;
+use std::collections::HashSet;
 use std::ffi::CString;
 use std::os::raw::c_char;
 use std::path::PathBuf;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
 const JSON_EMPTY_ARRAY: &str = "[]";
+/// Beside the database, not in it: an image clip is megabytes of pixels, and
+/// SQLite is the wrong place to keep them.
+const IMAGE_DIR_NAME: &str = "clipboard-images";
 
 /// One connection, opened once: `record` runs on every copy made anywhere in
 /// the OS, and `SqliteStore::open` re-runs the whole migration each time.
@@ -36,7 +40,8 @@ fn store() -> MutexGuard<'static, Option<(PathBuf, SqliteStore)>> {
 struct ClipboardEntryJSON {
     id: i64,
     content: String,
-    kind: String,
+    #[serde(rename = "contentHash")]
+    content_hash: String,
     #[serde(rename = "appBundleID", skip_serializing_if = "Option::is_none")]
     app_bundle_id: Option<String>,
     #[serde(rename = "copiedAtUnixS")]
@@ -48,9 +53,57 @@ impl From<ClipboardEntry> for ClipboardEntryJSON {
         Self {
             id: entry.id,
             content: entry.content,
-            kind: entry.kind,
+            content_hash: entry.content_hash,
             app_bundle_id: entry.app_bundle_id,
             copied_at_unix_s: entry.copied_at_unix_s,
+        }
+    }
+}
+
+/// Where image clips keep their bytes, created on demand. The shell writes the
+/// files here and rebuilds each path from the row's hash, so this is the one
+/// place the location is decided.
+fn image_dir() -> PathBuf {
+    let dir = default_db_path()
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("."))
+        .join(IMAGE_DIR_NAME);
+    let _ = std::fs::create_dir_all(&dir);
+    dir
+}
+
+/// Deletes every image file the table no longer refers to.
+///
+/// Unlinking at each deletion site instead would leave megabytes behind
+/// whenever a prune, a crash, or a failed write got in between. Sweeping
+/// against the rows is the same work and self-heals, and the directory holds
+/// tens of files, so the listing is cheap.
+///
+/// The one rule the shell has to honour: a file here is named starting with the
+/// hash of the row that owns it. Everything after that (extension, a thumbnail
+/// suffix) is the shell's business, so the two sides cannot drift over a
+/// filename format.
+fn sweep_orphan_images() {
+    let guard = store();
+    let Some((_, store)) = guard.as_ref() else {
+        return;
+    };
+    let Ok(live) = store.clipboard_image_hashes() else {
+        return;
+    };
+    let live: HashSet<String> = live.into_iter().collect();
+    drop(guard);
+
+    let Ok(entries) = std::fs::read_dir(image_dir()) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if !live.iter().any(|hash| name.starts_with(hash.as_str())) {
+            let _ = std::fs::remove_file(&path);
         }
     }
 }
@@ -59,38 +112,80 @@ impl From<ClipboardEntry> for ClipboardEntryJSON {
 /// the shell delete this clip later.
 pub(crate) fn look_clipboard_record_impl(
     content: *const c_char,
-    kind: *const c_char,
     app_bundle_id: *const c_char,
 ) -> i64 {
     let content = cstr_to_string(content);
     if content.trim().is_empty() {
         return 0;
     }
-    let kind = cstr_to_string(kind);
-    let kind = if kind.is_empty() {
-        "text".to_string()
-    } else {
-        kind
-    };
-    let app = cstr_to_string(app_bundle_id);
-    let app = if app.is_empty() { None } else { Some(app) };
+    let app = optional_string(app_bundle_id);
     let guard = store();
     let Some((_, store)) = guard.as_ref() else {
         return 0;
     };
     store
-        .record_clipboard_entry(&content, &kind, app.as_deref())
+        .record_clipboard_entry(&content, app.as_deref())
         .ok()
         .flatten()
         .unwrap_or(0)
 }
 
-/// JSON array of up to `limit` clips matching `query` (newest first), or `[]`.
-pub(crate) fn look_clipboard_list_json_impl(query: *const c_char, limit: u32) -> *mut c_char {
+/// Remembers a copied image, returning its row id (0 on failure). `label` is
+/// what the row is listed and searched by; `image_hash` names the file the
+/// shell already wrote under `look_clipboard_images_dir`.
+pub(crate) fn look_clipboard_record_image_impl(
+    label: *const c_char,
+    image_hash: *const c_char,
+    app_bundle_id: *const c_char,
+) -> i64 {
+    let label = cstr_to_string(label);
+    let image_hash = cstr_to_string(image_hash);
+    if label.trim().is_empty() || image_hash.trim().is_empty() {
+        return 0;
+    }
+    let app = optional_string(app_bundle_id);
+    let row_id = {
+        let guard = store();
+        let Some((_, store)) = guard.as_ref() else {
+            return 0;
+        };
+        store
+            .record_clipboard_image(&label, &image_hash, app.as_deref())
+            .ok()
+            .flatten()
+            .unwrap_or(0)
+    };
+    // A record can prune, and a prune leaves bytes behind.
+    sweep_orphan_images();
+    row_id
+}
+
+/// The directory image clips are stored in. The shell writes `<hash>.png` there
+/// before recording the row, and rebuilds the path from the hash when listing.
+pub(crate) fn look_clipboard_images_dir_impl() -> *mut c_char {
+    sweep_orphan_images();
+    let path = image_dir().to_string_lossy().into_owned();
+    let cstring = CString::new(path).unwrap_or_else(|_| CString::new("").expect("valid"));
+    store_json_allocation(cstring)
+}
+
+/// JSON array of up to `limit` clips of `kind` matching `query` (newest first),
+/// or `[]`. The kind is required: `c"` and `ci"` must not see each other's rows.
+pub(crate) fn look_clipboard_list_json_impl(
+    kind: *const c_char,
+    query: *const c_char,
+    limit: u32,
+) -> *mut c_char {
+    let kind = cstr_to_string(kind);
+    let kind = if kind.is_empty() {
+        CLIPBOARD_KIND_TEXT.to_string()
+    } else {
+        kind
+    };
     let query = cstr_to_string(query);
     let json = store()
         .as_ref()
-        .and_then(|(_, store)| store.clipboard_entries(&query, limit as usize).ok())
+        .and_then(|(_, store)| store.clipboard_entries(&kind, &query, limit as usize).ok())
         .map(|entries| {
             entries
                 .into_iter()
@@ -105,16 +200,28 @@ pub(crate) fn look_clipboard_list_json_impl(query: *const c_char, limit: u32) ->
 }
 
 pub(crate) fn look_clipboard_delete_impl(id: i64) -> bool {
-    store()
+    let deleted = store()
         .as_ref()
         .and_then(|(_, store)| store.delete_clipboard_entry(id).ok())
-        .unwrap_or(false)
+        .unwrap_or(false);
+    if deleted {
+        sweep_orphan_images();
+    }
+    deleted
 }
 
 /// Forgets every clip, returning how many were removed.
 pub(crate) fn look_clipboard_clear_impl() -> u32 {
-    store()
+    let removed = store()
         .as_ref()
         .and_then(|(_, store)| store.clear_clipboard_entries().ok())
-        .unwrap_or(0) as u32
+        .unwrap_or(0) as u32;
+    // The promise behind persisting history at all covers the pixels too.
+    sweep_orphan_images();
+    removed
+}
+
+fn optional_string(raw: *const c_char) -> Option<String> {
+    let value = cstr_to_string(raw);
+    if value.is_empty() { None } else { Some(value) }
 }

--- a/bridge/ffi/src/clipboard_api.rs
+++ b/bridge/ffi/src/clipboard_api.rs
@@ -14,8 +14,8 @@ use std::path::PathBuf;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
 const JSON_EMPTY_ARRAY: &str = "[]";
-/// Beside the database, not in it: an image clip is megabytes of pixels, and
-/// SQLite is the wrong place to keep them.
+/// Beside the database, not in it: SQLite is the wrong place for megabytes of
+/// pixels.
 const IMAGE_DIR_NAME: &str = "clipboard-images";
 
 /// One connection, opened once: `record` runs on every copy made anywhere in
@@ -60,9 +60,7 @@ impl From<ClipboardEntry> for ClipboardEntryJSON {
     }
 }
 
-/// Where image clips keep their bytes, created on demand. The shell writes the
-/// files here and rebuilds each path from the row's hash, so this is the one
-/// place the location is decided.
+/// The one place the location is decided; created on demand.
 fn image_dir() -> PathBuf {
     let dir = default_db_path()
         .parent()
@@ -72,17 +70,13 @@ fn image_dir() -> PathBuf {
     dir
 }
 
-/// Deletes every image file the table no longer refers to.
+/// Deletes every image file the table no longer refers to. Unlinking at each
+/// deletion site instead leaves megabytes behind whenever a prune, a crash or a
+/// failed write gets in between; sweeping self-heals, and the directory holds
+/// tens of files.
 ///
-/// Unlinking at each deletion site instead would leave megabytes behind
-/// whenever a prune, a crash, or a failed write got in between. Sweeping
-/// against the rows is the same work and self-heals, and the directory holds
-/// tens of files, so the listing is cheap.
-///
-/// The one rule the shell has to honour: a file here is named starting with the
-/// hash of the row that owns it. Everything after that (extension, a thumbnail
-/// suffix) is the shell's business, so the two sides cannot drift over a
-/// filename format.
+/// The shell's one obligation: a file here is named starting with the hash of
+/// the row that owns it. Anything after that is the shell's business.
 fn sweep_orphan_images() {
     let guard = store();
     let Some((_, store)) = guard.as_ref() else {
@@ -130,9 +124,8 @@ pub(crate) fn look_clipboard_record_impl(
         .unwrap_or(0)
 }
 
-/// Remembers a copied image, returning its row id (0 on failure). `label` is
-/// what the row is listed and searched by; `image_hash` names the file the
-/// shell already wrote under `look_clipboard_images_dir`.
+/// Returns the row id (0 on failure). `image_hash` names the file the shell
+/// already wrote under `look_clipboard_images_dir`.
 pub(crate) fn look_clipboard_record_image_impl(
     label: *const c_char,
     image_hash: *const c_char,
@@ -160,8 +153,7 @@ pub(crate) fn look_clipboard_record_image_impl(
     row_id
 }
 
-/// The directory image clips are stored in. The shell writes `<hash>.png` there
-/// before recording the row, and rebuilds the path from the hash when listing.
+/// Where the shell writes an image's bytes before recording its row.
 pub(crate) fn look_clipboard_images_dir_impl() -> *mut c_char {
     sweep_orphan_images();
     let path = image_dir().to_string_lossy().into_owned();
@@ -170,7 +162,7 @@ pub(crate) fn look_clipboard_images_dir_impl() -> *mut c_char {
 }
 
 /// JSON array of up to `limit` clips of `kind` matching `query` (newest first),
-/// or `[]`. The kind is required: `c"` and `ci"` must not see each other's rows.
+/// or `[]`.
 pub(crate) fn look_clipboard_list_json_impl(
     kind: *const c_char,
     query: *const c_char,
@@ -216,7 +208,6 @@ pub(crate) fn look_clipboard_clear_impl() -> u32 {
         .as_ref()
         .and_then(|(_, store)| store.clear_clipboard_entries().ok())
         .unwrap_or(0) as u32;
-    // The promise behind persisting history at all covers the pixels too.
     sweep_orphan_images();
     removed
 }

--- a/bridge/ffi/src/lib.rs
+++ b/bridge/ffi/src/lib.rs
@@ -850,20 +850,47 @@ pub extern "C" fn look_recent_urls_json(query: *const c_char, limit: u32) -> *mu
 #[unsafe(no_mangle)]
 pub extern "C" fn look_clipboard_record(
     content: *const c_char,
-    kind: *const c_char,
     app_bundle_id: *const c_char,
 ) -> i64 {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        clipboard_api::look_clipboard_record_impl(content, kind, app_bundle_id)
+        clipboard_api::look_clipboard_record_impl(content, app_bundle_id)
     }))
     .unwrap_or(0)
 }
 
-/// JSON array of up to `limit` remembered clips matching `query` (or `[]`).
+/// Remembers a copied image, returning its row id (0 on failure). The bytes are
+/// the shell's to write, under `image_hash`, inside the directory
+/// `look_clipboard_images_dir` names. Same concealed-clip rule as above.
 #[unsafe(no_mangle)]
-pub extern "C" fn look_clipboard_list_json(query: *const c_char, limit: u32) -> *mut c_char {
+pub extern "C" fn look_clipboard_record_image(
+    label: *const c_char,
+    image_hash: *const c_char,
+    app_bundle_id: *const c_char,
+) -> i64 {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        clipboard_api::look_clipboard_list_json_impl(query, limit)
+        clipboard_api::look_clipboard_record_image_impl(label, image_hash, app_bundle_id)
+    }))
+    .unwrap_or(0)
+}
+
+/// Where image clips keep their bytes. Each file's name starts with the hash of
+/// the row that owns it; anything not backed by a row is swept.
+#[unsafe(no_mangle)]
+pub extern "C" fn look_clipboard_images_dir() -> *mut c_char {
+    std::panic::catch_unwind(clipboard_api::look_clipboard_images_dir_impl)
+        .unwrap_or(std::ptr::null_mut())
+}
+
+/// JSON array of up to `limit` remembered clips of `kind` matching `query`
+/// (or `[]`).
+#[unsafe(no_mangle)]
+pub extern "C" fn look_clipboard_list_json(
+    kind: *const c_char,
+    query: *const c_char,
+    limit: u32,
+) -> *mut c_char {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        clipboard_api::look_clipboard_list_json_impl(kind, query, limit)
     }))
     .unwrap_or(std::ptr::null_mut())
 }

--- a/bridge/ffi/src/lib.rs
+++ b/bridge/ffi/src/lib.rs
@@ -859,8 +859,7 @@ pub extern "C" fn look_clipboard_record(
 }
 
 /// Remembers a copied image, returning its row id (0 on failure). The bytes are
-/// the shell's to write, under `image_hash`, inside the directory
-/// `look_clipboard_images_dir` names. Same concealed-clip rule as above.
+/// the shell's to write, under `image_hash`. Same concealed-clip rule as above.
 #[unsafe(no_mangle)]
 pub extern "C" fn look_clipboard_record_image(
     label: *const c_char,

--- a/core/engine/src/modes.rs
+++ b/core/engine/src/modes.rs
@@ -57,6 +57,13 @@ pub const MODES: &[Mode] = &[
         about: "clipboard history",
     },
     Mode {
+        name: "clipboard-image",
+        aliases: &["clipimg", "ci"],
+        prefix: "ci\"",
+        platforms: Platforms::MacOnly,
+        about: "copied images",
+    },
+    Mode {
         name: "apps",
         aliases: &["app"],
         prefix: "a\"",
@@ -359,6 +366,17 @@ mod tests {
         assert_eq!(resolve("cb").unwrap().name, "clipboard");
     }
 
+    /// The image history is its own mode, not a spelling of the text one: the
+    /// two lists cannot mix, so neither can the names that open them.
+    #[test]
+    fn copied_images_resolve_to_their_own_mode() {
+        assert_eq!(resolve("clipboard-image").unwrap().name, "clipboard-image");
+        assert_eq!(resolve("clipimg").unwrap().name, "clipboard-image");
+        assert_eq!(resolve("ci").unwrap().name, "clipboard-image");
+        assert_eq!(resolve("ci").unwrap().query("logo"), "ci\"logo");
+        assert_eq!(resolve("clip").unwrap().name, "clipboard");
+    }
+
     #[test]
     fn resolution_ignores_case_and_surrounding_space() {
         assert_eq!(resolve("Clipboard").unwrap().name, "clipboard");
@@ -523,6 +541,12 @@ mod tests {
         assert_eq!(resolve("processes").unwrap().platforms, Platforms::All);
         assert_eq!(resolve("dictionary").unwrap().platforms, Platforms::MacOnly);
         assert_eq!(resolve("ai").unwrap().platforms, Platforms::MacOnly);
+        // linows keeps clipboard history in its own JSON store, which has no
+        // image path, so it must not advertise `ci"`.
+        assert_eq!(
+            resolve("clipboard-image").unwrap().platforms,
+            Platforms::MacOnly
+        );
     }
 
     #[test]

--- a/core/engine/src/modes.rs
+++ b/core/engine/src/modes.rs
@@ -366,8 +366,7 @@ mod tests {
         assert_eq!(resolve("cb").unwrap().name, "clipboard");
     }
 
-    /// The image history is its own mode, not a spelling of the text one: the
-    /// two lists cannot mix, so neither can the names that open them.
+    /// The two lists cannot mix, so neither can the names that open them.
     #[test]
     fn copied_images_resolve_to_their_own_mode() {
         assert_eq!(resolve("clipboard-image").unwrap().name, "clipboard-image");
@@ -541,8 +540,7 @@ mod tests {
         assert_eq!(resolve("processes").unwrap().platforms, Platforms::All);
         assert_eq!(resolve("dictionary").unwrap().platforms, Platforms::MacOnly);
         assert_eq!(resolve("ai").unwrap().platforms, Platforms::MacOnly);
-        // linows keeps clipboard history in its own JSON store, which has no
-        // image path, so it must not advertise `ci"`.
+        // linows keeps clipboard history in its own store, with no image path.
         assert_eq!(
             resolve("clipboard-image").unwrap().platforms,
             Platforms::MacOnly

--- a/core/storage/src/lib.rs
+++ b/core/storage/src/lib.rs
@@ -18,14 +18,10 @@ const MAX_URL_HISTORY_ROWS: usize = 500;
 /// A recall corpus, not a paste ring - but still bounded: this is text the
 /// user copied.
 pub const MAX_CLIPBOARD_ROWS: usize = 5_000;
-/// Images are capped far lower than text, and separately: the bytes live on
-/// disk, so every row here is megabytes rather than characters. Pruning is per
-/// kind for the same reason - one shared cap lets a screenshot burst evict text
-/// the user still wanted.
+/// Capped far lower than text, and separately: each row is megabytes on disk,
+/// and a screenshot burst must not evict text under a shared cap.
 pub const MAX_CLIPBOARD_IMAGE_ROWS: usize = 50;
 
-/// The `kind` column's two values. The shell picks one on every read and write,
-/// so `c"` and `ci"` cannot see each other's rows.
 pub const CLIPBOARD_KIND_TEXT: &str = "text";
 pub const CLIPBOARD_KIND_IMAGE: &str = "image";
 
@@ -99,9 +95,7 @@ pub struct ClipboardEntry {
     pub id: i64,
     pub content: String,
     pub kind: String,
-    /// Identity of what was copied. For text it is derived from `content`; for
-    /// an image it is the hash of the pixel bytes, which is also the name of
-    /// the file holding them.
+    /// For an image, the hash of the pixels, which also names the file.
     pub content_hash: String,
     pub app_bundle_id: Option<String>,
     pub copied_at_unix_s: i64,
@@ -539,10 +533,9 @@ impl SqliteStore {
         self.insert_clip(content, &hash, CLIPBOARD_KIND_TEXT, app_bundle_id)
     }
 
-    /// Remembers a copied image. `label` is what the row is searched and listed
-    /// by; `image_hash` is the identity of the pixels, so re-copying the same
-    /// picture under a different name still lifts the one row. The bytes
-    /// themselves are the shell's to write, under that hash.
+    /// `label` is what the row is listed and searched by; `image_hash` is the
+    /// identity, so the same picture under a new name still lifts one row. The
+    /// bytes are the shell's to write, under that hash.
     pub fn record_clipboard_image(
         &self,
         label: &str,
@@ -555,8 +548,7 @@ impl SqliteStore {
         self.insert_clip(label, image_hash, CLIPBOARD_KIND_IMAGE, app_bundle_id)
     }
 
-    /// The hash is passed in rather than derived: only text hashes what it
-    /// stores, an image hashes bytes this layer never sees.
+    /// The hash is passed in: an image hashes bytes this layer never sees.
     fn insert_clip(
         &self,
         content: &str,
@@ -598,7 +590,7 @@ impl SqliteStore {
         };
         // Only the overflow: `WHERE id NOT IN (SELECT ... LIMIT cap)` would
         // scan the whole table on every copy, for nothing until the 5,001st.
-        // Scoped to the kind, so the two histories cannot evict each other.
+        // Per kind, so the two histories cannot evict each other.
         tx.execute(
             "DELETE FROM clipboard_entries
              WHERE kind = ?1 AND (copied_at_unix_s, id) < (
@@ -654,9 +646,8 @@ impl SqliteStore {
         Ok(rows)
     }
 
-    /// Every stored image's hash, which is also its filename. The shell sweeps
-    /// its image directory against this: a file with no row here is bytes the
-    /// user believes they deleted.
+    /// What the shell sweeps its image directory against: a file with no hash
+    /// here is bytes the user believes they deleted.
     pub fn clipboard_image_hashes(&self) -> StorageResult<Vec<String>> {
         let mut stmt = self
             .conn
@@ -1203,8 +1194,7 @@ mod tests {
             .clipboard_entries(CLIPBOARD_KIND_IMAGE, "", 10)
             .unwrap();
         assert_eq!(images.len(), 1);
-        // The path to the bytes is rebuilt from this, so it has to survive the
-        // round trip.
+        // The path to the bytes is rebuilt from this.
         assert_eq!(images[0].content_hash, "aaaa");
         assert_eq!(images[0].app_bundle_id.as_deref(), Some("com.apple.Safari"));
 

--- a/core/storage/src/lib.rs
+++ b/core/storage/src/lib.rs
@@ -18,6 +18,16 @@ const MAX_URL_HISTORY_ROWS: usize = 500;
 /// A recall corpus, not a paste ring - but still bounded: this is text the
 /// user copied.
 pub const MAX_CLIPBOARD_ROWS: usize = 5_000;
+/// Images are capped far lower than text, and separately: the bytes live on
+/// disk, so every row here is megabytes rather than characters. Pruning is per
+/// kind for the same reason - one shared cap lets a screenshot burst evict text
+/// the user still wanted.
+pub const MAX_CLIPBOARD_IMAGE_ROWS: usize = 50;
+
+/// The `kind` column's two values. The shell picks one on every read and write,
+/// so `c"` and `ci"` cannot see each other's rows.
+pub const CLIPBOARD_KIND_TEXT: &str = "text";
+pub const CLIPBOARD_KIND_IMAGE: &str = "image";
 
 const SETTINGS_KEY_WEB_SEARCH_ENABLED: &str = "web_search_enabled";
 const SETTINGS_KEY_WEB_SEARCH_ENGINE: &str = "web_search_engine";
@@ -89,6 +99,10 @@ pub struct ClipboardEntry {
     pub id: i64,
     pub content: String,
     pub kind: String,
+    /// Identity of what was copied. For text it is derived from `content`; for
+    /// an image it is the hash of the pixel bytes, which is also the name of
+    /// the file holding them.
+    pub content_hash: String,
     pub app_bundle_id: Option<String>,
     pub copied_at_unix_s: i64,
 }
@@ -519,6 +533,34 @@ impl SqliteStore {
     pub fn record_clipboard_entry(
         &self,
         content: &str,
+        app_bundle_id: Option<&str>,
+    ) -> StorageResult<Option<i64>> {
+        let hash = content_hash(content);
+        self.insert_clip(content, &hash, CLIPBOARD_KIND_TEXT, app_bundle_id)
+    }
+
+    /// Remembers a copied image. `label` is what the row is searched and listed
+    /// by; `image_hash` is the identity of the pixels, so re-copying the same
+    /// picture under a different name still lifts the one row. The bytes
+    /// themselves are the shell's to write, under that hash.
+    pub fn record_clipboard_image(
+        &self,
+        label: &str,
+        image_hash: &str,
+        app_bundle_id: Option<&str>,
+    ) -> StorageResult<Option<i64>> {
+        if image_hash.trim().is_empty() {
+            return Ok(None);
+        }
+        self.insert_clip(label, image_hash, CLIPBOARD_KIND_IMAGE, app_bundle_id)
+    }
+
+    /// The hash is passed in rather than derived: only text hashes what it
+    /// stores, an image hashes bytes this layer never sees.
+    fn insert_clip(
+        &self,
+        content: &str,
+        hash: &str,
         kind: &str,
         app_bundle_id: Option<&str>,
     ) -> StorageResult<Option<i64>> {
@@ -526,7 +568,6 @@ impl SqliteStore {
             return Ok(None);
         }
         let now = current_unix_s()?;
-        let hash = content_hash(content);
         let tx = self.conn.unchecked_transaction()?;
         // Replaced, not updated: an in-place update keeps the old id, and
         // within the same second the id breaks the recency tie - so a re-copy
@@ -550,16 +591,23 @@ impl SqliteStore {
             params![content, hash, kind, app, now],
         )?;
         let row_id = tx.last_insert_rowid();
+        let cap = if kind == CLIPBOARD_KIND_IMAGE {
+            MAX_CLIPBOARD_IMAGE_ROWS
+        } else {
+            MAX_CLIPBOARD_ROWS
+        };
         // Only the overflow: `WHERE id NOT IN (SELECT ... LIMIT cap)` would
         // scan the whole table on every copy, for nothing until the 5,001st.
+        // Scoped to the kind, so the two histories cannot evict each other.
         tx.execute(
             "DELETE FROM clipboard_entries
-             WHERE (copied_at_unix_s, id) < (
+             WHERE kind = ?1 AND (copied_at_unix_s, id) < (
                SELECT copied_at_unix_s, id FROM clipboard_entries
+               WHERE kind = ?1
                ORDER BY copied_at_unix_s DESC, id DESC
-               LIMIT 1 OFFSET ?1
+               LIMIT 1 OFFSET ?2
              )",
-            params![MAX_CLIPBOARD_ROWS as i64 - 1],
+            params![kind, cap as i64 - 1],
         )?;
         tx.commit()?;
         Ok(Some(row_id))
@@ -570,6 +618,7 @@ impl SqliteStore {
     /// This is the keyword tier; semantic recall ranks the same rows later.
     pub fn clipboard_entries(
         &self,
+        kind: &str,
         query: &str,
         limit: usize,
     ) -> StorageResult<Vec<ClipboardEntry>> {
@@ -580,28 +629,40 @@ impl SqliteStore {
                 id: row.get(0)?,
                 content: row.get(1)?,
                 kind: row.get(2)?,
-                app_bundle_id: row.get(3)?,
-                copied_at_unix_s: row.get(4)?,
+                content_hash: row.get(3)?,
+                app_bundle_id: row.get(4)?,
+                copied_at_unix_s: row.get(5)?,
             })
         };
-        let select = "SELECT id, content, kind, app_bundle_id, copied_at_unix_s
-                      FROM clipboard_entries";
+        let select = "SELECT id, content, kind, content_hash, app_bundle_id, copied_at_unix_s
+                      FROM clipboard_entries WHERE kind = ?1";
         let rows = if query.is_empty() {
             let mut stmt = self.conn.prepare(&format!(
-                "{select} ORDER BY copied_at_unix_s DESC, id DESC LIMIT ?1"
+                "{select} ORDER BY copied_at_unix_s DESC, id DESC LIMIT ?2"
             ))?;
-            let mapped = stmt.query_map(params![limit], map_row)?;
+            let mapped = stmt.query_map(params![kind, limit], map_row)?;
             mapped.collect::<rusqlite::Result<Vec<_>>>()?
         } else {
             let pattern = format!("%{}%", like_escape(query));
             let mut stmt = self.conn.prepare(&format!(
-                "{select} WHERE content LIKE ?1 ESCAPE '\\'
-                 ORDER BY copied_at_unix_s DESC, id DESC LIMIT ?2"
+                "{select} AND content LIKE ?2 ESCAPE '\\'
+                 ORDER BY copied_at_unix_s DESC, id DESC LIMIT ?3"
             ))?;
-            let mapped = stmt.query_map(params![pattern, limit], map_row)?;
+            let mapped = stmt.query_map(params![kind, pattern, limit], map_row)?;
             mapped.collect::<rusqlite::Result<Vec<_>>>()?
         };
         Ok(rows)
+    }
+
+    /// Every stored image's hash, which is also its filename. The shell sweeps
+    /// its image directory against this: a file with no row here is bytes the
+    /// user believes they deleted.
+    pub fn clipboard_image_hashes(&self) -> StorageResult<Vec<String>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT content_hash FROM clipboard_entries WHERE kind = ?1")?;
+        let mapped = stmt.query_map(params![CLIPBOARD_KIND_IMAGE], |row| row.get(0))?;
+        Ok(mapped.collect::<rusqlite::Result<Vec<_>>>()?)
     }
 
     pub fn delete_clipboard_entry(&self, id: i64) -> StorageResult<bool> {
@@ -1027,57 +1088,70 @@ mod tests {
     fn clipboard_history_dedupes_orders_and_stays_bounded() {
         let store = SqliteStore::open_in_memory().unwrap();
         store
-            .record_clipboard_entry("first clip", "text", Some("com.apple.Safari"))
+            .record_clipboard_entry("first clip", Some("com.apple.Safari"))
             .unwrap();
-        store
-            .record_clipboard_entry("second clip", "text", None)
-            .unwrap();
+        store.record_clipboard_entry("second clip", None).unwrap();
         // Re-copying moves the row to the top instead of adding a duplicate.
-        store
-            .record_clipboard_entry("first clip", "text", None)
-            .unwrap();
+        store.record_clipboard_entry("first clip", None).unwrap();
 
-        let all = store.clipboard_entries("", 10).unwrap();
+        let all = store
+            .clipboard_entries(CLIPBOARD_KIND_TEXT, "", 10)
+            .unwrap();
         assert_eq!(all.len(), 2);
         assert_eq!(all[0].content, "first clip");
         // The source app is kept from the first capture rather than nulled.
         assert_eq!(all[0].app_bundle_id.as_deref(), Some("com.apple.Safari"));
 
         // Substring search, case-insensitive, newest first.
-        let found = store.clipboard_entries("SECOND", 10).unwrap();
+        let found = store
+            .clipboard_entries(CLIPBOARD_KIND_TEXT, "SECOND", 10)
+            .unwrap();
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].content, "second clip");
         assert!(
             store
-                .clipboard_entries("nothing here", 10)
+                .clipboard_entries(CLIPBOARD_KIND_TEXT, "nothing here", 10)
                 .unwrap()
                 .is_empty()
         );
 
         // Empty and whitespace-only clips are not worth remembering.
-        store.record_clipboard_entry("   ", "text", None).unwrap();
-        assert_eq!(store.clipboard_entries("", 10).unwrap().len(), 2);
+        store.record_clipboard_entry("   ", None).unwrap();
+        assert_eq!(
+            store
+                .clipboard_entries(CLIPBOARD_KIND_TEXT, "", 10)
+                .unwrap()
+                .len(),
+            2
+        );
 
         // The row id comes back from record, so a freshly captured clip has a
         // handle to delete by - without it a "deleted" clip returns on the
         // next launch.
         let fresh = store
-            .record_clipboard_entry("third clip", "text", None)
+            .record_clipboard_entry("third clip", None)
             .unwrap()
             .expect("row id");
         assert!(store.delete_clipboard_entry(fresh).unwrap());
-        assert!(store.clipboard_entries("third", 10).unwrap().is_empty());
-        // Nothing stored means no id to hand back.
-        assert_eq!(
-            store.record_clipboard_entry("  ", "text", None).unwrap(),
-            None
+        assert!(
+            store
+                .clipboard_entries(CLIPBOARD_KIND_TEXT, "third", 10)
+                .unwrap()
+                .is_empty()
         );
+        // Nothing stored means no id to hand back.
+        assert_eq!(store.record_clipboard_entry("  ", None).unwrap(), None);
 
         let id = all[0].id;
         assert!(store.delete_clipboard_entry(id).unwrap());
         assert!(!store.delete_clipboard_entry(id).unwrap());
         assert_eq!(store.clear_clipboard_entries().unwrap(), 1);
-        assert!(store.clipboard_entries("", 10).unwrap().is_empty());
+        assert!(
+            store
+                .clipboard_entries(CLIPBOARD_KIND_TEXT, "", 10)
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[test]
@@ -1085,34 +1159,129 @@ mod tests {
         let store = SqliteStore::open_in_memory().unwrap();
         for i in 0..(MAX_CLIPBOARD_ROWS + 25) {
             store
-                .record_clipboard_entry(&format!("clip {i}"), "text", None)
+                .record_clipboard_entry(&format!("clip {i}"), None)
                 .unwrap();
         }
         let all = store
-            .clipboard_entries("", MAX_CLIPBOARD_ROWS + 100)
+            .clipboard_entries(CLIPBOARD_KIND_TEXT, "", MAX_CLIPBOARD_ROWS + 100)
             .unwrap();
         assert_eq!(all.len(), MAX_CLIPBOARD_ROWS);
         // The oldest went, not the newest: this is a recall corpus.
-        assert!(store.clipboard_entries("clip 0", 10).unwrap().is_empty());
+        assert!(
+            store
+                .clipboard_entries(CLIPBOARD_KIND_TEXT, "clip 0", 10)
+                .unwrap()
+                .is_empty()
+        );
         assert!(
             !store
-                .clipboard_entries(&format!("clip {}", MAX_CLIPBOARD_ROWS + 24), 10)
+                .clipboard_entries(
+                    CLIPBOARD_KIND_TEXT,
+                    &format!("clip {}", MAX_CLIPBOARD_ROWS + 24),
+                    10
+                )
                 .unwrap()
                 .is_empty()
         );
     }
 
     #[test]
-    fn a_typed_wildcard_is_searched_literally() {
+    fn image_clips_and_text_clips_cannot_see_each_other() {
+        let store = SqliteStore::open_in_memory().unwrap();
+        store.record_clipboard_entry("a note", None).unwrap();
+        store
+            .record_clipboard_image("Screenshot.png", "aaaa", Some("com.apple.Safari"))
+            .unwrap();
+
+        let text = store
+            .clipboard_entries(CLIPBOARD_KIND_TEXT, "", 10)
+            .unwrap();
+        assert_eq!(text.len(), 1);
+        assert_eq!(text[0].content, "a note");
+
+        let images = store
+            .clipboard_entries(CLIPBOARD_KIND_IMAGE, "", 10)
+            .unwrap();
+        assert_eq!(images.len(), 1);
+        // The path to the bytes is rebuilt from this, so it has to survive the
+        // round trip.
+        assert_eq!(images[0].content_hash, "aaaa");
+        assert_eq!(images[0].app_bundle_id.as_deref(), Some("com.apple.Safari"));
+
+        // The label is what search matches, since the content is a name.
+        assert_eq!(
+            store
+                .clipboard_entries(CLIPBOARD_KIND_IMAGE, "screenshot", 10)
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(store.clipboard_image_hashes().unwrap(), vec!["aaaa"]);
+    }
+
+    #[test]
+    fn re_copying_an_image_lifts_the_row_it_already_has() {
         let store = SqliteStore::open_in_memory().unwrap();
         store
-            .record_clipboard_entry("100% done", "text", None)
+            .record_clipboard_image("Screenshot.png", "aaaa", None)
             .unwrap();
         store
-            .record_clipboard_entry("nothing special", "text", None)
+            .record_clipboard_image("Other.png", "bbbb", None)
+            .unwrap();
+        // Same pixels, different name: one row, back on top.
+        store
+            .record_clipboard_image("Screenshot copy.png", "aaaa", None)
+            .unwrap();
+
+        let images = store
+            .clipboard_entries(CLIPBOARD_KIND_IMAGE, "", 10)
+            .unwrap();
+        assert_eq!(images.len(), 2);
+        assert_eq!(images[0].content, "Screenshot copy.png");
+
+        // No bytes, no row: the hash is the whole identity of an image clip.
+        assert_eq!(
+            store
+                .record_clipboard_image("Empty.png", "  ", None)
+                .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn image_pruning_is_capped_separately_from_text() {
+        let store = SqliteStore::open_in_memory().unwrap();
+        store.record_clipboard_entry("a note", None).unwrap();
+        for i in 0..(MAX_CLIPBOARD_IMAGE_ROWS + 5) {
+            store
+                .record_clipboard_image(&format!("shot {i}.png"), &format!("hash{i}"), None)
+                .unwrap();
+        }
+        let images = store
+            .clipboard_entries(CLIPBOARD_KIND_IMAGE, "", MAX_CLIPBOARD_IMAGE_ROWS + 100)
+            .unwrap();
+        assert_eq!(images.len(), MAX_CLIPBOARD_IMAGE_ROWS);
+        // A burst of screenshots must not evict the text the user still wants.
+        assert_eq!(
+            store
+                .clipboard_entries(CLIPBOARD_KIND_TEXT, "", 10)
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn a_typed_wildcard_is_searched_literally() {
+        let store = SqliteStore::open_in_memory().unwrap();
+        store.record_clipboard_entry("100% done", None).unwrap();
+        store
+            .record_clipboard_entry("nothing special", None)
             .unwrap();
         // Without escaping, "%" would match every row.
-        let found = store.clipboard_entries("100%", 10).unwrap();
+        let found = store
+            .clipboard_entries(CLIPBOARD_KIND_TEXT, "100%", 10)
+            .unwrap();
         assert_eq!(found.len(), 1);
     }
 


### PR DESCRIPTION
## Summary

- Clipboard history for images (MacOS only in the PR)
  - Automatically saved to the history when you: capture (`cmd + ctrl + shift + 4`) or copy any image on your PC or on your browsers.
  - Access the screen by the new prefix: `ci"`
  - Configurable env: `clipboard_history_limit` - how many entries you want to keep

- Tiny updates for buttons. 
- Tests added

## Why

#451 

## Testing

- `core`
  - [x] `cargo check --workspace --manifest-path core/Cargo.toml`
  - [x] `cargo test --workspace --manifest-path core/Cargo.toml`

- `bridge/ffi`
  - [x] `cargo check --manifest-path bridge/ffi/Cargo.toml`
  - [x] `cargo test --manifest-path bridge/ffi/Cargo.toml`
  - [x] macOS app (if `apps/macos/**` touched): `cd apps/macos/LauncherApp && swift test`
  - [x] macOS app (if `apps/macos/**` touched): `xcodebuild -project "apps/macos/LauncherApp/look-app.xcodeproj" -scheme "Look" -configuration Debug -sdk macosx build`
  - [x] Manual verification completed (if UI/behavior changed)

## Screenshots / Recordings (if UI changed)

<img width="905" height="653" alt="image" src="https://github.com/user-attachments/assets/8091755b-23a6-48ce-9dbe-52ee3d317f58" />


## Checklist

- [x] I have read and agree to the CLA (CLA.md)
- [x] PR title is clear and scoped
- [x] Docs updated for user-visible changes
- [x] No secrets or private files included
- [x] Backward compatibility considered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added copied-image history to the macOS launcher.
  - Search image clips with the `ci"` prefix, including case-insensitive matching.
  - View image thumbnails, dimensions, file size, capture time, and source details.
  - Copy images back to the clipboard, delete entries, and manage image history separately from text clips.
  - Added image-specific empty states and result previews.
- **Bug Fixes**
  - Prevented image clipboard searches from triggering unrelated web suggestions or standard search results.
  - Prevented oversized images from being saved to clipboard history.
  - Ensured clearing history cannot be undone by an in-progress image capture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->